### PR TITLE
Move the dynamic core CS to local variable

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -381,13 +381,13 @@ type, public :: MOM_control_struct ; private
 
   ! The remainder of this type provides pointers to child module control structures.
 
-  type(MOM_dyn_unsplit_CS),      pointer :: dyn_unsplit_CSp => NULL()
+  type(MOM_dyn_unsplit_CS) :: dyn_unsplit_CS
     !< Pointer to the control structure used for the unsplit dynamics
-  type(MOM_dyn_unsplit_RK2_CS),  pointer :: dyn_unsplit_RK2_CSp => NULL()
+  type(MOM_dyn_unsplit_RK2_CS) :: dyn_unsplit_RK2_CS
     !< Pointer to the control structure used for the unsplit RK2 dynamics
-  type(MOM_dyn_split_RK2_CS),    pointer :: dyn_split_RK2_CSp => NULL()
+  type(MOM_dyn_split_RK2_CS) :: dyn_split_RK2_CS
     !< Pointer to the control structure used for the mode-split RK2 dynamics
-  type(MOM_dyn_split_RK2b_CS),    pointer :: dyn_split_RK2b_CSp => NULL()
+  type(MOM_dyn_split_RK2b_CS) :: dyn_split_RK2b_CS
     !< Pointer to the control structure used for an alternate version of the mode-split RK2 dynamics
   type(thickness_diffuse_CS) :: thickness_diffuse_CSp
     !< Pointer to the control structure used for the isopycnal height diffusive transport.
@@ -1233,12 +1233,12 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
     if (CS%use_alt_split) then
       call step_MOM_dyn_split_RK2b(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
-                  CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CSp, calc_dtbt, CS%VarMix, &
+                  CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CS, calc_dtbt, CS%VarMix, &
                   CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
     else
       call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                   p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
-                  CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2_CSp, calc_dtbt, CS%VarMix, &
+                  CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2_CS, calc_dtbt, CS%VarMix, &
                   CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
     endif
     if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_split (step_MOM)")
@@ -1254,11 +1254,11 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
     if (CS%use_RK2) then
       call step_MOM_dyn_unsplit_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
-               CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_RK2_CSp, CS%VarMix, CS%MEKE, CS%pbv)
+               CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_RK2_CS, CS%VarMix, CS%MEKE, CS%pbv)
     else
       call step_MOM_dyn_unsplit(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
-               CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_CSp, CS%VarMix, CS%MEKE, CS%pbv, Waves=Waves)
+               CS%eta_av_bc, G, GV, US, CS%dyn_unsplit_CS, CS%VarMix, CS%MEKE, CS%pbv, Waves=Waves)
     endif
     if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_unsplit (step_MOM)")
 
@@ -1667,10 +1667,10 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
 
       if (CS%remap_aux_vars) then
         if (CS%split .and. CS%use_alt_split) then
-          call remap_dyn_split_RK2b_aux_vars(G, GV, CS%dyn_split_RK2b_CSp, h_old_u, h_old_v, &
+          call remap_dyn_split_RK2b_aux_vars(G, GV, CS%dyn_split_RK2b_CS, h_old_u, h_old_v, &
                                              h_new_u, h_new_v, CS%ALE_CSp)
         elseif (CS%split) then
-          call remap_dyn_split_RK2_aux_vars(G, GV, CS%dyn_split_RK2_CSp, h_old_u, h_old_v, h_new_u, h_new_v, CS%ALE_CSp)
+          call remap_dyn_split_RK2_aux_vars(G, GV, CS%dyn_split_RK2_CS, h_old_u, h_old_v, h_new_u, h_new_v, CS%ALE_CSp)
         endif
 
         if (associated(CS%OBC)) then
@@ -2802,16 +2802,16 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call set_restart_fields(GV, US, param_file, CS, restart_CSp)
   if (CS%split .and. CS%use_alt_split) then
     call register_restarts_dyn_split_RK2b(HI, GV, US, param_file, &
-             CS%dyn_split_RK2b_CSp, restart_CSp, CS%uh, CS%vh)
+             CS%dyn_split_RK2b_CS, restart_CSp, CS%uh, CS%vh)
   elseif (CS%split) then
     call register_restarts_dyn_split_RK2(HI, GV, US, param_file, &
-             CS%dyn_split_RK2_CSp, restart_CSp, CS%uh, CS%vh)
+             CS%dyn_split_RK2_CS, restart_CSp, CS%uh, CS%vh)
   elseif (CS%use_RK2) then
     call register_restarts_dyn_unsplit_RK2(HI, GV, param_file, &
-           CS%dyn_unsplit_RK2_CSp)
+           CS%dyn_unsplit_RK2_CS)
   else
     call register_restarts_dyn_unsplit(HI, GV, param_file, &
-           CS%dyn_unsplit_CSp)
+           CS%dyn_unsplit_CS)
   endif
 
   ! This subroutine calls user-specified tracer registration routines.
