### PR TITLE
Flux through static ice-shelf to icebergs/new diagnostics

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -124,8 +124,8 @@ type, public ::  ocean_public_type
     OBLD => NULL(),   & !< Ocean boundary layer depth [m].
     area => NULL(),   & !< cell area of the ocean surface [m2].
     calving => NULL(), &!< The mass per unit area of the ice shelf to convert to
-                        !!bergs [R Z ~> kg m-2].
-    calving_hflx => NULL() !< Calving heat flux [Q R Z T-1 ~> W m-2].
+                        !! bergs [kg m-2].
+    calving_hflx => NULL() !< Calving heat flux [W m-2].
   type(coupler_2d_bc_type) :: fields    !< A structure that may contain named
                                         !! arrays of tracer-related surface fields.
   integer                  :: avg_kount !< A count of contributions to running

--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -55,6 +55,7 @@ use MOM_verticalGrid, only : verticalGrid_type
 use MOM_ice_shelf, only : initialize_ice_shelf, shelf_calc_flux, ice_shelf_CS
 use MOM_ice_shelf, only : initialize_ice_shelf_fluxes, initialize_ice_shelf_forces
 use MOM_ice_shelf, only : add_shelf_forces, ice_shelf_end, ice_shelf_save_restart
+use MOM_ice_shelf, only : ice_sheet_calving_to_ocean_sfc
 use MOM_wave_interface, only: wave_parameters_CS, MOM_wave_interface_init
 use MOM_wave_interface, only: Update_Surface_Waves
 use iso_fortran_env, only : int64
@@ -121,7 +122,10 @@ type, public ::  ocean_public_type
                         !! formation in the ocean.
     melt_potential => NULL(), & !< Instantaneous heat used to melt sea ice [J m-2].
     OBLD => NULL(),   & !< Ocean boundary layer depth [m].
-    area => NULL()      !< cell area of the ocean surface [m2].
+    area => NULL(),   & !< cell area of the ocean surface [m2].
+    calving => NULL(), &!< The mass per unit area of the ice shelf to convert to
+                        !!bergs [R Z ~> kg m-2].
+    calving_hflx => NULL() !< Calving heat flux [Q R Z T-1 ~> W m-2].
   type(coupler_2d_bc_type) :: fields    !< A structure that may contain named
                                         !! arrays of tracer-related surface fields.
   integer                  :: avg_kount !< A count of contributions to running
@@ -157,6 +161,8 @@ type, public :: ocean_state_type ; private
                               !! ocean dynamics and forcing fluxes.
   real :: press_to_z          !< A conversion factor between pressure and ocean depth,
                               !! usually 1/(rho_0*g) [Z T2 R-1 L-2 ~> m Pa-1].
+  logical :: calve_ice_shelf_bergs = .false. !< If true, bergs are initialized according to
+                              !! ice shelf flux through the ice front
   real :: C_p                 !< The heat capacity of seawater [J degC-1 kg-1].
   logical :: offline_tracer_mode = .false. !< If false, use the model in prognostic mode
                               !! with the barotropic and baroclinic dynamics, thermodynamics,
@@ -221,7 +227,7 @@ contains
 !!   This subroutine initializes both the ocean state and the ocean surface type.
 !! Because of the way that indices and domains are handled, Ocean_sfc must have
 !! been used in a previous call to initialize_ocean_type.
-subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas_fields_ocn)
+subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas_fields_ocn, calve_ice_shelf_bergs)
   type(ocean_public_type), target, &
                        intent(inout) :: Ocean_sfc !< A structure containing various publicly
                                 !! visible ocean surface properties after initialization,
@@ -239,6 +245,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
                                               !! in the calculation of additional gas or other
                                               !! tracer fluxes, and can be used to spawn related
                                               !! internal variables in the ice model.
+  logical, optional,   intent(in)    :: calve_ice_shelf_bergs !< If true, track ice shelf flux through a
+                                              !! static ice shelf, so that it can be converted into icebergs
   ! Local variables
   real :: Rho0        ! The Boussinesq ocean density [R ~> kg m-3]
   real :: G_Earth     ! The gravitational acceleration [L2 Z-1 T-2 ~> m s-2]
@@ -247,6 +255,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
                       !! min(HFrz, OBLD), where OBLD is the boundary layer depth.
                       !! If HFrz <= 0 (default), melt potential will not be computed.
   logical :: use_melt_pot !< If true, allocate melt_potential array
+  logical :: point_calving ! Equals calve_ice_shelf_bergs if calve_ice_shelf_bergs is present
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -274,11 +283,11 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
   OS%Time = Time_in ; OS%Time_dyn = Time_in
   ! Call initialize MOM with an optional Ice Shelf CS which, if present triggers
   ! initialization of ice shelf parameters and arrays.
