### PR TITLE
Add maximum number of iterations in find_depth_of_pressure_in_cell

### DIFF
--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -1562,6 +1562,7 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
   real :: F_guess, F_l, F_r  ! Fractional positions [nondim]
   real :: GxRho ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: Pa, Pa_left, Pa_right, Pa_tol ! Pressure anomalies, P = integral of g*(rho-rho_ref) dz [R L2 T-2 ~> Pa]
+  integer :: m  ! A counter for how many iterations have been done in the while loop [nondim]
   character(len=240) :: msg
 
   GxRho = G_e * rho_ref
@@ -1589,8 +1590,14 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
 
   F_guess = F_l - Pa_left / (Pa_right - Pa_left) * (F_r - F_l)
   Pa = Pa_right - Pa_left ! To get into iterative loop
+  m = 0 ! Reset the counter for the loop to be zero
   do while ( abs(Pa) > Pa_tol )
 
+    m = m + 1
+    if (m > 30) then !Call an error, because convergence to the tolerance has not been achieved
+     write(msg,*) Pa_left,Pa,Pa_right,P_t-P_tgt,P_b-P_tgt
+     call MOM_error(FATAL, 'find_depth_of_pressure_in_cell completes too many iterations: /n'//msg)
+    endif
     z_out = z_t + ( z_b - z_t ) * F_guess
     Pa = frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, F_guess, EOS) - ( P_tgt - P_t )
 

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -1562,7 +1562,7 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
   real :: F_guess, F_l, F_r  ! Fractional positions [nondim]
   real :: GxRho ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: Pa, Pa_left, Pa_right, Pa_tol ! Pressure anomalies, P = integral of g*(rho-rho_ref) dz [R L2 T-2 ~> Pa]
-  integer :: m  ! A counter for how many iterations have been done in the while loop [nondim]
+  integer :: m  ! A counter for how many iterations have been done in the while loop
   character(len=240) :: msg
 
   GxRho = G_e * rho_ref
@@ -1594,9 +1594,9 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
   do while ( abs(Pa) > Pa_tol )
 
     m = m + 1
-    if (m > 30) then !Call an error, because convergence to the tolerance has not been achieved
+    if (m > 30) then ! Call an error, because convergence to the tolerance has not been achieved
      write(msg,*) Pa_left,Pa,Pa_right,P_t-P_tgt,P_b-P_tgt
