### PR TITLE
+(*)Fix problems with generic_tracer_min_max

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -99,8 +99,9 @@ implicit none ; private
 contains
 
   !> Unknown
-  subroutine g_tracer_flux_init(g_tracer)
+  subroutine g_tracer_flux_init(g_tracer, verbosity)
     type(g_tracer_type), pointer :: g_tracer !< Pointer to this tracer node
+    integer, optional, intent(in) :: verbosity !< A 0-9 integer indicating a level of verbosity
   end subroutine g_tracer_flux_init
 
   !> Unknown

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -746,9 +746,10 @@ subroutine call_tracer_stocks(h, stock_values, G, GV, US, CS, stock_names, stock
     call store_stocks("MOM_generic_tracer", ns, names, units, values_EFP, index, stock_val_EFP, &
                       set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
     nn=ns_tot-ns+1
-    nn=MOM_generic_tracer_min_max(nn, got_min_max, global_min,  global_max, &
-                                  xgmin, ygmin, zgmin, xgmax, ygmax, zgmax ,&
-                                  G, CS%MOM_generic_tracer_CSp,names, units)
+    if (present(got_min_max) .and. present(global_min) .and. present(global_max)) &
+      nn = MOM_generic_tracer_min_max(nn, got_min_max, global_min, global_max, &
+                                      G, CS%MOM_generic_tracer_CSp, names, units, &
+                                      xgmin, ygmin, zgmin, xgmax, ygmax, zgmax)
 
   endif
   if (CS%use_pseudo_salt_tracer) then


### PR DESCRIPTION
  Revise `MOM_generic_tracer_min_max()` and `array_global_min_max()` to fix several problems that had previously been noted, and to make the location arguments optional, reflecting that they are optional in the calling routine.  This requires a revision to the order of arguments to `MOM_generic_tracer_min_max()`. The interface to `array_global_min_max()` was extensively revised and simplified to replace several previous arguments with a single new `ocean_grid_type` argument, to make the location arguments optional, and add an optional `unscale` argument.

  This commit fixes a number of problems that had previously been noted with `array_global_min_max()`, including that:
 (1) It actually returns the global minimum and maximum values of the tracer;
 (2) It gives a position that is independent of the domain decomposition and grid rotation;
 (3) For all-zero arrays it correctly reports 0 for the minimum and maximum;
 (4) It properly handles unscaling of the input array;
 (5) It does not use a 3-d mask array that is actually just a 2-d mask array;
 (6) It is more efficient by grouping the global minimum and maximum calls.

  This commit also adds or revises comments to document the units and purpose of the remaining undocumented real variables in `MOM_generic_tracer.F90`.

  These changes were tested and verified to be correct by calling `array_global_min_max()` for temperatures and salinities from `write_energy()`, but those changes were not included in this commit.

  This commit also adds an optional verbosity argument to `g_tracer_flux_init()` in `config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90`, reflecting a change to `ocean_BGC/generic_tracers/generic_tracer_utils.F90` that was adopted in August of 2020, and is uses this new `verbosity` argument in the call from `MOM_generic_flux_init()`.

  While all solutions are bitwise identical, there are changes (corrections) in some diagnostic output, and there are changes to the arguments of publicly visible routines.