### PR TITLE
Use FMS1 for MacOS builds

### DIFF
--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -10,6 +10,8 @@ jobs:
     env:
       CC: gcc
       FC: gfortran
+      FMS_COMMIT: 2019.01.03
+      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -10,6 +10,8 @@ jobs:
     env:
       CC: gcc
       FC: gfortran
+      FMS_COMMIT: 2019.01.03
+      FRAMEWORK: fms1
 
     defaults:
       run:


### PR DESCRIPTION
- MacOS builds have been failing recently
- This is apparently due to a recent break in gfortran 14.1 which is now incompatible with FMS2
- A proposed (@marshallward) workaround is to revert to FMS1 for the MacOS builds, which indeed appears to work
- This commit sets FRAMEWORK=fms1 and FMS_COMMIT=2019.01.03 only for the MacOS builds
- It leaves all other builds on FMS2