### PR TITLE
Refactor Axis Information Handling for Improved Performance in ocean_sponge

### DIFF
--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -627,7 +627,8 @@ end subroutine horiz_interp_and_extrap_tracer_record
 subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
                                                  z_in, z_edges_in, missing_value, scale, &
                                                  homogenize, spongeOngrid, m_to_Z, &
-                                                 answers_2018, tr_iter_tol, answer_date)
+                                                 answers_2018, tr_iter_tol, answer_date, &
+                                                 axes)
 
   type(external_field), intent(in)     :: field      !< Handle for the time interpolated field
   type(time_type),       intent(in)    :: Time       !< A FMS time type
@@ -663,6 +664,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
                                                      !! Dates before 20190101 give the same  answers
                                                      !! as the code did in late 2018, while later versions
                                                      !! add parentheses for rotational symmetry.
+  type(axis_info), allocatable, dimension(:), optional, intent(inout) :: axes !< Axis types for the input data
 
   ! Local variables
   ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
@@ -742,7 +744,16 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
 
   call cpu_clock_begin(id_clock_read)
 
-  call get_external_field_info(field, size=fld_sz, axes=axes_data, missing=missing_val_in)
+  if (present(axes) .and. allocated(axes)) then
+    call get_external_field_info(field, size=fld_sz, missing=missing_val_in)
+    axes_data = axes
+  else
+    call get_external_field_info(field, size=fld_sz, axes=axes_data, missing=missing_val_in)
+    if (present(axes)) then
+      allocate(axes(4))
+      axes = axes_data
+    endif
+  endif
   missing_value = scale*missing_val_in
 
   verbosity = MOM_get_verbosity()

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -23,6 +23,7 @@ use MOM_grid,          only : ocean_grid_type
 use MOM_horizontal_regridding, only : horiz_interp_and_extrap_tracer
 use MOM_interpolate,   only : init_external_field, get_external_field_info, time_interp_external_init
 use MOM_interpolate,   only : external_field
+use MOM_io,            only : axis_info
 use MOM_remapping,     only : remapping_cs, remapping_core_h, initialize_remapping
 use MOM_spatial_means, only : global_i_mean
 use MOM_time_manager,  only : time_type
@@ -86,6 +87,7 @@ type :: p2d ; private
   character(len=:), allocatable  :: name  !< The name of the input field
   character(len=:), allocatable  :: long_name !< The long name of the input field
   character(len=:), allocatable  :: unit !< The unit of the input field
+  type(axis_info),  allocatable  :: axes_data(:) !< Axis types for the input field
 end type p2d
 
 !> ALE sponge control structure
@@ -770,7 +772,7 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
   CS%Ref_val(CS%fldno)%long_name = long_name
   CS%Ref_val(CS%fldno)%unit = unit
   fld_sz(1:4) = -1
-  call get_external_field_info(CS%Ref_val(CS%fldno)%field, size=fld_sz)
+  call get_external_field_info(CS%Ref_val(CS%fldno)%field, size=fld_sz, axes=CS%Ref_val(CS%fldno)%axes_data)
   nz_data = fld_sz(3)
   CS%Ref_val(CS%fldno)%nz_data = nz_data !< individual sponge fields may reside on a different vertical grid
   CS%Ref_val(CS%fldno)%num_tlevs = fld_sz(4)
@@ -868,7 +870,7 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
     CS%Ref_val_u%field = init_external_field(filename_u, fieldname_u)
   endif
   fld_sz(1:4) = -1
-  call get_external_field_info(CS%Ref_val_u%field, size=fld_sz)
+  call get_external_field_info(CS%Ref_val_u%field, size=fld_sz, axes=CS%Ref_val_u%axes_data)
   CS%Ref_val_u%nz_data = fld_sz(3)
   CS%Ref_val_u%num_tlevs = fld_sz(4)
   CS%Ref_val_u%scale = US%m_s_to_L_T ; if (present(scale)) CS%Ref_val_u%scale = scale
