### PR TITLE
Autoconf: Disable LDFLAGS for C testing

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -651,7 +651,7 @@ $(WORK)/%/restart/ocean.stats: $(BUILD)/symmetric/MOM6 | preproc
 # Not a true rule; only call this after `make test` to summarize test results.
 .PHONY: test.summary
 test.summary:
-	@./tools/report_test_results.sh $(WORK)/results
+	./tools/report_test_results.sh $(WORK)/results
 
 
 #---

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -81,8 +81,8 @@ AS_IF([test "x$with_driver" != "x"],
 
 
 # Explicitly assume free-form Fortran
-AC_LANG(Fortran)
-AC_FC_SRCEXT(f90)
+AC_LANG([Fortran])
+AC_FC_SRCEXT([f90])
 
 
 # Determine MPI compiler wrappers

--- a/ac/deps/configure.fms.ac
+++ b/ac/deps/configure.fms.ac
@@ -10,7 +10,16 @@ AC_INIT(
 AC_CONFIG_SRCDIR([fms/fms.F90])
 AC_CONFIG_MACRO_DIR([m4])
 
+
 # C configuration
+
+# Autoconf assumes that LDFLAGS can be passed to CFLAGS, even though this is
+# not valid in some compilers.  This can cause basic CC tests to fail.
+# Since we do not link with CC, we can safely disable LDFLAGS for AC_PROG_CC.
+FC_LDFLAGS="$LDFLAGS"
+LDFLAGS=""
+
+# C compiler verification
 AC_PROG_CC
 AX_MPI
 CC=$MPICC
@@ -55,10 +64,13 @@ AC_CHECK_FUNCS([gettid], [], [
 # FMS 2019.01.03 uses __APPLE__ to disable Linux CPU affinity calls.
 AC_CHECK_FUNCS([sched_getaffinity], [], [AC_DEFINE([__APPLE__])])
 
+# Restore LDFLAGS
+LDFLAGS="$FC_LDFLAGS"
+
 
 # Standard Fortran configuration
-AC_LANG(Fortran)
-AC_FC_SRCEXT(f90)
+AC_LANG([Fortran])
+AC_FC_SRCEXT([f90])
 AC_PROG_FC
 
 


### PR DESCRIPTION
Certain compilers would expect values passed to ld which cannot be passed to the C compiler.  This caused the autoconf C configuration to fail, since it uses to CC for linking rather than LD.

Since we never use the C compiler for linking, this is not something we need to be concerned about, and the LDFLAGS is disabled when testing the C compiler.

This is only a concern when using certain GPU-related flags in the Nvidia compiler, and is only a problem for libraries with a significant amount of C code, such as FMS.