### PR TITLE
Replace kind=8 with iso_fortran_env kinds

### DIFF
--- a/config_src/external/drifters/MOM_particles_types.F90
+++ b/config_src/external/drifters/MOM_particles_types.F90
@@ -3,6 +3,7 @@ module particles_types_mod
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use, intrinsic :: iso_fortran_env, only : int64
 use MOM_grid, only : ocean_grid_type
 use MOM_domains, only: domain2D
 
@@ -75,7 +76,7 @@ type, public :: xyt
   real :: vvel_old !< Previous meridional velocity component (m/s)
   integer :: year  !< Year of this record
   integer :: particle_num  !< Current particle number
-  integer(kind=8) :: id = -1 !< Particle Identifier
+  integer(kind=int64) :: id = -1 !< Particle Identifier
   type(xyt), pointer :: next=>null()  !< Pointer to the next position in the list
 end type xyt
 
@@ -98,8 +99,8 @@ type, public :: particle
   real :: start_day       !< origination position (degrees) and day
   integer :: start_year                         !< origination year
   real :: halo_part  !< equal to zero for particles on the computational domain, and 1 for particles on the halo
-  integer(kind=8) :: id                      !< particle identifier
-  integer(kind=8) :: drifter_num             !< particle identifier
+  integer(kind=int64) :: id                      !< particle identifier
+  integer(kind=int64) :: drifter_num             !< particle identifier
   integer :: ine                           !< nearest i-index in NE direction (for convenience)
   integer :: jne                           !< nearest j-index in NE direction (for convenience)
   real :: xi                               !< non-dimensional x-coordinate within current cell (0..1)
@@ -147,7 +148,7 @@ type, public :: particles !; private
   logical :: ignore_traj=.False. !< If true, then model does not write trajectory data at all
   logical :: use_new_predictive_corrective =.False. !< Flag to use Bob's predictive corrective particle scheme
   !Added by Alon
-  integer(kind=8) :: debug_particle_with_id = -1 !< If positive, monitors a part with this id
+  integer(kind=int64) :: debug_particle_with_id = -1 !< If positive, monitors a part with this id
   type(buffer), pointer :: obuffer_n=>null() !< Buffer for outgoing parts to the north
   type(buffer), pointer :: ibuffer_n=>null() !< Buffer for incoming parts from the north
   type(buffer), pointer :: obuffer_s=>null() !< Buffer for outgoing parts to the south

--- a/config_src/infra/FMS1/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_diag_manager_infra.F90
@@ -8,6 +8,7 @@ module MOM_diag_manager_infra
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use, intrinsic :: iso_fortran_env, only : real64
 use diag_axis_mod,    only : fms_axis_init=>diag_axis_init
 use diag_axis_mod,    only : fms_get_diag_axis_name => get_diag_axis_name
 use diag_axis_mod,    only : EAST, NORTH
@@ -359,7 +360,7 @@ end function send_data_infra_3d
 logical function send_data_infra_2d_r8(diag_field_id, field, is_in, ie_in, js_in, je_in, &
                                        time, mask, rmask, weight, err_msg)
   integer,                           intent(in) :: diag_field_id !< The diagnostic manager identifier for this field
-  real(kind=8), dimension(:,:),      intent(in) :: field !< A 2-d array of values being recorded
+  real(kind=real64), dimension(:,:), intent(in) :: field !< A 2-d array of values being recorded
   integer,                 optional, intent(in) :: is_in !< The starting i-index for the data being recorded
   integer,                 optional, intent(in) :: ie_in !< The end i-index for the data being recorded
   integer,                 optional, intent(in) :: js_in !< The starting j-index for the data being recorded
@@ -382,7 +383,7 @@ end function send_data_infra_2d_r8
 logical function send_data_infra_3d_r8(diag_field_id, field, is_in, ie_in, js_in, je_in, ks_in, ke_in, &
                                     time, mask, rmask, weight, err_msg)
   integer,                             intent(in) :: diag_field_id !< The diagnostic manager identifier for this field
