### PR TITLE
Remapping refactor and fix for mismatched ocean depths

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -263,10 +263,12 @@ $(BUILD)/timing/Makefile: MOM_ACFLAGS += --with-driver=timing_tests
 
 
 # Build executables
+.NOTPARALLEL:$(foreach e,$(UNIT_EXECS),$(BUILD)/unit/$(e))
 $(BUILD)/unit/test_%: $(BUILD)/unit/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
 $(BUILD)/unit/Makefile: $(foreach e,$(UNIT_EXECS),../config_src/drivers/unit_tests/$(e).F90)
 
+.NOTPARALLEL:$(foreach e,$(TIMING_EXECS),$(BUILD)/timing/$(e))
 $(BUILD)/timing/time_%: $(BUILD)/timing/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
 $(BUILD)/timing/Makefile: $(foreach e,$(TIMING_EXECS),../config_src/drivers/timing_tests/$(e).F90)

--- a/config_src/drivers/timing_tests/time_MOM_remapping.F90
+++ b/config_src/drivers/timing_tests/time_MOM_remapping.F90
@@ -1,0 +1,100 @@
+program time_MOM_remapping
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_remapping, only : remapping_CS
+use MOM_remapping, only : initialize_remapping
+use MOM_remapping, only : remapping_core_h
+
+implicit none
+
+type(remapping_CS) :: CS
+integer, parameter :: nk=75, nij=20*20, nits=10, nsamp=100, nschemes = 2
+character(len=10) :: scheme_labels(nschemes)
+real, dimension(nschemes) :: timings ! Time for nits of nij calls for each scheme [s]
+real, dimension(nschemes) :: tmean ! Mean time for a call [s]
+real, dimension(nschemes) :: tstd ! Standard deviation of time for a call [s]
+real, dimension(nschemes) :: tmin ! Shortest time for a call [s]
+real, dimension(nschemes) :: tmax ! Longest time for a call [s]
+real, dimension(:,:), allocatable :: u0, u1 ! Source/target values [arbitrary but same units as each other]
+real, dimension(:,:), allocatable :: h0, h1 ! Source target thicknesses [0..1]
+real :: start, finish ! Times [s]
+real :: h0sum, h1sum ! Totals of h0 and h1 [nondim]
+integer :: ij, k, isamp, iter, ischeme ! Indices and counters
+integer :: seed_size ! Number of integers used by seed
+integer, allocatable :: seed(:) ! Random number seed
+
+! Set seed for random numbers
+call random_seed(size=seed_size)
+allocate( seed(seed_Size) )
+seed(:) = 102030405
+call random_seed(put=seed)
+
+scheme_labels(1) = 'PCM'
+scheme_labels(2) = 'PLM'
+
+! Set up some test data (note: using k,i indexing rather than i,k)
+allocate( u0(nk,nij), h0(nk,nij), u1(nk,nij), h1(nk,nij) )
+call random_number(u0) ! In range 0-1
+call random_number(h0) ! In range 0-1
+call random_number(h1) ! In range 0-1
+do ij = 1, nij
+  h0(:,ij) = max(0., h0(:,ij) - 0.05) ! Make 5% of values equal to zero
+  h1(:,ij) = max(0., h1(:,ij) - 0.05) ! Make 5% of values equal to zero
+  h0sum = h0(1,ij)
+  h1sum = h1(1,ij)
+  do k = 2, nk
+    h0sum = h0sum + h0(k,ij)
+    h1sum = h1sum + h1(k,ij)
+  enddo
+  h0(:,ij) = h0(:,ij) / h0sum
+  h1(:,ij) = h1(:,ij) / h1sum
+enddo
+
+! Loop over many samples of timing loop to collect statistics
+tmean(:) = 0.
+tstd(:) = 0.
+tmin(:) = 1.e9
+tmax(:) = 0.
+do isamp = 1, nsamp
+  ! Time reconstruction + remapping
+  do ischeme = 1, nschemes
+    call initialize_remapping(CS, remapping_scheme=trim(scheme_labels(ischeme)))
+    call cpu_time(start)
+    do iter = 1, nits ! Make many passes to reduce sampling error
+      do ij = 1, nij ! Calling nij times to make similar to cost in MOM_ALE()
+        call remapping_core_h(CS, nk, h0(:,ij), u0(:,ij), nk, h1(:,ij), u1(:,ij))
+      enddo
+    enddo
+    call cpu_time(finish)
+    timings(ischeme) = (finish-start)/real(nits*nij) ! Average time per call
+  enddo
+  tmean(:) = tmean(:) + timings(:)
+  tstd(:) = tstd(:) + timings(:)**2 ! tstd contains sum of squares here
+  tmin(:) = min( tmin(:), timings(:) )
+  tmax(:) = max( tmax(:), timings(:) )
+enddo
+tmean(:) = tmean(:) / real(nsamp) ! convert to mean
+tstd(:) = tstd(:) / real(nsamp) ! convert to mean of squares
+tstd(:) = tstd(:) - tmean(:)**2  ! convert to variance
+tstd(:) = sqrt( tstd(:) * real(nsamp) / real(nsamp-1) ) ! convert to standard deviation
+
+
+! Display results in YAML
+write(*,'(a)') "{"
+do ischeme = 1, nschemes
+  write(*,"(2x,5a)") '"MOM_remapping remapping_core_h(remapping_scheme=', &
+                     trim(scheme_labels(ischeme)), ')": {'
+  write(*,"(4x,a,1pe11.4,',')") '"min": ',tmin(ischeme)
+  write(*,"(4x,a,1pe11.4,',')") '"mean":',tmean(ischeme)
+  write(*,"(4x,a,1pe11.4,',')") '"std": ',tstd(ischeme)
+  write(*,"(4x,a,i7,',')") '"n_samples": ',nsamp
+  if (ischeme.ne.nschemes) then
+    write(*,"(4x,a,1pe11.4,'},')") '"max": ',tmax(ischeme)
+  else
+    write(*,"(4x,a,1pe11.4,'}')") '"max": ',tmax(ischeme)
+  endif
+enddo
+write(*,'(a)') "}"
+
+end program time_MOM_remapping

