### PR TITLE
(*)Pass dz to user initialize_ALE_sponge calls

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1915,7 +1915,6 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
   character(len=40) :: mdl = "initialize_sponges_file"
   character(len=200) :: damping_file, uv_damping_file, state_file, state_uv_file  ! Strings for filenames
   character(len=200) :: filename, inputdir ! Strings for file/path and path.
-  type(verticalGrid_type) :: GV_loc ! A temporary vertical grid structure
 
   logical :: use_ALE ! True if ALE is being used, False if in layered mode
   logical :: time_space_interp_sponge ! If true use sponge data that need to be interpolated in both
@@ -2102,19 +2101,11 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
       enddo; enddo ; enddo
       deallocate(eta)
 
-      allocate(h(isd:ied,jsd:jed,nz_data))
       if (use_temperature) then
         allocate(tmp_T(isd:ied,jsd:jed,nz_data))
         allocate(tmp_S(isd:ied,jsd:jed,nz_data))
         call MOM_read_data(filename, potemp_var, tmp_T(:,:,:), G%Domain, scale=US%degC_to_C)
         call MOM_read_data(filename, salin_var, tmp_S(:,:,:), G%Domain, scale=US%ppt_to_S)
-      endif
-
-      GV_loc = GV ; GV_loc%ke = nz_data
-      if (use_temperature .and. associated(tv%eqn_of_state)) then
-        call dz_to_thickness(dz, tmp_T, tmp_S, tv%eqn_of_state, h, G, GV_loc, US)
-      else
-        call dz_to_thickness_simple(dz, h, G, GV_loc, US, layer_mode=.true.)
       endif
 
       if (sponge_uv) then
@@ -2132,7 +2123,6 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
         deallocate(tmp_S)
         deallocate(tmp_T)
       endif
-      deallocate(h)
       deallocate(dz)
 
       if (sponge_uv) then

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -63,7 +63,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   real :: U1(SZIB_(G),SZJ_(G),SZK_(GV)) ! A temporary array for u [L T-1 ~> m s-1]
   real :: V1(SZI_(G),SZJB_(G),SZK_(GV)) ! A temporary array for v [L T-1 ~> m s-1]
   real :: tmp(SZI_(G),SZJ_(G))        ! A temporary array for tracers.
-  real :: h(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for thickness at h points [H ~> m or kg m-2]
+  real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! Sponge layer thicknesses in height units [Z ~> m]
   real :: Idamp(SZI_(G),SZJ_(G))    ! The sponge damping rate at h points [T-1 ~> s-1]
   real :: TNUDG                     ! Nudging time scale [T ~> s]
   real :: pres(SZI_(G))             ! An array of the reference pressure [R L2 T-2 ~> Pa]
@@ -153,10 +153,10 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   call MOM_read_data(filename, salt_var, S(:,:,:), G%Domain, scale=US%ppt_to_S)
   if (use_ALE) then
 
-    call MOM_read_data(filename, h_var, h(:,:,:), G%Domain, scale=GV%m_to_H)
-    call pass_var(h, G%domain)
+    call MOM_read_data(filename, h_var, dz(:,:,:), G%Domain, scale=US%m_to_Z)
+    call pass_var(dz, G%domain)
 
-    call initialize_ALE_sponge(Idamp, G, GV, PF, ACSp, h, nz)
+    call initialize_ALE_sponge(Idamp, G, GV, PF, ACSp, dz, nz, data_h_is_Z=.true.)
 
     !  The remaining calls to set_up_sponge_field can be in any order.
     if ( associated(tv%T) ) call set_up_ALE_sponge_field(T, G, GV, tv%T, ACSp, 'temp', &

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -9,7 +9,6 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_interface_heights, only : dz_to_thickness, dz_to_thickness_simple
 use MOM_interface_heights, only : thickness_to_dz
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
@@ -352,7 +351,6 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
 
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
   real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! Sponge thicknesses in height units [Z ~> m]
-  real :: h(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge thicknesses [H ~> m or kg m-2]
   real :: S(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge salinities [S ~> ppt]
   real :: T(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge tempertures [C ~> degC], used only to convert thicknesses
                                        ! in non-Boussinesq mode
@@ -460,15 +458,8 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
       endif
     enddo ; enddo
 
-    ! Convert thicknesses from height units to thickness units
-    if (associated(tv%eqn_of_state)) then
-      call dz_to_thickness(dz, T, S, tv%eqn_of_state, h, G, GV, US)
-    else
-      call dz_to_thickness_simple(dz, h, G, GV, US, layer_mode=.true.)
-    endif
-
     ! Store damping rates and the grid on which the T/S sponge data will reside
-    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
+    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, dz, nz, data_h_is_Z=.true.)
 
     if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, GV, tv%S, ACSp, 'salt', &
                           sp_long_name='salinity', sp_unit='g kg-1 s-1')


### PR DESCRIPTION
  Pass vertical extents (`dz` in `[Z ~> m]`) instead of thicknesses (`h` in `[H ~> m or kg m-2]` and use `data_h_is_Z` flag in calls to `initialize_ALE_sponge()` calls from 5 user modules and avoid extra calls to `dz_to_thickness()` in these routines.  All Boussinesq solutions are bitwise identical, but in any non-Boussinesq configurations using ALE sponges, the previous conversion from `dz` to thickness and back again can change `dz` in the last bits, so some non-Boussinesq answers could change.