-  real(kind=8), dimension(:,:,:),      intent(in) :: field !< A rank 1 array of floating point values being recorded
+  real(kind=real64), dimension(:,:,:), intent(in) :: field !< A rank 1 array of floating point values being recorded
   integer,                   optional, intent(in) :: is_in !< The starting i-index for the data being recorded
   integer,                   optional, intent(in) :: ie_in !< The end i-index for the data being recorded
   integer,                   optional, intent(in) :: js_in !< The starting j-index for the data being recorded

--- a/config_src/infra/FMS2/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_diag_manager_infra.F90
@@ -8,6 +8,7 @@ module MOM_diag_manager_infra
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use, intrinsic :: iso_fortran_env, only : real64
 use diag_axis_mod,    only : fms_axis_init=>diag_axis_init
 use diag_axis_mod,    only : fms_get_diag_axis_name => get_diag_axis_name
 use diag_axis_mod,    only : EAST, NORTH
@@ -361,7 +362,7 @@ end function send_data_infra_3d
 logical function send_data_infra_2d_r8(diag_field_id, field, is_in, ie_in, js_in, je_in, &
                                        time, mask, rmask, weight, err_msg)
   integer,                           intent(in) :: diag_field_id !< The diagnostic manager identifier for this field
-  real(kind=8), dimension(:,:),      intent(in) :: field !< A 2-d array of values being recorded
+  real(kind=real64), dimension(:,:), intent(in) :: field !< A 2-d array of values being recorded
   integer,                 optional, intent(in) :: is_in !< The starting i-index for the data being recorded
   integer,                 optional, intent(in) :: ie_in !< The end i-index for the data being recorded
   integer,                 optional, intent(in) :: js_in !< The starting j-index for the data being recorded
@@ -384,7 +385,7 @@ end function send_data_infra_2d_r8
 logical function send_data_infra_3d_r8(diag_field_id, field, is_in, ie_in, js_in, je_in, ks_in, ke_in, &
                                     time, mask, rmask, weight, err_msg)
   integer,                             intent(in) :: diag_field_id !< The diagnostic manager identifier for this field
-  real(kind=8), dimension(:,:,:),      intent(in) :: field !< A rank 1 array of floating point values being recorded
+  real(kind=real64), dimension(:,:,:), intent(in) :: field !< A rank 1 array of floating point values being recorded
   integer,                   optional, intent(in) :: is_in !< The starting i-index for the data being recorded
   integer,                   optional, intent(in) :: ie_in !< The end i-index for the data being recorded
   integer,                   optional, intent(in) :: js_in !< The starting j-index for the data being recorded

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -4,6 +4,7 @@ module MOM_coms
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use, intrinsic :: iso_fortran_env, only : int64
 use MOM_coms_infra,    only : PE_here, root_PE, num_PEs, set_rootPE, Set_PElist, Get_PElist
 use MOM_coms_infra,    only : broadcast, field_chksum, MOM_infra_init, MOM_infra_end
 use MOM_coms_infra,    only : sum_across_PEs, max_across_PEs, min_across_PEs
@@ -25,7 +26,7 @@ public :: query_EFP_overflow_error, reset_EFP_overflow_error
 
 ! This module provides interfaces to the non-domain-oriented communication subroutines.
 
-integer(kind=8), parameter :: prec=2_8**46 !< The precision of each integer.
+integer(kind=int64), parameter :: prec = (2_int64)**46 !< The precision of each integer.
 real, parameter :: r_prec=2.0**46  !< A real version of prec [nondim].
 real, parameter :: I_prec=1.0/(2.0**46) !< The inverse of prec [nondim].
 integer, parameter :: max_count_prec=2**(63-46)-1