--- a/config_src/drivers/unit_tests/test_MOM_remapping.F90
+++ b/config_src/drivers/unit_tests/test_MOM_remapping.F90
@@ -1,0 +1,7 @@
+program test_MOM_remapping
+
+use MOM_remapping, only : remapping_unit_tests
+
+if (remapping_unit_tests(.true.)) stop 1
+
+end program test_MOM_remapping

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -493,8 +493,6 @@ subroutine remap_via_sub_cells( n0, h0, u0, ppoly0_E, ppoly0_coefs, n1, h1, meth
   integer :: i_sub ! Index of sub-cell
   integer :: i0 ! Index into h0(1:n0), source column
   integer :: i1 ! Index into h1(1:n1), target column
-  integer :: i_start0 ! Used to record which sub-cells map to source cells
-  integer :: i_start1 ! Used to record which sub-cells map to target cells
   integer :: i_max ! Used to record which sub-cell is the largest contribution of a source cell
   real :: dh_max ! Used to record which sub-cell is the largest contribution of a source cell [H]
   real, dimension(n0+n1+1) :: h_sub ! Width of each each sub-cell [H]
@@ -510,7 +508,6 @@ subroutine remap_via_sub_cells( n0, h0, u0, ppoly0_E, ppoly0_coefs, n1, h1, meth
   integer, dimension(n1) :: itgt_start ! Index of first sub-cell within each target cell
   integer, dimension(n1) :: itgt_end ! Index of last sub-cell within each target cell
   real :: xa, xb ! Non-dimensional position within a source cell (0..1) [nondim]
-  real :: h0_supply, h1_supply ! The amount of width available for constructing sub-cells [H]
   real :: dh ! The width of the sub-cell [H]
   real :: duh ! The total amount of accumulated stuff (u*h)  [A H]
   real :: dh0_eff ! Running sum of source cell thickness [H]
@@ -525,13 +522,278 @@ subroutine remap_via_sub_cells( n0, h0, u0, ppoly0_E, ppoly0_coefs, n1, h1, meth
   real :: u0tot, u1tot, u2tot ! Integrated reconstruction values [H A]
   real :: u_orig              ! The original value of the reconstruction in a cell [A]
   real :: u0min, u0max, u1min, u1max, u2min, u2max ! Minimum and maximum values of reconstructions [A]
-  logical :: src_has_volume !< True if h0 has not been consumed
-  logical :: tgt_has_volume !< True if h1 has not been consumed
 
   i0_last_thick_cell = 0
   do i0 = 1, n0
     u0_min(i0) = min(ppoly0_E(i0,1), ppoly0_E(i0,2))
     u0_max(i0) = max(ppoly0_E(i0,1), ppoly0_E(i0,2))
+    if (h0(i0)>0.) i0_last_thick_cell = i0
+  enddo
+
+  ! Calculate sub-layer thicknesses and indices connecting sub-layers to source and target grids
+  call intersect_src_tgt_grids( n0, h0, n1, h1, h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! Loop over each sub-cell to calculate average/integral values within each sub-cell.
+  ! Uses: h_sub, isub_src, h0_eff
+  ! Sets: u_sub, uh_sub
+  xa = 0.
+  dh0_eff = 0.
+  uh_sub(1) = 0.
+  u_sub(1) = ppoly0_E(1,1)
+  u02_err = 0.
+  do i_sub = 2, n0+n1
+
+    ! Sub-cell thickness from loop above
+    dh = h_sub(i_sub)
+
+    ! Source cell
+    i0 = isub_src(i_sub)
+
+    ! Evaluate average and integral for sub-cell i_sub.
+    ! Integral is over distance dh but expressed in terms of non-dimensional
+    ! positions with source cell from xa to xb  (0 <= xa <= xb <= 1).
+    dh0_eff = dh0_eff + dh ! Cumulative thickness within the source cell
+    if (h0_eff(i0)>0.) then
+      xb = dh0_eff / h0_eff(i0) ! This expression yields xa <= xb <= 1.0
+      xb = min(1., xb) ! This is only needed when the total target column is wider than the source column
+      u_sub(i_sub) = average_value_ppoly( n0, u0, ppoly0_E, ppoly0_coefs, method, i0, xa, xb)
+    else ! Vanished cell
+      xb = 1.
+      u_sub(i_sub) = u0(i0)
+    endif
+    if (debug_bounds) then
+      if (method<5 .and.(u_sub(i_sub)<u0_min(i0) .or. u_sub(i_sub)>u0_max(i0))) then
+        write(0,*) 'Sub cell average is out of bounds',i_sub,'method=',method
+        write(0,*) 'xa,xb: ',xa,xb
+        write(0,*) 'Edge values: ',ppoly0_E(i0,:),'mean',u0(i0)
+        write(0,*) 'a_c: ',(u0(i0)-ppoly0_E(i0,1))+(u0(i0)-ppoly0_E(i0,2))
+        write(0,*) 'Polynomial coeffs: ',ppoly0_coefs(i0,:)
+        write(0,*) 'Bounds min=',u0_min(i0),'max=',u0_max(i0)
+        write(0,*) 'Average: ',u_sub(i_sub),'rel to min=',u_sub(i_sub)-u0_min(i0),'rel to max=',u_sub(i_sub)-u0_max(i0)
+        call MOM_error( FATAL, 'MOM_remapping, remap_via_sub_cells: '//&
+             'Sub-cell average is out of bounds!' )
+      endif
+    endif
+    if (force_bounds_in_subcell) then
+      ! These next two lines should not be needed but when using PQM we found roundoff
+      ! can lead to overshoots. These lines sweep issues under the rug which need to be
+      ! properly .. later. -AJA
+      u_orig = u_sub(i_sub)
+      u_sub(i_sub) = max( u_sub(i_sub), u0_min(i0) )
+      u_sub(i_sub) = min( u_sub(i_sub), u0_max(i0) )
+      u02_err = u02_err + dh*abs( u_sub(i_sub) - u_orig )
+    endif
+    uh_sub(i_sub) = dh * u_sub(i_sub)
+
+    if (isub_src(i_sub+1) /= i0) then
+      ! If the next sub-cell is in a different source cell, reset the position counters
+      dh0_eff = 0.
+      xa = 0.
+    else
+      xa = xb ! Next integral will start at end of last
+    endif
+
+  enddo
+  u_sub(n0+n1+1) = ppoly0_E(n0,2)                   ! This value is only needed when total target column
+  uh_sub(n0+n1+1) = ppoly0_E(n0,2) * h_sub(n0+n1+1) ! is wider than the source column
+
+  if (adjust_thickest_subcell) then
+    ! Loop over each source cell substituting the integral/average for the thickest sub-cell (within
+    ! the source cell) with the residual of the source cell integral minus the other sub-cell integrals
+    ! aka a genius algorithm for accurate conservation when remapping from Robert Hallberg (@Hallberg-NOAA).
+    ! Uses: i0_last_thick_cell, isrc_max, h_sub, isrc_start, isrc_end, uh_sub, u0, h0
+    ! Updates: uh_sub
+    do i0 = 1, i0_last_thick_cell
+      i_max = isrc_max(i0)
+      dh_max = h_sub(i_max)
+      if (dh_max > 0.) then
+        ! duh will be the sum of sub-cell integrals within the source cell except for the thickest sub-cell.
+        duh = 0.
+        do i_sub = isrc_start(i0), isrc_end(i0)
+          if (i_sub /= i_max) duh = duh + uh_sub(i_sub)
+        enddo
+        uh_sub(i_max) = u0(i0)*h0(i0) - duh
+        u02_err = u02_err + max( abs(uh_sub(i_max)), abs(u0(i0)*h0(i0)), abs(duh) )
+      endif
+    enddo
+  endif
+
+  ! Loop over each target cell summing the integrals from sub-cells within the target cell.
+  ! Uses: itgt_start, itgt_end, h_sub, uh_sub, u_sub
+  ! Sets: u1
+  uh_err = 0.
+  do i1 = 1, n1
+    if (h1(i1) > 0.) then
+      duh = 0. ; dh = 0.
+      i_sub = itgt_start(i1)
+      if (force_bounds_in_target) then
+        u1min = u_sub(i_sub)
+        u1max = u_sub(i_sub)
+      endif
+      do i_sub = itgt_start(i1), itgt_end(i1)
+        if (force_bounds_in_target) then
+          u1min = min(u1min, u_sub(i_sub))
+          u1max = max(u1max, u_sub(i_sub))
+        endif
+        dh = dh + h_sub(i_sub)
+        duh = duh + uh_sub(i_sub)
+        ! This accumulates the contribution to the error bound for the sum of u*h
+        uh_err = uh_err + max(abs(duh),abs(uh_sub(i_sub)))*epsilon(duh)
+      enddo
+      u1(i1) = duh / dh
+      ! This is the contribution from the division to the error bound for the sum of u*h
+      uh_err = uh_err + abs(duh)*epsilon(duh)
+      if (force_bounds_in_target) then
+        u_orig = u1(i1)
+        u1(i1) = max(u1min, min(u1max, u1(i1)))
+        ! Adjusting to be bounded contributes to the error for the sum of u*h
+        uh_err = uh_err + dh*abs( u1(i1)-u_orig )
+      endif
+    else
+      u1(i1) = u_sub(itgt_start(i1))
+    endif
+  enddo
+
+  ! Check errors and bounds
+  if (debug_bounds) then
+    call measure_input_bounds( n0, h0, u0, ppoly0_E, h0tot, h0err, u0tot, u0err, u0min, u0max )
+    call measure_output_bounds( n1, h1, u1, h1tot, h1err, u1tot, u1err, u1min, u1max )
+    call measure_output_bounds( n0+n1+1, h_sub, u_sub, h2tot, h2err, u2tot, u2err, u2min, u2max )
+    if (method<5) then ! We except PQM until we've debugged it
+    if (     (abs(u1tot-u0tot)>(u0err+u1err)+uh_err+u02_err .and. abs(h1tot-h0tot)<h0err+h1err) &
+        .or. (abs(u2tot-u0tot)>u0err+u2err+u02_err .and. abs(h2tot-h0tot)<h0err+h2err) &
+        .or. (u1min<u0min .or. u1max>u0max) ) then
+      write(0,*) 'method = ',method
+      write(0,*) 'Source to sub-cells:'
+      write(0,*) 'H: h0tot=',h0tot,'h2tot=',h2tot,'dh=',h2tot-h0tot,'h0err=',h0err,'h2err=',h2err
+      if (abs(h2tot-h0tot)>h0err+h2err) &
+        write(0,*) 'H non-conservation difference=',h2tot-h0tot,'allowed err=',h0err+h2err,' <-----!'
+      write(0,*) 'UH: u0tot=',u0tot,'u2tot=',u2tot,'duh=',u2tot-u0tot,'u0err=',u0err,'u2err=',u2err,&
+                 'adjustment err=',u02_err
+      if (abs(u2tot-u0tot)>u0err+u2err) &
+        write(0,*) 'U non-conservation difference=',u2tot-u0tot,'allowed err=',u0err+u2err,' <-----!'
+      write(0,*) 'Sub-cells to target:'
+      write(0,*) 'H: h2tot=',h2tot,'h1tot=',h1tot,'dh=',h1tot-h2tot,'h2err=',h2err,'h1err=',h1err
+      if (abs(h1tot-h2tot)>h2err+h1err) &
+        write(0,*) 'H non-conservation difference=',h1tot-h2tot,'allowed err=',h2err+h1err,' <-----!'
+      write(0,*) 'UH: u2tot=',u2tot,'u1tot=',u1tot,'duh=',u1tot-u2tot,'u2err=',u2err,'u1err=',u1err,'uh_err=',uh_err
+      if (abs(u1tot-u2tot)>u2err+u1err) &
+        write(0,*) 'U non-conservation difference=',u1tot-u2tot,'allowed err=',u2err+u1err,' <-----!'
+      write(0,*) 'Source to target:'
+      write(0,*) 'H: h0tot=',h0tot,'h1tot=',h1tot,'dh=',h1tot-h0tot,'h0err=',h0err,'h1err=',h1err
+      if (abs(h1tot-h0tot)>h0err+h1err) &
+        write(0,*) 'H non-conservation difference=',h1tot-h0tot,'allowed err=',h0err+h1err,' <-----!'
+      write(0,*) 'UH: u0tot=',u0tot,'u1tot=',u1tot,'duh=',u1tot-u0tot,'u0err=',u0err,'u1err=',u1err,'uh_err=',uh_err
+      if (abs(u1tot-u0tot)>(u0err+u1err)+uh_err) &
+        write(0,*) 'U non-conservation difference=',u1tot-u0tot,'allowed err=',u0err+u1err+uh_err,' <-----!'
+      write(0,*) 'U: u0min=',u0min,'u1min=',u1min,'u2min=',u2min
+      if (u1min<u0min) write(0,*) 'U minimum overshoot=',u1min-u0min,' <-----!'
+      if (u2min<u0min) write(0,*) 'U2 minimum overshoot=',u2min-u0min,' <-----!'
+      write(0,*) 'U: u0max=',u0max,'u1max=',u1max,'u2max=',u2max
+      if (u1max>u0max) write(0,*) 'U maximum overshoot=',u1max-u0max,' <-----!'
+      if (u2max>u0max) write(0,*) 'U2 maximum overshoot=',u2max-u0max,' <-----!'
+      write(0,'(a3,6a24,2a3)') 'k','h0','left edge','u0','right edge','h1','u1','is','ie'
+      do k = 1, max(n0,n1)
+        if (k<=min(n0,n1)) then
+          write(0,'(i3,1p6e24.16,2i3)') k,h0(k),ppoly0_E(k,1),u0(k),ppoly0_E(k,2),h1(k),u1(k),itgt_start(k),itgt_end(k)
+        elseif (k>n0) then
+          write(0,'(i3,96x,1p2e24.16,2i3)') k,h1(k),u1(k),itgt_start(k),itgt_end(k)
+        else
+          write(0,'(i3,1p4e24.16)') k,h0(k),ppoly0_E(k,1),u0(k),ppoly0_E(k,2)
+        endif
+      enddo
+      write(0,'(a3,2a24)') 'k','u0','Polynomial coefficients'
+      do k = 1, n0
+        write(0,'(i3,1p6e24.16)') k,u0(k),ppoly0_coefs(k,:)
+      enddo
+      write(0,'(a3,3a24,a3,2a24)') 'k','Sub-cell h','Sub-cell u','Sub-cell hu','i0','xa','xb'
+      xa = 0.
+      dh0_eff = 0.
+      do k = 1, n0+n1+1
+        dh = h_sub(k)
+        i0 = isub_src(k)
+        dh0_eff = dh0_eff + dh ! Cumulative thickness within the source cell
+        xb = dh0_eff / h0_eff(i0) ! This expression yields xa <= xb <= 1.0
+        xb = min(1., xb) ! This is only needed when the total target column is wider than the source column
+        write(0,'(i3,1p3e24.16,i3,1p2e24.16)') k,h_sub(k),u_sub(k),uh_sub(k),i0,xa,xb
+        if (k<=n0+n1) then
+          if (isub_src(k+1) /= i0) then
+            dh0_eff = 0.; xa = 0.
+          else
+            xa = xb
+          endif
+        endif
+      enddo
+      call MOM_error( FATAL, 'MOM_remapping, remap_via_sub_cells: '//&
+             'Remapping result is inconsistent!' )
+    endif
+    endif ! method<5
+  endif ! debug_bounds
+
+  ! Include the error remapping from source to sub-cells in the estimate of total remapping error
+  uh_err = uh_err + u02_err
+
+  if (present(ah_sub)) ah_sub(1:n0+n1+1) = h_sub(1:n0+n1+1)
+  if (present(aisub_src)) aisub_src(1:n0+n1+1) = isub_src(1:n0+n1+1)
+  if (present(aiss)) aiss(1:n0) = isrc_start(1:n0)
+  if (present(aise)) aise(1:n0) = isrc_end(1:n0)
+
+end subroutine remap_via_sub_cells
+
+!> Returns the intersection of source and targets grids along with and auxiliary lists or indices.
+!!
+!! For source grid with thicknesses h0(1:n0) and target grid with thicknesses  h1(1:n1) the intersection
+!! or "subgrid" has thicknesses h_sub(1:n0+n1+1).
+!! h0 and h1 must have the same units. h_sub will return with the same units as h0 and h1.
+!!
+!! Notes on the algorithm:
+!! Internally, grids are defined by the interfaces (although we describe grids via thicknesses for accuracy).
+!! The intersection or union of two grids is thus defined by the super set of both lists of interfaces.
+!! Because both source and target grids can contain vanished cells, we do not eliminate repeated
+!! interfaces from the union.
+!! That is, the total number of interfaces of the sub-cells is equal to the total numer of interfaces of
+!! the source grid (n0+1) plus the total number of interfaces of the target grid (n1+1), i.e. n0+n1+2.
+!! Whenever target and source interfaces align, then the retention of identical interfaces leads to a
+!! vanished subcell.
+!! The remapping uses a common point of reference to the left (top) so there is always a vanished subcell
+!! at the left (top).
+!! If the total column thicknesses are the same, then the right (bottom) interfaces are also aligned and
+!! so the last subcell will also be vanished.
+subroutine intersect_src_tgt_grids( n0, h0, n1, h1, h_sub, h0_eff, &
+                                    isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  integer, intent(in)  :: n0      !< Number of cells in source grid
+  real,    intent(in)  :: h0(n0)  !< Source grid widths (size n0) [H]
+  integer, intent(in)  :: n1      !< Number of cells in target grid
+  real,    intent(in)  :: h1(n1)  !< Target grid widths (size n1) [H]
+  real,    intent(out) :: h_sub(n0+n1+1) !< Overlapping sub-cell thicknesses, h_sub [H]
+  real,    intent(out) :: h0_eff(n0) !< Effective thickness of source cells [H]
+  integer, intent(out) :: isrc_start(n0) !< Index of first sub-cell within each source cell
+  integer, intent(out) :: isrc_end(n0) !< Index of last sub-cell within each source cell
+  integer, intent(out) :: isrc_max(n0) !< Index of thickest sub-cell within each source cell
+  integer, intent(out) :: itgt_start(n1) !< Index of first sub-cell within each target cell
+  integer, intent(out) :: itgt_end(n1) !< Index of last sub-cell within each target cell
+  integer, intent(out) :: isub_src(n0+n1+1) !< Index of source cell for each sub-cell
+  ! Local variables
+  integer :: i_sub ! Index of sub-cell
+  integer :: i0 ! Index into h0(1:n0), source column
+  integer :: i1 ! Index into h1(1:n1), target column
+  integer :: i_start0 ! Used to record which sub-cells map to source cells
+  integer :: i_start1 ! Used to record which sub-cells map to target cells
+  integer :: i_max ! Used to record which sub-cell is the largest contribution of a source cell
+  real :: dh_max ! Used to record which sub-cell is the largest contribution of a source cell [H]
+  real :: h0_supply, h1_supply ! The amount of width available for constructing sub-cells [H]
+  real :: dh ! The width of the sub-cell [H]
+  real :: dh0_eff ! Running sum of source cell thickness [H]
+  ! For error checking/debugging
+  logical, parameter :: adjust_thickest_subcell = .true. ! To fix round-off conservation issues
+  logical, parameter :: debug_bounds = .false. ! For debugging overshoots etc.
+  integer :: i0_last_thick_cell
+  logical :: src_has_volume !< True if h0 has not been consumed
+  logical :: tgt_has_volume !< True if h1 has not been consumed
+
+  i0_last_thick_cell = 0
+  do i0 = 1, n0
     if (h0(i0)>0.) i0_last_thick_cell = i0
   enddo
 
@@ -661,207 +923,7 @@ subroutine remap_via_sub_cells( n0, h0, u0, ppoly0_E, ppoly0_coefs, n1, h1, meth
     endif
 
   enddo
-
-  ! Loop over each sub-cell to calculate average/integral values within each sub-cell.
-  xa = 0.
-  dh0_eff = 0.
-  uh_sub(1) = 0.
-  u_sub(1) = ppoly0_E(1,1)
-  u02_err = 0.
-  do i_sub = 2, n0+n1
-
-    ! Sub-cell thickness from loop above
-    dh = h_sub(i_sub)
-
-    ! Source cell
-    i0 = isub_src(i_sub)
-
-    ! Evaluate average and integral for sub-cell i_sub.
-    ! Integral is over distance dh but expressed in terms of non-dimensional
-    ! positions with source cell from xa to xb  (0 <= xa <= xb <= 1).
-    dh0_eff = dh0_eff + dh ! Cumulative thickness within the source cell
-    if (h0_eff(i0)>0.) then
-      xb = dh0_eff / h0_eff(i0) ! This expression yields xa <= xb <= 1.0
-      xb = min(1., xb) ! This is only needed when the total target column is wider than the source column
-      u_sub(i_sub) = average_value_ppoly( n0, u0, ppoly0_E, ppoly0_coefs, method, i0, xa, xb)
-    else ! Vanished cell
-      xb = 1.
-      u_sub(i_sub) = u0(i0)
-    endif
-    if (debug_bounds) then
-      if (method<5 .and.(u_sub(i_sub)<u0_min(i0) .or. u_sub(i_sub)>u0_max(i0))) then
-        write(0,*) 'Sub cell average is out of bounds',i_sub,'method=',method
-        write(0,*) 'xa,xb: ',xa,xb
-        write(0,*) 'Edge values: ',ppoly0_E(i0,:),'mean',u0(i0)
-        write(0,*) 'a_c: ',(u0(i0)-ppoly0_E(i0,1))+(u0(i0)-ppoly0_E(i0,2))
-        write(0,*) 'Polynomial coeffs: ',ppoly0_coefs(i0,:)
-        write(0,*) 'Bounds min=',u0_min(i0),'max=',u0_max(i0)
-        write(0,*) 'Average: ',u_sub(i_sub),'rel to min=',u_sub(i_sub)-u0_min(i0),'rel to max=',u_sub(i_sub)-u0_max(i0)
-        call MOM_error( FATAL, 'MOM_remapping, remap_via_sub_cells: '//&
-             'Sub-cell average is out of bounds!' )
-      endif
-    endif
-    if (force_bounds_in_subcell) then
-      ! These next two lines should not be needed but when using PQM we found roundoff
-      ! can lead to overshoots. These lines sweep issues under the rug which need to be
-      ! properly .. later. -AJA
-      u_orig = u_sub(i_sub)
-      u_sub(i_sub) = max( u_sub(i_sub), u0_min(i0) )
-      u_sub(i_sub) = min( u_sub(i_sub), u0_max(i0) )
-      u02_err = u02_err + dh*abs( u_sub(i_sub) - u_orig )
-    endif
-    uh_sub(i_sub) = dh * u_sub(i_sub)
-
-    if (isub_src(i_sub+1) /= i0) then
-      ! If the next sub-cell is in a different source cell, reset the position counters
-      dh0_eff = 0.
-      xa = 0.
-    else
-      xa = xb ! Next integral will start at end of last
-    endif
-
-  enddo
-  u_sub(n0+n1+1) = ppoly0_E(n0,2)                   ! This value is only needed when total target column
-  uh_sub(n0+n1+1) = ppoly0_E(n0,2) * h_sub(n0+n1+1) ! is wider than the source column
-
-  if (adjust_thickest_subcell) then
-    ! Loop over each source cell substituting the integral/average for the thickest sub-cell (within
-    ! the source cell) with the residual of the source cell integral minus the other sub-cell integrals
-    ! aka a genius algorithm for accurate conservation when remapping from Robert Hallberg (@Hallberg-NOAA).
-    do i0 = 1, i0_last_thick_cell
-      i_max = isrc_max(i0)
-      dh_max = h_sub(i_max)
-      if (dh_max > 0.) then
-        ! duh will be the sum of sub-cell integrals within the source cell except for the thickest sub-cell.
-        duh = 0.
-        do i_sub = isrc_start(i0), isrc_end(i0)
-          if (i_sub /= i_max) duh = duh + uh_sub(i_sub)
-        enddo
-        uh_sub(i_max) = u0(i0)*h0(i0) - duh
-        u02_err = u02_err + max( abs(uh_sub(i_max)), abs(u0(i0)*h0(i0)), abs(duh) )
-      endif
-    enddo
-  endif
-
-  ! Loop over each target cell summing the integrals from sub-cells within the target cell.
-  uh_err = 0.
-  do i1 = 1, n1
-    if (h1(i1) > 0.) then
-      duh = 0. ; dh = 0.
-      i_sub = itgt_start(i1)
-      if (force_bounds_in_target) then
-        u1min = u_sub(i_sub)
-        u1max = u_sub(i_sub)
-      endif
-      do i_sub = itgt_start(i1), itgt_end(i1)
-        if (force_bounds_in_target) then
-          u1min = min(u1min, u_sub(i_sub))
-          u1max = max(u1max, u_sub(i_sub))
-        endif
-        dh = dh + h_sub(i_sub)
-        duh = duh + uh_sub(i_sub)
-        ! This accumulates the contribution to the error bound for the sum of u*h
-        uh_err = uh_err + max(abs(duh),abs(uh_sub(i_sub)))*epsilon(duh)
-      enddo
-      u1(i1) = duh / dh
-      ! This is the contribution from the division to the error bound for the sum of u*h
-      uh_err = uh_err + abs(duh)*epsilon(duh)
-      if (force_bounds_in_target) then
-        u_orig = u1(i1)
-        u1(i1) = max(u1min, min(u1max, u1(i1)))
-        ! Adjusting to be bounded contributes to the error for the sum of u*h
-        uh_err = uh_err + dh*abs( u1(i1)-u_orig )
-      endif
-    else
-      u1(i1) = u_sub(itgt_start(i1))
-    endif
-  enddo
-
-  ! Check errors and bounds
-  if (debug_bounds) then
-    call measure_input_bounds( n0, h0, u0, ppoly0_E, h0tot, h0err, u0tot, u0err, u0min, u0max )
-    call measure_output_bounds( n1, h1, u1, h1tot, h1err, u1tot, u1err, u1min, u1max )
-    call measure_output_bounds( n0+n1+1, h_sub, u_sub, h2tot, h2err, u2tot, u2err, u2min, u2max )
-    if (method<5) then ! We except PQM until we've debugged it
-    if (     (abs(u1tot-u0tot)>(u0err+u1err)+uh_err+u02_err .and. abs(h1tot-h0tot)<h0err+h1err) &
-        .or. (abs(u2tot-u0tot)>u0err+u2err+u02_err .and. abs(h2tot-h0tot)<h0err+h2err) &
-        .or. (u1min<u0min .or. u1max>u0max) ) then
-      write(0,*) 'method = ',method
-      write(0,*) 'Source to sub-cells:'
-      write(0,*) 'H: h0tot=',h0tot,'h2tot=',h2tot,'dh=',h2tot-h0tot,'h0err=',h0err,'h2err=',h2err
-      if (abs(h2tot-h0tot)>h0err+h2err) &
-        write(0,*) 'H non-conservation difference=',h2tot-h0tot,'allowed err=',h0err+h2err,' <-----!'
-      write(0,*) 'UH: u0tot=',u0tot,'u2tot=',u2tot,'duh=',u2tot-u0tot,'u0err=',u0err,'u2err=',u2err,&
-                 'adjustment err=',u02_err
-      if (abs(u2tot-u0tot)>u0err+u2err) &
-        write(0,*) 'U non-conservation difference=',u2tot-u0tot,'allowed err=',u0err+u2err,' <-----!'
-      write(0,*) 'Sub-cells to target:'
-      write(0,*) 'H: h2tot=',h2tot,'h1tot=',h1tot,'dh=',h1tot-h2tot,'h2err=',h2err,'h1err=',h1err
-      if (abs(h1tot-h2tot)>h2err+h1err) &
-        write(0,*) 'H non-conservation difference=',h1tot-h2tot,'allowed err=',h2err+h1err,' <-----!'
-      write(0,*) 'UH: u2tot=',u2tot,'u1tot=',u1tot,'duh=',u1tot-u2tot,'u2err=',u2err,'u1err=',u1err,'uh_err=',uh_err
-      if (abs(u1tot-u2tot)>u2err+u1err) &
-        write(0,*) 'U non-conservation difference=',u1tot-u2tot,'allowed err=',u2err+u1err,' <-----!'
-      write(0,*) 'Source to target:'
-      write(0,*) 'H: h0tot=',h0tot,'h1tot=',h1tot,'dh=',h1tot-h0tot,'h0err=',h0err,'h1err=',h1err
-      if (abs(h1tot-h0tot)>h0err+h1err) &
-        write(0,*) 'H non-conservation difference=',h1tot-h0tot,'allowed err=',h0err+h1err,' <-----!'
-      write(0,*) 'UH: u0tot=',u0tot,'u1tot=',u1tot,'duh=',u1tot-u0tot,'u0err=',u0err,'u1err=',u1err,'uh_err=',uh_err
-      if (abs(u1tot-u0tot)>(u0err+u1err)+uh_err) &
-        write(0,*) 'U non-conservation difference=',u1tot-u0tot,'allowed err=',u0err+u1err+uh_err,' <-----!'
-      write(0,*) 'U: u0min=',u0min,'u1min=',u1min,'u2min=',u2min
-      if (u1min<u0min) write(0,*) 'U minimum overshoot=',u1min-u0min,' <-----!'
-      if (u2min<u0min) write(0,*) 'U2 minimum overshoot=',u2min-u0min,' <-----!'
-      write(0,*) 'U: u0max=',u0max,'u1max=',u1max,'u2max=',u2max
-      if (u1max>u0max) write(0,*) 'U maximum overshoot=',u1max-u0max,' <-----!'
-      if (u2max>u0max) write(0,*) 'U2 maximum overshoot=',u2max-u0max,' <-----!'
-      write(0,'(a3,6a24,2a3)') 'k','h0','left edge','u0','right edge','h1','u1','is','ie'
-      do k = 1, max(n0,n1)
-        if (k<=min(n0,n1)) then
-          write(0,'(i3,1p6e24.16,2i3)') k,h0(k),ppoly0_E(k,1),u0(k),ppoly0_E(k,2),h1(k),u1(k),itgt_start(k),itgt_end(k)
-        elseif (k>n0) then
-          write(0,'(i3,96x,1p2e24.16,2i3)') k,h1(k),u1(k),itgt_start(k),itgt_end(k)
-        else
-          write(0,'(i3,1p4e24.16)') k,h0(k),ppoly0_E(k,1),u0(k),ppoly0_E(k,2)
-        endif
-      enddo
-      write(0,'(a3,2a24)') 'k','u0','Polynomial coefficients'
-      do k = 1, n0
-        write(0,'(i3,1p6e24.16)') k,u0(k),ppoly0_coefs(k,:)
-      enddo
-      write(0,'(a3,3a24,a3,2a24)') 'k','Sub-cell h','Sub-cell u','Sub-cell hu','i0','xa','xb'
-      xa = 0.
-      dh0_eff = 0.
-      do k = 1, n0+n1+1
-        dh = h_sub(k)
-        i0 = isub_src(k)
-        dh0_eff = dh0_eff + dh ! Cumulative thickness within the source cell
-        xb = dh0_eff / h0_eff(i0) ! This expression yields xa <= xb <= 1.0
-        xb = min(1., xb) ! This is only needed when the total target column is wider than the source column
-        write(0,'(i3,1p3e24.16,i3,1p2e24.16)') k,h_sub(k),u_sub(k),uh_sub(k),i0,xa,xb
-        if (k<=n0+n1) then
-          if (isub_src(k+1) /= i0) then
-            dh0_eff = 0.; xa = 0.
-          else
-            xa = xb
-          endif
-        endif
-      enddo
-      call MOM_error( FATAL, 'MOM_remapping, remap_via_sub_cells: '//&
-             'Remapping result is inconsistent!' )
-    endif
-    endif ! method<5
-  endif ! debug_bounds
-
-  ! Include the error remapping from source to sub-cells in the estimate of total remapping error
-  uh_err = uh_err + u02_err
-
-  if (present(ah_sub)) ah_sub(1:n0+n1+1) = h_sub(1:n0+n1+1)
-  if (present(aisub_src)) aisub_src(1:n0+n1+1) = isub_src(1:n0+n1+1)
-  if (present(aiss)) aiss(1:n0) = isrc_start(1:n0)
-  if (present(aise)) aise(1:n0) = isrc_end(1:n0)
-
-end subroutine remap_via_sub_cells
+end subroutine intersect_src_tgt_grids
 
 !> Linearly interpolate interface data, u_src, from grid h_src to a grid h_dest
 subroutine interpolate_column(nsrc, h_src, u_src, ndest, h_dest, u_dest, mask_edges)
@@ -1362,6 +1424,8 @@ logical function remapping_unit_tests(verbose)
   real, allocatable, dimension(:,:) :: ppoly0_E     ! Edge values of polynomials [A]
   real, allocatable, dimension(:,:) :: ppoly0_S     ! Edge slopes of polynomials [A H-1]
   real, allocatable, dimension(:,:) :: ppoly0_coefs ! Coefficients of polynomials [A]
+  real, allocatable, dimension(:) :: h_sub, h0_eff ! Subgrid and effective source thicknesses [H]
+  integer, allocatable, dimension(:) :: isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src ! Indices
   integer :: answer_date  ! The vintage of the expressions to test
   real, parameter :: hNeglect_dflt = 1.0e-30 ! A thickness [H ~> m or kg m-2] that can be
                                       ! added to thicknesses in a denominator without
@@ -1428,9 +1492,13 @@ logical function remapping_unit_tests(verbose)
                             3, (/2.25,1.5,1./), INTEGRATION_PPM, .false., u2, err )
   call test%real_arr(3, u2, (/3.,-10.5,-12./), 'remap_via_sub_cells() 4')
 
+  deallocate(ppoly0_E, ppoly0_S, ppoly0_coefs)
+
+  ! ===============================================
+  ! This section tests the reconstruction functions
+  ! ===============================================
   if (verbose) write(stdout,*) '  - - - - - reconstruction tests - - - - -'
 
-  deallocate(ppoly0_E, ppoly0_S, ppoly0_coefs)
   allocate(ppoly0_coefs(5,6))
   allocate(ppoly0_E(5,2))
   allocate(ppoly0_S(5,2))
@@ -1508,6 +1576,10 @@ logical function remapping_unit_tests(verbose)
   call test%real_arr(5, ppoly0_coefs(:,2), (/0.,6.,0.,0.,0./), 'Limits PPM: P1')
   call test%real_arr(5, ppoly0_coefs(:,3), (/0.,-3.,3.,0.,0./), 'Limits PPM: P2')
 
+  ! ==============================================================
+  ! This section tests the components of remapping_via_sub_cells()
+  ! ==============================================================
+
   call PLM_reconstruction(4, (/0.,1.,1.,0./), (/5.,4.,2.,1./), ppoly0_E(1:4,:), &
                           ppoly0_coefs(1:4,:), h_neglect )
   call test%real_arr(4, ppoly0_E(1:4,1), (/5.,5.,3.,1./), 'PPM: left edges h=0110')
@@ -1520,6 +1592,179 @@ logical function remapping_unit_tests(verbose)
   deallocate(ppoly0_E, ppoly0_S, ppoly0_coefs)
 
   if (verbose) write(stdout,*) '  - - - - - interpolation tests - - - - -'
+
+  ! Test 1: n0=2, n1=3  Maps uniform grids with one extra target layer and no implicitly-vanished interior sub-layers
+  ! h_src =     |       3        |        3       |
+  ! h_tgt =     |     2    |     2     |    2     |
+  ! h_sub =     |0|   2    |  1  |  1  |    2   |0|
+  ! isrc_start  |1               |  4             |
+  ! isrc_end    |             3  |          5     |
+  ! isrc_max    |     2          |          5     |
+  ! itgt_start  |1         |  3        |    5     |
+  ! itgt_end    |     2    |        4  |         6|
+  ! isub_src    |1|   1    |  1  |  2  |    2   |2|
+  allocate( h_sub(6), h0_eff(2), isrc_start(2), isrc_end(2), isrc_max(2), itgt_start(3), itgt_end(3), isub_src(6) )
+  call intersect_src_tgt_grids( 2, (/3., 3./), &  ! n0, h0
+                                3, (/2., 2., 2./), &  ! n1, h1
+                                h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  if (verbose) write(stdout,*) "intersect_src_tgt_grids test 1: n0=2, n1=3"
+  if (verbose) write(stdout,*) "  h_src =     |     3     |     3     |"
+  if (verbose) write(stdout,*) "  h_tgt =     |   2   |   2   |   2   |"
+  call test%real_arr(6, h_sub, (/0.,2.,1.,1.,2.,0./), 'h_sub')
+  call test%real_arr(2, h0_eff, (/3.,3./), 'h0_eff')
+  call test%int_arr(2, isrc_start, (/1,4/), 'isrc_start')
+  call test%int_arr(2, isrc_end, (/3,5/), 'isrc_end')
+  call test%int_arr(2, isrc_max, (/2,5/), 'isrc_max')
+  call test%int_arr(3, itgt_start, (/1,3,5/), 'itgt_start')
+  call test%int_arr(3, itgt_end, (/2,4,6/), 'itgt_end')
+  call test%int_arr(6, isub_src, (/1,1,1,2,2,2/), 'isub_src')
+  deallocate( h_sub, h0_eff, isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! Test 2: n0=3, n1=2  Reverses "test 1" with more source than target layers
+  ! h_src =     |    2    |     2     |    2    |
+  ! h_tgt =     |      3        |        3      |
+  ! h_sub =     |0|  2    |  1  |  1  |    2  |0|
+  ! isrc_start  |1        |  3        |    5    |
+  ! isrc_end    |    2    |        4  |    5    |
+  ! isrc_max    |    2    |        4  |    5    |
+  ! itgt_start  |1              |  4            |
+  ! itgt_end    |            3  |              6|
+  ! isub_src    |1|  1    |  2  |  2  |    3  |3|
+  allocate( h_sub(6), h0_eff(3), isrc_start(3), isrc_end(3), isrc_max(3), itgt_start(2), itgt_end(2), isub_src(6) )
+  call intersect_src_tgt_grids( 3, (/2., 2., 2./), &  ! n0, h0
+                                2, (/3., 3./), &  ! n1, h1
+                                h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  if (verbose) write(stdout,*) "intersect_src_tgt_grids test 2: n0=3, n1=2"
+  if (verbose) write(stdout,*) "  h_src =     |   2   |   2   |   2   |"
+  if (verbose) write(stdout,*) "  h_tgt =     |     3     |     3     |"
+  call test%real_arr(6, h_sub, (/0.,2.,1.,1.,2.,0./), 'h_sub')
+  call test%real_arr(3, h0_eff, (/2.,2.,2./), 'h0_eff')
+  call test%int_arr(3, isrc_start, (/1,3,5/), 'isrc_start')
+  call test%int_arr(3, isrc_end, (/2,4,5/), 'isrc_end')
+  call test%int_arr(3, isrc_max, (/2,4,5/), 'isrc_max')
+  call test%int_arr(2, itgt_start, (/1,4/), 'itgt_start')
+  call test%int_arr(2, itgt_end, (/3,6/), 'itgt_end')
+  call test%int_arr(6, isub_src, (/1,1,2,2,3,3/), 'isub_src')
+  deallocate( h_sub, h0_eff, isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! Test 3: n0=2, n1=3  With aligned interfaces that lead to implicitly-vanished interior sub-layers
+  ! h_src =     |     2     |         4         |
+  ! h_tgt =     |     2     |    2    |    2    |
+  ! h_sub =     |0|   2     |0|  2    |    2  |0|
+  ! isrc_start  |1          |3                  |
+  ! isrc_end    |     2     |              5    |
+  ! isrc_max    |     2     |              5    |
+  ! itgt_start  |1          |    4    |    5    |
+  ! itgt_end    |            3|  4    |        6|
+  ! isub_src    |1|   1     |2|  2    |    2  |2|
+  allocate( h_sub(6), h0_eff(2), isrc_start(2), isrc_end(2), isrc_max(2), itgt_start(3), itgt_end(3), isub_src(6) )
+  call intersect_src_tgt_grids( 2, (/2., 4./), &  ! n0, h0
+                                3, (/2., 2., 2./), &  ! n1, h1
+                                h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  if (verbose) write(stdout,*) "intersect_src_tgt_grids test 3: n0=2, n1=3"
+  if (verbose) write(stdout,*) "  h_src =     |   2   |       4       |"
+  if (verbose) write(stdout,*) "  h_tgt =     |   2   |   2   |   2   |"
+  call test%real_arr(6, h_sub, (/0.,2.,0.,2.,2.,0./), 'h_sub')
+  call test%real_arr(2, h0_eff, (/2.,4./), 'h0_eff')
+  call test%int_arr(2, isrc_start, (/1,3/), 'isrc_start')
+  call test%int_arr(2, isrc_end, (/2,5/), 'isrc_end')
+  call test%int_arr(2, isrc_max, (/2,5/), 'isrc_max')
+  call test%int_arr(3, itgt_start, (/1,4,5/), 'itgt_start')
+  call test%int_arr(3, itgt_end, (/3,4,6/), 'itgt_end')
+  call test%int_arr(6, isub_src, (/1,1,2,2,2,2/), 'isub_src')
+  deallocate( h_sub, h0_eff, isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! Test 4: n0=2, n1=3  Incomplete target column, sum(h_tgt)<sum(h_src), useful for diagnostics
+  ! h_src =     |     2     |         4           |
+  ! h_tgt =     |     2     |    2    |  1  |
+  ! h_sub =     |0|   2     |0|  2    |  1  |  1  |
+  ! isrc_start  |1          |3                    |
+  ! isrc_end    |     2     |                  6  |
+  ! isrc_max    |     2     |    4                |
+  ! itgt_start  |1          |    4    |  5  |
+  ! itgt_end    |            3|  4    |  5  |
+  ! isub_src    |1|   1     |2|  2    |  2  |  2  |
+  allocate( h_sub(6), h0_eff(2), isrc_start(2), isrc_end(2), isrc_max(2), itgt_start(3), itgt_end(3), isub_src(6) )
+  call intersect_src_tgt_grids( 2, (/2., 4./), &  ! n0, h0
+                                3, (/2., 2., 1./), &  ! n1, h1
+                                h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  if (verbose) write(stdout,*) "intersect_src_tgt_grids test 4: n0=2, n1=3"
+  if (verbose) write(stdout,*) "  h_src =     |   2   |       4       |"
+  if (verbose) write(stdout,*) "  h_tgt =     |   2   |   2   | 1 |"
+  call test%real_arr(6, h_sub, (/0.,2.,0.,2.,1.,1./), 'h_sub')
+  call test%real_arr(2, h0_eff, (/2.,3./), 'h0_eff')
+  call test%int_arr(2, isrc_start, (/1,3/), 'isrc_start')
+  call test%int_arr(2, isrc_end, (/2,6/), 'isrc_end')
+  call test%int_arr(2, isrc_max, (/2,4/), 'isrc_max')
+  call test%int_arr(3, itgt_start, (/1,4,5/), 'itgt_start')
+  call test%int_arr(3, itgt_end, (/3,4,5/), 'itgt_end')
+  call test%int_arr(6, isub_src, (/1,1,2,2,2,2/), 'isub_src')
+  deallocate( h_sub, h0_eff, isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! Test 5: n0=2, n1=3  Target column exceeds source column, sum(h_tgt)>sum(h_src), useful for diagnostics
+  ! h_src =     |     2     |    2    |  1  |
+  ! h_tgt =     |     2     |         4           |
+  ! h_sub =     |0|   2     |0|  2    |  1  |  1  |
+  ! isrc_start  |1          |3        |  5        |
+  ! isrc_end    |     2     |    4    |  5        |
+  ! isrc_max    |     2     |    4    |  5  |     |
+  ! itgt_start  |1          |    4                |
+  ! itgt_end    |            3|                6  |
+  ! isub_src    |1|   1     |2|  2    |  3  |  3  |
+  allocate( h_sub(6), h0_eff(3), isrc_start(3), isrc_end(3), isrc_max(3), itgt_start(3), itgt_end(3), isub_src(6) )
+  call intersect_src_tgt_grids( 3, (/2., 2., 1./), &  ! n0, h0
+                                2, (/2., 4./), &  ! n1, h1
+                                h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  if (verbose) write(stdout,*) "intersect_src_tgt_grids test 5: n0=3, n1=2"
+  if (verbose) write(stdout,*) "  h_src =     |   2   |   2   | 1 |"
+  if (verbose) write(stdout,*) "  h_tgt =     |   2   |       4       |"
+  call test%real_arr(6, h_sub, (/0.,2.,0.,2.,1.,1./), 'h_sub')
+  call test%real_arr(3, h0_eff, (/2.,2.,1./), 'h0_eff')
+  call test%int_arr(3, isrc_start, (/1,3,5/), 'isrc_start')
+  call test%int_arr(3, isrc_end, (/2,4,5/), 'isrc_end')
+  call test%int_arr(3, isrc_max, (/2,4,5/), 'isrc_max')
+  call test%int_arr(2, itgt_start, (/1,4/), 'itgt_start')
+  call test%int_arr(2, itgt_end, (/3,6/), 'itgt_end')
+  call test%int_arr(6, isub_src, (/1,1,2,2,3,3/), 'isub_src')
+  deallocate( h_sub, h0_eff, isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! Test 6: n0=3, n1=5  Source and targets with vanished layers
+  ! h_src =     |      2      |0|      2      |
+  ! h_tgt =     |  1  |0|  1  |0|      2      |
+  ! h_sub =     |0| 1 |0|  1  |0|0|0|   2   |0|
+  ! isrc_start  |1            |5|6            |
+  ! isrc_end    |          4  |5|       8     |
+  ! isrc_max    |          4  |5|       8     |
+  ! itgt_start  |1    |3|  4      |7|   8     |
+  ! itgt_end    |   2 |3|        6|7|        9|
+  ! isub_src    |1| 1 |1|  1  |2|3|3|  3    |3|
+  allocate( h_sub(9), h0_eff(3), isrc_start(3), isrc_end(3), isrc_max(3), itgt_start(5), itgt_end(5), isub_src(9) )
+  call intersect_src_tgt_grids( 3, (/2., 0., 2./), &  ! n0, h0
+                                5, (/1., 0., 1., 0., 2./), &  ! n1, h1
+                                h_sub, h0_eff, &
+                                isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+  if (verbose) write(stdout,*) "intersect_src_tgt_grids test 6: n0=3, n1=5"
+  if (verbose) write(stdout,*) "  h_src =     |    2    |0|    2    |"
+  if (verbose) write(stdout,*) "  h_tgt =     | 1 |0| 1 |0|    2    |"
+  call test%real_arr(9, h_sub, (/0.,1.,0.,1.,0.,0.,0.,2.,0./), 'h_sub')
+  call test%real_arr(3, h0_eff, (/2.,0.,2./), 'h0_eff')
+  call test%int_arr(3, isrc_start, (/1,5,6/), 'isrc_start')
+  call test%int_arr(3, isrc_end, (/4,5,8/), 'isrc_end')
+  call test%int_arr(3, isrc_max, (/4,5,8/), 'isrc_max')
+  call test%int_arr(5, itgt_start, (/1,3,4,7,8/), 'itgt_start')
+  call test%int_arr(5, itgt_end, (/2,3,6,7,9/), 'itgt_end')
+  call test%int_arr(9, isub_src, (/1,1,1,1,2,3,3,3,3/), 'isub_src')
+  deallocate( h_sub, h0_eff, isrc_start, isrc_end, isrc_max, itgt_start, itgt_end, isub_src )
+
+  ! ============================================================
+  ! This section tests interpolation and reintegration functions
+  ! ============================================================
+  if (verbose) write(stdout,*) '- - - - - - - - - - interpolation tests  - - - - - - - - -'
 
   call test_interp(test, 'Identity: 3 layer', &
                      3, (/1.,2.,3./), (/1.,2.,3.,4./), &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -441,6 +441,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   real               :: Lscale_in, Lscale_out ! parameters controlling tracer values at the boundaries [L ~> m]
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: check_reconstruction, check_remapping, force_bounds_in_subcell
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
   character(len=64)  :: remappingScheme
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -695,10 +696,15 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date)
+    call get_param(param_file, mdl, "OBC_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for neutral diffusion. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for more details. "//&
+                 "We recommend setting this option to false.", default=.true.)
 
     allocate(OBC%remap_CS)
     call initialize_remapping(OBC%remap_CS, remappingScheme, boundary_extrapolation = .false., &
                check_reconstruction=check_reconstruction, check_remapping=check_remapping, &
+               om4_remap_via_sub_cells=om4_remap_via_sub_cells, &
                force_bounds_in_subcell=force_bounds_in_subcell, answer_date=OBC%remap_answer_date)
 
   endif ! OBC%number_of_segments > 0

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -1580,6 +1580,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   logical :: better_speed_est ! If true, use a more robust estimate of the first
                               ! mode wave speed as the starting point for iterations.
   logical :: split            ! True if using the barotropic-baroclinic split algorithm
+  logical :: om4_remap_via_sub_cells ! Use the OM4-era ramap_via_sub_cells for calculating the EBT structure
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_diagnostics" ! This module's name.
@@ -1617,6 +1618,10 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
   call get_param(param_file, mdl, "INTERNAL_WAVE_SPEED_BETTER_EST", better_speed_est, &
                  "If true, use a more robust estimate of the first mode wave speed as the "//&
                  "starting point for iterations.", default=.true.)
+  call get_param(param_file, mdl, "INTWAVE_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for calculating EBT structure. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for details. "//&
+                 "We recommend setting this option to false.", default=.true.)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
                  default=99991231)
@@ -1858,7 +1863,7 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
       (CS%id_cg_ebt>0) .or. (CS%id_Rd_ebt>0) .or. (CS%id_p_ebt>0)) then
     call wave_speed_init(CS%wave_speed, remap_answer_date=remap_answer_date, &
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &
-                         wave_speed_tol=wave_speed_tol)
+                         wave_speed_tol=wave_speed_tol, om4_remap_via_sub_cells=om4_remap_via_sub_cells)
   endif
 
   CS%id_mass_wt = register_diag_field('ocean_model', 'mass_wt', diag%axesT1, Time, &

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -1611,7 +1611,8 @@ end subroutine tridiag_det
 
 !> Initialize control structure for MOM_wave_speed
 subroutine wave_speed_init(CS, use_ebt_mode, mono_N2_column_fraction, mono_N2_depth, remap_answers_2018, &
-                           remap_answer_date, better_speed_est, min_speed, wave_speed_tol, c1_thresh)
+                           remap_answer_date, better_speed_est, om4_remap_via_sub_cells, &
+                           min_speed, wave_speed_tol, c1_thresh)
   type(wave_speed_CS), intent(inout) :: CS  !< Wave speed control struct
   logical, optional, intent(in) :: use_ebt_mode  !< If true, use the equivalent
                                      !! barotropic mode instead of the first baroclinic mode.
@@ -1630,6 +1631,8 @@ subroutine wave_speed_init(CS, use_ebt_mode, mono_N2_column_fraction, mono_N2_de
                                       !! forms of the same remapping expressions.
   logical, optional, intent(in) :: better_speed_est !< If true, use a more robust estimate of the first
                                      !! mode speed as the starting point for iterations.
+  logical, optional, intent(in) :: om4_remap_via_sub_cells !< Use the OM4-era ramap_via_sub_cells
+                                     !! for calculating the EBT structure
   real,    optional, intent(in) :: min_speed !< If present, set a floor in the first mode speed
                                      !! below which 0 is returned [L T-1 ~> m s-1].
   real,    optional, intent(in) :: wave_speed_tol !< The fractional tolerance for finding the
@@ -1656,6 +1659,7 @@ subroutine wave_speed_init(CS, use_ebt_mode, mono_N2_column_fraction, mono_N2_de
 
   ! The remap_answers_2018 argument here is irrelevant, because remapping is hard-coded to use PLM.
   call initialize_remapping(CS%remapping_CS, 'PLM', boundary_extrapolation=.false., &
+                            om4_remap_via_sub_cells=om4_remap_via_sub_cells, &
                             answer_date=CS%remap_answer_date)
 
 end subroutine wave_speed_init

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -3249,6 +3249,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                                   ! answers from 2018, while higher values use more robust
                                   ! forms of the same remapping expressions.
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: om4_remap_via_sub_cells ! Use the OM4-era ramap_via_sub_cells for diagnostics
   character(len=8)   :: this_pe
   character(len=240) :: doc_file, doc_file_dflt, doc_path
   character(len=240), allocatable :: diag_coords(:)
@@ -3280,6 +3281,10 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
                  default=99991231)
+  call get_param(param_file, mdl, "DIAG_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for diagnostics. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for details. "//&
+                 "We recommend setting this option to false.", default=.true.)
   call get_param(param_file, mdl, "REMAPPING_ANSWER_DATE", remap_answer_date, &
                  "The vintage of the expressions and order of arithmetic to use for remapping.  "//&
                  "Values below 20190101 result in the use of older, less accurate expressions "//&
@@ -3309,7 +3314,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
     allocate(diag_cs%diag_remap_cs(diag_cs%num_diag_coords))
     ! Initialize each diagnostic vertical coordinate
     do i=1, diag_cs%num_diag_coords
-      call diag_remap_init(diag_cs%diag_remap_cs(i), diag_coords(i), answer_date=remap_answer_date, GV=GV)
+      call diag_remap_init(diag_cs%diag_remap_cs(i), diag_coords(i), om4_remap_via_sub_cells, remap_answer_date, GV)
     enddo
     deallocate(diag_coords)
   endif

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -92,6 +92,7 @@ type :: diag_remap_ctrl
                                       !! vertical extents in [Z ~> m] for remapping extensive variables
   integer :: interface_axes_id = 0 !< Vertical axes id for remapping at interfaces
   integer :: layer_axes_id = 0 !< Vertical axes id for remapping on layers
+  logical :: om4_remap_via_sub_cells !< Use the OM4-era ramap_via_sub_cells
   integer :: answer_date      !< The vintage of the order of arithmetic and expressions
                               !! to use for remapping.  Values below 20190101 recover
                               !! the answers from 2018, while higher values use more
@@ -102,10 +103,11 @@ end type diag_remap_ctrl
 contains
 
 !> Initialize a diagnostic remapping type with the given vertical coordinate.
-subroutine diag_remap_init(remap_cs, coord_tuple, answer_date, GV)
+subroutine diag_remap_init(remap_cs, coord_tuple, om4_remap_via_sub_cells, answer_date, GV)
   type(diag_remap_ctrl), intent(inout) :: remap_cs    !< Diag remapping control structure
   character(len=*),      intent(in)    :: coord_tuple !< A string in form of
                                                       !! MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME
+  logical,               intent(in)    :: om4_remap_via_sub_cells !< Use the OM4-era ramap_via_sub_cells
   integer,               intent(in)    :: answer_date !< The vintage of the order of arithmetic and expressions
                                                       !! to use for remapping.  Values below 20190101 recover
                                                       !! the answers from 2018, while higher values use more
@@ -127,6 +129,7 @@ subroutine diag_remap_init(remap_cs, coord_tuple, answer_date, GV)
   remap_cs%configured = .false.
   remap_cs%initialized = .false.
   remap_cs%used = .false.
+  remap_cs%om4_remap_via_sub_cells = om4_remap_via_sub_cells
   remap_cs%answer_date = answer_date
   remap_cs%nz = 0
 
@@ -309,6 +312,7 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state, h_targe
   if (.not. remap_cs%initialized) then
     ! Initialize remapping and regridding on the first call
     call initialize_remapping(remap_cs%remap_cs, 'PPM_IH4', boundary_extrapolation=.false., &
+                              om4_remap_via_sub_cells=remap_cs%om4_remap_via_sub_cells, &
                               answer_date=remap_cs%answer_date)
     remap_cs%initialized = .true.
   endif

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2503,6 +2503,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
   character(len=64) :: remappingScheme
   real :: tempAvg  ! Spatially averaged temperatures on a layer [C ~> degC]
   real :: saltAvg  ! Spatially averaged salinities on a layer [S ~> ppt]
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm (only used if useALEremapping)
   logical :: do_conv_adj, ignore
   integer :: nPoints
   integer :: id_clock_routine, id_clock_ALE
@@ -2582,6 +2583,10 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date, do_not_log=just_read.or.(.not.GV%Boussinesq))
+    call get_param(PF, mdl, "Z_INIT_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for initialization. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for more details. "//&
+                 "We recommend setting this option to false.", default=.true.)
     if (.not.GV%Boussinesq) remap_answer_date = max(remap_answer_date, 20230701)
   endif
   call get_param(PF, mdl, "HOR_REGRID_ANSWER_DATE", hor_regrid_answer_date, &
@@ -2752,7 +2757,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
     ! Build the target grid (and set the model thickness to it)
 
     call ALE_initRegridding( GV, US, G%max_depth, PF, mdl, regridCS ) ! sets regridCS
-    call initialize_remapping( remapCS, remappingScheme, boundary_extrapolation=.false., answer_date=remap_answer_date )
+    call initialize_remapping( remapCS, remappingScheme, boundary_extrapolation=.false., &
+                               om4_remap_via_sub_cells=om4_remap_via_sub_cells, answer_date=remap_answer_date )
 
     ! Now remap from source grid to target grid, first setting reconstruction parameters
     if (remap_general) then

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -96,6 +96,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                                   ! remapping cell reconstructions [Z ~> m]
   real :: dz_neglect_edge         ! A negligibly small vertical layer extent used in
                                   ! remapping edge value calculations [Z ~> m]
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
   integer :: nPoints    ! The number of valid input data points in a column
   integer :: id_clock_routine, id_clock_ALE
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
@@ -137,6 +138,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
+    call get_param(PF, mdl, "Z_INIT_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for initialization. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for more details. "//&
+                 "We recommend setting this option to false.", default=.true.)
     if (.not.GV%Boussinesq) remap_answer_date = max(remap_answer_date, 20230701)
   endif
   call get_param(PF, mdl, "HOR_REGRID_ANSWER_DATE", hor_regrid_answer_date, &
@@ -174,7 +179,8 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
     allocate( dzSrc(isd:ied,jsd:jed,kd) )
     allocate( hSrc(isd:ied,jsd:jed,kd) )
     ! Set parameters for reconstructions
-    call initialize_remapping( remapCS, remapScheme, boundary_extrapolation=.false., answer_date=remap_answer_date )
+    call initialize_remapping( remapCS, remapScheme, boundary_extrapolation=.false., &
+                               om4_remap_via_sub_cells=om4_remap_via_sub_cells, answer_date=remap_answer_date )
     ! Next we initialize the regridding package so that it knows about the target grid
 
     do j = js, je ; do i = is, ie

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -183,6 +183,7 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
   character(len=80) :: remap_scheme
   character(len=80) :: bias_correction_file, inc_file
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
 
   if (associated(CS)) call MOM_error(FATAL, 'Calling oda_init with associated control structure')
   allocate(CS)
@@ -320,8 +321,10 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
   call get_param(PF, 'oda_driver', "REGRIDDING_COORDINATE_MODE", coord_mode, &
        "Coordinate mode for vertical regridding.", &
        default="ZSTAR", fail_if_missing=.false.)
+  call get_param(PF, mdl, "REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 do_not_log=.true., default=.true.)
   call initialize_regridding(CS%regridCS, CS%GV, CS%US, dG%max_depth,PF,'oda_driver',coord_mode,'','')
-  call initialize_remapping(CS%remapCS,remap_scheme)
+  call initialize_remapping(CS%remapCS, remap_scheme, om4_remap_via_sub_cells=om4_remap_via_sub_cells)
   call set_regrid_params(CS%regridCS, min_thickness=0.)
   isd = G%isd; ied = G%ied; jsd = G%jsd; jed = G%jed
 

--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -139,6 +139,8 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
   real    :: nhours_incupd, dt, dt_therm
   character(len=256) :: mesg
   character(len=64)  :: remapScheme
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
+
   if (.not.associated(CS)) then
     call MOM_error(WARNING, "initialize_oda_incupd called without an associated "// &
                             "control structure.")
@@ -191,6 +193,8 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
                  "When defined, the incoming oda_incupd data are "//&
                  "assumed to be on the model horizontal grid " , &
                  default=.true.)
+  call get_param(param_file, mdl, "REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 do_not_log=.true., default=.true.)
 
   CS%nz = GV%ke
 
@@ -232,7 +236,7 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
   ! Call the constructor for remapping control structure
   !### Revisit this hard-coded answer_date.
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
-                            answer_date=20190101)
+                            om4_remap_via_sub_cells=om4_remap_via_sub_cells, answer_date=20190101)
 end subroutine initialize_oda_incupd
 
 

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -2550,6 +2550,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   real, dimension(:,:), allocatable :: ridge_temp ! array for temporary storage of flags
                                                   ! of cells with double-reflecting ridges [nondim]
   logical :: use_int_tides, use_temperature
+  logical :: om4_remap_via_sub_cells ! Use the OM4-era ramap_via_sub_cells for calculating the EBT structure
   real    :: IGW_c1_thresh ! A threshold first mode internal wave speed below which all higher
                  ! mode speeds are not calculated but simply assigned a speed of 0 [L T-1 ~> m s-1].
   real    :: kappa_h2_factor    ! A roughness scaling factor [nondim]
@@ -2726,6 +2727,10 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  "mode speeds are not calculated but are simply reported as 0.  This must be "//&
                  "non-negative for the wave_speeds routine to be used.", &
                  units="m s-1", default=0.01, scale=US%m_s_to_L_T)
+  call get_param(param_file, mdl, "INTWAVE_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for calculating EBT structure. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for details. "//&
+                 "We recommend setting this option to false.", default=.true.)
 
   call get_param(param_file, mdl, "UNIFORM_TEST_CG", CS%uniform_test_cg, &
                  "If positive, a uniform group velocity of internal tide for test case", &
@@ -3107,7 +3112,8 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   enddo
 
   ! Initialize the module that calculates the wave speeds.
-  call wave_speed_init(CS%wave_speed, c1_thresh=IGW_c1_thresh)
+  call wave_speed_init(CS%wave_speed, c1_thresh=IGW_c1_thresh, &
+                       om4_remap_via_sub_cells=om4_remap_via_sub_cells)
 
 end subroutine internal_tides_init
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1204,6 +1204,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                               ! mode wave speed as the starting point for iterations.
   real :: Stanley_coeff    ! Coefficient relating the temperature gradient and sub-gridscale
                            ! temperature variance [nondim]
+  logical :: om4_remap_via_sub_cells ! Use the OM4-era ramap_via_sub_cells for calculating the EBT structure
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_lateral_mixing_coeffs" ! This module's name.
@@ -1607,10 +1608,14 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     call get_param(param_file, mdl, "INTERNAL_WAVE_SPEED_BETTER_EST", better_speed_est, &
                  "If true, use a more robust estimate of the first mode wave speed as the "//&
                  "starting point for iterations.", default=.true.)
+    call get_param(param_file, mdl, "EBT_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for calculating EBT structure. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for details. "//&
+                 "We recommend setting this option to false.", default=.true.)
     call wave_speed_init(CS%wave_speed, use_ebt_mode=CS%Resoln_use_ebt, &
                          mono_N2_depth=N2_filter_depth, remap_answer_date=remap_answer_date, &
                          better_speed_est=better_speed_est, min_speed=wave_speed_min, &
-                         wave_speed_tol=wave_speed_tol)
+                         om4_remap_via_sub_cells=om4_remap_via_sub_cells, wave_speed_tol=wave_speed_tol)
   endif
 
   ! Leith parameters

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -188,6 +188,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
   logical :: data_h_to_Z
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
   integer :: i, j, k, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
@@ -232,6 +233,10 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) CS%remap_answer_date = max(CS%remap_answer_date, 20230701)
+  call get_param(param_file, mdl, "SPONGE_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for ALE sponge. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for more details. "//&
+                 "We recommend setting this option to false.", default=.true.)
 
   call get_param(param_file, mdl, "HOR_REGRID_ANSWER_DATE", CS%hor_regrid_answer_date, &
                  "The vintage of the order of arithmetic for horizontal regridding.  "//&
@@ -282,6 +287,7 @@ subroutine initialize_ALE_sponge_fixed(Iresttime, G, GV, param_file, CS, data_h,
 
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
+                            om4_remap_via_sub_cells=om4_remap_via_sub_cells, &
                             answer_date=CS%remap_answer_date)
 
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
@@ -466,6 +472,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, US, param_file, CS, I
   logical :: use_sponge
   logical :: bndExtrapolation = .true. ! If true, extrapolate boundaries
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
   integer :: i, j, col, total_sponge_cols, total_sponge_cols_u, total_sponge_cols_v
 
   if (associated(CS)) then
@@ -508,6 +515,10 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, US, param_file, CS, I
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date)
+  call get_param(param_file, mdl, "SPONGE_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for ALE sponge. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for more details. "//&
+                 "We recommend setting this option to false.", default=.true.)
   call get_param(param_file, mdl, "HOR_REGRID_ANSWER_DATE", CS%hor_regrid_answer_date, &
                  "The vintage of the order of arithmetic for horizontal regridding.  "//&
                  "Dates before 20190101 give the same answers as the code did in late 2018, "//&
@@ -547,6 +558,7 @@ subroutine initialize_ALE_sponge_varying(Iresttime, G, GV, US, param_file, CS, I
 
 ! Call the constructor for remapping control structure
   call initialize_remapping(CS%remap_cs, remapScheme, boundary_extrapolation=bndExtrapolation, &
+                            om4_remap_via_sub_cells=om4_remap_via_sub_cells, &
                             answer_date=CS%remap_answer_date)
   call log_param(param_file, mdl, "!Total sponge columns at h points", total_sponge_cols, &
                  "The total number of columns where sponges are applied at h points.", like_default=.true.)

--- a/src/tracer/MOM_hor_bnd_diffusion.F90
+++ b/src/tracer/MOM_hor_bnd_diffusion.F90
@@ -88,6 +88,7 @@ logical function hor_bnd_diffusion_init(Time, G, GV, US, param_file, diag, diaba
   ! local variables
   character(len=80)  :: string ! Temporary strings
   logical :: boundary_extrap   ! controls if boundary extrapolation is used in the HBD code
+  logical :: om4_remap_via_sub_cells ! Use the OM4-era ramap_via_sub_cells for HBD
   logical :: debug             !< If true, write verbose checksums for debugging purposes
 
   if (ASSOCIATED(CS)) then
@@ -141,10 +142,15 @@ logical function hor_bnd_diffusion_init(Time, G, GV, US, param_file, diag, diaba
                  "for vertical remapping for all variables. "//&
                  "It can be one of the following schemes: "//&
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
+  call get_param(param_file, mdl, "HBD_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for horizontal boundary diffusion. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for details. "//&
+                 "We recommend setting this option to false.", default=.true.)
 
   ! GMM, TODO: add HBD params to control optional arguments in initialize_remapping.
-  call initialize_remapping( CS%remap_CS, string, boundary_extrapolation = boundary_extrap ,&
-       check_reconstruction=.false., check_remapping=.false.)
+  call initialize_remapping( CS%remap_CS, string, boundary_extrapolation=boundary_extrap, &
+                             om4_remap_via_sub_cells=om4_remap_via_sub_cells, &
+                             check_reconstruction=.false., check_remapping=.false.)
   call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
   call get_param(param_file, mdl, "DEBUG", debug, default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "HBD_DEBUG", CS%debug, &
@@ -841,8 +847,9 @@ logical function near_boundary_unit_tests( verbose )
   allocate(CS)
   ! fill required fields in CS
   CS%linear=.false.
-  call initialize_remapping( CS%remap_CS, 'PLM', boundary_extrapolation=.true. ,&
-       check_reconstruction=.true., check_remapping=.true.)
+  call initialize_remapping( CS%remap_CS, 'PLM', boundary_extrapolation=.true., &
+                             om4_remap_via_sub_cells=.true., & ! ### see fail below when using fixed remapping alg.
+                             check_reconstruction=.true., check_remapping=.true.)
   call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
   CS%H_subroundoff = 1.0E-20
   CS%debug=.false.
@@ -1032,6 +1039,7 @@ logical function near_boundary_unit_tests( verbose )
   call hbd_grid_test(SURFACE, hbl_L, hbl_R, h_L, h_R, CS)
   call fluxes_layer_method(SURFACE, nk, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
                            khtr_u, F_layer, 1., 1., CS%hbd_u_kmax(1,1), CS%hbd_grd_u(1,1,:), CS)
+ ! ### This test fails when om4_remap_via_sub_cells=.false.
   near_boundary_unit_tests = near_boundary_unit_tests .or. &
                              test_layer_fluxes( verbose, nk, test_name, F_layer, (/-1.0,-4.0/) )
 

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -151,6 +151,7 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
   logical :: debug                ! If true, write verbose checksums for debugging purposes.
   logical :: boundary_extrap      ! Indicate whether high-order boundary
                                   !! extrapolation should be used within boundary cells.
+  logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
 
   if (associated(CS)) then
     call MOM_error(FATAL, "neutral_diffusion_init called with associated control structure.")
@@ -231,8 +232,13 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
+    call get_param(param_file, mdl, "NDIFF_REMAPPING_USE_OM4_SUBCELLS", om4_remap_via_sub_cells, &
+                 "If true, use the OM4 remapping-via-subcells algorithm for neutral diffusion. "//&
+                 "See REMAPPING_USE_OM4_SUBCELLS for more details. "//&
+                 "We recommend setting this option to false.", default=.true.)
     if (.not.GV%Boussinesq) CS%remap_answer_date = max(CS%remap_answer_date, 20230701)
     call initialize_remapping( CS%remap_CS, string, boundary_extrapolation=boundary_extrap, &
+                               om4_remap_via_sub_cells=om4_remap_via_sub_cells, &
                                answer_date=CS%remap_answer_date )
     call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
     call get_param(param_file, mdl, "NEUTRAL_POS_METHOD", CS%neutral_pos_method,   &


### PR DESCRIPTION
This a significant refactor of the core remapping algorithm, with a patch at the end that fixes a bug for some situations mostly encountered when initializing from observations.

Commits include:
- Cleaning up compiler warnings in MOM_remapping.F90
- Added stand alone drivers for timing and unit tests of MOM_remapping.F90
- Re-factor of unit_tests() in MOM_remapping.F90 to use helper class making cleaner/shorter
- New tests of parts of `remap_via_sub_cells()` algorithm, added as `remap_via_sub_cells()` was deconstructed into three functions: intersect_src_tgt_grids(), remap_src_to_sub_grid(), and remap_sub_to_tgt_grid()
- The fix for reconstructions in top/bottom layers implemented as an alternative version of the remap_src_to_sub_grid() function (not an flag or optional argument)
  - Nine runtime parameters were added. This is necessary to confirm/assess which bits of the model are affected by the bug fix. While initialization is hypothesized as the main area of affect, the remapping of EBT structure, and diagnostics are places we should expect to see non-trivial changes also.

The refactor is in preparation to adding a suite of new reconstructions and new remapping options including conservative remapping of transport.