### PR TITLE
Add diag send complete calls

### DIFF
--- a/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
@@ -26,6 +26,7 @@ program Shelf_main
   use MOM_debugging,       only : MOM_debugging_init
   use MOM_diag_mediator,   only : diag_mediator_init, diag_mediator_infrastructure_init, set_axes_info
   use MOM_diag_mediator,   only : diag_mediator_end, diag_ctrl, diag_mediator_close_registration
+  use MOM_diag_manager_infra, only : diag_manager_set_time_end_infra
   use MOM_domains,         only : MOM_infra_init, MOM_infra_end
   use MOM_domains,         only : MOM_domains_init, clone_MOM_domain, pass_var
   use MOM_dyn_horgrid,     only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
@@ -324,6 +325,8 @@ program Shelf_main
                  timeunit=Time_unit, fail_if_missing=.true.)
     Time_end = daymax
   endif
+
+  call diag_manager_set_time_end_infra (Time_end)
 
   if (Time >= Time_end) call MOM_error(FATAL, &
     "Shelf_driver: The run has been started at or after the end time of the run.")

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -28,6 +28,7 @@ program MOM6
   use MOM_cpu_clock,       only : CLOCK_COMPONENT
   use MOM_data_override,   only : data_override_init
   use MOM_diag_mediator,   only : diag_mediator_end, diag_ctrl, diag_mediator_close_registration
+  use MOM_diag_manager_infra, only : diag_manager_set_time_end_infra
   use MOM,                 only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
   use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
@@ -374,6 +375,8 @@ program MOM6
                  timeunit=Time_unit, fail_if_missing=.true.)
     Time_end = daymax
   endif