@@ -879,7 +881,7 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
     CS%Ref_val_v%field = init_external_field(filename_v, fieldname_v)
   endif
   fld_sz(1:4) = -1
-  call get_external_field_info(CS%Ref_val_v%field, size=fld_sz)
+  call get_external_field_info(CS%Ref_val_v%field, size=fld_sz, axes=CS%Ref_val_v%axes_data)
   CS%Ref_val_v%nz_data = fld_sz(3)
   CS%Ref_val_v%num_tlevs = fld_sz(4)
   CS%Ref_val_v%scale = US%m_s_to_L_T ; if (present(scale)) CS%Ref_val_v%scale = scale
@@ -963,7 +965,7 @@ subroutine apply_ALE_sponge(h, tv, dt, G, GV, US, CS, Time)
       call horiz_interp_and_extrap_tracer(CS%Ref_val(m)%field, Time, G, sp_val, &
                 mask_z, z_in, z_edges_in, missing_value, &
                 scale=CS%Ref_val(m)%scale, spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z, &
-                answer_date=CS%hor_regrid_answer_date)
+                answer_date=CS%hor_regrid_answer_date, axes=CS%Ref_val(m)%axes_data)
       allocate( dz_src(nz_data) )
       allocate( tmpT1d(nz_data) )
       do c=1,CS%num_col
@@ -1053,7 +1055,7 @@ subroutine apply_ALE_sponge(h, tv, dt, G, GV, US, CS, Time)
       call horiz_interp_and_extrap_tracer(CS%Ref_val_u%field, Time, G, sp_val, &
                 mask_z, z_in, z_edges_in, missing_value, &
                 scale=CS%Ref_val_u%scale, spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z, &
-                answer_date=CS%hor_regrid_answer_date)
+                answer_date=CS%hor_regrid_answer_date, axes=CS%Ref_val_u%axes_data)
 
       ! Initialize mask_z halos to zero before pass_var, in case of no update
       mask_z(G%isc-1, G%jsc:G%jec, :) = 0.
@@ -1101,7 +1103,7 @@ subroutine apply_ALE_sponge(h, tv, dt, G, GV, US, CS, Time)
       call horiz_interp_and_extrap_tracer(CS%Ref_val_v%field, Time, G, sp_val, &
                 mask_z, z_in, z_edges_in, missing_value, &
                 scale=CS%Ref_val_v%scale, spongeOnGrid=CS%SpongeDataOngrid, m_to_Z=US%m_to_Z,&
-                answer_date=CS%hor_regrid_answer_date)
+                answer_date=CS%hor_regrid_answer_date, axes=CS%Ref_val_v%axes_data)
       ! Initialize mask_z halos to zero before pass_var, in case of no update
       mask_z(G%isc:G%iec, G%jsc-1, :) = 0.
       mask_z(G%isc:G%iec, G%jec+1, :) = 0.


### PR DESCRIPTION
This PR addresses issue #644 by introducing a logic change when calling `get_external_field_info` in `MOM_interp_infra.F90`. Since the axis, dimension, and missing value information for nudging are time-independent, there is no need to read this information from the NetCDF file at every time step when using `FMS2`. With this fix, the runtime of nudging experiments with `FMS1` and `FMS2` are now comparable:

FMS2 with new fix one year run:
```
                                      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
Total runtime                            1   9425.780744   9425.898127   9425.820889      0.036968  1.000     0     0  1645
(Ocean sponges)                      17520    445.104094   1139.163714    580.620263     63.931211  0.062    31     0  1645
```

FMS1 with new fix one year run:
```
                                      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
Total runtime                            1   9400.495175   9400.592062   9400.525483      0.031271  1.000     0     0  1645
(Ocean sponges)                      17520    446.976279   1156.951049    594.715797     65.370447  0.063    31     0  1645
```

Keep in mind, this is just a simple fix to allow users to run MOM6 with both the sponge option and FMS2 simultaneously. It would probably be better to refactor `FMS2/MOM_interp_infra.F90` in the future to fundamentally solve the issue.