### PR TITLE
Use FMS1 for MacOS builds

### DIFF
--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -10,6 +10,8 @@ jobs:
     env:
       CC: gcc
       FC: gfortran
+      FMS_COMMIT: 2019.01.03
+      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -10,6 +10,8 @@ jobs:
     env:
       CC: gcc
       FC: gfortran
+      FMS_COMMIT: 2019.01.03
+      FRAMEWORK: fms1
 
     defaults:
       run:


### PR DESCRIPTION
(This commit was added to gfdl-to-main-2024-05-16 and adding it to dev/gfdl will resolve the red-X we how on our own PRs)

- Given a recent incompatibility with FMS2 and gfortran 14.1 we need to revert to FMS1 for the MacOS builds.