### PR TITLE
(*)Fix Stokes drift spectrum rescaling

### DIFF
--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -717,8 +717,8 @@ subroutine Update_Surface_Waves(G, GV, US, Time_present, dt, CS, forces)
         do i=G%isc,G%iec
           !CS%Omega_w2x(i,j)   = forces%omega_w2x(i,j)
           do b=1,CS%NumBands
-            CS%UStk_Hb(i,j,b) = US%m_s_to_L_T*forces%UStkb(i,j,b)
-            CS%VStk_Hb(i,j,b) = US%m_s_to_L_T*forces%VStkb(i,j,b)
+            CS%UStk_Hb(i,j,b) = forces%UStkb(i,j,b)
+            CS%VStk_Hb(i,j,b) = forces%VStkb(i,j,b)
           enddo
         enddo
       enddo


### PR DESCRIPTION
  Eliminated unneeded rescaling factors when setting the surface Stokes drift spectrum variables (`UStk_Hb` and `VStk_Hb`) from `forces%[UV]Stkb` in `Update_Surface_Waves()`.  This bug appears to have been introduced when merging in code that updates the Stokes drifts that was added on one branch (dev/ncar) separately from changes in how these Stokes drifts are scaled in the `mech_forcing` type on anther branch (dev/gfdl), although it might just have been an oversight during refactoring.  All answers are bitwise identical when no dimensional rescaling is being used, but answers could change for some uncommon cases using the Stokes drift spectrum when dimensional rescaling is applied.