-
+  point_calving=.false.; if (present(calve_ice_shelf_bergs)) point_calving=calve_ice_shelf_bergs
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
                       Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       diag_ptr=OS%diag, count_calls=.true., ice_shelf_CSp=OS%ice_shelf_CSp, &
-                      waves_CSp=OS%Waves)
+                      waves_CSp=OS%Waves, calve_ice_shelf_bergs=point_calving)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
                               C_p_scaled=OS%fluxes%C_p, use_temp=use_temperature)
 
@@ -404,6 +413,13 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
 
     call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, OS%US)
 
+  endif
+
+  if (present(calve_ice_shelf_bergs)) then
+    if (calve_ice_shelf_bergs) then
+      call convert_shelf_state_to_ocean_type(Ocean_sfc, OS%Ice_shelf_CSp, OS%US)
+      OS%calve_ice_shelf_bergs=.true.
+    endif
   endif
 
   call close_param_file(param_file)
@@ -668,6 +684,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
 !  call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, OS%US, &
 !                                   OS%fluxes%p_surf_full, OS%press_to_z)
   call convert_state_to_ocean_type(OS%sfc_state, Ocean_sfc, OS%grid, OS%US)
+  if (OS%calve_ice_shelf_bergs) call convert_shelf_state_to_ocean_type(Ocean_sfc,OS%Ice_shelf_CSp, OS%US)
   Time1 = OS%Time ; if (do_dyn) Time1 = OS%Time_dyn
   call coupler_type_send_data(Ocean_sfc%fields, Time1)
 