@@ -73,7 +74,7 @@ end interface EFP_sum_across_PEs
 !!   Hallberg, R. & A. Adcroft, 2014: An Order-invariant Real-to-Integer Conversion Sum.
 !!   Parallel Computing, 40(5-6), doi:10.1016/j.parco.2014.04.007.
 type, public :: EFP_type ; private
-  integer(kind=8), dimension(ni) :: v !< The value in this type
+  integer(kind=int64), dimension(ni) :: v !< The value in this type
 end type EFP_type
 
 !> Add two extended-fixed-point numbers
@@ -115,8 +116,8 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
   ! of real numbers to give order-invariant sums that will reproduce
   ! across PE count.  This idea comes from R. Hallberg and A. Adcroft.
 
-  integer(kind=8), dimension(ni)  :: ints_sum
-  integer(kind=8) :: ival, prec_error
+  integer(kind=int64), dimension(ni)  :: ints_sum
+  integer(kind=int64) :: ival, prec_error
   real    :: rs ! The remaining value to add, in arbitrary units [a]
   real    :: max_mag_term ! A running maximum magnitude of the values in arbitrary units [a]
   logical :: over_check, do_sum_across_PEs
@@ -127,7 +128,7 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = (2_8**62 + (2_8**62 - 1)) / num_PEs()
+  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
 
   is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2 )
   if (present(isr)) then
@@ -176,7 +177,7 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
       sgn = 1 ; if (array(i,j)<0.0) sgn = -1
       rs = abs(array(i,j))
       do n=1,ni
-        ival = int(rs*I_pr(n), 8)
+        ival = int(rs*I_pr(n), kind=int64)
         rs = rs - ival*pr(n)
         ints_sum(n) = ints_sum(n) + sgn*ival
       enddo
@@ -245,8 +246,8 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
   ! of real numbers to give order-invariant sums that will reproduce
   ! across PE count.  This idea comes from R. Hallberg and A. Adcroft.
 
-  integer(kind=8), dimension(ni)  :: ints_sum
-  integer(kind=8) :: prec_error
+  integer(kind=int64), dimension(ni)  :: ints_sum
+  integer(kind=int64) :: prec_error
   real    :: rsum(1) ! The running sum, in arbitrary units [a]
   logical :: repro, do_sum_across_PEs
   character(len=256) :: mesg
@@ -257,7 +258,7 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = (2_8**62 + (2_8**62 - 1)) / num_PEs()
+  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
 
   is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2 )
   if (present(isr)) then
@@ -349,9 +350,9 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
 
   real    :: val ! The real number that is extracted in arbitrary units [a]
   real    :: max_mag_term ! A running maximum magnitude of the val's in arbitrary units [a]
-  integer(kind=8), dimension(ni)  :: ints_sum
-  integer(kind=8), dimension(ni,size(array,3))  :: ints_sums
-  integer(kind=8) :: prec_error
+  integer(kind=int64), dimension(ni)  :: ints_sum
+  integer(kind=int64), dimension(ni,size(array,3))  :: ints_sums
+  integer(kind=int64) :: prec_error
   character(len=256) :: mesg
   logical :: do_sum_across_PEs
   integer :: i, j, k, is, ie, js, je, ke, isz, jsz, n
@@ -360,7 +361,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = (2_8**62 + (2_8**62 - 1)) / num_PEs()
+  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
   max_mag_term = 0.0
 
   is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2) ; ke = size(array,3)
@@ -508,23 +509,23 @@ end function reproducing_sum_3d
 !> Convert a real number into the array of integers constitute its extended-fixed-point representation
 function real_to_ints(r, prec_error, overflow) result(ints)
   real,                      intent(in) :: r  !< The real number being converted in arbitrary units [a]
-  integer(kind=8), optional, intent(in) :: prec_error  !< The PE-count dependent precision of the
+  integer(kind=int64), optional, intent(in) :: prec_error  !< The PE-count dependent precision of the
                                               !! integers that is safe from overflows during global
                                               !! sums.  This will be larger than the compile-time
                                               !! precision parameter, and is used to detect overflows.
   logical,         optional, intent(inout) :: overflow !< Returns true if the conversion is being
                                               !! done on a value that is too large to be represented
