### PR TITLE
makedep: #if block fix

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -129,13 +129,9 @@ REPORT_ERROR_LOGS ?=
 TIME ?= time
 
 # Legacy external work directory
-#WORKSPACE ?=
 WORKSPACE ?= .
 
 # Set directories for build/ and work/
-#BUILD ?= $(WORKSPACE)build
-#DEPS ?= $(BUILD)/deps
-#WORK ?= $(WORKSPACE)work
 BUILD ?= $(WORKSPACE)/build
 DEPS ?= $(BUILD)/deps
 WORK ?= $(WORKSPACE)/work
@@ -297,12 +293,17 @@ $(BUILD)/timing/Makefile: MOM_ACFLAGS += --with-driver=timing_tests
 # Build executables
 $(BUILD)/unit/test_%: $(BUILD)/unit/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
+
 $(BUILD)/unit/Makefile: $(foreach e,$(UNIT_EXECS),../config_src/drivers/unit_tests/$(e).F90)
+
 $(BUILD)/timing/time_%: $(BUILD)/timing/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
+
 $(BUILD)/timing/Makefile: $(foreach e,$(TIMING_EXECS),../config_src/drivers/timing_tests/$(e).F90)
+
 $(BUILD)/%/MOM6: $(BUILD)/%/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
+
 FORCE:
 
 

--- a/ac/makedep
+++ b/ac/makedep
@@ -330,7 +330,7 @@ def scan_fortran_file(src_file, defines=None):
 
                 # XXX: Don't attempt to parse #if statements, but store the state.
                 # if/endif stack.  For now, assume that these always fail.
-                cpp_exclude = False
+                cpp_exclude = True
 
             # Complement #else condition group
             match = re_cpp_else.match(line)


### PR DESCRIPTION
Fixes an issue inside handling of #if preprocessor blocks.  Comments
suggest that we were always excluding the contents of such blocks, but
in fact we had the wrong value and were always including them.

Also some minor whitespace fixes in `.testing/Makefile`.