-     call MOM_error(FATAL, 'find_depth_of_pressure_in_cell completes too many iterations: /n'//msg)
+     call MOM_error(FATAL, 'find_depth_of_pressure_in_cell completes too many iterations: '//msg)
     endif
     z_out = z_t + ( z_b - z_t ) * F_guess
     Pa = frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, F_guess, EOS) - ( P_tgt - P_t )

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -234,11 +234,15 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: omega_tau2w_u !< angle between mtm flux and wind at u-pts [rad]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: omega_tau2w_v !< angle between mtm flux and wind at v-pts [rad]
 
-  real :: pi, Cemp_CG, tmp, cos_tmp, sin_tmp, omega_tmp !< constants and dummy variables
-  real :: du, dv, depth, sigma, Wind_x, Wind_y          !< intermediate variables
-  real :: taux, tauy, tauxDG, tauyDG, tauxDGup, tauyDGup, ustar2, tauh !< intermediate variables
-  real :: tauNLup, tauNLdn, tauNL_CG, tauNL_DG, tauNL_X, tauNL_Y, tau_MAG !< intermediate variables
-  real :: omega_w2s, omega_tau2s, omega_s2x, omega_tau2x, omega_tau2w, omega_s2w !< intermediate angles
+  real :: pi, Cemp_CG, tmp, cos_tmp, sin_tmp  !< constants and dummy variables [nondim]
+  real :: omega_tmp        !< A dummy angle [radians]
+  real :: du, dv           !< Velocity increments [L T-1 ~> m s-1]
+  real :: depth            !< Cumulative layer thicknesses [H ~> m or kg m=2]
+  real :: sigma            !< Fractional depth in the mixed layer [nondim]
+  real :: Wind_x, Wind_y   !< intermediate wind stress componenents [L2 T-2 ~> m2 s-2]
+  real :: taux, tauy, tauxDG, tauyDG, tauxDGup, tauyDGup, ustar2, tauh !< intermediate variables [L2 T-2 ~> m2 s-2]
+  real :: tauNLup, tauNLdn, tauNL_CG, tauNL_DG, tauNL_X, tauNL_Y, tau_MAG !< intermediate variables [L2 T-2 ~> m2 s-2]
+  real :: omega_w2s, omega_tau2s, omega_s2x, omega_tau2x, omega_tau2w, omega_s2w !< intermediate angles [radians]
   integer :: kblmin, kbld, kp1, k, nz !< vertical indices
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq ! horizontal indices
 
@@ -321,6 +325,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
   enddo
 
   if (CS%debug) then
+    !### These checksum calls are missing necessary dimensional scaling factors.
     call uvchksum("surface tau[xy]_[uv] ", taux_u, tauy_v, G%HI, haloshift=1, scalar_pair=.true.)
     call uvchksum("ustar2", ustar2_u, ustar2_v, G%HI, haloshift=0, scalar_pair=.true.)
     call uvchksum(" hbl", hbl_u ,   hbl_v , G%HI, haloshift=0, scalar_pair=.true.)
@@ -427,6 +432,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
         kbld  = min( (kbl_u(I,j)) , (nz-2) )
         if ( tau_u(I,j,kbld+2) > tau_u(I,j,kbld+1) ) kbld = kbld + 1
 
+        !### This expression is dimensionally inconsistent.
         tauh  =  tau_u(I,j,kbld+1) + GV%H_subroundoff
         ! surface boundary conditions
         depth   = 0.
@@ -437,6 +443,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
 
           ! linear stress mag
           tau_MAG   = (ustar2_u(I,j) * (1.-sigma) )  + (tauh * sigma )
+          !### The following expressions are dimensionally inconsistent.
           cos_tmp   = tauxDG_u(I,j,k+1) / (tau_u(I,j,k+1) + GV%H_subroundoff)
           sin_tmp   = tauyDG_u(I,j,k+1) / (tau_u(I,j,k+1) + GV%H_subroundoff)
 
@@ -457,6 +464,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
           tauNLdn  = tauNL_X
 
           ! nonlocal increment and update to uold
+          !### The following expression is dimensionally inconsistent and missing parentheses.
           du = (tauNLup - tauNLdn) * (dt/CS%h_u(I,j,k) + GV%H_subroundoff)
           ui(I,j,k)    = uold(I,j,k)  + du
           uold(I,j,k)  = du
@@ -496,6 +504,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
 
           ! linear stress
           tau_MAG   = (ustar2_v(i,J) * (1.-sigma))  + (tauh * sigma)
+          !### The following expressions are dimensionally inconsistent.
           cos_tmp   = tauxDG_v(i,J,k+1) / (tau_v(i,J,k+1)  + GV%H_subroundoff)
           sin_tmp   = tauyDG_v(i,J,k+1) / (tau_v(i,J,k+1)  + GV%H_subroundoff)
 
@@ -514,6 +523,8 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
           tauNL_X  = (tauNL_DG * cos_tmp - tauNL_CG * sin_tmp)
           tauNL_Y  = (tauNL_DG * sin_tmp + tauNL_CG * cos_tmp)
           tauNLdn  = tauNL_Y
+          !### The following expression is dimensionally inconsistent, [L T-1] vs. [L2 H-1 T-1] on the right,
+          !    and it is inconsistent with the counterpart expression for du.
           dv            = (tauNLup - tauNLdn) * (dt/(CS%h_v(i,J,k)) )
           vi(i,J,k)    = vold(i,J,k) + dv
           vold(i,J,k)  = dv
@@ -2634,7 +2645,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_vert_friction" ! This module's name.
   character(len=40)  :: thickness_units
-  real :: Kv_mks ! KVML in MKS
+  real :: Kv_mks ! KVML in MKS [m2 s-1]
 
   if (associated(CS)) then
     call MOM_error(WARNING, "vertvisc_init called with an associated "// &


### PR DESCRIPTION
Adds a maximum number of iterations to the subroutine `find_depth_of_pressure_in_cell` in `MOM_density_integrals`

This subroutine is called in `MOM_state_initialization` and calculates the pressure within a cell to determine where the ice shelf should be positioned vertically. It takes a z tolerance (controlled by the runtime parameter `TRIM_IC_Z_TOLERANCE`) and then iterates until the pressure anomaly from the reconstruction in the cell to the target pressure is sufficiently small (controlled by pa_tol = g x rho x z_tol).

Currently, the model just has a while loop for the tolerance, which means if the `TRIM_IC_Z_TOLERANCE` is set to a very small number e.g.1e-15, and convergence cannot be achieved due to numerical precision, then the model will hang and continue looping forever. 

I added a counter to count how many times it has iterated. In my preliminary tests with linear stratification for a few different geometries (therefore sampling a few different types of cells), depending on `TRIM_IC_Z_TOLERANCE` the subroutine either converged within 5 iterations and exited, or did not converge and kept repeating and hanging. Therefore I have hardcoded 30 as a maximum number of iterations. I currently have the model giving a fatal error if you exceed this (this would change answers from the model hanging and never running to the model giving a fatal error. Thus, this PR should not affect ice shelf initialisations that converged, assuming they also did so within 30 iterations, and should not change answers for any other configurations (note `find_depth_of_pressure_in_cell` is also called as a test in `MOM_state_initialization` but I don't see it used anywhere else.) Happy to add the bugfix as a runtime parameter if preferred!