-  integer(kind=8), dimension(ni)  :: ints
+  integer(kind=int64), dimension(ni)  :: ints
   !   This subroutine converts a real number to an equivalent representation
   ! using several long integers.
 
   real :: rs  ! The remaining value to add, in arbitrary units [a]
   character(len=80) :: mesg
-  integer(kind=8) :: ival, prec_err
+  integer(kind=int64) :: ival, prec_err
   integer :: sgn, i
 
   prec_err = prec ; if (present(prec_error)) prec_err = prec_error
-  ints(:) = 0_8
+  ints(:) = 0
   if ((r >= 1e30) .eqv. (r < 1e30)) then ; NaN_error = .true. ; return ; endif
 
   sgn = 1 ; if (r<0.0) sgn = -1
@@ -539,7 +540,7 @@ function real_to_ints(r, prec_error, overflow) result(ints)
   endif
 
   do i=1,ni
-    ival = int(rs*I_pr(i), 8)
+    ival = int(rs*I_pr(i), kind=int64)
     rs = rs - ival*pr(i)
     ints(i) = sgn*ival
   enddo
@@ -549,7 +550,7 @@ end function real_to_ints
 !> Convert the array of integers that constitute an extended-fixed-point
 !! representation into a real number
 function ints_to_real(ints) result(r)
-  integer(kind=8), dimension(ni), intent(in) :: ints !< The array of EFP integers
+  integer(kind=int64), dimension(ni), intent(in) :: ints !< The array of EFP integers
   real :: r  ! The real number that is extracted in arbitrary units [a]
   ! This subroutine reverses the conversion in real_to_ints.
 
@@ -562,9 +563,9 @@ end function ints_to_real
 !> Increment an array of integers that constitutes an extended-fixed-point
 !! representation with a another EFP number
 subroutine increment_ints(int_sum, int2, prec_error)
-  integer(kind=8), dimension(ni), intent(inout) :: int_sum !< The array of EFP integers being incremented
-  integer(kind=8), dimension(ni), intent(in)    :: int2    !< The array of EFP integers being added
-  integer(kind=8), optional,      intent(in)    :: prec_error !< The PE-count dependent precision of the
+  integer(kind=int64), dimension(ni), intent(inout) :: int_sum !< The array of EFP integers being incremented
+  integer(kind=int64), dimension(ni), intent(in)    :: int2    !< The array of EFP integers being added
+  integer(kind=int64), optional,      intent(in)    :: prec_error !< The PE-count dependent precision of the
                                               !! integers that is safe from overflows during global
                                               !! sums.  This will be larger than the compile-time
                                               !! precision parameter, and is used to detect overflows.
@@ -596,7 +597,7 @@ end subroutine increment_ints
 !> Increment an EFP number with a real number without doing any carrying of
 !! of overflows and using only minimal error checking.
 subroutine increment_ints_faster(int_sum, r, max_mag_term)
-  integer(kind=8), dimension(ni), intent(inout) :: int_sum  !< The array of EFP integers being incremented
+  integer(kind=int64), dimension(ni), intent(inout) :: int_sum  !< The array of EFP integers being incremented
   real,                           intent(in)    :: r        !< The real number being added in arbitrary units [a]
   real,                           intent(inout) :: max_mag_term !< A running maximum magnitude of the r's
                                                             !! in arbitrary units [a]
@@ -605,7 +606,7 @@ subroutine increment_ints_faster(int_sum, r, max_mag_term)
   ! representation in real_to_ints, but without doing any carrying of overflow.
   ! The entire operation is embedded in a single call for greater speed.
   real :: rs  ! The remaining value to add, in arbitrary units [a]
-  integer(kind=8) :: ival
+  integer(kind=int64) :: ival
   integer :: sgn, i
 
   if ((r >= 1e30) .eqv. (r < 1e30)) then ; NaN_error = .true. ; return ; endif