@@ -789,6 +806,8 @@ subroutine initialize_ocean_public_type(input_domain, Ocean_sfc, diag, gas_field
              Ocean_sfc%u_surf (isc:iec,jsc:jec), &
              Ocean_sfc%v_surf (isc:iec,jsc:jec), &
              Ocean_sfc%sea_lev(isc:iec,jsc:jec), &
+             Ocean_sfc%calving(isc:iec,jsc:jec), &
+             Ocean_sfc%calving_hflx(isc:iec,jsc:jec), &
              Ocean_sfc%area   (isc:iec,jsc:jec), &
              Ocean_sfc%melt_potential(isc:iec,jsc:jec), &
              Ocean_sfc%OBLD   (isc:iec,jsc:jec), &
@@ -799,6 +818,8 @@ subroutine initialize_ocean_public_type(input_domain, Ocean_sfc, diag, gas_field
   Ocean_sfc%u_surf(:,:)  = 0.0  ! time averaged u-current (m/sec) passed to atmosphere/ice models
   Ocean_sfc%v_surf(:,:)  = 0.0  ! time averaged v-current (m/sec)  passed to atmosphere/ice models
   Ocean_sfc%sea_lev(:,:) = 0.0  ! time averaged thickness of top model grid cell (m) plus patm/rho0/grav
+  Ocean_sfc%calving(:,:)  = 0.0  ! time accumulated ice sheet calving (kg m-2) passed to ice model
+  Ocean_sfc%calving_hflx(:,:) = 0.0 ! time accumulated ice sheet calving heat flux (W m-2) passed to ice model
   Ocean_sfc%frazil(:,:)  = 0.0  ! time accumulated frazil (J/m^2) passed to ice model
   Ocean_sfc%melt_potential(:,:)  = 0.0  ! time accumulated melt potential (J/m^2) passed to ice model
   Ocean_sfc%OBLD(:,:)    = 0.0  ! ocean boundary layer depth (m)
@@ -931,6 +952,24 @@ subroutine convert_state_to_ocean_type(sfc_state, Ocean_sfc, G, US, patm, press_
   endif
 
 end subroutine convert_state_to_ocean_type
+
+!> Converts the ice-shelf-to-ocean calving and calving_hflx variables from the ice-shelf state (ISS) type
+!! to the ocean public type
+subroutine convert_shelf_state_to_ocean_type(Ocean_sfc, CS, US)
+  type(ocean_public_type), &
+               target, intent(inout) :: Ocean_sfc !< A structure containing various publicly
+                                                  !! visible ocean surface fields, whose elements
+                                                  !! have their data set here.
+  type(ice_shelf_CS),      pointer :: CS        !< A pointer to the ice shelf control structure
+  type(unit_scale_type), intent(in)    :: US   !< A dimensional unit scaling type
+  integer :: isc_bnd, iec_bnd, jsc_bnd, jec_bnd, i, j
+
+  call get_domain_extent(Ocean_sfc%Domain, isc_bnd, iec_bnd, jsc_bnd, jec_bnd)
+
+  call ice_sheet_calving_to_ocean_sfc(CS,US,Ocean_sfc%calving(isc_bnd:iec_bnd,jsc_bnd:jec_bnd),&
+    Ocean_sfc%calving_hflx(isc_bnd:iec_bnd,jsc_bnd:jec_bnd))
+
+end subroutine convert_shelf_state_to_ocean_type
 
 !>   This subroutine extracts the surface properties from the ocean's internal
 !! state and stores them in the ocean type returned to the calling ice model.

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -2497,8 +2497,8 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
 
   enddo
 
-  call write_ice_shelf_energy(CS%dCS, G, US, ISS%mass_shelf, ISS%area_shelf_h, Time, &
-                              time_step=time_interval)
+  call write_ice_shelf_energy(CS%dCS, G, US, ISS%mass_shelf, Time, time_step=time_interval)
+
   do j=js,je ; do i=is,ie
     ISS%dhdt_shelf(i,j) = (ISS%h_shelf(i,j) - ISS%dhdt_shelf(i,j)) * Ifull_time_step
   enddo; enddo

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -350,10 +350,11 @@ subroutine post_IS_data_0d(diag_field_id, field, diag_cs, is_static)
   integer,           intent(in) :: diag_field_id !< The id for an output variable returned by a
                                                  !! previous call to register_diag_field.
   real,              intent(in) :: field         !< real value being offered for output or averaging
+                                                 !! in internally scaled arbitrary units [A ~> a]
   type(diag_ctrl), target, intent(in) :: diag_CS !< Structure used to regulate diagnostic output
   logical, optional, intent(in) :: is_static !< If true, this is a static field that is always offered.
   ! Local variables
-  real :: locfield
+  real :: locfield ! The field being offered in arbitrary unscaled units [a]
   logical :: used, is_stat
   type(diag_type), pointer :: diag => null()
 
@@ -459,22 +460,25 @@ function register_MOM_IS_diag_field(module_name, field_name, axes, init_time, &
   character(len=*), optional, intent(in) :: long_name !< Long name of a field.
   character(len=*), optional, intent(in) :: units !< Units of a field.
   character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
-  real,             optional, intent(in) :: missing_value !< A value that indicates missing values.
+  real,             optional, intent(in) :: missing_value !< A value that indicates missing values in
+                                                          !! output files, in unscaled arbitrary units [a]
   real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in MOM?)
+                                                     !! in arbitrary units [a]
   logical,          optional, intent(in) :: mask_variant !< If true a logical mask must be provided with
                                                          !! post_IS_data calls (not used in MOM?)
   logical,          optional, intent(in) :: verbose !< If true, FMS is verbose (not used in MOM?)
   logical,          optional, intent(in) :: do_not_log !< If true, do not log something (not used in MOM?)
   character(len=*), optional, intent(out):: err_msg !< String into which an error message might be
-                                                         !! placed (not used in MOM?)
+                                                    !! placed (not used in MOM?)
   character(len=*), optional, intent(in) :: interp_method !< If 'none' indicates the field should not
-                                                         !! be interpolated as a scalar
-  integer,          optional, intent(in) :: tile_count   !< no clue (not used in MOM_IS?)
-  real,             optional, intent(in) :: conversion !< A value to multiply data by before writing to file
-
+                                                          !! be interpolated as a scalar
+  integer,          optional, intent(in) :: tile_count !< no clue (not used in MOM_IS?)
+  real,             optional, intent(in) :: conversion !< A value to multiply data by before writing to file,
+                                                       !! often including factors to undo internal scaling and
+                                                       !! in units of [a A-1 ~> 1]
   ! Local variables
   character(len=240) :: mesg
-  real :: MOM_missing_value
+  real :: MOM_missing_value ! A value used to indicate missing values in output files, in arbitrary units [a]
   integer :: primary_id, fms_id
   type(diag_ctrl), pointer :: diag_cs => NULL() ! A structure that is used
                                                ! to regulate diagnostic output

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -27,6 +27,7 @@ public enable_averages
 public MOM_IS_diag_mediator_init, MOM_IS_diag_mediator_end, set_IS_diag_mediator_grid
 public MOM_IS_diag_mediator_close_registration, get_diag_time_end
 public MOM_diag_axis_init, register_static_field_infra
+public register_MOM_IS_scalar_field, post_IS_data_0d
 
 !> 2D/3D axes type to contain 1D axes handles and pointers to masks
 type, public :: axesType
@@ -344,6 +345,35 @@ subroutine post_IS_data(diag_field_id, field, diag_cs, is_static, mask)
 
 end subroutine post_IS_data
 
+!> Make a real ice shelf scalar diagnostic available for averaging or output
+subroutine post_IS_data_0d(diag_field_id, field, diag_cs, is_static)
+  integer,           intent(in) :: diag_field_id !< The id for an output variable returned by a
+                                                 !! previous call to register_diag_field.
+  real,              intent(in) :: field         !< real value being offered for output or averaging
+  type(diag_ctrl), target, intent(in) :: diag_CS !< Structure used to regulate diagnostic output
+  logical, optional, intent(in) :: is_static !< If true, this is a static field that is always offered.
+  ! Local variables
+  real :: locfield
+  logical :: used, is_stat
+  type(diag_type), pointer :: diag => null()
+
+  is_stat = .false. ; if (present(is_static)) is_stat = is_static
+
+  call assert(diag_field_id < diag_cs%next_free_diag_id, &
+              'post_data_0d: Unregistered diagnostic id')
+  diag => diag_cs%diags(diag_field_id)
+
+  locfield = field
+  if (diag%conversion_factor /= 0.) &
+    locfield = locfield * diag%conversion_factor
+
+  if (is_stat) then
+    used = send_data_infra(diag%fms_diag_id, locfield)
+  elseif (diag_cs%ave_enabled) then
+    used = send_data_infra(diag%fms_diag_id, locfield, diag_cs%time_end)
+  endif
+end subroutine post_IS_data_0d
+
 
 !> Enable the accumulation of time averages over the specified time interval.
 subroutine enable_averaging(time_int_in, time_end_in, diag_cs)
@@ -512,6 +542,71 @@ function register_MOM_IS_diag_field(module_name, field_name, axes, init_time, &
   register_diag_field = primary_id
 
 end function register_MOM_IS_diag_field
+
+!> Returns the "MOM_IS_diag_mediator" handle for a group of diagnostics derived from one scalar.
+function register_MOM_IS_scalar_field(module_name, field_name, axes, init_time, &
+            long_name, units, missing_value, range, standard_name, &
+            do_not_log, err_msg, conversion) result (register_scalar_field)
+  integer :: register_scalar_field  !< The returned diagnostic handle
+  character(len=*), intent(in) :: module_name !< Name of this module, usually "ice_model"
+  character(len=*), intent(in) :: field_name !< Name of the diagnostic field
+  type(axesType),   intent(in) :: axes       !< The axis group for this field
+  type(time_type),  intent(in) :: init_time !< Time at which a field is first available?
+  character(len=*), optional, intent(in) :: long_name !< Long name of a field.
+  character(len=*), optional, intent(in) :: units !< Units of a field.
+  character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
+  real,             optional, intent(in) :: missing_value !< A value that indicates missing values.
+  real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in MOM?)
+  logical,          optional, intent(in) :: do_not_log !< If true, do not log something (not used in MOM?)
+  character(len=*), optional, intent(out):: err_msg !< String into which an error message might be
+                                                         !! placed (not used in MOM?)
+  real,             optional, intent(in) :: conversion !< A value to multiply data by before writing to file
+
+  ! Local variables
+  character(len=240) :: mesg
+  real :: MOM_missing_value
+  integer :: primary_id, fms_id
+  type(diag_ctrl), pointer :: diag_cs => NULL() ! A structure that is used
+                                               ! to regulate diagnostic output
+  type(diag_type), pointer :: diag => NULL()
+
+  MOM_missing_value = axes%diag_cs%missing_value
+  if (present(missing_value)) MOM_missing_value = missing_value
+
+  diag_cs => axes%diag_cs
+  primary_id = -1
+
+  fms_id = register_diag_field_infra(module_name, field_name, &
+         init_time, long_name=long_name, units=units, missing_value=MOM_missing_value, &
+         range=range, standard_name=standard_name, do_not_log=do_not_log, err_msg=err_msg)
+
+  if (fms_id > 0) then
+    primary_id = get_new_diag_id(diag_cs)
+    diag => diag_cs%diags(primary_id)
+    diag%fms_diag_id = fms_id
+    if (len(field_name) > len(diag%name)) then
+      diag%name = field_name(1:len(diag%name))
+    else ; diag%name = field_name ; endif
+
+      if (present(conversion)) diag%conversion_factor = conversion
+    endif
+
+    if (is_root_pe() .and. diag_CS%doc_unit > 0) then
+      if (primary_id > 0) then
+        mesg = '"'//trim(module_name)//'", "'//trim(field_name)//'"  [Used]'
+      else
+        mesg = '"'//trim(module_name)//'", "'//trim(field_name)//'"  [Unused]'
+      endif
+      write(diag_CS%doc_unit, '(a)') trim(mesg)
+      if (present(long_name)) call describe_option("long_name", long_name, diag_CS)
+      if (present(units)) call describe_option("units", units, diag_CS)
+      if (present(standard_name)) &
+        call describe_option("standard_name", standard_name, diag_CS)
+    endif
+
+  register_scalar_field = primary_id
+
+end function register_MOM_IS_scalar_field
 
 !> Registers a static diagnostic, returning an integer handle
 function register_MOM_IS_static_field(module_name, field_name, axes, &

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -34,7 +34,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public register_ice_shelf_dyn_restarts, initialize_ice_shelf_dyn, update_ice_shelf
+public register_ice_shelf_dyn_restarts, initialize_ice_shelf_dyn, update_ice_shelf, IS_dynamics_post_data
 public ice_time_step_CFL, ice_shelf_dyn_end, change_in_draft, write_ice_shelf_energy
 public shelf_advance_front, ice_shelf_min_thickness_calve, calve_to_mask
 
@@ -133,6 +133,7 @@ type, public :: ice_shelf_dyn_CS ; private
 
   real :: g_Earth      !< The gravitational acceleration [L2 Z-1 T-2 ~> m s-2].
   real :: density_ice  !< A typical density of ice [R ~> kg m-3].
+  real :: Cp_ice       !< The heat capacity of fresh ice [Q C-1 ~> J kg-1 degC-1].
 
   logical :: advect_shelf !< If true (default), advect ice shelf and evolve thickness
   logical :: alternate_first_direction_IS !< If true, alternate whether the x- or y-direction
@@ -388,7 +389,7 @@ subroutine register_ice_shelf_dyn_restarts(G, US, param_file, CS, restart_CS)
 end subroutine register_ice_shelf_dyn_restarts
 
 !> Initializes shelf model data, parameters and diagnostics
-subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_sim, &
+subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_sim, Cp_ice, &
                                     Input_start_time, directory, solo_ice_sheet_in)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(time_type),         intent(inout) :: Time !< The clock that that will indicate the model time
@@ -400,6 +401,7 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
   type(diag_ctrl), target, intent(in)    :: diag !< A structure that is used to regulate the diagnostic output.
   logical,                 intent(in)    :: new_sim !< If true this is a new simulation, otherwise
                                                  !! has been started from a restart file.
+  real,                    intent(in)    :: Cp_ice !< Heat capacity of ice (J kg-1 K-1)
   type(time_type),         intent(in)    :: Input_start_time !< The start time of the simulation.
   character(len=*),        intent(in)    :: directory  !< The directory where the ice sheet energy file goes.
   logical,       optional, intent(in)    :: solo_ice_sheet_in !< If present, this indicates whether
@@ -552,7 +554,8 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
   call get_param(param_file, mdl, "MIN_THICKNESS_SIMPLE_CALVE", CS%min_thickness_simple_calve, &
                  "Min thickness rule for the VERY simple calving law",&
                  units="m", default=0.0, scale=US%m_to_Z)
-
+  CS%Cp_ice = Cp_ice !Heat capacity of ice (J kg-1 K-1), needed for heat flux of any bergs calved from
+                     !the ice shelf and for ice sheet temperature solver
   !for write_ice_shelf_energy
       ! Note that the units of CS%Timeunit are the MKS units of [s].
   call get_param(param_file, mdl, "TIMEUNIT", CS%Timeunit, &
@@ -774,6 +777,15 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
        'taub', 'MPa s m-1', conversion=1e-6*US%RL2_T2_to_Pa/(365.0*86400.0*US%L_T_to_m_s))
     CS%id_OD_av = register_diag_field('ice_shelf_model','OD_av',CS%diag%axesT1, Time, &
        'intermediate ocean column thickness passed to ice model', 'm', conversion=US%Z_to_m)
+
+    !Update these variables so that they are nonzero in case
+    !IS_dynamics_post_data is called before update_ice_shelf
+    if (CS%id_taudx_shelf>0 .or. CS%id_taudy_shelf>0) &
+      call calc_shelf_driving_stress(CS, ISS, G, US, CS%taudx_shelf, CS%taudy_shelf, CS%OD_av)
+    if (CS%id_taub>0) &
+      call calc_shelf_taub(CS, ISS, G, US, CS%u_shelf, CS%v_shelf)
+    if (CS%id_visc_shelf>0) &
+      call calc_shelf_visc(CS, ISS, G, US, CS%u_shelf, CS%v_shelf)
   endif
 
   if (new_sim) then
@@ -850,7 +862,8 @@ end function ice_time_step_CFL
 
 !> This subroutine updates the ice shelf velocities, mass, stresses and properties due to the
 !! ice shelf dynamics.
-subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled_grounding, must_update_vel)
+subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, calve_ice_shelf_bergs, &
+                            ocean_mass, coupled_grounding, must_update_vel)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< The ice shelf dynamics control structure
   type(ice_shelf_state),  intent(inout) :: ISS !< A structure with elements that describe
                                               !! the ice-shelf state
@@ -858,17 +871,14 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled
   type(unit_scale_type),  intent(in)    :: US !< A structure containing unit conversion factors
   real,                   intent(in)    :: time_step !< time step [T ~> s]
   type(time_type),        intent(in)    :: Time !< The current model time
+  logical,                intent(in)    :: calve_ice_shelf_bergs !< To convert ice flux through front
+                                                                 !! to bergs
   real, dimension(SZDI_(G),SZDJ_(G)), &
                 optional, intent(in)    :: ocean_mass !< If present this is the mass per unit area
                                               !! of the ocean [R Z ~> kg m-2].
   logical,      optional, intent(in)    :: coupled_grounding !< If true, the grounding line is
                                               !! determined by coupled ice-ocean dynamics
   logical,      optional, intent(in)    :: must_update_vel !< Always update the ice velocities if true.
-  real, dimension(SZDIB_(G),SZDJB_(G))  :: taud_x, taud_y  !<area-averaged driving stress [R L2 T-2 ~> Pa]
-  real, dimension(SZDI_(G),SZDJ_(G))  :: ice_visc !< area-averaged vertically integrated ice viscosity
-                                              !! [R L2 Z T-1 ~> Pa s m]
-  real, dimension(SZDI_(G),SZDJ_(G))  :: basal_tr !< area-averaged taub_beta field related to basal traction,
-                                              !! [R L1 T-1 ~> Pa s m-1]
   integer :: iters
   logical :: update_ice_vel, coupled_GL
 
@@ -879,7 +889,7 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled
   if (present(ocean_mass) .and. present(coupled_grounding)) coupled_GL = coupled_grounding
 !
   if (CS%advect_shelf) then
-    call ice_shelf_advect(CS, ISS, G, time_step, Time)
+    call ice_shelf_advect(CS, ISS, G, time_step, Time, calve_ice_shelf_bergs)
     if (CS%alternate_first_direction_IS) then
       CS%first_direction_IS = modulo(CS%first_direction_IS+1,2)
       CS%first_dir_restart_IS = real(CS%first_direction_IS)
@@ -897,12 +907,25 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled
 
   if (update_ice_vel) then
     call ice_shelf_solve_outer(CS, ISS, G, US, CS%u_shelf, CS%v_shelf,CS%taudx_shelf,CS%taudy_shelf, iters, Time)
+    CS%elapsed_velocity_time = 0.0
   endif
 
 ! call ice_shelf_temp(CS, ISS, G, US, time_step, ISS%water_flux, Time)
 
-  if (CS%elapsed_velocity_time >= CS%velocity_update_time_step) then
-    call enable_averages(CS%elapsed_velocity_time, Time, CS%diag)
+end subroutine update_ice_shelf
+
+!> Ice shelf dynamics post_data calls
+subroutine IS_dynamics_post_data(time_step, Time, CS, G)
+  real :: time_step !< Length of time for post data averaging [T ~> s].
+  type(time_type),        intent(in)    :: Time !< The current model time
+  type(ice_shelf_dyn_CS), intent(inout) :: CS !< The ice shelf dynamics control structure
+  type(ocean_grid_type),  intent(in) :: G  !< The grid structure used by the ice shelf.
+  real, dimension(SZDIB_(G),SZDJB_(G))  :: taud_x, taud_y  !<area-averaged driving stress [R L2 T-2 ~> Pa]
+  real, dimension(SZDI_(G),SZDJ_(G))  :: ice_visc !< area-averaged vertically integrated ice viscosity
+                                                  !! [R L2 Z T-1 ~> Pa s m]
+  real, dimension(SZDI_(G),SZDJ_(G))  :: basal_tr !< area-averaged taub_beta field related to basal traction,
+                                                  !! [R L1 T-1 ~> Pa s m-1]
+    call enable_averages(time_step, Time, CS%diag)
     if (CS%id_col_thick > 0) call post_data(CS%id_col_thick, CS%OD_av, CS%diag)
     if (CS%id_u_shelf > 0) call post_data(CS%id_u_shelf, CS%u_shelf, CS%diag)
     if (CS%id_v_shelf > 0) call post_data(CS%id_v_shelf, CS%v_shelf, CS%diag)
@@ -931,7 +954,6 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled
       basal_tr(:,:) = CS%basal_traction(:,:)*G%IareaT(:,:)
       call post_data(CS%id_taub, basal_tr, CS%diag)
     endif
-!!
     if (CS%id_u_mask > 0) call post_data(CS%id_u_mask, CS%umask, CS%diag)
     if (CS%id_v_mask > 0) call post_data(CS%id_v_mask, CS%vmask, CS%diag)
     if (CS%id_ufb_mask > 0) call post_data(CS%id_ufb_mask, CS%u_face_mask_bdry, CS%diag)
@@ -939,11 +961,7 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, ocean_mass, coupled
 !   if (CS%id_t_mask > 0) call post_data(CS%id_t_mask, CS%tmask, CS%diag)
 
     call disable_averaging(CS%diag)
-
-    CS%elapsed_velocity_time = 0.0
-  endif
-
-end subroutine update_ice_shelf
+end subroutine IS_dynamics_post_data
 
 !>  Writes the total ice shelf kinetic energy and mass to an ascii file
 subroutine write_ice_shelf_energy(CS, G, US, mass, day, time_step)
@@ -1080,14 +1098,15 @@ end subroutine write_ice_shelf_energy
 !> This subroutine takes the velocity (on the Bgrid) and timesteps h_t = - div (uh) once.
 !! Additionally, it will update the volume of ice in partially-filled cells, and update
 !! hmask accordingly
-subroutine ice_shelf_advect(CS, ISS, G, time_step, Time)
+subroutine ice_shelf_advect(CS, ISS, G, time_step, Time, calve_ice_shelf_bergs)
   type(ice_shelf_dyn_CS), intent(inout) :: CS !< The ice shelf dynamics control structure
   type(ice_shelf_state),  intent(inout) :: ISS !< A structure with elements that describe
                                                !! the ice-shelf state
   type(ocean_grid_type),  intent(inout) :: G  !< The grid structure used by the ice shelf.
   real,                   intent(in)    :: time_step !< time step [T ~> s]
   type(time_type),        intent(in)    :: Time !< The current model time
-
+  logical,                intent(in)    :: calve_ice_shelf_bergs !< If true, track ice shelf flux through a
+                                               !! static ice shelf, so that it can be converted into icebergs
 
 ! 3/8/11 DNG
 !
@@ -1155,6 +1174,23 @@ subroutine ice_shelf_advect(CS, ISS, G, time_step, Time)
     if (CS%calve_to_mask) then
       call calve_to_mask(G, ISS%h_shelf, ISS%area_shelf_h, ISS%hmask, CS%calve_mask)
     endif
+  elseif (calve_ice_shelf_bergs) then
+    !advect the front to create partially-filled cells
+    call shelf_advance_front(CS, ISS, G, ISS%hmask, uh_ice, vh_ice)
+    !add mass of the partially-filled cells to calving field, which is used to initialize icebergs
+    !Then, remove the partially-filled cells from the ice shelf
+    ISS%calving(:,:)=0.0
+    ISS%calving_hflx(:,:)=0.0
+    do j=jsc,jec; do i=isc,iec
+      if (ISS%hmask(i,j)==2) then
+        ISS%calving(i,j) = (ISS%h_shelf(i,j) * CS%density_ice) * &
+                           (ISS%area_shelf_h(i,j) * G%IareaT(i,j)) / time_step
+        ISS%calving_hflx(i,j) = (CS%Cp_ice * CS%t_shelf(i,j)) * &
+                                ((ISS%h_shelf(i,j) * CS%density_ice) * &
+                                (ISS%area_shelf_h(i,j) * G%IareaT(i,j)))
+        ISS%h_shelf(i,j) = 0.0; ISS%area_shelf_h(i,j) = 0.0; ISS%hmask(i,j) = 0.0
+      endif
+    enddo; enddo
   endif
 
   do j=jsc,jec; do i=isc,iec

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -36,7 +36,8 @@ implicit none ; private
 
 public register_ice_shelf_dyn_restarts, initialize_ice_shelf_dyn, update_ice_shelf, IS_dynamics_post_data
 public ice_time_step_CFL, ice_shelf_dyn_end, change_in_draft, write_ice_shelf_energy
-public shelf_advance_front, ice_shelf_min_thickness_calve, calve_to_mask
+public shelf_advance_front, ice_shelf_min_thickness_calve, calve_to_mask, volume_above_floatation
+public masked_var_grounded
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -913,6 +914,52 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, calve_ice_shelf_ber
 ! call ice_shelf_temp(CS, ISS, G, US, time_step, ISS%water_flux, Time)
 
 end subroutine update_ice_shelf
+
+subroutine volume_above_floatation(CS, G, ISS, vab)
+  type(ice_shelf_dyn_CS), intent(in) :: CS !< The ice shelf dynamics control structure
+  type(ocean_grid_type),  intent(in) :: G  !< The grid structure used by the ice shelf.
+  type(ice_shelf_state),  intent(in) :: ISS !< A structure with elements that describe
+                                            !! the ice-shelf state
+  real, intent(out) :: vab !< area integrated volume above floatation
+  real, dimension(SZI_(G),SZJ_(G))  :: vab_cell !< cell-wise volume above floatation [Z ~> m}
+  integer :: is,ie,js,je,i,j
+  real :: rhoi_rhow, rhow_rhoi
+
+  if (CS%GL_couple) &
+    call MOM_error(FATAL, "MOM_ice_shelf_dyn, volume above floatation calculation assumes GL_couple=.FALSE..")
+
+  vab_cell(:,:)=0.0
+  rhoi_rhow = CS%density_ice / CS%density_ocean_avg
+  rhow_rhoi = CS%density_ocean_avg / CS%density_ice
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+
+  do j = js,je; do i = is,ie
+    if (ISS%hmask(i,j)>0) then
+      if (CS%bed_elev(i,j) <= 0) then
+        !grounded above sea level
+        vab_cell(i,j)= (ISS%h_shelf(i,j) * G%US%Z_to_m) * (ISS%area_shelf_h(i,j) * G%US%L_to_m**2)
+      else
+        !grounded if vab_cell(i,j) > 0
+        vab_cell(i,j) = (max(ISS%h_shelf(i,j) - rhow_rhoi * CS%bed_elev(i,j), 0.0) * G%US%Z_to_m) * &
+                        (ISS%area_shelf_h(i,j) * G%US%L_to_m**2)
+      endif
+    endif
+  enddo; enddo
+
+  vab = reproducing_sum(vab_cell)
+end subroutine volume_above_floatation
+
+!> multiplies a variable with the ice sheet grounding fraction
+subroutine masked_var_grounded(G,CS,var,varout)
+  type(ocean_grid_type), intent(in) :: G !< The grid structure used by the ice shelf.
+  type(ice_shelf_dyn_CS), intent(in) :: CS !< The ice shelf dynamics control structure
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: var !< variable in
+  real, dimension(SZI_(G),SZJ_(G)), intent(out)  :: varout !<variable out
+  integer :: i,j
+  do j = G%jsc,G%jec; do i = G%isc,G%iec
+      varout(i,j) = var(i,j) * CS%ground_frac(i,j)
+  enddo; enddo
+end subroutine masked_var_grounded
 
 !> Ice shelf dynamics post_data calls
 subroutine IS_dynamics_post_data(time_step, Time, CS, G)

--- a/src/ice_shelf/MOM_ice_shelf_state.F90
+++ b/src/ice_shelf/MOM_ice_shelf_state.F90
@@ -46,9 +46,13 @@ type, public :: ice_shelf_state
     tflux_shelf => NULL(), &   !< The downward diffusive heat flux in the ice
                                !! shelf at the ice-ocean interface [Q R Z T-1 ~> W m-2].
 
-    tfreeze => NULL()          !< The freezing point potential temperature
+    tfreeze => NULL(), &       !< The freezing point potential temperature
                                !! at the ice-ocean interface [C ~> degC].
 
+    !only active when calve_ice_shelf_bergs=true:
+    calving => NULL(), &       !< The mass flux per unit area of the ice shelf to convert to
+                               !!bergs [RZ_T ~> kg m-2 s-1].
+    calving_hflx => NULL()     !< Calving heat flux [Q R Z T-1 ~> W m-2].
 end type ice_shelf_state
 
 contains
@@ -80,6 +84,8 @@ subroutine ice_shelf_state_init(ISS, G)
   allocate(ISS%tflux_shelf(isd:ied,jsd:jed), source=0.0 )
   allocate(ISS%tfreeze(isd:ied,jsd:jed), source=0.0 )
 
+  allocate(ISS%calving(isd:ied,jsd:jed), source=0.0 )
+  allocate(ISS%calving_hflx(isd:ied,jsd:jed), source=0.0 )
 end subroutine ice_shelf_state_init
 
 
@@ -93,6 +99,8 @@ subroutine ice_shelf_state_end(ISS)
 
   deallocate(ISS%tflux_ocn, ISS%water_flux, ISS%salt_flux, ISS%tflux_shelf)
   deallocate(ISS%tfreeze)
+
+  deallocate(ISS%calving, ISS%calving_hflx)
 
   deallocate(ISS)
 

--- a/src/ice_shelf/MOM_ice_shelf_state.F90
+++ b/src/ice_shelf/MOM_ice_shelf_state.F90
@@ -51,7 +51,7 @@ type, public :: ice_shelf_state
 
     !only active when calve_ice_shelf_bergs=true:
     calving => NULL(), &       !< The mass flux per unit area of the ice shelf to convert to
-                               !!bergs [RZ_T ~> kg m-2 s-1].
+                               !! bergs [R Z T-1 ~> kg m-2 s-1].
     calving_hflx => NULL()     !< Calving heat flux [Q R Z T-1 ~> W m-2].
 end type ice_shelf_state
 


### PR DESCRIPTION
Added variables for the accumulated iceberg mass and heat flux due to calving from ice shelves (flux through the static ice front). These variables will be passed to the coupler and SIS2/iceberg module to initialize bergs.
See related changes in:
Coupler: https://github.com/alex-huth/FMScoupler/commit/3e80bbc
SIS2: https://github.com/NOAA-GFDL/SIS2/pull/209

It was easiest to tag a few other changes onto this PR as well:
-fixed the ice-shelf SMB override
-reorganized ice-shelf post data calls so that they do not strictly have to be called at multiples of the ice velocity time step.
-Added ice-shelf scalar diagnostics related to volume-above-floatation and surface/basal mass balance.