### PR TITLE
CI: Fix FMS_COMMIT, remove FRAMEWORK

### DIFF
--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -11,7 +11,6 @@ jobs:
       CC: gcc
       FC: gfortran
       FMS_COMMIT: 2019.01.03
-      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -11,7 +11,6 @@ jobs:
       CC: gcc
       FC: gfortran
       FMS_COMMIT: 2019.01.03
-      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -20,7 +20,6 @@
 #
 # General test configuration:
 #   MPIRUN                  MPI job launcher (mpirun, srun, etc)
-#   FRAMEWORK               Model framework (fms1 or fms2)
 #   DO_REPRO_TESTS          Enable production ("repro") testing equivalence
 #   DO_REGRESSION_TESTS     Enable regression tests (usually dev/gfdl)
 #   DO_COVERAGE             Enable code coverage and generate .gcov reports
@@ -74,8 +73,11 @@ AC_SRCDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../ac
 # User-defined configuration
 -include config.mk
 
-# Set the infra framework
-FRAMEWORK ?= fms2
+# Set the FMS library
+FMS_COMMIT ?= 2023.03
+FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
+export FMS_COMMIT
+export FMS_URL
 
 # Set the MPI launcher here
 # TODO: This needs more automated configuration

--- a/.testing/README.rst
+++ b/.testing/README.rst
@@ -47,9 +47,11 @@ Several of the following may require configuration for particular systems.
    Name of the MPI launcher.  Often this is ``mpirun`` or ``mpiexec`` but may
    all need to run through a scheduler, e.g. ``srun`` if using Slurm.
 
-``FRAMEWORK`` (*default:* ``fms1``)
-   Select either the legacy FMS framework (``fms1``) or an FMS2 I/O compatible
-   version (``fms2``).
+``FMS_COMMIT`` (*default:* ``2023.03``)
+   Set the FMS version, either by tag or commit (as defined in ``FMS_URL``).
+
+``FMS_URL`` (*default*: ``https://github.com/NOAA-GFDL/FMS.git``)
+   Set the URL of the FMS repository.
 
 ``DO_REPRO_TESTS`` (*default:* *none*)
    Set to ``true`` to test the REPRO build and confirm equivalence of DEBUG and


### PR DESCRIPTION
This patch fixes ``FMS_COMMIT`` and ``FMS_URL`` so that they are properly exported to ``ac/deps/Makefile`` and used in the .testing FMS build.

It also removes any references to the FRAMEWORK flag, which is no longer needed to identify the FMS API.