+
+  call diag_manager_set_time_end_infra(Time_end)
 
   call get_param(param_file, mod_name, "SINGLE_STEPPING_CALL", single_step_call, &
                  "If true, advance the state of MOM with a single step "//&

--- a/config_src/infra/FMS1/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_diag_manager_infra.F90
@@ -57,6 +57,7 @@ public get_MOM_diag_axis_name
 public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
+public diag_send_complete_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -450,5 +451,10 @@ subroutine MOM_diag_field_add_attribute_i1d(diag_field_id, att_name, att_value)
   call FMS_diag_field_add_attribute(diag_field_id, att_name, att_value)
 
 end subroutine MOM_diag_field_add_attribute_i1d
+
+!> Finishes the diag manager reduction methods as needed for the time_step
+!! Needed for backwards compatibility, does nothing
+subroutine diag_send_complete_infra ()
+end subroutine diag_send_complete_infra
 
 end module MOM_diag_manager_infra

--- a/config_src/infra/FMS1/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_diag_manager_infra.F90
@@ -58,6 +58,7 @@ public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
 public diag_send_complete_infra
+public diag_manager_set_time_end_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -452,9 +453,13 @@ subroutine MOM_diag_field_add_attribute_i1d(diag_field_id, att_name, att_value)
 
 end subroutine MOM_diag_field_add_attribute_i1d
 
-!> Finishes the diag manager reduction methods as needed for the time_step
-!! Needed for backwards compatibility, does nothing
+!> Needed for backwards compatibility, does nothing
 subroutine diag_send_complete_infra ()
 end subroutine diag_send_complete_infra
+
+!> Needed for backwards compatibility, does nothing
+subroutine diag_manager_set_time_end_infra(time)
+  type(time_type), intent(in) :: time !< The model time that simulation ends
+end subroutine diag_manager_set_time_end_infra
 
 end module MOM_diag_manager_infra

--- a/config_src/infra/FMS2/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_diag_manager_infra.F90
@@ -15,6 +15,7 @@ use diag_data_mod,    only : null_axis_id
 use diag_manager_mod, only : fms_diag_manager_init => diag_manager_init
 use diag_manager_mod, only : fms_diag_manager_end => diag_manager_end
 use diag_manager_mod, only : diag_send_complete
+use diag_manager_mod, only : diag_manager_set_time_end
 use diag_manager_mod, only : send_data_fms => send_data
 use diag_manager_mod, only : fms_diag_field_add_attribute => diag_field_add_attribute
 use diag_manager_mod, only : DIAG_FIELD_NOT_FOUND
@@ -59,6 +60,7 @@ public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
 public diag_send_complete_infra
+public diag_manager_set_time_end_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -460,5 +462,12 @@ subroutine diag_send_complete_infra ()
   !! It won't have any impact when diag_manager_nml::use_modern_diag=.false.
   call diag_send_complete (set_time(0))
 end subroutine diag_send_complete_infra
+
+!> Sets the time that the simulation ends in the diag manager
+subroutine diag_manager_set_time_end_infra(time)
+  type(time_type),           optional, intent(in) :: time  !< The time the simulation ends
+
+  call diag_manager_set_time_end(time)
+end subroutine diag_manager_set_time_end_infra
 
 end module MOM_diag_manager_infra

--- a/config_src/infra/FMS2/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_diag_manager_infra.F90
@@ -14,13 +14,14 @@ use diag_axis_mod,    only : EAST, NORTH
 use diag_data_mod,    only : null_axis_id
 use diag_manager_mod, only : fms_diag_manager_init => diag_manager_init
 use diag_manager_mod, only : fms_diag_manager_end => diag_manager_end
+use diag_manager_mod, only : diag_send_complete
 use diag_manager_mod, only : send_data_fms => send_data
 use diag_manager_mod, only : fms_diag_field_add_attribute => diag_field_add_attribute
 use diag_manager_mod, only : DIAG_FIELD_NOT_FOUND
 use diag_manager_mod, only : register_diag_field_fms => register_diag_field
 use diag_manager_mod, only : register_static_field_fms => register_static_field
 use diag_manager_mod, only : get_diag_field_id_fms => get_diag_field_id
-use MOM_time_manager, only : time_type
+use MOM_time_manager, only : time_type, set_time
 use MOM_domain_infra, only : MOM_domain_type
 use MOM_error_infra,  only : MOM_error => MOM_err, FATAL, WARNING
 
@@ -57,6 +58,7 @@ public get_MOM_diag_axis_name
 public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
+public diag_send_complete_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -450,5 +452,13 @@ subroutine MOM_diag_field_add_attribute_i1d(diag_field_id, att_name, att_value)
   call FMS_diag_field_add_attribute(diag_field_id, att_name, att_value)
 
 end subroutine MOM_diag_field_add_attribute_i1d
+
+!> Finishes the diag manager reduction methods as needed for the time_step
+subroutine diag_send_complete_infra ()
+  !! The time_step in the diag_send_complete call is a dummy argument, needed for backwards compatibility
+  !! It won't be used at all when diag_manager_nml::use_modern_diag=.true.
+  !! It won't have any impact when diag_manager_nml::use_modern_diag=.false.
+  call diag_send_complete (set_time(0))
+end subroutine diag_send_complete_infra
 
 end module MOM_diag_manager_infra

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -14,6 +14,7 @@ use MOM_diag_manager_infra, only : diag_axis_init=>MOM_diag_axis_init, get_MOM_d
 use MOM_diag_manager_infra, only : send_data_infra, MOM_diag_field_add_attribute, EAST, NORTH
 use MOM_diag_manager_infra, only : register_diag_field_infra, register_static_field_infra
 use MOM_diag_manager_infra, only : get_MOM_diag_field_id, DIAG_FIELD_NOT_FOUND
+use MOM_diag_manager_infra, only : diag_send_complete_infra
 use MOM_diag_remap,       only : diag_remap_ctrl, diag_remap_update, diag_remap_calc_hmask
 use MOM_diag_remap,       only : diag_remap_init, diag_remap_end, diag_remap_do_remap
 use MOM_diag_remap,       only : vertically_reintegrate_diag_field, vertically_interpolate_diag_field
@@ -2057,6 +2058,7 @@ end subroutine enable_averages
 subroutine disable_averaging(diag_cs)
   type(diag_ctrl), intent(inout) :: diag_CS !< Structure used to regulate diagnostic output
 
+  call diag_send_complete_infra()
   diag_cs%time_int = 0.0
   diag_cs%ave_enabled = .false.
 


### PR DESCRIPTION
These are updates needed for the new diag manager (FMS2024.01+):
- Adds `diag_send_complete_infra` and `diag_manager_set_time_end_infra` subroutines to the FMS1/FMS2 infra. 
The subroutines in FMS1 do nothing and are there just for backwards compatibility.
- `diag_send_complete_infra` is called inside `disable_averaging`
- `diag_manager_set_time_end_infra` is called in the solo and ice_solo_drivers (without this, the solo tests will crash with an error like `diag_manager_set_time_end must be called before diag_send_complete`)