### PR TITLE
+(*)Fix rotation of coupler_type variables

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -339,14 +339,14 @@ contains
 !! the ocean model. Unused fields are unallocated.
 subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                   gas_fields_ocn, use_meltpot, use_iceshelves, &
-                                  omit_frazil)
+                                  omit_frazil, sfc_state_in, turns)
   type(ocean_grid_type), intent(in)    :: G                !< ocean grid structure
   type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be allocated.
   logical,     optional, intent(in)    :: use_temperature  !< If true, allocate the space for thermodynamic variables.
   logical,     optional, intent(in)    :: do_integrals     !< If true, allocate the space for vertically
                                                            !! integrated fields.
   type(coupler_1d_bc_type), &
-               optional, intent(in)    :: gas_fields_ocn  !< If present, this type describes the ocean
+               optional, intent(in)    :: gas_fields_ocn   !< If present, this type describes the
                                               !! ocean and surface-ice fields that will participate
                                               !! in the calculation of additional gas or other
                                               !! tracer fluxes, and can be used to spawn related
@@ -356,9 +356,20 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                                            !! under ice shelves.
   logical,     optional, intent(in)    :: omit_frazil      !< If present and false, do not allocate the space to
                                                            !! pass frazil fluxes to the coupler
+  type(surface), &
+               optional, intent(in)    :: sfc_state_in     !< If present and its tr_fields are initialized,
+                                              !! this type describes the ocean and surface-ice fields that
+                                              !! will participate in the calculation of additional gas or
+                                              !! other tracer fluxes, and can be used to spawn related
+                                              !! internal variables in the ice model.  If gas_fields_ocn
+                                              !! is present, it is used and tr_fields_in is ignored.
+  integer,     optional, intent(in)    :: turns  !< If present, the number of counterclockwise quarter
+                                                 !! turns to use on the new grid.
 
   ! local variables
   logical :: use_temp, alloc_integ, use_melt_potential, alloc_iceshelves, alloc_frazil
+  logical :: even_turns  ! True if turns is absent or even
+  integer :: tr_field_i_mem(4), tr_field_j_mem(4)
   integer :: is, ie, js, je, isd, ied, jsd, jed
   integer :: isdB, iedB, jsdB, jedB
 
@@ -406,9 +417,22 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
     allocate(sfc_state%tauy_shelf(isd:ied,JsdB:JedB), source=0.0)
   endif
 
-  if (present(gas_fields_ocn)) &
+  ! The data fields in the coupler_2d_bc_type are never rotated.
+  even_turns = .true. ; if (present(turns)) even_turns = (modulo(turns, 2) == 0)
+  if (even_turns) then
+    tr_field_i_mem(1:4) = (/is,is,ie,ie/) ; tr_field_j_mem(1:4) = (/js,js,je,je/)
+  else
+    tr_field_i_mem(1:4) = (/js,js,je,je/) ; tr_field_j_mem(1:4) = (/is,is,ie,ie/)
+  endif
+  if (present(gas_fields_ocn)) then
     call coupler_type_spawn(gas_fields_ocn, sfc_state%tr_fields, &
-                            (/is,is,ie,ie/), (/js,js,je,je/), as_needed=.true.)
+                            tr_field_i_mem, tr_field_j_mem, as_needed=.true.)
+  elseif (present(sfc_state_in)) then
+    if (coupler_type_initialized(sfc_state_in%tr_fields)) then
+      call coupler_type_spawn(sfc_state_in%tr_fields, sfc_state%tr_fields, &
+                              tr_field_i_mem, tr_field_j_mem, as_needed=.true.)
+    endif
+  endif
 
   sfc_state%arrays_allocated = .true.
 
@@ -439,10 +463,10 @@ end subroutine deallocate_surface_state
 
 !> Rotate the surface state fields from the input to the model indices.
 subroutine rotate_surface_state(sfc_state_in, sfc_state, G, turns)
-  type(surface), intent(in) :: sfc_state_in
-  type(surface), intent(inout) :: sfc_state
-  type(ocean_grid_type), intent(in) :: G
-  integer, intent(in) :: turns
+  type(surface), intent(in) :: sfc_state_in  !< The input unrotated surface state type that is the data source.
+  type(surface), intent(inout) :: sfc_state  !< The rotated surface state type whose arrays will be filled in
+  type(ocean_grid_type), intent(in) :: G     !< The ocean grid structure
+  integer, intent(in) :: turns   !< The number of counterclockwise quarter turns to use on the rotated grid.
 
   logical :: use_temperature, do_integrals, use_melt_potential, use_iceshelves
 
@@ -455,13 +479,9 @@ subroutine rotate_surface_state(sfc_state_in, sfc_state, G, turns)
       .and. allocated(sfc_state_in%tauy_shelf)
 
   if (.not. sfc_state%arrays_allocated) then