@@ -620,7 +621,7 @@ subroutine increment_ints_faster(int_sum, r, max_mag_term)
   endif
 
   do i=1,ni
-    ival = int(rs*I_pr(i), 8)
+    ival = int(rs*I_pr(i), kind=int64)
     rs = rs - ival*pr(i)
     int_sum(i) = int_sum(i) + sgn*ival
   enddo
@@ -629,9 +630,9 @@ end subroutine increment_ints_faster
 
 !> This subroutine handles carrying of the overflow.
 subroutine carry_overflow(int_sum, prec_error)
-  integer(kind=8), dimension(ni), intent(inout) :: int_sum  !< The array of EFP integers being
+  integer(kind=int64), dimension(ni), intent(inout) :: int_sum  !< The array of EFP integers being
                                               !! modified by carries, but without changing value.
-  integer(kind=8),                intent(in)    :: prec_error  !< The PE-count dependent precision of the
+  integer(kind=int64),                intent(in)    :: prec_error  !< The PE-count dependent precision of the
                                               !! integers that is safe from overflows during global
                                               !! sums.  This will be larger than the compile-time
                                               !! precision parameter, and is used to detect overflows.
@@ -653,7 +654,7 @@ end subroutine carry_overflow
 !> This subroutine carries the overflow, and then makes sure that
 !! all integers are of the same sign as the overall value.
 subroutine regularize_ints(int_sum)
-  integer(kind=8), dimension(ni), &
+  integer(kind=int64), dimension(ni), &
     intent(inout) :: int_sum !< The array of integers being modified to take a
                              !! regular form with all integers of the same sign,
                              !! but without changing value.
@@ -799,8 +800,8 @@ subroutine EFP_list_sum_across_PEs(EFPs, nval, errors)
   !   This subroutine does a sum across PEs of a list of EFP variables,
   ! returning the sums in place, with all overflows carried.
 
-  integer(kind=8), dimension(ni,nval) :: ints
-  integer(kind=8) :: prec_error
+  integer(kind=int64), dimension(ni,nval) :: ints
+  integer(kind=int64) :: prec_error
   logical :: error_found
   character(len=256) :: mesg
   integer :: i, n
@@ -809,7 +810,7 @@ subroutine EFP_list_sum_across_PEs(EFPs, nval, errors)
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = (2_8**62 + (2_8**62 - 1)) / num_PEs()
+  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
   ! overflow_error is an overflow error flag for the whole module.
   overflow_error = .false. ; error_found = .false.
 
@@ -846,8 +847,8 @@ subroutine EFP_val_sum_across_PEs(EFP, error)
   !   This subroutine does a sum across PEs of a list of EFP variables,
   ! returning the sums in place, with all overflows carried.
 
-  integer(kind=8), dimension(ni) :: ints
-  integer(kind=8) :: prec_error
+  integer(kind=int64), dimension(ni) :: ints
+  integer(kind=int64) :: prec_error
   logical :: error_found
   character(len=256) :: mesg
   integer :: n
@@ -856,7 +857,7 @@ subroutine EFP_val_sum_across_PEs(EFP, error)
     "reproducing_sum: Too many processors are being used for the value of "//&
     "prec.  Reduce prec to (2^63-1)/num_PEs.")
 
-  prec_error = (2_8**62 + (2_8**62 - 1)) / num_PEs()
+  prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
   ! overflow_error is an overflow error flag for the whole module.
   overflow_error = .false. ; error_found = .false.
 

--- a/src/framework/MOM_intrinsic_functions.F90
+++ b/src/framework/MOM_intrinsic_functions.F90
@@ -176,7 +176,7 @@ pure function descale(x, e_a, s_a) result(a)
     ! Biased exponent of x
 
   ! Apply the corrected exponent and sign to x.
