### PR TITLE
Fix bug in radiation OBC update

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1421,7 +1421,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
                  "what is already being done with the primary state variables.  "//&
                  "The default should be changed to true.", default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "USE_OBC_U_INST_BUG", CS%use_obc_uinst_bug, &
-                 "If true, use a bug in the update of the radiation open boundary conditions"//&
+                 "If true, use a bug in the update of the radiation open boundary conditions "//&
                  "that uses the instantaneous velocity rather than the time-averaged velocity.",&
                   default=.true.)
   if (CS%remap_aux .and. .not.CS%store_CAu) call MOM_error(FATAL, &


### PR DESCRIPTION
When the update to the radiation OBC's is called the time-averaged velocity should be used, not the instantaneous velocity. This was fixed in the RK2B algorithm but not in RK2A in part because of how the update to the OBC's is between a non-blocking update.

The original sequence has been preserved, but an additional call to update the radiation OBC's has been added after the blocking update which should only be do if OBC's are used and  the bug flag is set to false. 

This PR will not change answers for simulations without OBC's and will only change answers for cases with OBC's when `USE_OBC_U_INST_BUG = True`. 