### PR TITLE
CI: parse_perf.py bugfix

### DIFF
--- a/.testing/tools/parse_perf.py
+++ b/.testing/tools/parse_perf.py
@@ -102,7 +102,7 @@ def parse_perf_report(perf_data_path):
 
                     if tok == '>':
                         bracks -= 1
-                    if tok == '(':
+                    if tok == ')':
                         parens -= 1
 
                 # Strip any whitespace tokens


### PR DESCRIPTION
Bracket counter for `<..>` was correct but `(..)` was broken, it was counting `(` but not `)`.  I can only presume that such cases were very rare.

This patch fixes the closed parenthesis count.