### PR TITLE
Perf: Better error report for failed parsing

### DIFF
--- a/.testing/tools/parse_perf.py
+++ b/.testing/tools/parse_perf.py
@@ -58,9 +58,16 @@ def parse_perf_report(perf_data_path):
 
             # get per-symbol count
             else:
-                tokens = line.split()
-                symbol = tokens[2]
-                period = int(tokens[3])
+                try:
+                    tokens = line.split()
+                    symbol = tokens[2]
+                    period = int(tokens[3])
+                except ValueError:
+                    print("parse_perf.py: Error extracting symbol count",
+                            file=sys.stderr)
+                    print("line:", repr(line), file=sys.stderr)
+                    print("tokens:", tokens, file=sys.stderr)
+                    raise
 
                 profile[event_name]['symbol'][symbol] = period
 


### PR DESCRIPTION
Print the line and its tokenization in parse_perf.py if the tokenization fails for any reason.  This is most likely to occur if the fourth token is not an integer.

This is possibly a platform-dependent issue, and not something easily replicated on any machine we are using, so it is easier to simply integrate it into the codebase.