-    call allocate_surface_state(sfc_state, G, &
-        use_temperature=use_temperature, &
-        do_integrals=do_integrals, &
-        use_meltpot=use_melt_potential, &
-        use_iceshelves=use_iceshelves &
-    )
-    sfc_state%arrays_allocated = .true.
+    call allocate_surface_state(sfc_state, G, use_temperature=use_temperature, &
+            do_integrals=do_integrals, use_meltpot=use_melt_potential, &
+            use_iceshelves=use_iceshelves, sfc_state_in=sfc_state_in, turns=turns)
   endif
 
   if (use_temperature) then

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -372,7 +372,7 @@ subroutine DOME_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -331,7 +331,7 @@ subroutine ISOMIP_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -453,9 +453,9 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   !   The -GV%Rho0 changes the sign convention of the flux and with the scaling factors changes
   ! the units of the flux from [Conc. m s-1] to [Conc. R Z T-1 ~> Conc. kg m-2 s-1].
   call extract_coupler_type_data(fluxes%tr_fluxes, CS%ind_cfc_11_flux, CFC11_flux, &
-                                 scale_factor=-GV%Rho0*US%m_to_Z*US%T_to_s, idim=idim, jdim=jdim)
+                                 scale_factor=-GV%Rho0*US%m_to_Z*US%T_to_s, idim=idim, jdim=jdim, turns=G%HI%turns)
   call extract_coupler_type_data(fluxes%tr_fluxes, CS%ind_cfc_12_flux, CFC12_flux, &
-                                 scale_factor=-GV%Rho0*US%m_to_Z*US%T_to_s, idim=idim, jdim=jdim)
+                                 scale_factor=-GV%Rho0*US%m_to_Z*US%T_to_s, idim=idim, jdim=jdim, turns=G%HI%turns)
 
   ! Use a tridiagonal solver to determine the concentrations after the
   ! surface source is applied and diapycnal advection and diffusion occurs.
@@ -587,13 +587,13 @@ subroutine OCMIP2_CFC_surface_state(sfc_state, h, G, GV, US, CS)
   !   These calls load these values into the appropriate arrays in the
   ! coupler-type structure.
   call set_coupler_type_data(CFC11_alpha, CS%ind_cfc_11_flux, sfc_state%tr_fields, &
-                             solubility=.true., idim=idim, jdim=jdim)
+                             solubility=.true., idim=idim, jdim=jdim, turns=G%HI%turns)
   call set_coupler_type_data(CFC11_Csurf, CS%ind_cfc_11_flux, sfc_state%tr_fields, &
-                             idim=idim, jdim=jdim)
+                             idim=idim, jdim=jdim, turns=G%HI%turns)
   call set_coupler_type_data(CFC12_alpha, CS%ind_cfc_12_flux, sfc_state%tr_fields, &
-                             solubility=.true., idim=idim, jdim=jdim)
+                             solubility=.true., idim=idim, jdim=jdim, turns=G%HI%turns)
   call set_coupler_type_data(CFC12_Csurf, CS%ind_cfc_12_flux, sfc_state%tr_fields, &
-                             idim=idim, jdim=jdim)
+                             idim=idim, jdim=jdim, turns=G%HI%turns)
 
 end subroutine OCMIP2_CFC_surface_state
 

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -329,7 +329,7 @@ subroutine advection_test_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -340,7 +340,7 @@ subroutine boundary_impulse_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -395,7 +395,7 @@ subroutine dye_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -559,7 +559,7 @@ subroutine ideal_age_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -466,7 +466,7 @@ subroutine oil_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -427,7 +427,7 @@ subroutine USER_tracer_surface_state(sfc_state, h, G, GV, CS)
       !   This call loads the surface values into the appropriate array in the
       ! coupler-type structure.
       call set_coupler_type_data(CS%tr(:,:,1,m), CS%ind_tr(m), sfc_state%tr_fields, &
-                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/) )
+                   idim=(/isd, is, ie, ied/), jdim=(/jsd, js, je, jed/), turns=G%HI%turns)
     enddo
   endif
 


### PR DESCRIPTION
  This commit adds the necessary information about the turns of the model grid relative to the (unrotated) `coupler_type` data fields that are inside of the `forcing` type and `surface_state` type and are used with passive tracers, so that certain tracer packages can now be used with rotated grids.  The previous version had problems where the model would not run when `ROTATE_INTEX = True` and the CFCs (and probably other passive tracers) were being used, as noted at NOAA-GFDL/MOM6/issues/621.  These problems have now been fixed.

  There are new calls to `coupler_type_spawn()` in `allocate_forcing_by_ref()` and `allocate_surface_state()` that manage the creation of the `coupler_2d_bt_types` for unrotated types based on information from their rotated counterparts.

  There is a new optional `turns` argument to `allocate_forcing_by_ref()` and new optional `sfc_state_in` and `turns` arguments to `allocate_surface_state()`, and these are now being used in at least 6 places where unrotated temporary `surface_state` or `forcing` types are being set up.

  There are also new optional `turns` arguments to `extract_coupler_type_data()` and `set_coupler_type_data()` that are used to deal with the fact that the internal data arrays in the `coupler_bc_types` are never rotated, unlike the other MOM6 arrays, because they have to be passed directly into the generic tracer code. These new turns arguments are used in 14 calls from various tracer packages, including in 6 calls from the OCMIP2_CFC code.

  There are 4 new calls to `deallocate_surface_state()` or `deallocate_forcing_type()` that were added to avoid (presumably minor) memory leaks when grid rotation is enabled.  These new calls are in `initialize_ice_shelf_fluxes()`, `shelf_calc_flux()` and in the surface flux diagnostics section of `step_MOM()`.

  All answers are bitwise identical in any cases that worked previously, but some cases with grid rotation that previously were failing with cryptic error messages are now running successfully.  There are new optional arguments to several publicly visible routines.