-  xb = transfer(x, 1_8)
+  xb = transfer(x, 1_int64)
   e_x = ibits(xb, expbit, explen)
   call mvbits(e_a + e_x, 0, explen, xb, expbit)
   call mvbits(s_a, 0, 1, xb, signbit)

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -3,6 +3,7 @@ module MOM_restart
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use, intrinsic :: iso_fortran_env, only : int64
 use MOM_checksums, only : chksum => rotated_field_chksum
 use MOM_domains, only : PE_here, num_PEs, AGRID, BGRID_NE, CGRID_NE
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, NOTE, is_root_pe
@@ -1348,12 +1349,12 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   character(len=256) :: restartname     ! The restart file name (no dir).
   character(len=8)   :: suffix          ! A suffix (like _2) that is appended
                                         ! to the name of files after the first.
-  integer(kind=8) :: var_sz, size_in_file ! The size in bytes of each variable
+  integer(kind=int64) :: var_sz, size_in_file ! The size in bytes of each variable
                                         ! and the variables already in a file.
-  integer(kind=8), parameter :: max_file_size = 4294967292_8 ! The maximum size in bytes for the
+  integer(kind=int64), parameter :: max_file_size = 4294967292_int64 ! The maximum size in bytes for the
                                         ! starting position of each variable in a file's record,
                                         ! based on the use of NetCDF 3.6 or later.  For earlier
-                                        ! versions of NetCDF, the value was 2147483647_8.
+                                        ! versions of NetCDF, the value was 2147483647_int64.
   integer :: start_var, next_var        ! The starting variables of the
                                         ! current and next files.
   type(MOM_infra_file) :: IO_handle     ! The I/O handle of the open fileset
@@ -1365,7 +1366,7 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   real :: restart_time                  ! The model time at whic the restart file is being written [days]
   character(len=32) :: filename_appendix = '' ! Appendix to filename for ensemble runs
   integer :: length                     ! The length of a text string.
-  integer(kind=8) :: check_val(CS%max_fields,1)
+  integer(kind=int64) :: check_val(CS%max_fields,1)
   integer :: isL, ieL, jsL, jeL, pos
   integer :: turns
   integer, parameter :: nmax_extradims = 5
@@ -1570,8 +1571,8 @@ subroutine restore_state(filename, directory, day, G, CS)
   real, allocatable :: time_vals(:)  ! Times from a file extracted with getl_file_times [days]
   type(MOM_field), allocatable :: fields(:)
   logical            :: is_there_a_checksum ! Is there a valid checksum that should be checked.
-  integer(kind=8)    :: checksum_file  ! The checksum value recorded in the input file.
-  integer(kind=8)    :: checksum_data  ! The checksum value for the data that was read in.
+  integer(kind=int64) :: checksum_file  ! The checksum value recorded in the input file.
+  integer(kind=int64) :: checksum_data  ! The checksum value for the data that was read in.
 
   if (.not.CS%initialized) call MOM_error(FATAL, "MOM_restart " // &
       "restore_state: Module must be initialized before it is used.")
@@ -2182,7 +2183,7 @@ function get_variable_byte_size(hor_grid, z_grid, t_grid, G, num_z) result(var_s
   character(len=8),      intent(in) :: t_grid   !< A time string to interpret
   type(ocean_grid_type), intent(in) :: G        !< The ocean's grid structure
   integer,               intent(in) :: num_z    !< The number of vertical layers in the grid
-  integer(kind=8) :: var_sz !< The function result, the size in bytes of a variable
+  integer(kind=int64) :: var_sz !< The function result, the size in bytes of a variable
 
   ! Local variables
   integer :: var_periods  ! The number of entries in a time-periodic axis


### PR DESCRIPTION
This patch replaces references to kind=8 with the corresponding Fortran kind identifiers as defined in iso_fortran_env.

Although these are widely equal to 8, there are a number of compilers (notably NAG, also others) which set it to a different value.

This improves the portability of the code (albeit in a rather minor way).