### PR TITLE
Add rescaling parameter to kappa shear

### DIFF
--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -54,9 +54,9 @@ type, public :: Kappa_shear_CS ; private
   real    :: lambda2_N_S     !<   The square of the ratio of the coefficients of
                              !! the buoyancy and shear scales in the diffusivity
                              !! equation, 0 to eliminate the shear scale [nondim].
-  real    :: lz_rescale      !<   A coefficient to rescale the distance to the nearest 
-                             !! solid boundary. This adjustment is to account for 
-                             !! regions where 3 dimensional turbulence prevents the 
+  real    :: lz_rescale      !<   A coefficient to rescale the distance to the nearest
+                             !! solid boundary. This adjustment is to account for
+                             !! regions where 3 dimensional turbulence prevents the
                              !! growth of shear instabilies [nondim].
   real    :: TKE_bg          !<   The background level of TKE [Z2 T-2 ~> m2 s-2].
   real    :: kappa_0         !<   The background diapycnal diffusivity [H Z T-1 ~> m2 s-1 or Pa s]
@@ -804,8 +804,8 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, hlay, dz_la
     ! Find the inverse of the squared distances from the boundaries,
     I_L2_bdry(K) = ((dist_from_top(K) + dist_from_bot) * (h_from_top(K) + h_from_bot)) / &
                    ((dist_from_top(K) * dist_from_bot) * (h_from_top(K) * h_from_bot))
-    ! reduce the distance by a factor of "lz_rescale" 
-    I_L2_bdry(K) = I_lz_rescale_sqr*I_L2_bdry(K) 
+    ! reduce the distance by a factor of "lz_rescale"
+    I_L2_bdry(K) = I_lz_rescale_sqr*I_L2_bdry(K)
   enddo
 
   !   Determine the velocities and thicknesses after eliminating massless
@@ -1929,10 +1929,10 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
                  "This is only used if USE_JACKSON_PARAM is true.", &
                  units="nondim", default=0.0, do_not_log=just_read)
   call get_param(param_file, mdl, "LZ_RESCALE", CS%lz_rescale, &
-                 "A coefficient to rescale the distance to the nearest solid boundary. "//& 
-                 "This adjustment is to account for regions where 3 dimensional turbulence "//&  
+                 "A coefficient to rescale the distance to the nearest solid boundary. "//&
+                 "This adjustment is to account for regions where 3 dimensional turbulence "//&
                  "prevents the growth of shear instabilies [nondim].", &
-                 units="nondim", default=1.0) 
+                 units="nondim", default=1.0)
   call get_param(param_file, mdl, "KAPPA_SHEAR_TOL_ERR", CS%kappa_tol_err, &
                  "The fractional error in kappa that is tolerated. "//&
                  "Iteration stops when changes between subsequent "//&

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -801,10 +801,11 @@ subroutine kappa_shear_column(kappa, tke, dt, nzc, f2, surface_pres, hlay, dz_la
   do K=nzc,2,-1
     dist_from_bot = dist_from_bot + dz_lay(k)
     h_from_bot = h_from_bot + hlay(k)
-    !I_L2_bdry(K) = ((dist_from_top(K) + dist_from_bot) * (h_from_top(K) + h_from_bot)) / &
-    !               ((dist_from_top(K) * dist_from_bot) * (h_from_top(K) * h_from_bot))
-    I_L2_bdry(K) = I_lz_rescale_sqr*((dist_from_top(K) + dist_from_bot) * (h_from_top(K) + h_from_bot)) / &
+    ! Find the inverse of the squared distances from the boundaries,
+    I_L2_bdry(K) = ((dist_from_top(K) + dist_from_bot) * (h_from_top(K) + h_from_bot)) / &
                    ((dist_from_top(K) * dist_from_bot) * (h_from_top(K) * h_from_bot))
+    ! reduce the distance by a factor of "lz_rescale" 
+    I_L2_bdry(K) = I_lz_rescale_sqr*I_L2_bdry(K) 
   enddo
 
   !   Determine the velocities and thicknesses after eliminating massless


### PR DESCRIPTION
Add a parameter (beta) to rescale the distance to the nearest solid boundary that is used within calculation of kappa shear. While rescaling this value is nonphysical, this adjustment can be thought of as not allowing shear instabilities to grow up to the full distance to the nearest boundary because of other turbulent processes which would disrupt their growth. By default, this parameter is 1.0 and should not impact existing solutions. 

This modification to the kappa shear parameterization was developed by Wei Cheng, Al Hermann, and Vivek Seelanki and tested in simulations of the North East Pacific regional model developed by Liz Drenkard. In the Bering Sea, which is shallow and has strong tides, the well observed cold pool and seasonal stratification were being disrupted because of excessive shear mixing. A number of solutions were tested but the rescaling of Lz implemented here was found to improve both metrics. This adjustment impacts Lz (defined just after equation 14 in Jackson et al 2008)  which is half the
harmonic mean of the distance to the nearest sold boundary (ocean bottom of ocean surface). 

The impact of beta on the strength of Kd_shear within the Bering Sea are plotted here (figure from Wei Cheng). Adjusting beta has a similar impact as adjusting lambda, which is the ratio of the turbulent and buoyant length scales and is constrained to be O(1) .
![kd_shear-fig1](https://github.com/NOAA-GFDL/MOM6/assets/114184229/cd2d0c62-0a73-4508-84db-03be2e961cb2)

The impacts of this new adjustment can be seen in the Bering Sea Cold Pool index, a measure of the area were ocean bottom temperature is below a certain value in the summer. Setting beta=0.2 results in better agreement with observations in hindecast simulations (figure from Liz Drenkard). 
![beta_cold_pool_improvement](https://github.com/NOAA-GFDL/MOM6/assets/114184229/a6b2c39c-1016-458a-83b0-4fed226bfc50)

This new parameter should be tested in the global domains which include overflows and other regions for which the kappa shear parameterization was developed. However, in the short term this adjustment is a pragmatic fix for clear biases within the Bering Sea and possibly other similar regions. 