### PR TITLE
+(*)Fix sign of neutral_slope_x diagnostic with no EOS

### DIFF
--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -356,8 +356,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
           slope = 0.0
         endif
       else ! With .not.use_EOS, the layers are constant density.
-        slope = (e(i,j,K)-e(i+1,j,K)) * G%IdxCu(I,j)
+        slope = (e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j)
       endif
+
       if (local_open_u_BC) then
         l_seg = OBC%segnum_u(I,j)
         if (l_seg /= OBC_NONE) then
@@ -372,7 +373,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 !           endif
           endif
         endif
-        slope = slope * max(g%mask2dT(i,j),g%mask2dT(i+1,j))
+        slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
       endif
       slope_x(I,j,K) = slope
       if (present(dzSxN)) &
@@ -504,11 +505,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         else ! Just in case mag_grad2 = 0 ever.
           slope = 0.0
         endif
-
-
       else ! With .not.use_EOS, the layers are constant density.
-        slope = (e(i,j,K)-e(i,j+1,K)) * G%IdyCv(i,J)
+        slope = (e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J)
       endif
+
       if (local_open_v_BC) then
         l_seg = OBC%segnum_v(i,J)
         if (l_seg /= OBC_NONE) then
@@ -523,7 +523,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 !           endif
           endif
         endif
-        slope = slope * max(g%mask2dT(i,j),g%mask2dT(i,j+1))
+        slope = slope * max(G%mask2dT(i,j), G%mask2dT(i,j+1))
       endif
       slope_y(i,J,K) = slope
       if (present(dzSyN)) &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1041,10 +1041,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             if (present_slope_x) then
               Slope = slope_x(I,j,k)
             else
-              Slope = ((e(i,j,K)-e(i+1,j,K))*G%IdxCu(I,j)) * G%OBCmaskCu(I,j)
+              Slope = ((e(i+1,j,K)-e(i,j,K))*G%IdxCu(I,j)) * G%OBCmaskCu(I,j)
             endif
             if (CS%id_slope_x > 0) CS%diagSlopeX(I,j,k) = Slope
-            Sfn_unlim_u(I,K) = ((KH_u(I,j,K)*G%dy_Cu(I,j))*Slope)
+            Sfn_unlim_u(I,K) = -(KH_u(I,j,K)*G%dy_Cu(I,j))*Slope
             dzN2_u(I,K) = GV%g_prime(K)
           endif ! if (use_EOS)
         else ! if (k > nk_linear)
@@ -1361,10 +1361,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
             if (present_slope_y) then
               Slope = slope_y(i,J,k)
             else
-              Slope = ((e(i,j,K)-e(i,j+1,K))*G%IdyCv(i,J)) * G%OBCmaskCv(i,J)
+              Slope = ((e(i,j+1,K)-e(i,j,K))*G%IdyCv(i,J)) * G%OBCmaskCv(i,J)
             endif
             if (CS%id_slope_y > 0) CS%diagSlopeY(I,j,k) = Slope
-            Sfn_unlim_v(i,K) = ((KH_v(i,J,K)*G%dx_Cv(i,J))*Slope)
+            Sfn_unlim_v(i,K) = -((KH_v(i,J,K)*G%dx_Cv(i,J))*Slope)
             dzN2_v(i,K) = GV%g_prime(K)
           endif ! if (use_EOS)
         else ! if (k > nk_linear)
@@ -2451,19 +2451,19 @@ end subroutine thickness_diffuse_end
 !! to the potential density slope
 !! \f[
 !! \vec{\psi} = - \kappa_h \frac{\nabla_z \rho}{\partial_z \rho}
-!! = \frac{g\kappa_h}{\rho_o} \frac{\nabla \rho}{N^2} = \kappa_h \frac{M^2}{N^2}
+!! = \frac{g\kappa_h}{\rho_o} \frac{\nabla \rho}{N^2} = -\kappa_h \frac{M^2}{N^2}
 !! \f]
 !! but for robustness the scheme is implemented as
 !! \f[
-!! \vec{\psi} = \kappa_h \frac{M^2}{\sqrt{N^4 + M^4}}
+!! \vec{\psi} = -\kappa_h \frac{M^2}{\sqrt{N^4 + M^4}}
 !! \f]
-!! since the quantity \f$\frac{M^2}{\sqrt{N^2 + M^2}}\f$ is bounded between $-1$ and $1$ and does not change sign
+!! since the quantity \f$\frac{M^2}{\sqrt{N^4 + M^4}}\f$ is bounded between $-1$ and $1$ and does not change sign
 !! if \f$N^2<0\f$.
 !!
 !! Optionally, the method of Ferrari et al, 2010, can be used to obtain the streamfunction which solves the
 !! vertically elliptic equation:
 !! \f[
-!! \gamma_F \partial_z c^2 \partial_z \psi - N_*^2 \psi  = ( 1 + \gamma_F ) \kappa_h N_*^2 \frac{M^2}{\sqrt{N^4+M^4}}
+!! \gamma_F \partial_z c^2 \partial_z \psi - N_*^2 \psi  = -( 1 + \gamma_F ) \kappa_h N_*^2 \frac{M^2}{\sqrt{N^4+M^4}}
 !! \f]
 !! which recovers the previous streamfunction relation in the limit that \f$ c \rightarrow 0 \f$.
 !! Here, \f$c=\max(c_{min},c_g)\f$ is the maximum of either \f$c_{min}\f$ and either the first baroclinic mode


### PR DESCRIPTION
  Corrected the sign convention used for the `neutral_slope_x` and `neutral_slope_y` diagnostics in cases when there is not an equation of state being used to match the usual sign convention (interfaces sloping up to the east or north is a positive slope) and to match what is done when an equation of state is being used to calculate neutral density slopes rather than just basing the slopes of the interfaces alone.  The same correction was made to the `slope_x` and `slope_y` arguments returned from `calc_isoneutral_slopes()`, and self-consistent changes were made to the overturning streamfunction calculations in `thickness_diffuse_full()`.

  In addition, there were some corrections made to the documentation at the end of MOM_thickness_diffuse.F90, and the `calculate_slopes` argument to `calc_slope_functions_using_just_e()` that was always hard-coded to .true. was eliminated to avoid any confusion about whether these changes might propagate beyond the interface height diffusion calculations.  This commit addresses most aspects of the issue discussed at github.com/NOAA-GFDL/MOM6/issues/359, although it does not change the sign convention for the overturning streamfunction.

  All solutions are bitwise identical, but there is a change in the sign convention for two diagnostics and two arguments to a publicly visible interface in pure layer mode when no equation of state is used.