@@ -3222,13 +3222,13 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     allocate(eta(SZI_(G),SZJ_(G)), source=0.0)
     if (CS%use_alt_split) then
       call initialize_dyn_split_RK2b(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
-              G, GV, US, param_file, diag, CS%dyn_split_RK2b_CSp, restart_CSp, &
+              G, GV, US, param_file, diag, CS%dyn_split_RK2b_CS, restart_CSp, &
               CS%dt, CS%ADp, CS%CDp, MOM_internal_state, CS%VarMix, CS%MEKE, &
               CS%thickness_diffuse_CSp, CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, &
               CS%visc, dirs, CS%ntrunc, CS%pbv, calc_dtbt=calc_dtbt, cont_stencil=CS%cont_stencil)
     else
       call initialize_dyn_split_RK2(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
-              G, GV, US, param_file, diag, CS%dyn_split_RK2_CSp, restart_CSp, &
+              G, GV, US, param_file, diag, CS%dyn_split_RK2_CS, restart_CSp, &
               CS%dt, CS%ADp, CS%CDp, MOM_internal_state, CS%VarMix, CS%MEKE, &
               CS%thickness_diffuse_CSp, CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, &
               CS%visc, dirs, CS%ntrunc, CS%pbv, calc_dtbt=calc_dtbt, cont_stencil=CS%cont_stencil)
@@ -3247,13 +3247,13 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     endif
   elseif (CS%use_RK2) then
     call initialize_dyn_unsplit_RK2(CS%u, CS%v, CS%h, Time, G, GV, US,     &
-            param_file, diag, CS%dyn_unsplit_RK2_CSp,                      &
+            param_file, diag, CS%dyn_unsplit_RK2_CS,                       &
             CS%ADp, CS%CDp, MOM_internal_state, CS%OBC,                    &
             CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, CS%visc, dirs, &
             CS%ntrunc, cont_stencil=CS%cont_stencil)
   else
     call initialize_dyn_unsplit(CS%u, CS%v, CS%h, Time, G, GV, US,         &
-            param_file, diag, CS%dyn_unsplit_CSp,                          &
+            param_file, diag, CS%dyn_unsplit_CS,                           &
             CS%ADp, CS%CDp, MOM_internal_state, CS%OBC,                    &
             CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, CS%visc, dirs, &
             CS%ntrunc, cont_stencil=CS%cont_stencil)
@@ -4170,13 +4170,13 @@ subroutine MOM_end(CS)
   if (CS%offline_tracer_mode) call offline_transport_end(CS%offline_CSp)
 
   if (CS%split .and. CS%use_alt_split) then
-    call end_dyn_split_RK2b(CS%dyn_split_RK2b_CSp)
+    call end_dyn_split_RK2b(CS%dyn_split_RK2b_CS)
   elseif (CS%split) then
-    call end_dyn_split_RK2(CS%dyn_split_RK2_CSp)
+    call end_dyn_split_RK2(CS%dyn_split_RK2_CS)
   elseif (CS%use_RK2) then
-    call end_dyn_unsplit_RK2(CS%dyn_unsplit_RK2_CSp)
+    call end_dyn_unsplit_RK2(CS%dyn_unsplit_RK2_CS)
   else
-    call end_dyn_unsplit(CS%dyn_unsplit_CSp)
+    call end_dyn_unsplit(CS%dyn_unsplit_CS)
   endif
 
   if (CS%use_particles) then

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -316,7 +316,7 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
                                                                    !! since last tracer advection [H L2 ~> m3 or kg]
   real, dimension(SZI_(G),SZJ_(G)),  intent(out)   :: eta_av       !< Free surface height or column mass
                                                                    !! averaged over time step [H ~> m or kg m-2]
-  type(MOM_dyn_split_RK2b_CS),       pointer       :: CS           !< Module control structure
+  type(MOM_dyn_split_RK2b_CS), target, intent(inout) :: CS         !< Module control structure
   logical,                           intent(in)    :: calc_dtbt    !< If true, recalculate the barotropic time step
   type(VarMix_CS),                   intent(inout) :: VarMix       !< Variable mixing control structure
   type(MEKE_type),                   intent(inout) :: MEKE         !< MEKE fields
