### PR TITLE
*Fix ALE_remap_scalar call with h_in_Z_units

### DIFF
--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -200,8 +200,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
     enddo ; enddo
 
     if (h_is_in_Z_units) then
+      ! Because h is in units of [Z ~> m], dzSrc is already in the right units, but we need to
+      ! specify negligible thickness values with the right units.
       dz_neglect = set_dz_neglect(GV, US, remap_answer_date, dz_neglect_edge)
-      call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date, &
+      call ALE_remap_scalar(remapCS, G, GV, kd, dzSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date, &
                             H_neglect=dz_neglect, H_neglect_edge=dz_neglect_edge)
     else
       ! Equation of state data is not available, so a simpler rescaling will have to suffice,


### PR DESCRIPTION
  Corrected an argument to the call to `ALE_remap_scalar()` when `h_is_in_Z_units` is true in `MOM_initialize_tracer_from_Z()`, to avoid the problems documented in github.com/NOAA-GFDL/MOM6/issues/589.  A comment was also added explaining the logic of what is going on in this fork of the code.  This commit will change answers with some generic tracers that are initialized from a Z-space input file, restoring them to previous values that worked previously (before about Feb. 1, 2024 on dev/gfdl) in Boussinesq configurations without dimensional consistency testing, but in a new form that does pass the dimensional consistency testing for depths and thicknesses.  All answers are bitwise identical in any cases that do not use generic tracers.