@@ -1136,7 +1136,7 @@ subroutine register_restarts_dyn_split_RK2b(HI, GV, US, param_file, CS, restart_
   type(verticalGrid_type),       intent(in)    :: GV         !< ocean vertical grid structure
   type(unit_scale_type),         intent(in)    :: US         !< A dimensional unit scaling type
   type(param_file_type),         intent(in)    :: param_file !< parameter file
-  type(MOM_dyn_split_RK2b_CS),   pointer       :: CS         !< module control structure
+  type(MOM_dyn_split_RK2b_CS), intent(inout) :: CS           !< module control structure
   type(MOM_restart_CS),          intent(inout) :: restart_CS !< MOM restart control structure
   real, dimension(SZIB_(HI),SZJ_(HI),SZK_(GV)), &
                          target, intent(inout) :: uh !< zonal volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
@@ -1151,14 +1151,6 @@ subroutine register_restarts_dyn_split_RK2b(HI, GV, US, param_file, CS, restart_
 
   isd  = HI%isd  ; ied  = HI%ied  ; jsd  = HI%jsd  ; jed  = HI%jed ; nz = GV%ke
   IsdB = HI%IsdB ; IedB = HI%IedB ; JsdB = HI%JsdB ; JedB = HI%JedB
-
-  ! This is where a control structure specific to this module would be allocated.
-  if (associated(CS)) then
-    call MOM_error(WARNING, "register_restarts_dyn_split_RK2b called with an associated "// &
-                             "control structure.")
-    return
-  endif
-  allocate(CS)
 
   ALLOC_(CS%diffu(IsdB:IedB,jsd:jed,nz)) ; CS%diffu(:,:,:) = 0.0
   ALLOC_(CS%diffv(isd:ied,JsdB:JedB,nz)) ; CS%diffv(:,:,:) = 0.0
@@ -1201,7 +1193,7 @@ end subroutine register_restarts_dyn_split_RK2b
 subroutine remap_dyn_split_RK2b_aux_vars(G, GV, CS, h_old_u, h_old_v, h_new_u, h_new_v, ALE_CSp)
   type(ocean_grid_type),            intent(inout) :: G        !< ocean grid structure
   type(verticalGrid_type),          intent(in)    :: GV       !< ocean vertical grid structure
-  type(MOM_dyn_split_RK2b_CS),      pointer       :: CS       !< module control structure
+  type(MOM_dyn_split_RK2b_CS), intent(inout) :: CS            !< module control structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                                     intent(in)    :: h_old_u  !< Source grid thickness at zonal
                                                               !! velocity points [H ~> m or kg m-2]
@@ -1244,7 +1236,7 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
   type(time_type),          target, intent(in)    :: Time       !< current model time
   type(param_file_type),            intent(in)    :: param_file !< parameter file for parsing
   type(diag_ctrl),          target, intent(inout) :: diag       !< to control diagnostics
-  type(MOM_dyn_split_RK2b_CS),      pointer       :: CS         !< module control structure
+  type(MOM_dyn_split_RK2b_CS), target, intent(inout) :: CS      !< module control structure
   type(MOM_restart_CS),             intent(inout) :: restart_CS !< MOM restart control structure
   real,                             intent(in)    :: dt         !< time step [T ~> s]
   type(accel_diag_ptrs),    target, intent(inout) :: Accel_diag !< points to momentum equation terms for
@@ -1285,8 +1277,6 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
-  if (.not.associated(CS)) call MOM_error(FATAL, &
-      "initialize_dyn_split_RK2b called with an unassociated control structure.")
   if (CS%module_is_initialized) then
     call MOM_error(WARNING, "initialize_dyn_split_RK2b called with a control "// &
                             "structure that has already been initialized.")
@@ -1636,7 +1626,8 @@ end subroutine initialize_dyn_split_RK2b
 
 !> Close the dyn_split_RK2b module
 subroutine end_dyn_split_RK2b(CS)
-  type(MOM_dyn_split_RK2b_CS), pointer :: CS  !< module control structure
+  type(MOM_dyn_split_RK2b_CS), intent(inout) :: CS
+    !< module control structure
 
   call barotropic_end(CS%barotropic_CSp)
 
@@ -1664,8 +1655,6 @@ subroutine end_dyn_split_RK2b(CS)
 
   call dealloc_BT_cont_type(CS%BT_cont)
   deallocate(CS%AD_pred)
-
-  deallocate(CS)
 end subroutine end_dyn_split_RK2b
 
 


### PR DESCRIPTION
This patch redefines the dynamic timestep control structures such as MOM_dyn_split_RK2 from pointers to local variables.

This change resolves a mysterious error in Nvidia Fortran when these control structures were deallocated.  The problem appears to have been introduced when the abstract EOS base class was introduced.  However, the connection between these two types is not clear, since neither one references the other.  Nonetheless, if the CS does not need to be deallocated, then problem solved. (...?)

This also progresses our overall desire to remove all unnecessary pointers from the source.