### PR TITLE
diffusivities from internal tides ray tracing algo

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2890,7 +2890,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   if (.not. CS%adiabatic) then
-    call register_diabatic_restarts(G, US, param_file, CS%int_tide_CSp, restart_CSp)
+    call register_diabatic_restarts(G, GV, US, param_file, CS%int_tide_CSp, restart_CSp)
   endif
 
   call callTree_waypoint("restart registration complete (initialize_MOM)")

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -394,7 +394,7 @@ end subroutine find_col_avg_SpV
 
 !> Determine the in situ density averaged over a specified distance from the bottom,
 !! calculating it as the inverse of the mass-weighted average specific volume.
-subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot)
+subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot, h_bot, k_bot)
   type(ocean_grid_type),    intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type),  intent(in)  :: GV   !< The ocean's vertical grid structure
   type(unit_scale_type),    intent(in)  :: US   !< A dimensional unit scaling type
@@ -409,6 +409,8 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot)
                                                 !! thermodynamic fields.
   integer,                  intent(in)  :: j    !< j-index of row to work on
   real, dimension(SZI_(G)), intent(out) :: Rho_bot  !< Near-bottom density [R ~> kg m-3].
+  real, dimension(SZI_(G)), optional, intent(out) :: h_bot !< Bottom boundary layer thickness [H ~> m].
+  integer, dimension(SZI_(G)), optional, intent(out) :: k_bot !< Bottom boundary layer top layer index [nondim].
 
   ! Local variables
   real :: hb(SZI_(G))         ! Running sum of the thickness in the bottom boundary layer [H ~> m or kg m-2]
@@ -441,6 +443,53 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot)
     do i=is,ie
       rho_bot(i) = GV%Rho0
     enddo
+
+    ! Obtain bottom boundary layer thickness and index of top layer
+    do i=is,ie
+      hb(i) = 0.0 ; h_bot(i) = 0.0 ; k_bot(i) = nz
+      dz_bbl_rem(i) = G%mask2dT(i,j) * max(0.0, dz_avg(i))
+      do_i(i) = .true.
+      if (G%mask2dT(i,j) <= 0.0) then
+        h_bbl_frac(i) = 0.0
+        do_i(i) = .false.
+      endif
+    enddo
+
+    do k=nz,1,-1
+      do_any = .false.
+      do i=is,ie ; if (do_i(i)) then
+        if (dz(i,k) < dz_bbl_rem(i)) then
+          ! This layer is fully within the averaging depth.
+          dz_bbl_rem(i) = dz_bbl_rem(i) - dz(i,k)
+          hb(i) = hb(i) + h(i,j,k)
+          k_bot(i) = k
+          do_any = .true.
+        else
+          if (dz(i,k) > 0.0) then
+            frac_in = dz_bbl_rem(i) / dz(i,k)
+            if (frac_in >= 0.5) k_bot(i) = k ! update bbl top index if >= 50% of layer
+          else
+            frac_in = 0.0
+          endif
+          h_bbl_frac(i) = frac_in * h(i,j,k)
+          dz_bbl_rem(i) = 0.0
+          do_i(i) = .false.
+        endif
+      endif ; enddo
+      if (.not.do_any) exit
+    enddo
+    do i=is,ie ; if (do_i(i)) then
+      ! The nominal bottom boundary layer is thicker than the water column, but layer 1 is
+      ! already included in the averages.  These values are set so that the call to find
+      ! the layer-average specific volume will behave sensibly.
+      h_bbl_frac(i) = 0.0
+    endif ; enddo
+
+    do i=is,ie
+      if (hb(i) + h_bbl_frac(i) < GV%H_subroundoff) h_bbl_frac(i) = GV%H_subroundoff
+      h_bot(i) = hb(i) + h_bbl_frac(i)
+    enddo
+
   else
     ! Check that SpV_avg has been set.
     if (tv%valid_SpV_halo < 0) call MOM_error(FATAL, &
@@ -450,7 +499,7 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot)
     ! specified distance, with care taken to avoid having compressibility lead to an imprint
     ! of the layer thicknesses on this density.
     do i=is,ie
-      hb(i) = 0.0 ; SpV_h_bot(i) = 0.0
+      hb(i) = 0.0 ; SpV_h_bot(i) = 0.0 ; h_bot(i) = 0.0 ; k_bot(i) = nz
       dz_bbl_rem(i) = G%mask2dT(i,j) * max(0.0, dz_avg(i))
       do_i(i) = .true.
       if (G%mask2dT(i,j) <= 0.0) then
@@ -470,10 +519,12 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot)
           SpV_h_bot(i) = SpV_h_bot(i) + h(i,j,k) * tv%SpV_avg(i,j,k)
           dz_bbl_rem(i) = dz_bbl_rem(i) - dz(i,k)
           hb(i) = hb(i) + h(i,j,k)
+          k_bot(i) = k
           do_any = .true.
         else
           if (dz(i,k) > 0.0) then
             frac_in = dz_bbl_rem(i) / dz(i,k)
+            if (frac_in >= 0.5) k_bot(i) = k ! update bbl top index if >= 50% of layer
           else
             frac_in = 0.0
           endif
@@ -516,6 +567,7 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot)
     do i=is,ie
       if (hb(i) + h_bbl_frac(i) < GV%H_subroundoff) h_bbl_frac(i) = GV%H_subroundoff
       rho_bot(i) = G%mask2dT(i,j) * (hb(i) + h_bbl_frac(i)) / (SpV_h_bot(i) + h_bbl_frac(i)*SpV_bbl(i))
+      h_bot(i) = hb(i) + h_bbl_frac(i)
     enddo
   endif
 

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -394,10 +394,12 @@ end subroutine find_col_avg_SpV
 
 !> Determine the in situ density averaged over a specified distance from the bottom,
 !! calculating it as the inverse of the mass-weighted average specific volume.
-subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot, h_bot, k_bot)
+subroutine find_rho_bottom(G, GV, US, tv, h, dz, pres_int, dz_avg, j, Rho_bot, h_bot, k_bot)
   type(ocean_grid_type),    intent(in)  :: G    !< The ocean's grid structure
   type(verticalGrid_type),  intent(in)  :: GV   !< The ocean's vertical grid structure
   type(unit_scale_type),    intent(in)  :: US   !< A dimensional unit scaling type
+  type(thermo_var_ptrs),    intent(in)  :: tv   !< Structure containing pointers to any available
+                                                !! thermodynamic fields.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                             intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZK_(GV)), &
@@ -405,12 +407,10 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot, h
   real, dimension(SZI_(G),SZK_(GV)+1), &
                             intent(in)  :: pres_int !< Pressure at each interface [R L2 T-2 ~> Pa]
   real, dimension(SZI_(G)), intent(in)  :: dz_avg !< The vertical distance over which to average [Z ~> m]
-  type(thermo_var_ptrs),    intent(in)  :: tv   !< Structure containing pointers to any available
-                                                !! thermodynamic fields.
   integer,                  intent(in)  :: j    !< j-index of row to work on
   real, dimension(SZI_(G)), intent(out) :: Rho_bot  !< Near-bottom density [R ~> kg m-3].
-  real, dimension(SZI_(G)), optional, intent(out) :: h_bot !< Bottom boundary layer thickness [H ~> m or kg m-2]
-  integer, dimension(SZI_(G)), optional, intent(out) :: k_bot !< Bottom boundary layer top layer index
+  real, dimension(SZI_(G)), intent(out) :: h_bot !< Bottom boundary layer thickness [H ~> m or kg m-2]
+  integer, dimension(SZI_(G)), intent(out) :: k_bot !< Bottom boundary layer top layer index
 
   ! Local variables
   real :: hb(SZI_(G))         ! Running sum of the thickness in the bottom boundary layer [H ~> m or kg m-2]

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -409,8 +409,8 @@ subroutine find_rho_bottom(h, dz, pres_int, dz_avg, tv, j, G, GV, US, Rho_bot, h
                                                 !! thermodynamic fields.
   integer,                  intent(in)  :: j    !< j-index of row to work on
   real, dimension(SZI_(G)), intent(out) :: Rho_bot  !< Near-bottom density [R ~> kg m-3].
-  real, dimension(SZI_(G)), optional, intent(out) :: h_bot !< Bottom boundary layer thickness [H ~> m].
-  integer, dimension(SZI_(G)), optional, intent(out) :: k_bot !< Bottom boundary layer top layer index [nondim].
+  real, dimension(SZI_(G)), optional, intent(out) :: h_bot !< Bottom boundary layer thickness [H ~> m or kg m-2]
+  integer, dimension(SZI_(G)), optional, intent(out) :: k_bot !< Bottom boundary layer top layer index
 
   ! Local variables
   real :: hb(SZI_(G))         ! Running sum of the thickness in the bottom boundary layer [H ~> m or kg m-2]

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -327,9 +327,13 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   real :: En_initial, Delta_E_check                  ! Energies for debugging [H Z2 T-2 ~> m3 s-2 or J m-2]
   real :: TKE_Froude_loss_check, TKE_Froude_loss_tot ! Energy losses for debugging [H Z2 T-3 ~> m3 s-3 or W m-2]
   real :: HZ2_T3_to_W_m2                             ! unit conversion factor for TKE from internal to mks
+                                                     ! [H Z2 T-3 ~> m3 s-3 or W m-2]
   real :: HZ2_T2_to_J_m2                             ! unit conversion factor for Energy from internal to mks
+                                                     ! [H Z2 T-2 ~> m3 s-2 or J m-2]
   real :: W_m2_to_HZ2_T3                             ! unit conversion factor for TKE from mks to internal
+                                                     ! [m3 s-3 or W m-2 ~> H Z2 T-3]
   real :: J_m2_to_HZ2_T2                             ! unit conversion factor for Energy from mks to internal
+                                                     ! [m3 s-2 or J m-2 ~> H Z2 T-2]
   character(len=160) :: mesg  ! The text of an error message
   integer :: En_halo_ij_stencil ! The halo size needed for energy advection
   integer :: a, m, fr, i, j, k, is, ie, js, je, isd, ied, jsd, jed, nAngle
@@ -425,8 +429,8 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%u_struct_bot(:,:,1), "Ustruct_bot mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
     call hchksum(CS%u_struct_max(:,:,1), "Ustruct_max mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
     call hchksum(CS%int_w2(:,:,1),   "int_w2", G%HI, haloshift=0, scale=GV%H_to_MKS)
-    call hchksum(CS%int_U2(:,:,1),   "int_U2", G%HI, haloshift=0, scale=GV%H_to_m*US%m_to_Z**2)
-    call hchksum(CS%int_N2w2(:,:,1), "int_N2w2", G%HI, haloshift=0, scale=GV%H_to_m*US%s_to_T**2)
+    call hchksum(CS%int_U2(:,:,1),   "int_U2", G%HI, haloshift=0, scale=GV%H_to_mks*US%m_to_Z**2)
+    call hchksum(CS%int_N2w2(:,:,1), "int_N2w2", G%HI, haloshift=0, scale=GV%H_to_mks*US%s_to_T**2)
   endif
 
   ! Set the wave speeds for the modes, using cg(n) ~ cg(1)/n.**********************
@@ -1277,8 +1281,8 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
   real    :: En_negl         ! negligibly small number to prevent division by zero [H Z2 T-2 ~> m3 s-2 or J m-2]
   real    :: En_a, En_b      ! energy before and after timestep [H Z2 T-2 ~> m3 s-2 or J m-2]
   real    :: I_dt            ! The inverse of the timestep [T-1 ~> s-1]
-  real    :: J_m2_to_HZ2_T2  ! unit conversion factor for Energy from mks to internal
-  real    :: HZ2_T3_to_W_m2  ! unit conversion factor for Energy from internal to mks
+  real    :: J_m2_to_HZ2_T2  ! unit conversion factor for Energy from mks to internal [m3 s-2 or J m-2 ~> H Z2 T-2]
+  real    :: HZ2_T3_to_W_m2  ! unit conversion factor for Energy from internal to mks [H Z2 T-3 ~> m3 s-3 or W m-2]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
@@ -3244,7 +3248,7 @@ subroutine register_int_tide_restarts(G, GV, US, param_file, CS, restart_CS)
 
   type(axis_info) :: axes_inttides(2)
   real, dimension(:), allocatable :: angles, freqs ! Lables for angles and frequencies [nondim]
-  real :: HZ2_T2_to_J_m2                           ! unit conversion factor for Energy from internal to mks
+  real :: HZ2_T2_to_J_m2  ! unit conversion factor for Energy from internal to mks [H Z2 T-2 ~> m3 s-2 or J m-2]
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
@@ -3374,10 +3378,10 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                                 ! nominal ocean depth, or a negative value for no limit [nondim]
   real    :: period_1           ! The period of the gravest modeled mode [T ~> s]
   real    :: period             ! A tidal period read from namelist [T ~> s]
-  real    :: HZ2_T2_to_J_m2     ! unit conversion factor for Energy from internal to mks
-  real    :: HZ2_T3_to_W_m2     ! unit conversion factor for TKE from internal to mks
-  real    :: W_m2_to_HZ2_T3     ! unit conversion factor for TKE from mks to internal
-  real    :: J_m2_to_HZ2_T2     ! unit conversion factor for Energy from mks to internal
+  real    :: HZ2_T2_to_J_m2     ! unit conversion factor for Energy from internal to mks [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real    :: HZ2_T3_to_W_m2     ! unit conversion factor for TKE from internal to mks [H Z2 T-3 ~> m3 s-3 or W m-2]
+  real    :: W_m2_to_HZ2_T3     ! unit conversion factor for TKE from mks to internal [m3 s-3 or W m-2 ~> H Z2 T-3]
+  real    :: J_m2_to_HZ2_T2     ! unit conversion factor for Energy from mks to internal [m3 s-2 or J m-2 ~> H Z2 T-2]
   integer :: num_angle, num_freq, num_mode, m, fr
   integer :: isd, ied, jsd, jed, a, id_ang, i, j, nz
   type(axes_grp) :: axes_ang

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -89,48 +89,48 @@ type, public :: int_tide_CS ; private
   real, allocatable, dimension(:,:,:,:) :: cp
                         !< horizontal phase speed [L T-1 ~> m s-1]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_leak_loss
-                        !< energy lost due to misc background processes [H Z2 T-3 ~> W m-2]
+                        !< energy lost due to misc background processes [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_quad_loss
-                        !< energy lost due to quadratic bottom drag [H Z2 T-3 ~> W m-2]
+                        !< energy lost due to quadratic bottom drag [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_Froude_loss
-                        !< energy lost due to wave breaking [H Z2 T-3 ~> W m-2]
+                        !< energy lost due to wave breaking [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: TKE_itidal_loss_fixed
                         !< Fixed part of the energy lost due to small-scale drag [H Z2 L-2 ~> kg m-2] here;
                         !! This will be multiplied by N and the squared near-bottom velocity (and by
                         !! the near-bottom density in non-Boussinesq mode) to get the energy losses
                         !! in [R Z4 H-1 L-2 ~> kg m-2 or m]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_itidal_loss
-                        !< energy lost due to small-scale wave drag [H Z2 T-3 ~> W m-2]
+                        !< energy lost due to small-scale wave drag [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_residual_loss
-                        !< internal tide energy loss due to the residual at slopes [H Z2 T-3 ~> W m-2]
+                        !< internal tide energy loss due to the residual at slopes [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_slope_loss
-                        !< internal tide energy loss due to the residual at slopes [H Z2 T-3 ~> W m-2]
+                        !< internal tide energy loss due to the residual at slopes [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: TKE_input_glo_dt
-                        !< The energy input to the internal waves * dt [H Z2 T-2 ~> J m-2].
+                        !< The energy input to the internal waves * dt [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, allocatable, dimension(:,:) :: TKE_leak_loss_glo_dt
-                        !< energy lost due to misc background processes * dt [H Z2 T-2 ~> J m-2]
+                        !< energy lost due to misc background processes * dt [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable, dimension(:,:) :: TKE_quad_loss_glo_dt
-                        !< energy lost due to quadratic bottom drag * dt [H Z2 T-2 ~> J m-2]
+                        !< energy lost due to quadratic bottom drag * dt [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable, dimension(:,:) :: TKE_Froude_loss_glo_dt
-                        !< energy lost due to wave breaking [H Z2 T-2 ~> J m-2]
+                        !< energy lost due to wave breaking [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable, dimension(:,:) :: TKE_itidal_loss_glo_dt
-                        !< energy lost due to small-scale wave drag [H Z2 T-2 ~> J m-2]
+                        !< energy lost due to small-scale wave drag [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable, dimension(:,:) :: TKE_residual_loss_glo_dt
-                        !< internal tide energy loss due to the residual at slopes [H Z2 T-2 ~> J m-2]
+                        !< internal tide energy loss due to the residual at slopes [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable, dimension(:,:) :: error_mode
-                        !< internal tide energy budget error for each mode [H Z2 T-2 ~> J m-2]
+                        !< internal tide energy budget error for each mode [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable, dimension(:,:) :: tot_leak_loss !< Energy loss rates due to misc background processes,
-                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: tot_quad_loss !< Energy loss rates due to quadratic bottom drag,
-                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: tot_itidal_loss !< Energy loss rates due to small-scale drag,
-                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~>  m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: tot_Froude_loss !< Energy loss rates due to wave breaking,
-                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: tot_residual_loss !< Energy loss rates due to residual on slopes,
-                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:) :: tot_allprocesses_loss !< Energy loss rates due to all processes,
-                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> m3 s-3 or W m-2]
   real, allocatable, dimension(:,:,:,:) :: w_struct !< Vertical structure of vertical velocity (normalized)
                         !! for each frequency and each mode [nondim]
   real, allocatable, dimension(:,:,:,:) :: u_struct !< Vertical structure of horizontal velocity (normalized and
@@ -168,35 +168,35 @@ type, public :: int_tide_CS ; private
   logical :: apply_Froude_drag
                         !< If true, apply wave breaking as a sink.
   real :: En_check_tol  !< An energy density tolerance for flagging points with small negative
-                        !! internal tide energy [H Z2 T-2 ~> J m-2]
+                        !! internal tide energy [H Z2 T-2 ~> m3 s-2 or J m-2]
   logical :: apply_residual_drag
                         !< If true, apply sink from residual term of reflection/transmission.
   real, allocatable :: En(:,:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,frequency,mode)
-                        !! integrated within an angular and frequency band [H Z2 T-2 ~> J m-2]
+                        !! integrated within an angular and frequency band [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable :: En_ini_glo(:,:)
                         !< The internal wave energy density as a function of (frequency,mode)
-                        !! integrated within an angular and frequency band [H Z2 T-2 ~> J m-2]
+                        !! integrated within an angular and frequency band [H Z2 T-2 ~> m3 s-2 or J m-2]
                         !! only at the start of the routine (for diags)
   real, allocatable :: En_end_glo(:,:)
                         !< The internal wave energy density as a function of (frequency,mode)
-                        !! integrated within an angular and frequency band [H Z2 T-2 ~> J m-2]
+                        !! integrated within an angular and frequency band [H Z2 T-2 ~> m3 s-2 or J m-2]
                         !! only at the end of the routine (for diags)
   real, allocatable :: En_restart_mode1(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 1 [H Z2 T-2 ~> J m-2]
+                        !! for mode 1 [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable :: En_restart_mode2(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 2 [H Z2 T-2 ~> J m-2]
+                        !! for mode 2 [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable :: En_restart_mode3(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 3 [H Z2 T-2 ~> J m-2]
+                        !! for mode 3 [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable :: En_restart_mode4(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 4 [H Z2 T-2 ~> J m-2]
+                        !! for mode 4 [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, allocatable :: En_restart_mode5(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 5 [H Z2 T-2 ~> J m-2]
+                        !! for mode 5 [H Z2 T-2 ~> m3 s-2 or J m-2]
 
   real, allocatable, dimension(:) :: frequency  !< The frequency of each band [T-1 ~> s-1].
   real :: Int_tide_decay_scale  !< vertical decay scale for St Laurent profile [Z ~> m]
@@ -275,7 +275,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq) :: &
-    TKE_itidal_input, & !< The energy input to the internal waves [H Z2 T-3 ~> W m-2].
+    TKE_itidal_input, & !< The energy input to the internal waves [H Z2 T-3 ~> m3 s-3 or W m-2].
     vel_btTide !< Barotropic velocity read from file [L T-1 ~> m s-1].
 
   real, dimension(SZI_(G),SZJ_(G),2) :: &
@@ -283,24 +283,24 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   real, dimension(SZI_(G),SZJ_(G),CS%nMode) :: &
     cn             ! baroclinic internal gravity wave speeds for each mode [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq,CS%nMode) :: &
-    tot_En_mode, & ! energy summed over angles only [H Z2 T-2 ~> J m-2]
+    tot_En_mode, & ! energy summed over angles only [H Z2 T-2 ~> m3 s-2 or J m-2]
     Ub, &          ! near-bottom horizontal velocity of wave (modal) [L T-1 ~> m s-1]
     Umax           ! Maximum horizontal velocity of wave (modal) [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq,CS%nMode) :: &
     drag_scale     ! bottom drag scale [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     tot_vel_btTide2, & ! [L2 T-2 ~> m2 s-2]
-    tot_En, &      ! energy summed over angles, modes, frequencies [H Z2 T-2 ~> J m-2]
+    tot_En, &      ! energy summed over angles, modes, frequencies [H Z2 T-2 ~> m3 s-2 or J m-2]
     tot_leak_loss, tot_quad_loss, tot_itidal_loss, tot_Froude_loss, tot_residual_loss, tot_allprocesses_loss, &
-                   ! energy loss rates summed over angle, freq, and mode [H Z2 T-3 ~> W m-2]
+                   ! energy loss rates summed over angle, freq, and mode [H Z2 T-3 ~> m3 s-3 or W m-2]
     htot, &        ! The vertical sum of the layer thicknesses [H ~> m or kg m-2]
-    itidal_loss_mode, & ! Energy lost due to small-scale wave drag, summed over angles [H Z2 T-3 ~> W m-2]
+    itidal_loss_mode, & ! Energy lost due to small-scale wave drag, summed over angles [H Z2 T-3 ~> m3 s-3 or W m-2]
     leak_loss_mode, &
     quad_loss_mode, &
     Froude_loss_mode, &
     residual_loss_mode, &
     allprocesses_loss_mode  ! Total energy loss rates for a given mode and frequency (summed over
-                            ! all angles) [H Z2 T-3 ~> W m-2]
+                            ! all angles) [H Z2 T-3 ~> m3 s-3 or W m-2]
   real :: frac_per_sector ! The inverse of the number of angular, modal and frequency bins [nondim]
   real :: f2       ! The squared Coriolis parameter interpolated to a tracer point [T-2 ~> s-2]
   real :: Kmag2    ! A squared horizontal wavenumber [L-2 ~> m-2]
@@ -316,12 +316,12 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   real :: loss_rate  ! An energy loss rate [T-1 ~> s-1]
   real :: Fr2_max    ! The column maximum internal wave Froude number squared [nondim]
   real :: cn_subRO        ! A tiny wave speed to prevent division by zero [L T-1 ~> m s-1]
-  real :: en_subRO        ! A tiny energy to prevent division by zero [H Z2 T-2 ~> J m-2]
-  real :: En_a, En_b                                 ! Energies for time stepping [H Z2 T-2 ~> J m-2]
-  real :: En_new, En_check                           ! Energies for debugging [H Z2 T-2 ~> J m-2]
-  real :: En_sumtmp                                  ! Energies for debugging [H Z2 T-2 ~> J m-2]
-  real :: En_initial, Delta_E_check                  ! Energies for debugging [H Z2 T-2 ~> J m-2]
-  real :: TKE_Froude_loss_check, TKE_Froude_loss_tot ! Energy losses for debugging [H Z2 T-3 ~> W m-2]
+  real :: en_subRO        ! A tiny energy to prevent division by zero [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real :: En_a, En_b                                 ! Energies for time stepping [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real :: En_new, En_check                           ! Energies for debugging [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real :: En_sumtmp                                  ! Energies for debugging [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real :: En_initial, Delta_E_check                  ! Energies for debugging [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real :: TKE_Froude_loss_check, TKE_Froude_loss_tot ! Energy losses for debugging [H Z2 T-3 ~> m3 s-3 or W m-2]
   real :: HZ2_T3_to_W_m2                             ! unit conversion factor for TKE from internal to mks
   real :: HZ2_T2_to_J_m2                             ! unit conversion factor for Energy from internal to mks
   real :: W_m2_to_HZ2_T3                             ! unit conversion factor for TKE from mks to internal
@@ -337,10 +337,10 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nAngle = CS%NAngle
 
-  HZ2_T3_to_W_m2 = GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T**3)
-  HZ2_T2_to_J_m2 = GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T**2)
-  W_m2_to_HZ2_T3 = GV%m_to_H*(US%m_to_Z**2)*(US%T_to_s**3)
-  J_m2_to_HZ2_T2 = GV%m_to_H*(US%m_to_Z**2)*(US%T_to_s**2)
+  HZ2_T3_to_W_m2 = GV%H_to_kg_m2*(US%Z_to_m**2)*(US%s_to_T**3)
+  HZ2_T2_to_J_m2 = GV%H_to_kg_m2*(US%Z_to_m**2)*(US%s_to_T**2)
+  W_m2_to_HZ2_T3 = GV%kg_m2_to_H*(US%m_to_Z**2)*(US%T_to_s**3)
+  J_m2_to_HZ2_T2 = GV%kg_m2_to_H*(US%m_to_Z**2)*(US%T_to_s**2)
 
   cn_subRO = 1e-30*US%m_s_to_L_T
   en_subRO = 1e-30*J_m2_to_HZ2_T2
@@ -418,7 +418,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%u_struct(:,:,:,1), "Ustruct mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
     call hchksum(CS%u_struct_bot(:,:,1), "Ustruct_bot mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
     call hchksum(CS%u_struct_max(:,:,1), "Ustruct_max mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
-    call hchksum(CS%int_w2(:,:,1),   "int_w2", G%HI, haloshift=0, scale=GV%H_to_m)
+    call hchksum(CS%int_w2(:,:,1),   "int_w2", G%HI, haloshift=0, scale=GV%H_to_MKS)
     call hchksum(CS%int_U2(:,:,1),   "int_U2", G%HI, haloshift=0, scale=GV%H_to_m*US%m_to_Z**2)
     call hchksum(CS%int_N2w2(:,:,1), "int_N2w2", G%HI, haloshift=0, scale=GV%H_to_m*US%s_to_T**2)
   endif
@@ -667,7 +667,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
       ! to each En component (technically not correct; fix later)
       En_b = CS%En(i,j,a,fr,m) ! save previous value
       En_a = CS%En(i,j,a,fr,m) / (1.0 + dt * CS%decay_rate) ! implicit update
-      CS%TKE_leak_loss(i,j,a,fr,m) = (En_b - En_a) * I_dt ! compute exact loss rate [H Z2 T-3 ~> W m-2]
+      CS%TKE_leak_loss(i,j,a,fr,m) = (En_b - En_a) * I_dt ! compute exact loss rate [H Z2 T-3 ~> m3 s-3 or W m-2]
       CS%En(i,j,a,fr,m) = En_a ! update value
     enddo ; enddo ; enddo ; enddo ; enddo
   endif
@@ -1201,7 +1201,7 @@ subroutine sum_En(G, GV, US, CS, En, label)
   type(unit_scale_type),  intent(in) :: US !< A dimensional unit scaling type
   type(int_tide_CS),      intent(inout) :: CS !< Internal tide control structure
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle), &
-                          intent(in) :: En !< The energy density of the internal tides [H Z2 T-2 ~> J m-2].
+                          intent(in) :: En !< The energy density of the internal tides [H Z2 T-2 ~> m3 s-2 or J m-2].
   character(len=*),       intent(in) :: label !< A label to use in error messages
   ! Local variables
   real :: En_sum   ! The total energy in MKS units for potential output [J]
@@ -1252,22 +1252,24 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
                              intent(in) :: TKE_loss_fixed !< Fixed part of energy loss [R Z4 H-1 L-2 ~> kg m-2 or m]
                                                  !! (rho*kappa*h^2) or (kappa*h^2).
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle,CS%nFreq,CS%nMode), &
-                             intent(inout) :: En !< Energy density of the internal waves [H Z2 T-2 ~> J m-2].
+                             intent(inout) :: En !< Energy density of the internal waves [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle,CS%nFreq,CS%nMode), &
-                             intent(out)   :: TKE_loss    !< Energy loss rate [H Z2 T-3 ~> W m-2]
+                             intent(out)   :: TKE_loss    !< Energy loss rate [H Z2 T-3 ~> m3 s-3 or W m-2]
                                                  !! (q*rho*kappa*h^2*N*U^2).
   real,                      intent(in)    :: dt !< Time increment [T ~> s].
   integer, optional,         intent(in)    :: halo_size !< The halo size over which to do the calculations
   ! Local variables
   integer :: j, i, m, fr, a, is, ie, js, je, halo
-  real    :: En_tot          ! energy for a given mode, frequency, and point summed over angles [H Z2 T-2 ~> J m-2]
-  real    :: TKE_loss_tot    ! dissipation for a given mode, frequency, and point summed over angles [H Z2 T-3 ~> W m-2]
+  real    :: En_tot          ! energy for a given mode, frequency
+                             ! and point summed over angles [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real    :: TKE_loss_tot    ! dissipation for a given mode, frequency
+                             ! and point summed over angles [H Z2 T-3 ~> m3 s-3 or W m-2]
   real    :: frac_per_sector ! fraction of energy in each wedge [nondim]
   real    :: q_itides        ! fraction of energy actually lost to mixing (remainder, 1-q, is
                              ! assumed to stay in propagating mode for now - BDM) [nondim]
   real    :: loss_rate       ! approximate loss rate for implicit calc [T-1 ~> s-1]
-  real    :: En_negl         ! negligibly small number to prevent division by zero [H Z2 T-2 ~> J m-2]
-  real    :: En_a, En_b      ! energy before and after timestep [H Z2 T-2 ~> J m-2]
+  real    :: En_negl         ! negligibly small number to prevent division by zero [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real    :: En_a, En_b      ! energy before and after timestep [H Z2 T-2 ~> m3 s-2 or J m-2]
   real    :: I_dt            ! The inverse of the timestep [T-1 ~> s-1]
   real    :: J_m2_to_HZ2_T2  ! unit conversion factor for Energy from mks to internal
   real    :: HZ2_T3_to_W_m2  ! unit conversion factor for Energy from internal to mks
@@ -1301,7 +1303,7 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
       En_tot = En_tot + En(i,j,a,fr,m)
     enddo
 
-    ! Calculate TKE loss rate; units of [H Z2 T-3 ~> W m-2] here.
+    ! Calculate TKE loss rate; units of [H Z2 T-3 ~> m3 s-3 or W m-2] here.
     if (GV%Boussinesq .or. GV%semi_Boussinesq) then
       TKE_loss_tot = q_itides * GV%RZ_to_H*GV%Z_to_H*TKE_loss_fixed(i,j)*Nb(i,j)*Ub(i,j,fr,m)**2
     else
@@ -1313,7 +1315,7 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
     if (En_tot > 0.0) then
       do a=1,CS%nAngle
         frac_per_sector = En(i,j,a,fr,m)/En_tot
-        TKE_loss(i,j,a,fr,m) = frac_per_sector*TKE_loss_tot           ! [H Z2 T-3  ~> W m-2]
+        TKE_loss(i,j,a,fr,m) = frac_per_sector*TKE_loss_tot           ! [H Z2 T-3  ~> m3 s-3 or W m-2]
         loss_rate = TKE_loss(i,j,a,fr,m) / (En(i,j,a,fr,m) + En_negl) ! [T-1 ~> s-1]
         En_b = En(i,j,a,fr,m)
         En_a = En(i,j,a,fr,m) / (1.0 + dt*loss_rate)
@@ -1342,7 +1344,7 @@ subroutine get_lowmode_loss(i,j,G,CS,mechanism,TKE_loss_sum)
   type(int_tide_CS),     intent(in)  :: CS  !< Internal tide control structure
   character(len=*),      intent(in)  :: mechanism    !< The named mechanism of loss to return
   real,                  intent(out) :: TKE_loss_sum !< Total energy loss rate due to specified
-                                                     !! mechanism [H Z2 T-3 ~> W m-2].
+                                                     !! mechanism [H Z2 T-3 ~> m3 s-3 or W m-2].
 
   if (mechanism == 'LeakDrag')  TKE_loss_sum = CS%tot_leak_loss(i,j)
   if (mechanism == 'QuadDrag')  TKE_loss_sum = CS%tot_quad_loss(i,j)
@@ -1795,7 +1797,7 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                          intent(inout) :: En   !< The internal gravity wave energy density as a
                                                !! function of space and angular resolution,
-                                               !! [H Z2 T-2 ~> J m-2].
+                                               !! [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(G%isd:G%ied,G%jsd:G%jed),        &
                          intent(in)    :: cn   !< Baroclinic mode speed [L T-1 ~> m s-1].
   real,                  intent(in)    :: freq !< Wave frequency [T-1 ~> s-1].
@@ -1806,13 +1808,14 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
   ! Local variables
   integer, parameter :: stencil = 2
   real, dimension(SZI_(G),1-stencil:NAngle+stencil) :: &
-    En2d                  ! The internal gravity wave energy density in zonal slices [H Z2 T-2 ~> J m-2]
+    En2d                  ! The internal gravity wave energy density in zonal slices [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, dimension(1-stencil:NAngle+stencil) :: &
     cos_angle, sin_angle  ! The cosine and sine of each angle [nondim]
   real, dimension(SZI_(G)) :: &
     Dk_Dt_Kmag, Dl_Dt_Kmag ! Rates of angular refraction [T-1 ~> s-1]
   real, dimension(SZI_(G),0:nAngle) :: &
-    Flux_E                ! The flux of energy between successive angular wedges within a timestep [H Z2 T-2 ~> J m-2]
+    Flux_E                ! The flux of energy between successive angular wedges
+                          ! within a timestep [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, dimension(SZI_(G),SZJ_(G),1-stencil:NAngle+stencil) :: &
     CFL_ang               ! The CFL number of angular refraction [nondim]
   real, dimension(G%IsdB:G%IedB,G%jsd:G%jed) :: cn_u !< Internal wave group velocity at U-point [L T-1 ~> m s-1]
@@ -1945,21 +1948,21 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
   integer,                   intent(in)    :: halo_ang !< The halo size in angular space
   real, dimension(1-halo_ang:NAngle+halo_ang),   &
                              intent(in)    :: En2d    !< The internal gravity wave energy density as a
-                                                      !! function of angular resolution [H Z2 T-2 ~> J m-2].
+                                                      !! function of angular resolution [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(1-halo_ang:NAngle+halo_ang),   &
                              intent(in)    :: CFL_ang !< The CFL number of the energy advection across angles [nondim]
   real, dimension(0:NAngle), intent(out)   :: Flux_En !< The time integrated internal wave energy flux
-                                                      !! across angles  [H Z2 T-2 ~> J m-2].
+                                                      !! across angles  [H Z2 T-2 ~> m3 s-2 or J m-2].
   ! Local variables
-  real :: flux         ! The internal wave energy flux across angles  [H Z2 T-3 ~> W m-2].
+  real :: flux         ! The internal wave energy flux across angles  [H Z2 T-3 ~> m3 s-3 or W m-2].
   real :: u_ang        ! Angular propagation speed [Rad T-1 ~> Rad s-1]
   real :: Angle_size   ! The size of each orientation wedge in radians [Rad]
   real :: I_Angle_size ! The inverse of the orientation wedges [Rad-1]
   real :: I_dt         ! The inverse of the timestep [T-1 ~> s-1]
-  real :: aR, aL       ! Left and right edge estimates of energy density [H Z2 T-2 rad-1 ~> J m-2 rad-1]
+  real :: aR, aL       ! Left and right edge estimates of energy density [H Z2 T-2 rad-1 ~> m3 s-2 rad-1 or J m-2 rad-1]
   real :: Ep, Ec, Em   ! Mean angular energy density for three successive wedges in angular
-                       ! orientation [H Z2 T-2 rad-1 ~> J m-2 rad-1]
-  real :: dA, curv_3   ! Difference and curvature of energy density [H Z2 T-2 rad-1 ~> J m-2 rad-1]
+                       ! orientation [H Z2 T-2 rad-1 ~> m3 s-2 rad-1 or J m-2 rad-1]
+  real :: dA, curv_3   ! Difference and curvature of energy density [H Z2 T-2 rad-1 ~> m3 s-2 rad-1 or J m-2 rad-1]
   real, parameter :: oneSixth = 1.0/6.0  ! One sixth [nondim]
   integer :: a
 
@@ -1973,7 +1976,7 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
     if (u_ang >= 0.0) then
       ! Implementation of PPM-H3
       ! Convert wedge-integrated energy density into angular energy densities for three successive
-      ! wedges around the source wedge for this flux [H Z2 T-2 rad-1 ~> J m-2 rad-1].
+      ! wedges around the source wedge for this flux [H Z2 T-2 rad-1 ~> m3 s-2 rad-1 or J m-2 rad-1].
       Ep = En2d(a+1)*I_Angle_size
       Ec = En2d(a)  *I_Angle_size
       Em = En2d(a-1)*I_Angle_size
@@ -1991,15 +1994,15 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
         aR = 3.*Ec - 2.*aL   ! Flatten the profile to move the extremum to the right edge
       endif
       curv_3 = (aR + aL) - 2.0*Ec ! Curvature
-      ! Calculate angular flux rate [H Z2 T-3 ~> W m-2]
+      ! Calculate angular flux rate [H Z2 T-3 ~> m3 s-3 or W m-2]
       flux = u_ang*( aR + CFL_ang(A) * ( 0.5*(aL - aR) + curv_3 * (CFL_ang(A) - 1.5) ) )
-      ! Calculate amount of energy fluxed between wedges [H Z2 T-2 ~> J m-2]
+      ! Calculate amount of energy fluxed between wedges [H Z2 T-2 ~> m3 s-2 or J m-2]
       Flux_En(A) = dt * flux
       !Flux_En(A) = (dt * I_Angle_size) * flux
     else
       ! Implementation of PPM-H3
       ! Convert wedge-integrated energy density into angular energy densities for three successive
-      ! wedges around the source wedge for this flux [H Z2 T-2 rad-1 ~> J m-2 rad-1].
+      ! wedges around the source wedge for this flux [H Z2 T-2 rad-1 ~> m3 s-2 rad-1 or J m-2 rad-1].
       Ep = En2d(a+2)*I_Angle_size
       Ec = En2d(a+1)*I_Angle_size
       Em = En2d(a)  *I_Angle_size
@@ -2017,10 +2020,10 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
         aR = 3.*Ec - 2.*aL   ! Flatten the profile to move the extremum to the right edge
       endif
       curv_3 = (aR + aL) - 2.0*Ec ! Curvature
-      ! Calculate angular flux rate [H Z2 T-3 ~> W m-2]
+      ! Calculate angular flux rate [H Z2 T-3 ~> m3 s-3 or W m-2]
       ! Note that CFL_ang is negative here, so it looks odd compared with equivalent expressions.
       flux = u_ang*( aL - CFL_ang(A) * ( 0.5*(aR - aL) + curv_3 * (-CFL_ang(A) - 1.5) ) )
-      ! Calculate amount of energy fluxed between wedges [H Z2 T-2 ~> J m-2]
+      ! Calculate amount of energy fluxed between wedges [H Z2 T-2 ~> m3 s-2 or J m-2]
       Flux_En(A) = dt * flux
       !Flux_En(A) = (dt * I_Angle_size) * flux
     endif
@@ -2036,7 +2039,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                          intent(inout) :: En   !< The internal gravity wave energy density as a
                                                !! function of space and angular resolution,
-                                               !! [H Z2 T-2 ~> J m-2].
+                                               !! [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(G%isd:G%ied,G%jsd:G%jed),        &
                          intent(in)    :: cn   !< Baroclinic mode speed [L T-1 ~> m s-1].
   real,                  intent(in)    :: freq !< Wave frequency [T-1 ~> s-1].
@@ -2045,7 +2048,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
   type(int_tide_CS),     intent(inout)    :: CS   !< Internal tide control structure
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                          intent(inout) :: residual_loss !< internal tide energy loss due
-                                                        !! to the residual at slopes [H Z2 T-3 ~> W m-2].
+                                                        !! to the residual at slopes [H Z2 T-3 ~> m3 s-3 or W m-2].
   ! Local variables
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB) :: &
     speed  ! The magnitude of the group velocity at the q points for corner adv [L T-1 ~> m s-1].
@@ -2208,7 +2211,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   type(ocean_grid_type),  intent(in)    :: G     !< The ocean's grid structure.
   real, dimension(G%isd:G%ied,G%jsd:G%jed),   &
                           intent(inout) :: En    !< The energy density integrated over an angular
-                                                 !! band [H Z2 T-2 ~> J m-2].
+                                                 !! band [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed), &
                           intent(in)    :: speed !< The magnitude of the group velocity at the cell
                                                  !! corner points [L T-1 ~> m s-1].
@@ -2246,7 +2249,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: x, y ! coordinates of cell corners [L ~> m]
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: Idx, Idy ! inverse of dx,dy at cell corners [L-1 ~> m-1]
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: dx, dy ! dx,dy at cell corners [L ~> m]
-  real, dimension(2) :: E_new ! Energy in cell after advection for subray [H Z2 T-2 ~> J m-2]; set size
+  real, dimension(2) :: E_new ! Energy in cell after advection for subray [H Z2 T-2 ~> m3 s-2 or J m-2]; set size
                               ! here to define Nsubrays - this should be made an input option later!
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
@@ -2499,7 +2502,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
                                                !! discretized wave energy spectrum.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
                            intent(inout) :: En !< The energy density integrated over an angular
-                                               !! band [H Z2 T-2 ~> J m-2].
+                                               !! band [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(G%IsdB:G%IedB,G%jsd:G%jed),        &
                            intent(in)    :: speed_x !< The magnitude of the group velocity at the
                                                !! Cu points [L T-1 ~> m s-1].
@@ -2512,17 +2515,17 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
                            intent(inout) :: residual_loss !< internal tide energy loss due
-                                                          !! to the residual at slopes [H Z2 T-3 ~> W m-2].
+                                                          !! to the residual at slopes [H Z2 T-3 ~> m3 s-3 or W m-2].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    EnL, EnR    ! Left and right face energy densities [H Z2 T-2 ~> J m-2].
+    EnL, EnR    ! Left and right face energy densities [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZIB_(G),SZJ_(G)) :: &
-    flux_x      ! The internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
+    flux_x      ! The internal wave energy flux [H Z2 L2 T-3 ~> m5 s-3 or J s-1].
   real, dimension(SZIB_(G)) :: &
     cg_p, &     ! The x-direction group velocity [L T-1 ~> m s-1]
-    flux1       ! A 1-d copy of the x-direction internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
+    flux1       ! A 1-d copy of the x-direction internal wave energy flux [H Z2 L2 T-3 ~> m5 s-3 or J s-1].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle) :: &
-    Fdt_m, Fdt_p! Left and right energy fluxes [H Z2 L2 T-2 ~> J]
+    Fdt_m, Fdt_p! Left and right energy fluxes [H Z2 L2 T-2 ~> m5 s-2 or J]
   integer :: i, j, ish, ieh, jsh, jeh, a
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
@@ -2547,8 +2550,8 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
     enddo
 
     do j=jsh,jeh ; do i=ish,ieh
-      Fdt_m(i,j,a) = dt*flux_x(I-1,j) ! left face influx  [H Z2 L2 T-2 ~> J]
-      Fdt_p(i,j,a) = -dt*flux_x(I,j)  ! right face influx [H Z2 L2 T-2 ~> J]
+      Fdt_m(i,j,a) = dt*flux_x(I-1,j) ! left face influx  [H Z2 L2 T-2 ~> m5 s-2 or J]
+      Fdt_p(i,j,a) = -dt*flux_x(I,j)  ! right face influx [H Z2 L2 T-2 ~> m5 s-2 or J]
 
       ! only compute residual loss on partial reflection cells, remove numerical noise elsewhere
       if (CS%refl_pref_logical(i,j)) then
@@ -2567,7 +2570,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
   call reflect(Fdt_p, Nangle, CS, G, LB)
   !call teleport(Fdt_p, Nangle, CS, G, LB)
 
-  ! Update reflected energy [H Z2 T-2 ~> J m-2]
+  ! Update reflected energy [H Z2 T-2 ~> m3 s-2 or J m-2]
   do a=1,Nangle ; do j=jsh,jeh ; do i=ish,ieh
     En(i,j,a) = En(i,j,a) + G%IareaT(i,j)*(Fdt_m(i,j,a) + Fdt_p(i,j,a))
   enddo ; enddo ; enddo
@@ -2581,7 +2584,7 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
                                                !! discretized wave energy spectrum.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle), &
                            intent(inout) :: En !< The energy density integrated over an angular
-                                               !! band [H Z2 T-2 ~> J m-2].
+                                               !! band [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(G%isd:G%ied,G%JsdB:G%JedB),      &
                            intent(in)    :: speed_y !< The magnitude of the group velocity at the
                                                !! Cv points [L T-1 ~> m s-1].
@@ -2594,17 +2597,17 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
                            intent(inout) :: residual_loss !< internal tide energy loss due
-                                                          !! to the residual at slopes [H Z2 T-3 ~> W m-2].
+                                                          !! to the residual at slopes [H Z2 T-3 ~> m3 s-3 or W m-2].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    EnL, EnR    ! South and north face energy densities [H Z2 T-2 ~> J m-2].
+    EnL, EnR    ! South and north face energy densities [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZI_(G),SZJB_(G)) :: &
-    flux_y      ! The internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
+    flux_y      ! The internal wave energy flux [H Z2 L2 T-3 ~> m5 s-3 or J s-1].
   real, dimension(SZI_(G)) :: &
     cg_p, &     ! The y-direction group velocity [L T-1 ~> m s-1]
-    flux1       ! A 1-d copy of the y-direction internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
+    flux1       ! A 1-d copy of the y-direction internal wave energy flux [H Z2 L2 T-3 ~> m5 s-3 or J s-1].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle) :: &
-    Fdt_m, Fdt_p! South and north energy fluxes [H Z2 L2 T-2 ~> J]
+    Fdt_m, Fdt_p! South and north energy fluxes [H Z2 L2 T-2 ~> m5 s-2 or J]
   integer :: i, j, ish, ieh, jsh, jeh, a
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
@@ -2629,8 +2632,8 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
     enddo
 
     do j=jsh,jeh ; do i=ish,ieh
-      Fdt_m(i,j,a) = dt*flux_y(i,J-1) ! south face influx [H Z2 L2 T-2 ~> J]
-      Fdt_p(i,j,a) = -dt*flux_y(i,J)  ! north face influx [H Z2 L2 T-2 ~> J]
+      Fdt_m(i,j,a) = dt*flux_y(i,J-1) ! south face influx [H Z2 L2 T-2 ~> m5 s-2 or J]
+      Fdt_p(i,j,a) = -dt*flux_y(i,J)  ! north face influx [H Z2 L2 T-2 ~> m5 s-2 or J]
 
       ! only compute residual loss on partial reflection cells, remove numerical noise elsewhere
       if (CS%refl_pref_logical(i,j)) then
@@ -2649,7 +2652,7 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
   call reflect(Fdt_p, Nangle, CS, G, LB)
   !call teleport(Fdt_p, Nangle, CS, G, LB)
 
-  ! Update reflected energy [H Z2 T-2 ~> J m-2]
+  ! Update reflected energy [H Z2 T-2 ~> m3 s-2 or J m-2]
   do a=1,Nangle ; do j=jsh,jeh ; do i=ish,ieh
     En(i,j,a) = En(i,j,a) + G%IareaT(i,j)*(Fdt_m(i,j,a) + Fdt_p(i,j,a))
   enddo ; enddo ; enddo
@@ -2661,12 +2664,12 @@ subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, US, j, ish, ieh, vol_CFL)
   type(ocean_grid_type),     intent(in)    :: G  !< The ocean's grid structure.
   real, dimension(SZIB_(G)), intent(in)    :: u  !< The zonal velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G)),  intent(in)    :: h  !< Energy density used to calculate the fluxes
-                                                 !! [H Z2 T-2 ~> J m-2].
+                                                 !! [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZI_(G)),  intent(in)    :: hL !< Left- Energy densities in the reconstruction
-                                                 !! [H Z2 T-2 ~> J m-2].
+                                                 !! [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZI_(G)),  intent(in)    :: hR !< Right- Energy densities in the reconstruction
-                                                 !! [H Z2 T-2 ~> J m-2].
-  real, dimension(SZIB_(G)), intent(out) :: uh !< The zonal energy transport [H Z2 L2 T-3 ~> J s-1].
+                                                 !! [H Z2 T-2 ~> m3 s-2 or J m-2].
+  real, dimension(SZIB_(G)), intent(out) :: uh !< The zonal energy transport [H Z2 L2 T-3 ~> m5 s-3 or J s-1].
   real,                      intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),     intent(in)    :: US !< A dimensional unit scaling type
   integer,                   intent(in)    :: j  !< The j-index to work on.
@@ -2676,7 +2679,7 @@ subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, US, j, ish, ieh, vol_CFL)
                                                  !! the cell areas when estimating the CFL number.
   ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim].
-  real :: curv_3 ! A measure of the energy density curvature over a grid length [H Z2 T-2 ~> J m-2]
+  real :: curv_3 ! A measure of the energy density curvature over a grid length [H Z2 T-2 ~> m3 s-2 or J m-2]
   integer :: i
 
   do I=ish-1,ieh
@@ -2704,12 +2707,13 @@ subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, US, J, ish, ieh, vol_CFL)
   type(ocean_grid_type),            intent(in)    :: G  !< The ocean's grid structure.
   real, dimension(SZI_(G)),         intent(in)    :: v  !< The meridional velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: h  !< Energy density used to calculate the
-                                                        !! fluxes [H Z2 T-2 ~> J m-2].
+                                                        !! fluxes [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: hL !< Left- Energy densities in the
-                                                        !! reconstruction [H Z2 T-2 ~> J m-2].
+                                                        !! reconstruction [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: hR !< Right- Energy densities in the
-                                                        !! reconstruction [H Z2 T-2 ~> J m-2].
-  real, dimension(SZI_(G)),         intent(out) :: vh !< The meridional energy transport [H Z2 L2 T-3 ~> J s-1].
+                                                        !! reconstruction [H Z2 T-2 ~> m3 s-2 or J m-2].
+  real, dimension(SZI_(G)),         intent(out) :: vh !< The meridional energy transport
+                                                      !! [H Z2 L2 T-3 ~> m5 s-3 or J s-1].
   real,                             intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),            intent(in)    :: US !< A dimensional unit scaling type
   integer,                          intent(in)    :: J  !< The j-index to work on.
@@ -2720,7 +2724,7 @@ subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, US, J, ish, ieh, vol_CFL)
                                                         !! the CFL number.
   ! Local variables
   real :: CFL ! The CFL number based on the local velocity and grid spacing [nondim].
-  real :: curv_3 ! A measure of the energy density curvature over a grid length [H Z2 T-2 ~> J m-2]
+  real :: curv_3 ! A measure of the energy density curvature over a grid length [H Z2 T-2 ~> m3 s-2 or J m-2]
   integer :: i
 
   do i=ish,ieh
@@ -2750,7 +2754,7 @@ subroutine reflect(En, NAngle, CS, G, LB)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                           intent(inout) :: En !< The internal gravity wave energy density as a
                                               !! function of space and angular resolution
-                                              !! [H Z2 T-2 ~> J m-2].
+                                              !! [H Z2 T-2 ~> m3 s-2 or J m-2].
   type(int_tide_CS),      intent(in)    :: CS !< Internal tide control structure
   type(loop_bounds_type), intent(in)    :: LB !< A structure with the active energy loop bounds.
 
@@ -2762,7 +2766,7 @@ subroutine reflect(En, NAngle, CS, G, LB)
                                            ! values should collocate with angle_c [nondim]
   logical, dimension(G%isd:G%ied,G%jsd:G%jed) :: ridge
                                            ! tags of cells with double reflection
-  real, dimension(1:Nangle) :: En_reflected ! Energy reflected [H Z2 T-2 ~> J m-2].
+  real, dimension(1:Nangle) :: En_reflected ! Energy reflected [H Z2 T-2 ~> m3 s-2 or J m-2].
 
   real    :: TwoPi                         ! 2*pi = 6.2831853... [nondim]
   real    :: Angle_size                    ! size of beam wedge [rad]
@@ -2857,7 +2861,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                           intent(inout) :: En !< The internal gravity wave energy density as a
                                               !! function of space and angular resolution
-                                              !! [H Z2 T-2 ~> J m-2].
+                                              !! [H Z2 T-2 ~> m3 s-2 or J m-2].
   type(int_tide_CS),      intent(in)    :: CS !< Internal tide control structure
   type(loop_bounds_type), intent(in)    :: LB !< A structure with the active energy loop bounds.
   ! Local variables
@@ -2875,7 +2879,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
   real, dimension(1:NAngle)   :: angle_i    ! angle of incident ray wrt equator [rad]
   real, dimension(1:NAngle)   :: cos_angle  ! Cosine of the beam angle relative to eastward [nondim]
   real, dimension(1:NAngle)   :: sin_angle  ! Sine of the beam angle relative to eastward [nondim]
-  real                        :: En_tele    ! energy to be "teleported" [H Z2 T-2 ~> J m-2]
+  real                        :: En_tele    ! energy to be "teleported" [H Z2 T-2 ~> m3 s-2 or J m-2]
   character(len=160) :: mesg  ! The text of an error message
   integer :: i, j, a
   integer :: ish, ieh, jsh, jeh     ! start and end local indices on data domain
@@ -2950,7 +2954,7 @@ subroutine correct_halo_rotation(En, test, G, NAngle, halo)
   type(ocean_grid_type),      intent(in)    :: G    !< The ocean's grid structure
   real, dimension(:,:,:,:,:), intent(inout) :: En   !< The internal gravity wave energy density as a
                                        !! function of space, angular orientation, frequency,
-                                       !! and vertical mode [H Z2 T-2 ~> J m-2].
+                                       !! and vertical mode [H Z2 T-2 ~> m3 s-2 or J m-2].
   real, dimension(SZI_(G),SZJ_(G),2), &
                               intent(in)    :: test !< An x-unit vector that has been passed through
                                        !! the halo updates, to enable the rotation of the
@@ -2960,7 +2964,7 @@ subroutine correct_halo_rotation(En, test, G, NAngle, halo)
   integer,                    intent(in)    :: halo   !< The halo size over which to do the calculations
   ! Local variables
   real, dimension(G%isd:G%ied,NAngle) :: En2d ! A zonal row of the internal gravity wave energy density
-                                              ! in a frequency band and mode [H Z2 T-2 ~> J m-2].
+                                              ! in a frequency band and mode [H Z2 T-2 ~> m3 s-2 or J m-2].
   integer, dimension(G%isd:G%ied) :: a_shift
   integer :: i_first, i_last, a_new
   integer :: a, i, j, ish, ieh, jsh, jeh, m, fr
@@ -3007,19 +3011,23 @@ end subroutine correct_halo_rotation
 !> Calculates left/right edge values for PPM reconstruction in x-direction.
 subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [H Z2 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D)
+                                                        !! [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D)
+                                                        !! [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D)
+                                                        !! [H Z2 T-2 ~> m3 s-2 or J m-2]
   type(loop_bounds_type),           intent(in)  :: LB   !< A structure with the active loop bounds.
   logical,                          intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width
+                                           ! [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, parameter :: oneSixth = 1./6. ! One sixth [nondim]
-  real :: h_ip1, h_im1 ! The energy densities at adjacent points [H Z2 T-2 ~> J m-2]
+  real :: h_ip1, h_im1 ! The energy densities at adjacent points [H Z2 T-2 ~> m3 s-2 or J m-2]
   real :: dMx, dMn ! The maximum and minimum of values of energy density at adjacent points
-                   ! relative to the center point [H Z2 T-2 ~> J m-2]
+                   ! relative to the center point [H Z2 T-2 ~> m3 s-2 or J m-2]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, isl, iel, jsl, jel, stencil
 
@@ -3082,19 +3090,23 @@ end subroutine PPM_reconstruction_x
 !> Calculates left/right edge valus for PPM reconstruction in y-direction.
 subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [H Z2 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D)
+                                                        !! [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D)
+                                                        !! [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D)
+                                                        !! [H Z2 T-2 ~> m3 s-2 or J m-2]
   type(loop_bounds_type),           intent(in)  :: LB   !< A structure with the active loop bounds.
   logical,                          intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width
+                                           ! [H Z2 T-2 ~> m3 s-2 or J m-2]
   real, parameter :: oneSixth = 1./6. ! One sixth [nondim]
-  real :: h_jp1, h_jm1 ! The energy densities at adjacent points [H Z2 T-2 ~> J m-2]
+  real :: h_jp1, h_jm1 ! The energy densities at adjacent points [H Z2 T-2 ~> m3 s-2 or J m-2]
   real :: dMx, dMn ! The maximum and minimum of values of energy density at adjacent points
-                   ! relative to the center point [H Z2 T-2 ~> J m-2]
+                   ! relative to the center point [H Z2 T-2 ~> m3 s-2 or J m-2]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, isl, iel, jsl, jel, stencil
 
@@ -3158,18 +3170,22 @@ end subroutine PPM_reconstruction_y
 !! than h_min, with a minimum of h_min otherwise.
 subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
   type(ocean_grid_type),            intent(in)     :: G     !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)     :: h_in  !< Energy density in each sector (2D) [H Z2 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_L   !< Left edge value of reconstruction  [H Z2 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value of reconstruction [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)     :: h_in  !< Energy density in each sector (2D)
+                                                            !! [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_L   !< Left edge value of reconstruction
+                                                            !!  [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value of reconstruction
+                                                            !! [H Z2 T-2 ~> m3 s-2 or J m-2]
   real,                             intent(in)     :: h_min !< The minimum value that can be
-                                                            !! obtained by a concave parabolic fit [H Z2 T-2 ~> J m-2]
+                                                            !! obtained by a concave parabolic fit
+                                                            !! [H Z2 T-2 ~> m3 s-2 or J m-2]
   integer,                          intent(in)     :: iis   !< Start i-index for computations
   integer,                          intent(in)     :: iie   !< End i-index for computations
   integer,                          intent(in)     :: jis   !< Start j-index for computations
   integer,                          intent(in)     :: jie   !< End j-index for computations
   ! Local variables
-  real    :: curv    ! The cell-area normalized curvature [H Z2 T-2 ~> J m-2]
-  real    :: dh      ! The difference between the edge values [H Z2 T-2 ~> J m-2]
+  real    :: curv    ! The cell-area normalized curvature [H Z2 T-2 ~> m3 s-2 or J m-2]
+  real    :: dh      ! The difference between the edge values [H Z2 T-2 ~> m3 s-2 or J m-2]
   real    :: scale   ! A rescaling factor used to give a minimum cell value of at least h_min [nondim]
   integer :: i, j
 
@@ -3194,8 +3210,9 @@ subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
   enddo ; enddo
 end subroutine PPM_limit_pos
 
-subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
+subroutine register_int_tide_restarts(G, GV, US, param_file, CS, restart_CS)
   type(ocean_grid_type), intent(in) :: G          !< The ocean's grid structure
+  type(verticalGrid_type),intent(in):: GV         !< The ocean's vertical grid structure.
   type(unit_scale_type), intent(in) :: US         !< A dimensional unit scaling type
   type(param_file_type), intent(in) :: param_file !< A structure to parse for run-time parameters
   type(int_tide_CS),     pointer    :: CS         !< Internal tide control structure
@@ -3210,8 +3227,11 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
 
   type(axis_info) :: axes_inttides(2)
   real, dimension(:), allocatable :: angles, freqs ! Lables for angles and frequencies [nondim]
+  real :: HZ2_T2_to_J_m2                           ! unit conversion factor for Energy from internal to mks
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
+
+  HZ2_T2_to_J_m2 = GV%H_to_kg_m2*(US%Z_to_m**2)*(US%s_to_T**2)
 
   if (associated(CS)) then
     call MOM_error(WARNING, "register_int_tide_restarts called "//&
@@ -3252,7 +3272,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   ! register all 4d restarts and copy into full Energy array when restarting from previous state
   call register_restart_field(CS%En_restart_mode1(:,:,:,:), "IW_energy_mode1", .false., restart_CS, &
                               longname="The internal wave energy density f(i,j,angle,freq) for mode 1", &
-                              units="J m-2", conversion=US%RZ3_T3_to_W_m2*US%T_to_s, z_grid='1', t_grid="s", &
+                              units="J m-2", conversion=HZ2_T2_to_J_m2, z_grid='1', t_grid="s", &
                               extra_axes=axes_inttides)
 
   do fr=1,num_freq ; do a=1,num_angle ; do j=jsd,jed ; do i=isd,ied
@@ -3262,7 +3282,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   if (num_mode >= 2) then
     call register_restart_field(CS%En_restart_mode2(:,:,:,:), "IW_energy_mode2", .false., restart_CS, &
                                 longname="The internal wave energy density f(i,j,angle,freq) for mode 2", &
-                                units="J m-2", conversion=US%RZ3_T3_to_W_m2*US%T_to_s, z_grid='1', t_grid="s", &
+                                units="J m-2", conversion=HZ2_T2_to_J_m2, z_grid='1', t_grid="s", &
                                 extra_axes=axes_inttides)
 
     do fr=1,num_freq ; do a=1,num_angle ; do j=jsd,jed ; do i=isd,ied
@@ -3274,7 +3294,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   if (num_mode >= 3) then
     call register_restart_field(CS%En_restart_mode3(:,:,:,:), "IW_energy_mode3", .false., restart_CS, &
                                 longname="The internal wave energy density f(i,j,angle,freq) for mode 3", &
-                                units="J m-2", conversion=US%RZ3_T3_to_W_m2*US%T_to_s, z_grid='1', t_grid="s", &
+                                units="J m-2", conversion=HZ2_T2_to_J_m2, z_grid='1', t_grid="s", &
                                 extra_axes=axes_inttides)
 
     do fr=1,num_freq ; do a=1,num_angle ; do j=jsd,jed ; do i=isd,ied
@@ -3286,7 +3306,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   if (num_mode >= 4) then
     call register_restart_field(CS%En_restart_mode4(:,:,:,:), "IW_energy_mode4", .false., restart_CS, &
                                 longname="The internal wave energy density f(i,j,angle,freq) for mode 4", &
-                                units="J m-2", conversion=US%RZ3_T3_to_W_m2*US%T_to_s, z_grid='1', t_grid="s", &
+                                units="J m-2", conversion=HZ2_T2_to_J_m2, z_grid='1', t_grid="s", &
                                 extra_axes=axes_inttides)
 
     do fr=1,num_freq ; do a=1,num_angle ; do j=jsd,jed ; do i=isd,ied
@@ -3298,7 +3318,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   if (num_mode >= 5) then
     call register_restart_field(CS%En_restart_mode5(:,:,:,:), "IW_energy_mode5", .false., restart_CS, &
                                 longname="The internal wave energy density f(i,j,angle,freq) for mode 5", &
-                                units="J m-2", conversion=US%RZ3_T3_to_W_m2*US%T_to_s, z_grid='1', t_grid="s", &
+                                units="J m-2", conversion=HZ2_T2_to_J_m2, z_grid='1', t_grid="s", &
                                 extra_axes=axes_inttides)
 
     do fr=1,num_freq ; do a=1,num_angle ; do j=jsd,jed ; do i=isd,ied
@@ -3312,7 +3332,7 @@ end subroutine register_int_tide_restarts
 !> This subroutine initializes the internal tides module.
 subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type), target,   intent(in)    :: Time !< The current model time.
-  type(ocean_grid_type),     intent(inout) :: G    !< The ocean's grid structure.
+  type(ocean_grid_type),     intent(in)    :: G    !< The ocean's grid structure.
   type(verticalGrid_type),   intent(in)    :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),     intent(in)    :: US   !< A dimensional unit scaling type
   type(param_file_type),     intent(in)    :: param_file !< A structure to parse for run-time
@@ -3337,6 +3357,9 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                                 ! nominal ocean depth, or a negative value for no limit [nondim]
   real    :: period_1           ! The period of the gravest modeled mode [T ~> s]
   real    :: period             ! A tidal period read from namelist [T ~> s]
+  real    :: HZ2_T2_to_J_m2     ! unit conversion factor for Energy from internal to mks
+  real    :: HZ2_T3_to_W_m2     ! unit conversion factor for TKE from internal to mks
+  real    :: W_m2_to_HZ2_T3     ! unit conversion factor for TKE from mks to internal
   integer :: num_angle, num_freq, num_mode, m, fr
   integer :: isd, ied, jsd, jed, a, id_ang, i, j, nz
   type(axes_grp) :: axes_ang
@@ -3357,6 +3380,10 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   nz = GV%ke
+
+  HZ2_T2_to_J_m2 = GV%H_to_kg_m2*(US%Z_to_m**2)*(US%s_to_T**2)
+  HZ2_T3_to_W_m2 = GV%H_to_kg_m2*(US%Z_to_m**2)*(US%s_to_T**3)
+  W_m2_to_HZ2_T3 = GV%kg_m2_to_H*(US%m_to_Z**2)*(US%T_to_s**3)
 
   CS%initialized = .true.
 
@@ -3523,7 +3550,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "EN_CHECK_TOLERANCE", CS%En_check_tol, &
                  "An energy density tolerance for flagging points with small negative "//&
                  "internal tide energy.", &
-                 units="J m-2", default=1.0, scale=US%W_m2_to_RZ3_T3*US%s_to_T, &
+                 units="J m-2", default=1.0, scale=W_m2_to_HZ2_T3, &
                  do_not_log=.not.CS%apply_Froude_drag)
   call get_param(param_file, mdl, "CDRAG", CS%cdrag, &
                  "CDRAG is the drag coefficient relating the magnitude of "//&
@@ -3626,7 +3653,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     endif
     ! Compute the fixed part; units are [R Z4 H-1 L-2 ~> kg m-2 or m] here
     ! will be multiplied by N and the squared near-bottom velocity (and by the
-    ! near-bottom density in non-Boussinesq mode) to get into [H Z2 T-3 ~> W m-2]
+    ! near-bottom density in non-Boussinesq mode) to get into [H Z2 T-3 ~> m3 s-3 or W m-2]
     CS%TKE_itidal_loss_fixed(i,j) = 0.5*kappa_h2_factor* GV%H_to_RZ * US%L_to_Z*kappa_itides * h2(i,j)
   enddo ; enddo
 
@@ -3771,7 +3798,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
   ! Register 2-D energy density (summed over angles, freq, modes)
   CS%id_tot_En = register_diag_field('ocean_model', 'ITide_tot_En', diag%axesT1, &
                  Time, 'Internal tide total energy density', &
-                 'J m-2', conversion=US%RZ3_T3_to_W_m2*US%T_to_s)
+                 'J m-2', conversion=HZ2_T2_to_J_m2)
 
   allocate(CS%id_itide_drag(CS%nFreq, CS%nMode), source=-1)
   allocate(CS%id_TKE_itidal_input(CS%nFreq), source=-1)
@@ -3782,27 +3809,27 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
 
     CS%id_TKE_itidal_input(fr) = register_diag_field('ocean_model', var_name, diag%axesT1, &
                                                      Time, 'Conversion from barotropic to baroclinic tide, '//&
-                                                     var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                                                     var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
   enddo
   ! Register 2-D energy losses (summed over angles, freq, modes)
   CS%id_tot_leak_loss = register_diag_field('ocean_model', 'ITide_tot_leak_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss to background drag', &
-                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                'W m-2', conversion=HZ2_T3_to_W_m2)
   CS%id_tot_quad_loss = register_diag_field('ocean_model', 'ITide_tot_quad_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss to bottom drag', &
-                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                'W m-2', conversion=HZ2_T3_to_W_m2)
   CS%id_tot_itidal_loss = register_diag_field('ocean_model', 'ITide_tot_itidal_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss to wave drag', &
-                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                'W m-2', conversion=HZ2_T3_to_W_m2)
   CS%id_tot_Froude_loss = register_diag_field('ocean_model', 'ITide_tot_Froude_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss to wave breaking', &
-                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                'W m-2', conversion=HZ2_T3_to_W_m2)
   CS%id_tot_residual_loss = register_diag_field('ocean_model', 'ITide_tot_residual_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss to residual on slopes', &
-                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                'W m-2', conversion=HZ2_T3_to_W_m2)
   CS%id_tot_allprocesses_loss = register_diag_field('ocean_model', 'ITide_tot_allprocesses_loss', diag%axesT1, &
                 Time, 'Internal tide energy loss summed over all processes', &
-                'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                'W m-2', conversion=HZ2_T3_to_W_m2)
 
   allocate(CS%id_En_mode(CS%nFreq,CS%nMode), source=-1)
   allocate(CS%id_En_ang_mode(CS%nFreq,CS%nMode), source=-1)
@@ -3834,14 +3861,14 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     write(var_name, '("Itide_En_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy density in frequency ",i1," mode ",i1)') fr, m
     CS%id_En_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'J m-2', conversion=US%RZ3_T3_to_W_m2*US%T_to_s)
+                 diag%axesT1, Time, var_descript, 'J m-2', conversion=HZ2_T2_to_J_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
     ! Register 3-D (i,j,a) energy density for each frequency and mode
     write(var_name, '("Itide_En_ang_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide angular energy density in frequency ",i1," mode ",i1)') fr, m
     CS%id_En_ang_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 axes_ang, Time, var_descript, 'J m-2 band-1', conversion=US%RZ3_T3_to_W_m2*US%T_to_s)
+                 axes_ang, Time, var_descript, 'J m-2 band-1', conversion=HZ2_T2_to_J_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
     ! Register 2-D energy loss (summed over angles) for each frequency and mode
@@ -3849,37 +3876,37 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     write(var_name, '("Itide_wavedrag_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy loss due to wave-drag from frequency ",i1," mode ",i1)') fr, m
     CS%id_itidal_loss_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                 diag%axesT1, Time, var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
     ! Leakage loss
     write(var_name, '("Itide_leak_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy loss due to leakage from frequency ",i1," mode ",i1)') fr, m
     CS%id_leak_loss_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                 diag%axesT1, Time, var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
     ! Quad loss
     write(var_name, '("Itide_quad_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy quad loss from frequency ",i1," mode ",i1)') fr, m
     CS%id_quad_loss_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                 diag%axesT1, Time, var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
     ! Froude loss
     write(var_name, '("Itide_froude_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy Froude loss from frequency ",i1," mode ",i1)') fr, m
     CS%id_froude_loss_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                 diag%axesT1, Time, var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
     ! residual losses
     write(var_name, '("Itide_residual_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy residual loss from frequency ",i1," mode ",i1)') fr, m
     CS%id_residual_loss_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                 diag%axesT1, Time, var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
     ! all loss processes
     write(var_name, '("Itide_allprocesses_loss_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy loss due to all processes from frequency ",i1," mode ",i1)') fr, m
     CS%id_allprocesses_loss_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 diag%axesT1, Time, var_descript, 'W m-2', conversion=US%RZ3_T3_to_W_m2)
+                 diag%axesT1, Time, var_descript, 'W m-2', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
     ! Register 3-D (i,j,a) energy loss for each frequency and mode
@@ -3887,7 +3914,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     write(var_name, '("Itide_wavedrag_loss_ang_freq",i1,"_mode",i1)') fr, m
     write(var_descript, '("Internal tide energy loss due to wave-drag from frequency ",i1," mode ",i1)') fr, m
     CS%id_itidal_loss_ang_mode(fr,m) = register_diag_field('ocean_model', var_name, &
-                 axes_ang, Time, var_descript, 'W m-2 band-1', conversion=US%RZ3_T3_to_W_m2)
+                 axes_ang, Time, var_descript, 'W m-2 band-1', conversion=HZ2_T3_to_W_m2)
     call MOM_mesg("Registering "//trim(var_name)//", Described as: "//var_descript, 5)
 
     ! Register 2-D period-averaged near-bottom horizontal velocity for each frequency and mode

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1562,7 +1562,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, visc, dz, j, N2_lay, N2_int
           if (non_Bous) then
             Kd_leak_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_leak(i,k) * dz(i,k) * tv%SpV_avg(i,j,k)
           else
-            Kd_leak_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_leak(i,k) * dz(i,k) / GV%Rho0
+            Kd_leak_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_leak(i,k) * dz(i,k) * GV%RZ_to_H
           endif
         else
           Kd_leak_lay(k) = 0.
@@ -1588,7 +1588,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, visc, dz, j, N2_lay, N2_int
           if (non_Bous) then
             Kd_Froude_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_Froude(i,k) * dz(i,k) * tv%SpV_avg(i,j,k)
           else
-            Kd_Froude_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_Froude(i,k) * dz(i,k) / GV%Rho0
+            Kd_Froude_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_Froude(i,k) * dz(i,k) * GV%RZ_to_H
           endif
         else
           Kd_Froude_lay(k) = 0.
@@ -1614,7 +1614,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, visc, dz, j, N2_lay, N2_int
           if (non_Bous) then
             Kd_itidal_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_itidal(i,k) * dz(i,k) * tv%SpV_avg(i,j,k)
           else
-            Kd_itidal_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_itidal(i,k) * dz(i,k) / GV%Rho0
+            Kd_itidal_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_itidal(i,k) * dz(i,k) * GV%RZ_to_H
           endif
         else
           Kd_itidal_lay(k) = 0.
@@ -1640,7 +1640,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, visc, dz, j, N2_lay, N2_int
           if (non_Bous) then
             Kd_slope_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_slope(i,k) * dz(i,k) * tv%SpV_avg(i,j,k)
           else
-            Kd_slope_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_slope(i,k) * dz(i,k) / GV%Rho0
+            Kd_slope_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_slope(i,k) * dz(i,k) * GV%RZ_to_H
           endif
         else
           Kd_slope_lay(k) = 0.
@@ -1666,7 +1666,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, visc, dz, j, N2_lay, N2_int
           if (non_Bous) then
             Kd_quad_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_quad(i,k) * dz(i,k) * tv%SpV_avg(i,j,k)
           else
-            Kd_quad_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_quad(i,k) * dz(i,k) / GV%Rho0
+            Kd_quad_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_quad(i,k) * dz(i,k) * GV%RZ_to_H
           endif
         else
           Kd_quad_lay(k) = 0.

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -89,48 +89,48 @@ type, public :: int_tide_CS ; private
   real, allocatable, dimension(:,:,:,:) :: cp
                         !< horizontal phase speed [L T-1 ~> m s-1]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_leak_loss
-                        !< energy lost due to misc background processes [R Z3 T-3 ~> W m-2]
+                        !< energy lost due to misc background processes [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_quad_loss
-                        !< energy lost due to quadratic bottom drag [R Z3 T-3 ~> W m-2]
+                        !< energy lost due to quadratic bottom drag [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_Froude_loss
-                        !< energy lost due to wave breaking [R Z3 T-3 ~> W m-2]
+                        !< energy lost due to wave breaking [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: TKE_itidal_loss_fixed
-                        !< Fixed part of the energy lost due to small-scale drag [R Z3 L-2 ~> kg m-2] here;
+                        !< Fixed part of the energy lost due to small-scale drag [H Z2 L-2 ~> kg m-2] here;
                         !! This will be multiplied by N and the squared near-bottom velocity (and by
                         !! the near-bottom density in non-Boussinesq mode) to get the energy losses
                         !! in [R Z4 H-1 L-2 ~> kg m-2 or m]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_itidal_loss
-                        !< energy lost due to small-scale wave drag [R Z3 T-3 ~> W m-2]
+                        !< energy lost due to small-scale wave drag [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_residual_loss
-                        !< internal tide energy loss due to the residual at slopes [R Z3 T-3 ~> W m-2]
+                        !< internal tide energy loss due to the residual at slopes [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:,:,:,:) :: TKE_slope_loss
-                        !< internal tide energy loss due to the residual at slopes [R Z3 T-3 ~> W m-2]
+                        !< internal tide energy loss due to the residual at slopes [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: TKE_input_glo_dt
-                        !< The energy input to the internal waves * dt [R Z3 T-2 ~> J m-2].
+                        !< The energy input to the internal waves * dt [H Z2 T-2 ~> J m-2].
   real, allocatable, dimension(:,:) :: TKE_leak_loss_glo_dt
-                        !< energy lost due to misc background processes * dt [R Z3 T-2 ~> J m-2]
+                        !< energy lost due to misc background processes * dt [H Z2 T-2 ~> J m-2]
   real, allocatable, dimension(:,:) :: TKE_quad_loss_glo_dt
-                        !< energy lost due to quadratic bottom drag * dt [R Z3 T-2 ~> J m-2]
+                        !< energy lost due to quadratic bottom drag * dt [H Z2 T-2 ~> J m-2]
   real, allocatable, dimension(:,:) :: TKE_Froude_loss_glo_dt
-                        !< energy lost due to wave breaking [R Z3 T-2 ~> J m-2]
+                        !< energy lost due to wave breaking [H Z2 T-2 ~> J m-2]
   real, allocatable, dimension(:,:) :: TKE_itidal_loss_glo_dt
-                        !< energy lost due to small-scale wave drag [R Z3 T-2 ~> J m-2]
+                        !< energy lost due to small-scale wave drag [H Z2 T-2 ~> J m-2]
   real, allocatable, dimension(:,:) :: TKE_residual_loss_glo_dt
-                        !< internal tide energy loss due to the residual at slopes [R Z3 T-2 ~> J m-2]
+                        !< internal tide energy loss due to the residual at slopes [H Z2 T-2 ~> J m-2]
   real, allocatable, dimension(:,:) :: error_mode
-                        !< internal tide energy budget error for each mode [R Z3 T-2 ~> J m-2]
+                        !< internal tide energy budget error for each mode [H Z2 T-2 ~> J m-2]
   real, allocatable, dimension(:,:) :: tot_leak_loss !< Energy loss rates due to misc background processes,
-                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_quad_loss !< Energy loss rates due to quadratic bottom drag,
-                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_itidal_loss !< Energy loss rates due to small-scale drag,
-                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_Froude_loss !< Energy loss rates due to wave breaking,
-                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_residual_loss !< Energy loss rates due to residual on slopes,
-                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:) :: tot_allprocesses_loss !< Energy loss rates due to all processes,
-                        !! summed over angle, frequency and mode [R Z3 T-3 ~> W m-2]
+                        !! summed over angle, frequency and mode [H Z2 T-3 ~> W m-2]
   real, allocatable, dimension(:,:,:,:) :: w_struct !< Vertical structure of vertical velocity (normalized)
                         !! for each frequency and each mode [nondim]
   real, allocatable, dimension(:,:,:,:) :: u_struct !< Vertical structure of horizontal velocity (normalized and
@@ -168,35 +168,35 @@ type, public :: int_tide_CS ; private
   logical :: apply_Froude_drag
                         !< If true, apply wave breaking as a sink.
   real :: En_check_tol  !< An energy density tolerance for flagging points with small negative
-                        !! internal tide energy [R Z3 T-2 ~> J m-2]
+                        !! internal tide energy [H Z2 T-2 ~> J m-2]
   logical :: apply_residual_drag
                         !< If true, apply sink from residual term of reflection/transmission.
   real, allocatable :: En(:,:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,frequency,mode)
-                        !! integrated within an angular and frequency band [R Z3 T-2 ~> J m-2]
+                        !! integrated within an angular and frequency band [H Z2 T-2 ~> J m-2]
   real, allocatable :: En_ini_glo(:,:)
                         !< The internal wave energy density as a function of (frequency,mode)
-                        !! integrated within an angular and frequency band [R Z3 T-2 ~> J m-2]
+                        !! integrated within an angular and frequency band [H Z2 T-2 ~> J m-2]
                         !! only at the start of the routine (for diags)
   real, allocatable :: En_end_glo(:,:)
                         !< The internal wave energy density as a function of (frequency,mode)
-                        !! integrated within an angular and frequency band [R Z3 T-2 ~> J m-2]
+                        !! integrated within an angular and frequency band [H Z2 T-2 ~> J m-2]
                         !! only at the end of the routine (for diags)
   real, allocatable :: En_restart_mode1(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 1 [R Z3 T-2 ~> J m-2]
+                        !! for mode 1 [H Z2 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode2(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 2 [R Z3 T-2 ~> J m-2]
+                        !! for mode 2 [H Z2 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode3(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 3 [R Z3 T-2 ~> J m-2]
+                        !! for mode 3 [H Z2 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode4(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 4 [R Z3 T-2 ~> J m-2]
+                        !! for mode 4 [H Z2 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode5(:,:,:,:)
                         !< The internal wave energy density as a function of (i,j,angle,freq)
-                        !! for mode 5 [R Z3 T-2 ~> J m-2]
+                        !! for mode 5 [H Z2 T-2 ~> J m-2]
 
   real, allocatable, dimension(:) :: frequency  !< The frequency of each band [T-1 ~> s-1].
   real :: Int_tide_decay_scale  !< vertical decay scale for St Laurent profile [Z ~> m]
@@ -275,7 +275,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq) :: &
-    TKE_itidal_input, & !< The energy input to the internal waves [R Z3 T-3 ~> W m-2].
+    TKE_itidal_input, & !< The energy input to the internal waves [H Z2 T-3 ~> W m-2].
     vel_btTide !< Barotropic velocity read from file [L T-1 ~> m s-1].
 
   real, dimension(SZI_(G),SZJ_(G),2) :: &
@@ -283,24 +283,24 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   real, dimension(SZI_(G),SZJ_(G),CS%nMode) :: &
     cn             ! baroclinic internal gravity wave speeds for each mode [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq,CS%nMode) :: &
-    tot_En_mode, & ! energy summed over angles only [R Z3 T-2 ~> J m-2]
+    tot_En_mode, & ! energy summed over angles only [H Z2 T-2 ~> J m-2]
     Ub, &          ! near-bottom horizontal velocity of wave (modal) [L T-1 ~> m s-1]
     Umax           ! Maximum horizontal velocity of wave (modal) [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),CS%nFreq,CS%nMode) :: &
     drag_scale     ! bottom drag scale [T-1 ~> s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     tot_vel_btTide2, & ! [L2 T-2 ~> m2 s-2]
-    tot_En, &      ! energy summed over angles, modes, frequencies [R Z3 T-2 ~> J m-2]
+    tot_En, &      ! energy summed over angles, modes, frequencies [H Z2 T-2 ~> J m-2]
     tot_leak_loss, tot_quad_loss, tot_itidal_loss, tot_Froude_loss, tot_residual_loss, tot_allprocesses_loss, &
-                   ! energy loss rates summed over angle, freq, and mode [R Z3 T-3 ~> W m-2]
+                   ! energy loss rates summed over angle, freq, and mode [H Z2 T-3 ~> W m-2]
     htot, &        ! The vertical sum of the layer thicknesses [H ~> m or kg m-2]
-    itidal_loss_mode, & ! Energy lost due to small-scale wave drag, summed over angles [R Z3 T-3 ~> W m-2]
+    itidal_loss_mode, & ! Energy lost due to small-scale wave drag, summed over angles [H Z2 T-3 ~> W m-2]
     leak_loss_mode, &
     quad_loss_mode, &
     Froude_loss_mode, &
     residual_loss_mode, &
     allprocesses_loss_mode  ! Total energy loss rates for a given mode and frequency (summed over
-                            ! all angles) [R Z3 T-3 ~> W m-2]
+                            ! all angles) [H Z2 T-3 ~> W m-2]
   real :: frac_per_sector ! The inverse of the number of angular, modal and frequency bins [nondim]
   real :: f2       ! The squared Coriolis parameter interpolated to a tracer point [T-2 ~> s-2]
   real :: Kmag2    ! A squared horizontal wavenumber [L-2 ~> m-2]
@@ -316,12 +316,16 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   real :: loss_rate  ! An energy loss rate [T-1 ~> s-1]
   real :: Fr2_max    ! The column maximum internal wave Froude number squared [nondim]
   real :: cn_subRO        ! A tiny wave speed to prevent division by zero [L T-1 ~> m s-1]
-  real :: en_subRO        ! A tiny energy to prevent division by zero [R Z3 T-2 ~> J m-2]
-  real :: En_a, En_b                                 ! Energies for time stepping [R Z3 T-2 ~> J m-2]
-  real :: En_new, En_check                           ! Energies for debugging [R Z3 T-2 ~> J m-2]
-  real :: En_sumtmp                                  ! Energies for debugging [R Z3 T-2 ~> J m-2]
-  real :: En_initial, Delta_E_check                  ! Energies for debugging [R Z3 T-2 ~> J m-2]
-  real :: TKE_Froude_loss_check, TKE_Froude_loss_tot ! Energy losses for debugging [R Z3 T-3 ~> W m-2]
+  real :: en_subRO        ! A tiny energy to prevent division by zero [H Z2 T-2 ~> J m-2]
+  real :: En_a, En_b                                 ! Energies for time stepping [H Z2 T-2 ~> J m-2]
+  real :: En_new, En_check                           ! Energies for debugging [H Z2 T-2 ~> J m-2]
+  real :: En_sumtmp                                  ! Energies for debugging [H Z2 T-2 ~> J m-2]
+  real :: En_initial, Delta_E_check                  ! Energies for debugging [H Z2 T-2 ~> J m-2]
+  real :: TKE_Froude_loss_check, TKE_Froude_loss_tot ! Energy losses for debugging [H Z2 T-3 ~> W m-2]
+  real :: HZ2_T3_to_W_m2                             ! unit conversion factor for TKE from internal to mks
+  real :: HZ2_T2_to_J_m2                             ! unit conversion factor for Energy from internal to mks
+  real :: W_m2_to_HZ2_T3                             ! unit conversion factor for TKE from mks to internal
+  real :: J_m2_to_HZ2_T2                             ! unit conversion factor for Energy from mks to internal
   character(len=160) :: mesg  ! The text of an error message
   integer :: En_halo_ij_stencil ! The halo size needed for energy advection
   integer :: a, m, fr, i, j, k, is, ie, js, je, isd, ied, jsd, jed, nAngle
@@ -333,8 +337,13 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nAngle = CS%NAngle
 
+  HZ2_T3_to_W_m2 = GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T**3)
+  HZ2_T2_to_J_m2 = GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T**2)
+  W_m2_to_HZ2_T3 = GV%m_to_H*(US%m_to_Z**2)*(US%T_to_s**3)
+  J_m2_to_HZ2_T2 = GV%m_to_H*(US%m_to_Z**2)*(US%T_to_s**2)
+
   cn_subRO = 1e-30*US%m_s_to_L_T
-  en_subRO = 1e-30*US%W_m2_to_RZ3_T3*US%s_to_T
+  en_subRO = 1e-30*J_m2_to_HZ2_T2
 
   I_dt = 1.0 / dt
 
@@ -382,7 +391,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     do m=1,CS%nMode ; do fr=1,CS%nFreq
       En_sumtmp = 0.
       do a=1,CS%nAngle
-        En_sumtmp = En_sumtmp + global_area_integral(CS%En(:,:,a,fr,m), G, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+        En_sumtmp = En_sumtmp + global_area_integral(CS%En(:,:,a,fr,m), G, scale=HZ2_T2_to_J_m2)
       enddo
       CS%En_ini_glo(fr,m) = En_sumtmp
     enddo ; enddo
@@ -407,6 +416,8 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(cn(:,:,1), "CN mode 1", G%HI, haloshift=0, scale=US%L_to_m*US%s_to_T)
     call hchksum(CS%w_struct(:,:,:,1), "Wstruct mode 1", G%HI, haloshift=0)
     call hchksum(CS%u_struct(:,:,:,1), "Ustruct mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
+    call hchksum(CS%u_struct_bot(:,:,1), "Ustruct_bot mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
+    call hchksum(CS%u_struct_max(:,:,1), "Ustruct_max mode 1", G%HI, haloshift=0, scale=US%m_to_Z)
     call hchksum(CS%int_w2(:,:,1),   "int_w2", G%HI, haloshift=0, scale=GV%H_to_m)
     call hchksum(CS%int_U2(:,:,1),   "int_U2", G%HI, haloshift=0, scale=GV%H_to_m*US%m_to_Z**2)
     call hchksum(CS%int_N2w2(:,:,1), "int_N2w2", G%HI, haloshift=0, scale=GV%H_to_m*US%s_to_T**2)
@@ -427,8 +438,8 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
 
     if (CS%debug) then
       call hchksum(TKE_itidal_input(:,:,1), "TKE_itidal_input", G%HI, haloshift=0, &
-                   scale=US%R_to_kg_m3*(US%Z_to_m**3)*(US%s_to_T**3))
-      call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides bf input", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                   scale=GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T)**3)
+      call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides bf input", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     endif
 
     if (CS%energized_angle <= 0) then
@@ -467,14 +478,14 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   if (CS%init_forcing_only) CS%add_tke_forcing=.false.
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af input", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af input", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     ! save forcing for online budget
     do m=1,CS%nMode ; do fr=1,CS%nFreq
       En_sumtmp = 0.
       do a=1,CS%nAngle
         En_sumtmp = En_sumtmp + global_area_integral(dt*frac_per_sector*(1.0-CS%q_itides)* &
                                                      CS%fraction_tidal_input(fr,m)*TKE_itidal_input(:,:,fr), &
-                                                     G, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                                                     G, scale=HZ2_T2_to_J_m2)
       enddo
       CS%TKE_input_glo_dt(fr,m) = En_sumtmp
     enddo ; enddo
@@ -486,9 +497,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   call start_group_pass(pass_test, G%domain)
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af halo", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af halo", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after forcing')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after forcing')
       if (is_root_pe()) print *, 'prop_int_tide: after forcing', CS%En_sum
     enddo ; enddo
   endif
@@ -513,9 +524,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af refr", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af refr", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after 1/2 refraction')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after 1/2 refraction')
       if (is_root_pe()) print *, 'prop_int_tide: after 1/2 refraction', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
@@ -543,9 +554,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   call correct_halo_rotation(CS%En, test, G, CS%nAngle, halo=En_halo_ij_stencil)
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af halo R", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af halo R", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after correct halo rotation')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after correct halo rotation')
       if (is_root_pe()) print *, 'prop_int_tide: after correct halo rotation', CS%En_sum
     enddo ; enddo
   endif
@@ -559,7 +570,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
 
     if (CS%apply_propagation) then
       call propagate(CS%En(:,:,:,fr,m), cn(:,:,m), CS%frequency(fr), dt, &
-                     G, US, CS, CS%NAngle, CS%TKE_slope_loss(:,:,:,fr,m))
+                     G, GV, US, CS, CS%NAngle, CS%TKE_slope_loss(:,:,:,fr,m))
       endif
   enddo ; enddo
 
@@ -574,9 +585,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af prop", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af prop", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after propagate')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after propagate')
       if (is_root_pe()) print *, 'prop_int_tide: after propagate', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
@@ -616,9 +627,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af refr2", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af refr2", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after 2/2 refraction')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after 2/2 refraction')
       if (is_root_pe()) print *, 'prop_int_tide: after 2/2 refraction', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
@@ -656,7 +667,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
       ! to each En component (technically not correct; fix later)
       En_b = CS%En(i,j,a,fr,m) ! save previous value
       En_a = CS%En(i,j,a,fr,m) / (1.0 + dt * CS%decay_rate) ! implicit update
-      CS%TKE_leak_loss(i,j,a,fr,m) = (En_b - En_a) * I_dt ! compute exact loss rate [R Z3 T-3 ~> W m-2]
+      CS%TKE_leak_loss(i,j,a,fr,m) = (En_b - En_a) * I_dt ! compute exact loss rate [H Z2 T-3 ~> W m-2]
       CS%En(i,j,a,fr,m) = En_a ! update value
     enddo ; enddo ; enddo ; enddo ; enddo
   endif
@@ -672,11 +683,11 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after leak", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after leak", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after background drag')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after background drag')
       if (is_root_pe()) print *, 'prop_int_tide: after background drag', CS%En_sum
-      call sum_En(G, US, CS, CS%TKE_leak_loss(:,:,:,fr,m) * dt, 'prop_int_tide: loss after background drag')
+      call sum_En(G, GV, US, CS, CS%TKE_leak_loss(:,:,:,fr,m) * dt, 'prop_int_tide: loss after background drag')
       if (is_root_pe()) print *, 'prop_int_tide: loss after background drag', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
@@ -696,7 +707,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
       En_sumtmp = 0.
       do a=1,CS%nAngle
         En_sumtmp = En_sumtmp + global_area_integral(CS%TKE_leak_loss(:,:,a,fr,m)*dt, G, &
-                                                     scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                                                     scale=HZ2_T2_to_J_m2)
       enddo
       CS%TKE_leak_loss_glo_dt(fr,m) = En_sumtmp
     enddo ; enddo
@@ -720,14 +731,15 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
       do m=1,CS%NMode ; do fr=1,CS%Nfreq ; do j=jsd,jed ; do i=isd,ied
         I_D_here = 1.0 / (max(htot(i,j), CS%drag_min_depth))
         drag_scale(i,j,fr,m) = CS%cdrag * sqrt(max(0.0, US%L_to_Z**2*tot_vel_btTide2(i,j) + &
-                             tot_En_mode(i,j,fr,m) * GV%RZ_to_H * I_D_here)) * GV%Z_to_H*I_D_here
+                             tot_En_mode(i,j,fr,m) * I_D_here)) * GV%Z_to_H*I_D_here
       enddo ; enddo ; enddo ; enddo
     else
       do m=1,CS%NMode ; do fr=1,CS%Nfreq ; do j=jsd,jed ; do i=isd,ied
-        I_mass = GV%RZ_to_H / (max(htot(i,j), CS%drag_min_depth))
+        I_D_here = 1.0 / (max(htot(i,j), CS%drag_min_depth))
+        I_mass = GV%RZ_to_H * I_D_here
         drag_scale(i,j,fr,m) = (CS%cdrag * (Rho_bot(i,j)*I_mass)) * &
                               sqrt(max(0.0, US%L_to_Z**2*tot_vel_btTide2(i,j) + &
-                                            tot_En_mode(i,j,fr,m) * I_mass))
+                                            tot_En_mode(i,j,fr,m) * I_D_here))
       enddo ; enddo ; enddo ; enddo
     endif
 
@@ -755,13 +767,13 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after quad", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after quad", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     ! save loss term for online budget
     do m=1,CS%nMode ; do fr=1,CS%nFreq
       En_sumtmp = 0.
       do a=1,CS%nAngle
         En_sumtmp = En_sumtmp + global_area_integral(CS%TKE_quad_loss(:,:,a,fr,m)*dt, G, &
-                                                     scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                                                     scale=HZ2_T2_to_J_m2)
       enddo
       CS%TKE_quad_loss_glo_dt(fr,m) = En_sumtmp
     enddo ; enddo
@@ -805,7 +817,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
           PE_term = 0.25*GV%H_to_RZ*( CS%int_N2w2(i,j,m) / freq2 )
 
           if (KE_term + PE_term > 0.0) then
-            W0 = sqrt( tot_En_mode(i,j,fr,m) / (KE_term + PE_term) )
+            W0 = sqrt( GV%H_to_RZ * tot_En_mode(i,j,fr,m) / (KE_term + PE_term) )
           else
             !call MOM_error(WARNING, "MOM internal tides: KE + PE <= 0.0; setting to W0 to 0.0")
             W0 = 0.0
@@ -842,9 +854,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after wave", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after wave", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: before Froude drag')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: before Froude drag')
       if (is_root_pe()) print *, 'prop_int_tide: before Froude drag', CS%En_sum
     enddo ; enddo
     ! save loss term for online budget, may want to add a debug flag later
@@ -852,7 +864,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
       En_sumtmp = 0.
       do a=1,CS%nAngle
         En_sumtmp = En_sumtmp + global_area_integral(CS%TKE_itidal_loss(:,:,a,fr,m)*dt, G, &
-                                                     scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                                                     scale=HZ2_T2_to_J_m2)
       enddo
       CS%TKE_itidal_loss_glo_dt(fr,m) = En_sumtmp
     enddo ; enddo
@@ -916,11 +928,11 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after froude", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after froude", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after Froude drag')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after Froude drag')
       if (is_root_pe()) print *, 'prop_int_tide: after Froude drag', CS%En_sum
-      call sum_En(G, US, CS, CS%TKE_Froude_loss(:,:,:,fr,m) * dt, 'prop_int_tide: loss after Froude drag')
+      call sum_En(G, GV, US, CS, CS%TKE_Froude_loss(:,:,:,fr,m) * dt, 'prop_int_tide: loss after Froude drag')
       if (is_root_pe()) print *, 'prop_int_tide: loss after Froude drag', CS%En_sum
     enddo ; enddo
     ! save loss term for online budget, may want to add a debug flag later
@@ -928,7 +940,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
       En_sumtmp = 0.
       do a=1,CS%nAngle
         En_sumtmp = En_sumtmp + global_area_integral(CS%TKE_Froude_loss(:,:,a,fr,m)*dt, G, &
-                                                     scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                                                     scale=HZ2_T2_to_J_m2)
       enddo
       CS%TKE_Froude_loss_glo_dt(fr,m) = En_sumtmp
     enddo ; enddo
@@ -971,16 +983,16 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
   endif
 
   if (CS%debug) then
-    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after slope", G%HI, haloshift=0, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after slope", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide')
     enddo ; enddo
     ! save loss term for online budget
     do m=1,CS%nMode ; do fr=1,CS%nFreq
       En_sumtmp = 0.
       do a=1,CS%nAngle
         En_sumtmp = En_sumtmp + global_area_integral(CS%TKE_residual_loss(:,:,a,fr,m)*dt, G, &
-                                                     scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+                                                     scale=HZ2_T2_to_J_m2)
       enddo
       CS%TKE_residual_loss_glo_dt(fr,m) = En_sumtmp
     enddo ; enddo
@@ -992,7 +1004,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     do m=1,CS%nMode ; do fr=1,CS%nFreq
       En_sumtmp = 0.
       do a=1,CS%nAngle
-        En_sumtmp = En_sumtmp + global_area_integral(CS%En(:,:,a,fr,m), G, scale=US%RZ3_T3_to_W_m2*US%T_to_s)
+        En_sumtmp = En_sumtmp + global_area_integral(CS%En(:,:,a,fr,m), G, scale=HZ2_T2_to_J_m2)
       enddo
       CS%En_end_glo(fr,m) = En_sumtmp
     enddo ; enddo
@@ -1183,12 +1195,13 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
 end subroutine propagate_int_tide
 
 !> Checks for energy conservation on computational domain
-subroutine sum_En(G, US, CS, En, label)
+subroutine sum_En(G, GV, US, CS, En, label)
   type(ocean_grid_type),  intent(in) :: G  !< The ocean's grid structure.
+  type(verticalGrid_type),intent(in) :: GV !< The ocean's vertical grid structure.
   type(unit_scale_type),  intent(in) :: US !< A dimensional unit scaling type
   type(int_tide_CS),      intent(inout) :: CS !< Internal tide control structure
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle), &
-                          intent(in) :: En !< The energy density of the internal tides [R Z3 T-2 ~> J m-2].
+                          intent(in) :: En !< The energy density of the internal tides [H Z2 T-2 ~> J m-2].
   character(len=*),       intent(in) :: label !< A label to use in error messages
   ! Local variables
   real :: En_sum   ! The total energy in MKS units for potential output [J]
@@ -1200,7 +1213,7 @@ subroutine sum_En(G, US, CS, En, label)
 
   En_sum = 0.0
   do a=1,CS%nAngle
-    En_sum = En_sum + global_area_integral(En(:,:,a), G, unscale=US%RZ3_T3_to_W_m2*US%T_to_s)
+    En_sum = En_sum + global_area_integral(En(:,:,a), G, unscale=GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T)**2)
   enddo
   CS%En_sum = En_sum
   !En_sum_diff = En_sum - CS%En_sum
@@ -1239,29 +1252,34 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
                              intent(in) :: TKE_loss_fixed !< Fixed part of energy loss [R Z4 H-1 L-2 ~> kg m-2 or m]
                                                  !! (rho*kappa*h^2) or (kappa*h^2).
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle,CS%nFreq,CS%nMode), &
-                             intent(inout) :: En !< Energy density of the internal waves [R Z3 T-2 ~> J m-2].
+                             intent(inout) :: En !< Energy density of the internal waves [H Z2 T-2 ~> J m-2].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,CS%NAngle,CS%nFreq,CS%nMode), &
-                             intent(out)   :: TKE_loss    !< Energy loss rate [R Z3 T-3 ~> W m-2]
+                             intent(out)   :: TKE_loss    !< Energy loss rate [H Z2 T-3 ~> W m-2]
                                                  !! (q*rho*kappa*h^2*N*U^2).
   real,                      intent(in)    :: dt !< Time increment [T ~> s].
   integer, optional,         intent(in)    :: halo_size !< The halo size over which to do the calculations
   ! Local variables
   integer :: j, i, m, fr, a, is, ie, js, je, halo
-  real    :: En_tot          ! energy for a given mode, frequency, and point summed over angles [R Z3 T-2 ~> J m-2]
-  real    :: TKE_loss_tot    ! dissipation for a given mode, frequency, and point summed over angles [R Z3 T-3 ~> W m-2]
+  real    :: En_tot          ! energy for a given mode, frequency, and point summed over angles [H Z2 T-2 ~> J m-2]
+  real    :: TKE_loss_tot    ! dissipation for a given mode, frequency, and point summed over angles [H Z2 T-3 ~> W m-2]
   real    :: frac_per_sector ! fraction of energy in each wedge [nondim]
   real    :: q_itides        ! fraction of energy actually lost to mixing (remainder, 1-q, is
                              ! assumed to stay in propagating mode for now - BDM) [nondim]
   real    :: loss_rate       ! approximate loss rate for implicit calc [T-1 ~> s-1]
-  real    :: En_negl         ! negligibly small number to prevent division by zero [R Z3 T-2 ~> J m-2]
-  real    :: En_a, En_b      ! energy before and after timestep [R Z3 T-2 ~> J m-2]
+  real    :: En_negl         ! negligibly small number to prevent division by zero [H Z2 T-2 ~> J m-2]
+  real    :: En_a, En_b      ! energy before and after timestep [H Z2 T-2 ~> J m-2]
   real    :: I_dt            ! The inverse of the timestep [T-1 ~> s-1]
+  real    :: J_m2_to_HZ2_T2  ! unit conversion factor for Energy from mks to internal
+  real    :: HZ2_T3_to_W_m2  ! unit conversion factor for Energy from internal to mks
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
+  J_m2_to_HZ2_T2 = GV%m_to_H*(US%m_to_Z**2)*(US%T_to_s**2)
+  HZ2_T3_to_W_m2 = GV%H_to_m*(US%Z_to_m**2)*(US%s_to_T**3)
+
   I_dt = 1.0 / dt
   q_itides = CS%q_itides
-  En_negl = 1e-30*US%kg_m3_to_R*US%m_to_Z**3*US%T_to_s**2
+  En_negl = 1e-30*J_m2_to_HZ2_T2
 
   if (present(halo_size)) then
     halo = halo_size
@@ -1283,11 +1301,11 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
       En_tot = En_tot + En(i,j,a,fr,m)
     enddo
 
-    ! Calculate TKE loss rate; units of [R Z3 T-3 ~> W m-2] here.
+    ! Calculate TKE loss rate; units of [H Z2 T-3 ~> W m-2] here.
     if (GV%Boussinesq .or. GV%semi_Boussinesq) then
-      TKE_loss_tot = q_itides * GV%Z_to_H * TKE_loss_fixed(i,j) * Nb(i,j) * Ub(i,j,fr,m)**2
+      TKE_loss_tot = q_itides * GV%RZ_to_H * GV%Z_to_H * TKE_loss_fixed(i,j) * Nb(i,j) * Ub(i,j,fr,m)**2
     else
-      TKE_loss_tot = q_itides * (GV%RZ_to_H * Rho_bot(i,j)) * TKE_loss_fixed(i,j) * Nb(i,j) * Ub(i,j,fr,m)**2
+      TKE_loss_tot = q_itides * (GV%RZ_to_H * GV%RZ_to_H * Rho_bot(i,j)) * TKE_loss_fixed(i,j) * Nb(i,j) * Ub(i,j,fr,m)**2
     endif
 
     ! Update energy remaining (this is a pseudo implicit calc)
@@ -1295,7 +1313,7 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
     if (En_tot > 0.0) then
       do a=1,CS%nAngle
         frac_per_sector = En(i,j,a,fr,m)/En_tot
-        TKE_loss(i,j,a,fr,m) = frac_per_sector*TKE_loss_tot           ! [R Z3 T-3  ~> W m-2]
+        TKE_loss(i,j,a,fr,m) = frac_per_sector*TKE_loss_tot           ! [H Z2 T-3  ~> W m-2]
         loss_rate = TKE_loss(i,j,a,fr,m) / (En(i,j,a,fr,m) + En_negl) ! [T-1 ~> s-1]
         En_b = En(i,j,a,fr,m)
         En_a = En(i,j,a,fr,m) / (1.0 + dt*loss_rate)
@@ -1324,7 +1342,7 @@ subroutine get_lowmode_loss(i,j,G,CS,mechanism,TKE_loss_sum)
   type(int_tide_CS),     intent(in)  :: CS  !< Internal tide control structure
   character(len=*),      intent(in)  :: mechanism    !< The named mechanism of loss to return
   real,                  intent(out) :: TKE_loss_sum !< Total energy loss rate due to specified
-                                                     !! mechanism [R Z3 T-3 ~> W m-2].
+                                                     !! mechanism [H Z2 T-3 ~> W m-2].
 
   if (mechanism == 'LeakDrag')  TKE_loss_sum = CS%tot_leak_loss(i,j)
   if (mechanism == 'QuadDrag')  TKE_loss_sum = CS%tot_quad_loss(i,j)
@@ -1623,11 +1641,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
         ! layer diffusivity for processus
         if (h(i,j,k) >= CS%min_thick_layer_Kd) then
           TKE_to_Kd_lim = min(TKE_to_Kd(i,k), CS%max_TKE_to_Kd)
-          if (non_Bous) then
-            Kd_leak_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_leak(i,k) * h(i,j,k) * tv%SpV_avg(i,j,k)
-          else
-            Kd_leak_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_leak(i,k) * h(i,j,k) * GV%RZ_to_H
-          endif
+          Kd_leak_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_leak(i,k) * h(i,j,k)
         else
           Kd_leak_lay(k) = 0.
         endif
@@ -1649,11 +1663,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
         ! layer diffusivity for processus
         if (h(i,j,k) >= CS%min_thick_layer_Kd) then
           TKE_to_Kd_lim = min(TKE_to_Kd(i,k), CS%max_TKE_to_Kd)
-          if (non_Bous) then
-            Kd_Froude_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_Froude(i,k) * h(i,j,k) * tv%SpV_avg(i,j,k)
-          else
-            Kd_Froude_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_Froude(i,k) * h(i,j,k) * GV%RZ_to_H
-          endif
+          Kd_Froude_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_Froude(i,k) * h(i,j,k)
         else
           Kd_Froude_lay(k) = 0.
         endif
@@ -1675,11 +1685,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
         ! layer diffusivity for processus
         if (h(i,j,k) >= CS%min_thick_layer_Kd) then
           TKE_to_Kd_lim = min(TKE_to_Kd(i,k), CS%max_TKE_to_Kd)
-          if (non_Bous) then
-            Kd_itidal_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_itidal(i,k) * h(i,j,k) * tv%SpV_avg(i,j,k)
-          else
-            Kd_itidal_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_itidal(i,k) * h(i,j,k) * GV%RZ_to_H
-          endif
+          Kd_itidal_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_itidal(i,k) * h(i,j,k)
         else
           Kd_itidal_lay(k) = 0.
         endif
@@ -1701,11 +1707,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
         ! layer diffusivity for processus
         if (h(i,j,k) >= CS%min_thick_layer_Kd) then
           TKE_to_Kd_lim = min(TKE_to_Kd(i,k), CS%max_TKE_to_Kd)
-          if (non_Bous) then
-            Kd_slope_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_slope(i,k) * h(i,j,k) * tv%SpV_avg(i,j,k)
-          else
-            Kd_slope_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_slope(i,k) * h(i,j,k) * GV%RZ_to_H
-          endif
+          Kd_slope_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_slope(i,k) * h(i,j,k)
         else
           Kd_slope_lay(k) = 0.
         endif
@@ -1727,11 +1729,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
         ! layer diffusivity for processus
         if (h(i,j,k) >= CS%min_thick_layer_Kd) then
           TKE_to_Kd_lim = min(TKE_to_Kd(i,k), CS%max_TKE_to_Kd)
-          if (non_Bous) then
-            Kd_quad_lay(k) = GV%Z_to_H * TKE_loss * TKE_to_Kd_lim * profile_quad(i,k) * h(i,j,k) * tv%SpV_avg(i,j,k)
-          else
-            Kd_quad_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_quad(i,k) * h(i,j,k) * GV%RZ_to_H
-          endif
+          Kd_quad_lay(k) = TKE_loss * TKE_to_Kd_lim * profile_quad(i,k) * h(i,j,k)
         else
           Kd_quad_lay(k) = 0.
         endif
@@ -1797,7 +1795,7 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                          intent(inout) :: En   !< The internal gravity wave energy density as a
                                                !! function of space and angular resolution,
-                                               !! [R Z3 T-2 ~> J m-2].
+                                               !! [H Z2 T-2 ~> J m-2].
   real, dimension(G%isd:G%ied,G%jsd:G%jed),        &
                          intent(in)    :: cn   !< Baroclinic mode speed [L T-1 ~> m s-1].
   real,                  intent(in)    :: freq !< Wave frequency [T-1 ~> s-1].
@@ -1808,13 +1806,13 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
   ! Local variables
   integer, parameter :: stencil = 2
   real, dimension(SZI_(G),1-stencil:NAngle+stencil) :: &
-    En2d                  ! The internal gravity wave energy density in zonal slices [R Z3 T-2 ~> J m-2]
+    En2d                  ! The internal gravity wave energy density in zonal slices [H Z2 T-2 ~> J m-2]
   real, dimension(1-stencil:NAngle+stencil) :: &
     cos_angle, sin_angle  ! The cosine and sine of each angle [nondim]
   real, dimension(SZI_(G)) :: &
     Dk_Dt_Kmag, Dl_Dt_Kmag ! Rates of angular refraction [T-1 ~> s-1]
   real, dimension(SZI_(G),0:nAngle) :: &
-    Flux_E                ! The flux of energy between successive angular wedges within a timestep [R Z3 T-2 ~> J m-2]
+    Flux_E                ! The flux of energy between successive angular wedges within a timestep [H Z2 T-2 ~> J m-2]
   real, dimension(SZI_(G),SZJ_(G),1-stencil:NAngle+stencil) :: &
     CFL_ang               ! The CFL number of angular refraction [nondim]
   real, dimension(G%IsdB:G%IedB,G%jsd:G%jed) :: cn_u !< Internal wave group velocity at U-point [L T-1 ~> m s-1]
@@ -1947,21 +1945,21 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
   integer,                   intent(in)    :: halo_ang !< The halo size in angular space
   real, dimension(1-halo_ang:NAngle+halo_ang),   &
                              intent(in)    :: En2d    !< The internal gravity wave energy density as a
-                                                      !! function of angular resolution [R Z3 T-2 ~> J m-2].
+                                                      !! function of angular resolution [H Z2 T-2 ~> J m-2].
   real, dimension(1-halo_ang:NAngle+halo_ang),   &
                              intent(in)    :: CFL_ang !< The CFL number of the energy advection across angles [nondim]
   real, dimension(0:NAngle), intent(out)   :: Flux_En !< The time integrated internal wave energy flux
-                                                      !! across angles  [R Z3 T-2 ~> J m-2].
+                                                      !! across angles  [H Z2 T-2 ~> J m-2].
   ! Local variables
-  real :: flux         ! The internal wave energy flux across angles  [R Z3 T-3 ~> W m-2].
+  real :: flux         ! The internal wave energy flux across angles  [H Z2 T-3 ~> W m-2].
   real :: u_ang        ! Angular propagation speed [Rad T-1 ~> Rad s-1]
   real :: Angle_size   ! The size of each orientation wedge in radians [Rad]
   real :: I_Angle_size ! The inverse of the orientation wedges [Rad-1]
   real :: I_dt         ! The inverse of the timestep [T-1 ~> s-1]
-  real :: aR, aL       ! Left and right edge estimates of energy density [R Z3 T-2 rad-1 ~> J m-2 rad-1]
+  real :: aR, aL       ! Left and right edge estimates of energy density [H Z2 T-2 rad-1 ~> J m-2 rad-1]
   real :: Ep, Ec, Em   ! Mean angular energy density for three successive wedges in angular
-                       ! orientation [R Z3 T-2 rad-1 ~> J m-2 rad-1]
-  real :: dA, curv_3   ! Difference and curvature of energy density [R Z3 T-2 rad-1 ~> J m-2 rad-1]
+                       ! orientation [H Z2 T-2 rad-1 ~> J m-2 rad-1]
+  real :: dA, curv_3   ! Difference and curvature of energy density [H Z2 T-2 rad-1 ~> J m-2 rad-1]
   real, parameter :: oneSixth = 1.0/6.0  ! One sixth [nondim]
   integer :: a
 
@@ -1975,7 +1973,7 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
     if (u_ang >= 0.0) then
       ! Implementation of PPM-H3
       ! Convert wedge-integrated energy density into angular energy densities for three successive
-      ! wedges around the source wedge for this flux [R Z3 T-2 rad-1 ~> J m-2 rad-1].
+      ! wedges around the source wedge for this flux [H Z2 T-2 rad-1 ~> J m-2 rad-1].
       Ep = En2d(a+1)*I_Angle_size
       Ec = En2d(a)  *I_Angle_size
       Em = En2d(a-1)*I_Angle_size
@@ -1993,15 +1991,15 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
         aR = 3.*Ec - 2.*aL   ! Flatten the profile to move the extremum to the right edge
       endif
       curv_3 = (aR + aL) - 2.0*Ec ! Curvature
-      ! Calculate angular flux rate [R Z3 T-3 ~> W m-2]
+      ! Calculate angular flux rate [H Z2 T-3 ~> W m-2]
       flux = u_ang*( aR + CFL_ang(A) * ( 0.5*(aL - aR) + curv_3 * (CFL_ang(A) - 1.5) ) )
-      ! Calculate amount of energy fluxed between wedges [R Z3 T-2 ~> J m-2]
+      ! Calculate amount of energy fluxed between wedges [H Z2 T-2 ~> J m-2]
       Flux_En(A) = dt * flux
       !Flux_En(A) = (dt * I_Angle_size) * flux
     else
       ! Implementation of PPM-H3
       ! Convert wedge-integrated energy density into angular energy densities for three successive
-      ! wedges around the source wedge for this flux [R Z3 T-2 rad-1 ~> J m-2 rad-1].
+      ! wedges around the source wedge for this flux [H Z2 T-2 rad-1 ~> J m-2 rad-1].
       Ep = En2d(a+2)*I_Angle_size
       Ec = En2d(a+1)*I_Angle_size
       Em = En2d(a)  *I_Angle_size
@@ -2019,10 +2017,10 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
         aR = 3.*Ec - 2.*aL   ! Flatten the profile to move the extremum to the right edge
       endif
       curv_3 = (aR + aL) - 2.0*Ec ! Curvature
-      ! Calculate angular flux rate [R Z3 T-3 ~> W m-2]
+      ! Calculate angular flux rate [H Z2 T-3 ~> W m-2]
       ! Note that CFL_ang is negative here, so it looks odd compared with equivalent expressions.
       flux = u_ang*( aL - CFL_ang(A) * ( 0.5*(aR - aL) + curv_3 * (-CFL_ang(A) - 1.5) ) )
-      ! Calculate amount of energy fluxed between wedges [R Z3 T-2 ~> J m-2]
+      ! Calculate amount of energy fluxed between wedges [H Z2 T-2 ~> J m-2]
       Flux_En(A) = dt * flux
       !Flux_En(A) = (dt * I_Angle_size) * flux
     endif
@@ -2030,14 +2028,15 @@ subroutine PPM_angular_advect(En2d, CFL_ang, Flux_En, NAngle, dt, halo_ang)
 end subroutine PPM_angular_advect
 
 !> Propagates internal waves at a single frequency.
-subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
+subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
   type(ocean_grid_type), intent(inout) :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
   integer,               intent(in)    :: NAngle !< The number of wave orientations in the
                                                !! discretized wave energy spectrum.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                          intent(inout) :: En   !< The internal gravity wave energy density as a
                                                !! function of space and angular resolution,
-                                               !! [R Z3 T-2 ~> J m-2].
+                                               !! [H Z2 T-2 ~> J m-2].
   real, dimension(G%isd:G%ied,G%jsd:G%jed),        &
                          intent(in)    :: cn   !< Baroclinic mode speed [L T-1 ~> m s-1].
   real,                  intent(in)    :: freq !< Wave frequency [T-1 ~> s-1].
@@ -2046,7 +2045,7 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
   type(int_tide_CS),     intent(inout)    :: CS   !< Internal tide control structure
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                          intent(inout) :: residual_loss !< internal tide energy loss due
-                                                        !! to the residual at slopes [R Z3 T-3 ~> W m-2].
+                                                        !! to the residual at slopes [H Z2 T-3 ~> W m-2].
   ! Local variables
   real, dimension(G%IsdB:G%IedB,G%JsdB:G%JedB) :: &
     speed  ! The magnitude of the group velocity at the q points for corner adv [L T-1 ~> m s-1].
@@ -2095,7 +2094,7 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
 
   if (CS%debug) then
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'propagate: top of routine')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: top of routine')
       if (is_root_pe()) print *, 'propagate: top of routine', CS%En_sum
     enddo ; enddo
   endif
@@ -2162,7 +2161,7 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
 
     if (CS%debug) then
       do m=1,CS%nMode ; do fr=1,CS%Nfreq
-        call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'propagate: after propagate_x')
+        call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: after propagate_x')
         if (is_root_pe()) print *, 'propagate: after propagate_x', CS%En_sum
       enddo ; enddo
     endif
@@ -2173,7 +2172,7 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
 
     if (CS%debug) then
       do m=1,CS%nMode ; do fr=1,CS%Nfreq
-        call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'propagate: after halo update')
+        call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: after halo update')
         if (is_root_pe()) print *, 'propagate: after halo update', CS%En_sum
       enddo ; enddo
     endif
@@ -2187,7 +2186,7 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
 
     if (CS%debug) then
       do m=1,CS%nMode ; do fr=1,CS%Nfreq
-        call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'propagate: after propagate_y')
+        call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: after propagate_y')
         if (is_root_pe()) print *, 'propagate: after propagate_y', CS%En_sum
       enddo ; enddo
     endif
@@ -2196,7 +2195,7 @@ subroutine propagate(En, cn, freq, dt, G, US, CS, NAngle, residual_loss)
 
   if (CS%debug) then
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
-      call sum_En(G, US, CS, CS%En(:,:,:,fr,m), 'propagate: bottom of routine')
+      call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: bottom of routine')
       if (is_root_pe()) print *, 'propagate: bottom of routine', CS%En_sum
     enddo ; enddo
   endif
@@ -2209,7 +2208,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   type(ocean_grid_type),  intent(in)    :: G     !< The ocean's grid structure.
   real, dimension(G%isd:G%ied,G%jsd:G%jed),   &
                           intent(inout) :: En    !< The energy density integrated over an angular
-                                                 !! band [R Z3 T-2 ~> J m-2].
+                                                 !! band [H Z2 T-2 ~> J m-2].
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed), &
                           intent(in)    :: speed !< The magnitude of the group velocity at the cell
                                                  !! corner points [L T-1 ~> m s-1].
@@ -2247,7 +2246,7 @@ subroutine propagate_corner_spread(En, energized_wedge, NAngle, speed, dt, G, CS
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: x, y ! coordinates of cell corners [L ~> m]
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: Idx, Idy ! inverse of dx,dy at cell corners [L-1 ~> m-1]
   real, dimension(G%IsdB:G%IedB,G%Jsd:G%Jed) :: dx, dy ! dx,dy at cell corners [L ~> m]
-  real, dimension(2) :: E_new ! Energy in cell after advection for subray [R Z3 T-2 ~> J m-2]; set size
+  real, dimension(2) :: E_new ! Energy in cell after advection for subray [H Z2 T-2 ~> J m-2]; set size
                               ! here to define Nsubrays - this should be made an input option later!
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
@@ -2500,7 +2499,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
                                                !! discretized wave energy spectrum.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
                            intent(inout) :: En !< The energy density integrated over an angular
-                                               !! band [R Z3 T-2 ~> J m-2].
+                                               !! band [H Z2 T-2 ~> J m-2].
   real, dimension(G%IsdB:G%IedB,G%jsd:G%jed),        &
                            intent(in)    :: speed_x !< The magnitude of the group velocity at the
                                                !! Cu points [L T-1 ~> m s-1].
@@ -2513,17 +2512,17 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
                            intent(inout) :: residual_loss !< internal tide energy loss due
-                                                          !! to the residual at slopes [R Z3 T-3 ~> W m-2].
+                                                          !! to the residual at slopes [H Z2 T-3 ~> W m-2].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    EnL, EnR    ! Left and right face energy densities [R Z3 T-2 ~> J m-2].
+    EnL, EnR    ! Left and right face energy densities [H Z2 T-2 ~> J m-2].
   real, dimension(SZIB_(G),SZJ_(G)) :: &
-    flux_x      ! The internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
+    flux_x      ! The internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
   real, dimension(SZIB_(G)) :: &
     cg_p, &     ! The x-direction group velocity [L T-1 ~> m s-1]
-    flux1       ! A 1-d copy of the x-direction internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
+    flux1       ! A 1-d copy of the x-direction internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle) :: &
-    Fdt_m, Fdt_p! Left and right energy fluxes [R Z3 L2 T-2 ~> J]
+    Fdt_m, Fdt_p! Left and right energy fluxes [H Z2 L2 T-2 ~> J]
   integer :: i, j, ish, ieh, jsh, jeh, a
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
@@ -2548,8 +2547,8 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
     enddo
 
     do j=jsh,jeh ; do i=ish,ieh
-      Fdt_m(i,j,a) = dt*flux_x(I-1,j) ! left face influx  [R Z3 L2 T-2 ~> J]
-      Fdt_p(i,j,a) = -dt*flux_x(I,j)  ! right face influx [R Z3 L2 T-2 ~> J]
+      Fdt_m(i,j,a) = dt*flux_x(I-1,j) ! left face influx  [H Z2 L2 T-2 ~> J]
+      Fdt_p(i,j,a) = -dt*flux_x(I,j)  ! right face influx [H Z2 L2 T-2 ~> J]
 
       ! only compute residual loss on partial reflection cells, remove numerical noise elsewhere
       if (CS%refl_pref_logical(i,j)) then
@@ -2568,7 +2567,7 @@ subroutine propagate_x(En, speed_x, Cgx_av, dCgx, dt, G, US, Nangle, CS, LB, res
   call reflect(Fdt_p, Nangle, CS, G, LB)
   !call teleport(Fdt_p, Nangle, CS, G, LB)
 
-  ! Update reflected energy [R Z3 T-2 ~> J m-2]
+  ! Update reflected energy [H Z2 T-2 ~> J m-2]
   do a=1,Nangle ; do j=jsh,jeh ; do i=ish,ieh
     En(i,j,a) = En(i,j,a) + G%IareaT(i,j)*(Fdt_m(i,j,a) + Fdt_p(i,j,a))
   enddo ; enddo ; enddo
@@ -2582,7 +2581,7 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
                                                !! discretized wave energy spectrum.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle), &
                            intent(inout) :: En !< The energy density integrated over an angular
-                                               !! band [R Z3 T-2 ~> J m-2].
+                                               !! band [H Z2 T-2 ~> J m-2].
   real, dimension(G%isd:G%ied,G%JsdB:G%JedB),      &
                            intent(in)    :: speed_y !< The magnitude of the group velocity at the
                                                !! Cv points [L T-1 ~> m s-1].
@@ -2595,17 +2594,17 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
   type(loop_bounds_type),  intent(in)    :: LB !< A structure with the active energy loop bounds.
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle),   &
                            intent(inout) :: residual_loss !< internal tide energy loss due
-                                                          !! to the residual at slopes [R Z3 T-3 ~> W m-2].
+                                                          !! to the residual at slopes [H Z2 T-3 ~> W m-2].
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    EnL, EnR    ! South and north face energy densities [R Z3 T-2 ~> J m-2].
+    EnL, EnR    ! South and north face energy densities [H Z2 T-2 ~> J m-2].
   real, dimension(SZI_(G),SZJB_(G)) :: &
-    flux_y      ! The internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
+    flux_y      ! The internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
   real, dimension(SZI_(G)) :: &
     cg_p, &     ! The y-direction group velocity [L T-1 ~> m s-1]
-    flux1       ! A 1-d copy of the y-direction internal wave energy flux [R Z3 L2 T-3 ~> J s-1].
+    flux1       ! A 1-d copy of the y-direction internal wave energy flux [H Z2 L2 T-3 ~> J s-1].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,Nangle) :: &
-    Fdt_m, Fdt_p! South and north energy fluxes [R Z3 L2 T-2 ~> J]
+    Fdt_m, Fdt_p! South and north energy fluxes [H Z2 L2 T-2 ~> J]
   integer :: i, j, ish, ieh, jsh, jeh, a
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh
@@ -2630,8 +2629,8 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
     enddo
 
     do j=jsh,jeh ; do i=ish,ieh
-      Fdt_m(i,j,a) = dt*flux_y(i,J-1) ! south face influx [R Z3 L2 T-2 ~> J]
-      Fdt_p(i,j,a) = -dt*flux_y(i,J)  ! north face influx [R Z3 L2 T-2 ~> J]
+      Fdt_m(i,j,a) = dt*flux_y(i,J-1) ! south face influx [H Z2 L2 T-2 ~> J]
+      Fdt_p(i,j,a) = -dt*flux_y(i,J)  ! north face influx [H Z2 L2 T-2 ~> J]
 
       ! only compute residual loss on partial reflection cells, remove numerical noise elsewhere
       if (CS%refl_pref_logical(i,j)) then
@@ -2650,7 +2649,7 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
   call reflect(Fdt_p, Nangle, CS, G, LB)
   !call teleport(Fdt_p, Nangle, CS, G, LB)
 
-  ! Update reflected energy [R Z3 T-2 ~> J m-2]
+  ! Update reflected energy [H Z2 T-2 ~> J m-2]
   do a=1,Nangle ; do j=jsh,jeh ; do i=ish,ieh
     En(i,j,a) = En(i,j,a) + G%IareaT(i,j)*(Fdt_m(i,j,a) + Fdt_p(i,j,a))
   enddo ; enddo ; enddo
@@ -2662,12 +2661,12 @@ subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, US, j, ish, ieh, vol_CFL)
   type(ocean_grid_type),     intent(in)    :: G  !< The ocean's grid structure.
   real, dimension(SZIB_(G)), intent(in)    :: u  !< The zonal velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G)),  intent(in)    :: h  !< Energy density used to calculate the fluxes
-                                                 !! [R Z3 T-2 ~> J m-2].
+                                                 !! [H Z2 T-2 ~> J m-2].
   real, dimension(SZI_(G)),  intent(in)    :: hL !< Left- Energy densities in the reconstruction
-                                                 !! [R Z3 T-2 ~> J m-2].
+                                                 !! [H Z2 T-2 ~> J m-2].
   real, dimension(SZI_(G)),  intent(in)    :: hR !< Right- Energy densities in the reconstruction
-                                                 !! [R Z3 T-2 ~> J m-2].
-  real, dimension(SZIB_(G)), intent(out) :: uh !< The zonal energy transport [R Z3 L2 T-3 ~> J s-1].
+                                                 !! [H Z2 T-2 ~> J m-2].
+  real, dimension(SZIB_(G)), intent(out) :: uh !< The zonal energy transport [H Z2 L2 T-3 ~> J s-1].
   real,                      intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),     intent(in)    :: US !< A dimensional unit scaling type
   integer,                   intent(in)    :: j  !< The j-index to work on.
@@ -2677,7 +2676,7 @@ subroutine zonal_flux_En(u, h, hL, hR, uh, dt, G, US, j, ish, ieh, vol_CFL)
                                                  !! the cell areas when estimating the CFL number.
   ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim].
-  real :: curv_3 ! A measure of the energy density curvature over a grid length [R Z3 T-2 ~> J m-2]
+  real :: curv_3 ! A measure of the energy density curvature over a grid length [H Z2 T-2 ~> J m-2]
   integer :: i
 
   do I=ish-1,ieh
@@ -2705,12 +2704,12 @@ subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, US, J, ish, ieh, vol_CFL)
   type(ocean_grid_type),            intent(in)    :: G  !< The ocean's grid structure.
   real, dimension(SZI_(G)),         intent(in)    :: v  !< The meridional velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: h  !< Energy density used to calculate the
-                                                        !! fluxes [R Z3 T-2 ~> J m-2].
+                                                        !! fluxes [H Z2 T-2 ~> J m-2].
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: hL !< Left- Energy densities in the
-                                                        !! reconstruction [R Z3 T-2 ~> J m-2].
+                                                        !! reconstruction [H Z2 T-2 ~> J m-2].
   real, dimension(SZI_(G),SZJ_(G)), intent(in)    :: hR !< Right- Energy densities in the
-                                                        !! reconstruction [R Z3 T-2 ~> J m-2].
-  real, dimension(SZI_(G)),         intent(out) :: vh !< The meridional energy transport [R Z3 L2 T-3 ~> J s-1].
+                                                        !! reconstruction [H Z2 T-2 ~> J m-2].
+  real, dimension(SZI_(G)),         intent(out) :: vh !< The meridional energy transport [H Z2 L2 T-3 ~> J s-1].
   real,                             intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),            intent(in)    :: US !< A dimensional unit scaling type
   integer,                          intent(in)    :: J  !< The j-index to work on.
@@ -2721,7 +2720,7 @@ subroutine merid_flux_En(v, h, hL, hR, vh, dt, G, US, J, ish, ieh, vol_CFL)
                                                         !! the CFL number.
   ! Local variables
   real :: CFL ! The CFL number based on the local velocity and grid spacing [nondim].
-  real :: curv_3 ! A measure of the energy density curvature over a grid length [R Z3 T-2 ~> J m-2]
+  real :: curv_3 ! A measure of the energy density curvature over a grid length [H Z2 T-2 ~> J m-2]
   integer :: i
 
   do i=ish,ieh
@@ -2751,7 +2750,7 @@ subroutine reflect(En, NAngle, CS, G, LB)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                           intent(inout) :: En !< The internal gravity wave energy density as a
                                               !! function of space and angular resolution
-                                              !! [R Z3 T-2 ~> J m-2].
+                                              !! [H Z2 T-2 ~> J m-2].
   type(int_tide_CS),      intent(in)    :: CS !< Internal tide control structure
   type(loop_bounds_type), intent(in)    :: LB !< A structure with the active energy loop bounds.
 
@@ -2763,7 +2762,7 @@ subroutine reflect(En, NAngle, CS, G, LB)
                                            ! values should collocate with angle_c [nondim]
   logical, dimension(G%isd:G%ied,G%jsd:G%jed) :: ridge
                                            ! tags of cells with double reflection
-  real, dimension(1:Nangle) :: En_reflected ! Energy reflected [R Z3 T-2 ~> J m-2].
+  real, dimension(1:Nangle) :: En_reflected ! Energy reflected [H Z2 T-2 ~> J m-2].
 
   real    :: TwoPi                         ! 2*pi = 6.2831853... [nondim]
   real    :: Angle_size                    ! size of beam wedge [rad]
@@ -2858,7 +2857,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
   real, dimension(G%isd:G%ied,G%jsd:G%jed,NAngle), &
                           intent(inout) :: En !< The internal gravity wave energy density as a
                                               !! function of space and angular resolution
-                                              !! [R Z3 T-2 ~> J m-2].
+                                              !! [H Z2 T-2 ~> J m-2].
   type(int_tide_CS),      intent(in)    :: CS !< Internal tide control structure
   type(loop_bounds_type), intent(in)    :: LB !< A structure with the active energy loop bounds.
   ! Local variables
@@ -2876,7 +2875,7 @@ subroutine teleport(En, NAngle, CS, G, LB)
   real, dimension(1:NAngle)   :: angle_i    ! angle of incident ray wrt equator [rad]
   real, dimension(1:NAngle)   :: cos_angle  ! Cosine of the beam angle relative to eastward [nondim]
   real, dimension(1:NAngle)   :: sin_angle  ! Sine of the beam angle relative to eastward [nondim]
-  real                        :: En_tele    ! energy to be "teleported" [R Z3 T-2 ~> J m-2]
+  real                        :: En_tele    ! energy to be "teleported" [H Z2 T-2 ~> J m-2]
   character(len=160) :: mesg  ! The text of an error message
   integer :: i, j, a
   integer :: ish, ieh, jsh, jeh     ! start and end local indices on data domain
@@ -2951,7 +2950,7 @@ subroutine correct_halo_rotation(En, test, G, NAngle, halo)
   type(ocean_grid_type),      intent(in)    :: G    !< The ocean's grid structure
   real, dimension(:,:,:,:,:), intent(inout) :: En   !< The internal gravity wave energy density as a
                                        !! function of space, angular orientation, frequency,
-                                       !! and vertical mode [R Z3 T-2 ~> J m-2].
+                                       !! and vertical mode [H Z2 T-2 ~> J m-2].
   real, dimension(SZI_(G),SZJ_(G),2), &
                               intent(in)    :: test !< An x-unit vector that has been passed through
                                        !! the halo updates, to enable the rotation of the
@@ -2961,7 +2960,7 @@ subroutine correct_halo_rotation(En, test, G, NAngle, halo)
   integer,                    intent(in)    :: halo   !< The halo size over which to do the calculations
   ! Local variables
   real, dimension(G%isd:G%ied,NAngle) :: En2d ! A zonal row of the internal gravity wave energy density
-                                              ! in a frequency band and mode [R Z3 T-2 ~> J m-2].
+                                              ! in a frequency band and mode [H Z2 T-2 ~> J m-2].
   integer, dimension(G%isd:G%ied) :: a_shift
   integer :: i_first, i_last, a_new
   integer :: a, i, j, ish, ieh, jsh, jeh, m, fr
@@ -3008,19 +3007,19 @@ end subroutine correct_halo_rotation
 !> Calculates left/right edge values for PPM reconstruction in x-direction.
 subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [R Z3 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
   type(loop_bounds_type),           intent(in)  :: LB   !< A structure with the active loop bounds.
   logical,                          intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [H Z2 T-2 ~> J m-2]
   real, parameter :: oneSixth = 1./6. ! One sixth [nondim]
-  real :: h_ip1, h_im1 ! The energy densities at adjacent points [R Z3 T-2 ~> J m-2]
+  real :: h_ip1, h_im1 ! The energy densities at adjacent points [H Z2 T-2 ~> J m-2]
   real :: dMx, dMn ! The maximum and minimum of values of energy density at adjacent points
-                   ! relative to the center point [R Z3 T-2 ~> J m-2]
+                   ! relative to the center point [H Z2 T-2 ~> J m-2]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, isl, iel, jsl, jel, stencil
 
@@ -3083,19 +3082,19 @@ end subroutine PPM_reconstruction_x
 !> Calculates left/right edge valus for PPM reconstruction in y-direction.
 subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, simple_2nd)
   type(ocean_grid_type),            intent(in)  :: G    !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [R Z3 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: h_in !< Energy density in a sector (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_l  !< Left edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: h_r  !< Right edge value of reconstruction (2D) [H Z2 T-2 ~> J m-2]
   type(loop_bounds_type),           intent(in)  :: LB   !< A structure with the active loop bounds.
   logical,                          intent(in)  :: simple_2nd !< If true, use the arithmetic mean
                                                         !! energy densities as default edge values
                                                         !! for a simple 2nd order scheme.
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slope in energy density times the cell width [H Z2 T-2 ~> J m-2]
   real, parameter :: oneSixth = 1./6. ! One sixth [nondim]
-  real :: h_jp1, h_jm1 ! The energy densities at adjacent points [R Z3 T-2 ~> J m-2]
+  real :: h_jp1, h_jm1 ! The energy densities at adjacent points [H Z2 T-2 ~> J m-2]
   real :: dMx, dMn ! The maximum and minimum of values of energy density at adjacent points
-                   ! relative to the center point [R Z3 T-2 ~> J m-2]
+                   ! relative to the center point [H Z2 T-2 ~> J m-2]
   character(len=256) :: mesg  ! The text of an error message
   integer :: i, j, isl, iel, jsl, jel, stencil
 
@@ -3159,18 +3158,18 @@ end subroutine PPM_reconstruction_y
 !! than h_min, with a minimum of h_min otherwise.
 subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
   type(ocean_grid_type),            intent(in)     :: G     !< The ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)), intent(in)     :: h_in  !< Energy density in each sector (2D) [R Z3 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_L   !< Left edge value of reconstruction  [R Z3 T-2 ~> J m-2]
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value of reconstruction [R Z3 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in)     :: h_in  !< Energy density in each sector (2D) [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_L   !< Left edge value of reconstruction  [H Z2 T-2 ~> J m-2]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout)  :: h_R   !< Right edge value of reconstruction [H Z2 T-2 ~> J m-2]
   real,                             intent(in)     :: h_min !< The minimum value that can be
-                                                            !! obtained by a concave parabolic fit [R Z3 T-2 ~> J m-2]
+                                                            !! obtained by a concave parabolic fit [H Z2 T-2 ~> J m-2]
   integer,                          intent(in)     :: iis   !< Start i-index for computations
   integer,                          intent(in)     :: iie   !< End i-index for computations
   integer,                          intent(in)     :: jis   !< Start j-index for computations
   integer,                          intent(in)     :: jie   !< End j-index for computations
   ! Local variables
-  real    :: curv    ! The cell-area normalized curvature [R Z3 T-2 ~> J m-2]
-  real    :: dh      ! The difference between the edge values [R Z3 T-2 ~> J m-2]
+  real    :: curv    ! The cell-area normalized curvature [H Z2 T-2 ~> J m-2]
+  real    :: dh      ! The difference between the edge values [H Z2 T-2 ~> J m-2]
   real    :: scale   ! A rescaling factor used to give a minimum cell value of at least h_min [nondim]
   integer :: i, j
 
@@ -3627,7 +3626,7 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
     endif
     ! Compute the fixed part; units are [R Z4 H-1 L-2 ~> kg m-2 or m] here
     ! will be multiplied by N and the squared near-bottom velocity (and by the
-    ! near-bottom density in non-Boussinesq mode) to get into [R Z3 T-3 ~> W m-2]
+    ! near-bottom density in non-Boussinesq mode) to get into [H Z2 T-3 ~> W m-2]
     CS%TKE_itidal_loss_fixed(i,j) = 0.5*kappa_h2_factor* GV%H_to_RZ * US%L_to_Z*kappa_itides * h2(i,j)
   enddo ; enddo
 

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1303,9 +1303,9 @@ subroutine itidal_lowmode_loss(G, GV, US, CS, Nb, Rho_bot, Ub, En, TKE_loss_fixe
 
     ! Calculate TKE loss rate; units of [H Z2 T-3 ~> W m-2] here.
     if (GV%Boussinesq .or. GV%semi_Boussinesq) then
-      TKE_loss_tot = q_itides * GV%RZ_to_H * GV%Z_to_H * TKE_loss_fixed(i,j) * Nb(i,j) * Ub(i,j,fr,m)**2
+      TKE_loss_tot = q_itides * GV%RZ_to_H*GV%Z_to_H*TKE_loss_fixed(i,j)*Nb(i,j)*Ub(i,j,fr,m)**2
     else
-      TKE_loss_tot = q_itides * (GV%RZ_to_H * GV%RZ_to_H * Rho_bot(i,j)) * TKE_loss_fixed(i,j) * Nb(i,j) * Ub(i,j,fr,m)**2
+      TKE_loss_tot = q_itides * (GV%RZ_to_H*GV%RZ_to_H*Rho_bot(i,j))*TKE_loss_fixed(i,j)*Nb(i,j)*Ub(i,j,fr,m)**2
     endif
 
     ! Update energy remaining (this is a pseudo implicit calc)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3588,8 +3588,9 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 end subroutine diabatic_driver_init
 
 !> Routine to register restarts, pass-through to children modules
-subroutine register_diabatic_restarts(G, US, param_file, int_tide_CSp, restart_CSp)
+subroutine register_diabatic_restarts(G, GV, US, param_file, int_tide_CSp, restart_CSp)
   type(ocean_grid_type), intent(in)    :: G           !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)  :: GV          !< The ocean's vertical grid structure
   type(unit_scale_type), intent(in)    :: US          !< A dimensional unit scaling type
   type(param_file_type), intent(in)    :: param_file  !< A structure to parse for run-time parameters
   type(int_tide_CS),     pointer       :: int_tide_CSp !< Internal tide control structure
@@ -3602,7 +3603,7 @@ subroutine register_diabatic_restarts(G, US, param_file, int_tide_CSp, restart_C
   call read_param(param_file, "INTERNAL_TIDES", use_int_tides)
 
   if (use_int_tides) then
-    call register_int_tide_restarts(G, US, param_file, int_tide_CSp, restart_CSp)
+    call register_int_tide_restarts(G, GV, US, param_file, int_tide_CSp, restart_CSp)
   endif
 
 end subroutine register_diabatic_restarts

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -116,8 +116,8 @@ subroutine set_int_tide_input(u, v, h, tv, fluxes, itide, dt, G, GV, US, CS)
                         ! equation of state.
   logical :: avg_enabled  ! for testing internal tides (BDM)
   type(time_type) :: time_end        !< For use in testing internal tides (BDM)
-  real :: HZ2_T3_to_W_m2  ! unit conversion factor for TKE from internal to mks
-  real :: W_m2_to_HZ2_T3  ! unit conversion factor for TKE from mks to internal
+  real :: HZ2_T3_to_W_m2  ! unit conversion factor for TKE from internal to mks [H Z2 T-3 ~> m3 s-3 or W m-2]
+  real :: W_m2_to_HZ2_T3  ! unit conversion factor for TKE from mks to internal [m3 s-3 or W m-2 ~> H Z2 T-3]
 
   integer :: i, j, is, ie, js, je, nz, isd, ied, jsd, jed
   integer :: i_global, j_global
@@ -404,8 +404,8 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
   real :: kappa_h2_factor    ! factor for the product of wavenumber * rms sgs height [nondim].
   real :: kappa_itides       ! topographic wavenumber and non-dimensional scaling [L-1 ~> m-1]
   real :: min_zbot_itides    ! Minimum ocean depth for internal tide conversion [Z ~> m].
-  real :: HZ2_T3_to_W_m2     ! unit conversion factor for TKE from internal to mks
-  real :: W_m2_to_HZ2_T3     ! unit conversion factor for TKE from mks to internal
+  real :: HZ2_T3_to_W_m2     ! unit conversion factor for TKE from internal to mks [H Z2 T-3 ~> m3 s-3 or W m-2]
+  real :: W_m2_to_HZ2_T3     ! unit conversion factor for TKE from mks to internal [m3 s-3 or W m-2 ~> H Z2 T-3]
   integer :: tlen_days       !< Time interval from start for adding wave source
                              !! for testing internal tides (BDM)
   integer :: i, j, is, ie, js, je, isd, ied, jsd, jed

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -228,7 +228,9 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, US, N2_bot, rho_bo
     hb, &         ! The thickness of the water column below the midpoint of a layer [H ~> m or kg m-2]
     z_from_bot, & ! The distance of a layer center from the bottom [Z ~> m]
     dRho_dT, &    ! The partial derivative of density with temperature [R C-1 ~> kg m-3 degC-1]
-    dRho_dS       ! The partial derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
+    dRho_dS, &    ! The partial derivative of density with salinity [R S-1 ~> kg m-3 ppt-1].
+    h_bot         ! The bottom boundary layer thickness [H ~> m].
+  integer, dimension(SZI_(G)) :: k_bot ! Bottom boundary layer top layer index [nondim].
 
   real :: dz_int  ! The vertical extent of water associated with an interface [Z ~> m]
   real :: G_Rho0  ! The gravitational acceleration, sometimes divided by the Boussinesq
@@ -247,7 +249,7 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, US, N2_bot, rho_bo
   enddo
 
   !$OMP parallel do default(none) shared(is,ie,js,je,nz,tv,fluxes,G,GV,US,h,T_f,S_f, &
-  !$OMP                                  h2,N2_bot,rho_bot,G_Rho0,EOSdom) &
+  !$OMP                                  h2,N2_bot,rho_bot,h_bot,k_bot,G_Rho0,EOSdom) &
   !$OMP                          private(pres,Temp_Int,Salin_Int,dRho_dT,dRho_dS, &
   !$OMP                                  dz,hb,dRho_bot,z_from_bot,do_i,h_amp,do_any,dz_int) &
   !$OMP                     firstprivate(dRho_int)
@@ -324,7 +326,7 @@ subroutine find_N2_bottom(h, tv, T_f, S_f, h2, fluxes, G, GV, US, N2_bot, rho_bo
       enddo
     else
       ! Average the density over the envelope of the topography.
-      call find_rho_bottom(h, dz, pres, h_amp, tv, j, G, GV, US, Rho_bot(:,j))
+      call find_rho_bottom(h, dz, pres, h_amp, tv, j, G, GV, US, Rho_bot(:,j), h_bot, k_bot)
     endif
   enddo
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -23,7 +23,7 @@ use MOM_forcing_type,        only : forcing, optics_type
 use MOM_full_convection,     only : full_convection
 use MOM_grid,                only : ocean_grid_type
 use MOM_interface_heights,   only : thickness_to_dz, find_rho_bottom
-use MOM_internal_tides,      only : int_tide_CS, get_lowmode_loss
+use MOM_internal_tides,      only : int_tide_CS, get_lowmode_loss, get_lowmode_diffusivity
 use MOM_intrinsic_functions, only : invcosh
 use MOM_io,                  only : slasher, MOM_read_data
 use MOM_isopycnal_slopes,    only : vert_fill_TS
@@ -148,6 +148,7 @@ type, public :: set_diffusivity_CS ; private
   logical :: double_diffusion !< If true, enable double-diffusive mixing using an old method.
   logical :: use_CVMix_ddiff  !< If true, enable double-diffusive mixing via CVMix.
   logical :: use_tidal_mixing !< If true, activate tidal mixing diffusivity.
+  logical :: use_int_tides    !< If true, use internal tides ray tracing
   logical :: simple_TKE_to_Kd !< If true, uses a simple estimate of Kd/TKE that
                               !! does not rely on a layer-formulation.
   real    :: Max_Rrho_salt_fingers      !< max density ratio for salt fingering [nondim]
@@ -176,8 +177,11 @@ type, public :: set_diffusivity_CS ; private
   !>@{ Diagnostic IDs
   integer :: id_maxTKE     = -1, id_TKE_to_Kd   = -1, id_Kd_user    = -1
   integer :: id_Kd_layer   = -1, id_Kd_BBL      = -1, id_N2         = -1
-  integer :: id_Kd_Work    = -1, id_KT_extra    = -1, id_KS_extra   = -1, id_R_rho = -1
-  integer :: id_Kd_bkgnd   = -1, id_Kv_bkgnd    = -1
+  integer :: id_Kd_Work    = -1, id_KT_extra    = -1, id_KS_extra   = -1, id_R_rho    = -1
+  integer :: id_Kd_bkgnd   = -1, id_Kv_bkgnd    = -1, id_Kd_leak    = -1
+  integer :: id_Kd_quad    = -1, id_Kd_itidal   = -1, id_Kd_Froude  = -1, id_Kd_slope = -1
+  integer :: id_prof_leak  = -1, id_prof_quad   = -1, id_prof_itidal= -1
+  integer :: id_prof_Froude= -1, id_prof_slope  = -1, id_bbl_thick = -1, id_kbbl = -1
   !>@}
 
 end type set_diffusivity_CS
@@ -185,16 +189,29 @@ end type set_diffusivity_CS
 !> This structure has memory for used in calculating diagnostics of diffusivity
 type diffusivity_diags
   real, pointer, dimension(:,:,:) :: &
-    N2_3d    => NULL(), & !< squared buoyancy frequency at interfaces [T-2 ~> s-2]
-    Kd_user  => NULL(), & !< user-added diffusivity at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
-    Kd_BBL   => NULL(), & !< BBL diffusivity at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
-    Kd_work  => NULL(), & !< layer integrated work by diapycnal mixing [R Z3 T-3 ~> W m-2]
-    maxTKE   => NULL(), & !< energy required to entrain to h_max [H Z2 T-3 ~> m3 s-3 or W m-2]
-    Kd_bkgnd => NULL(), & !< Background diffusivity at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
-    Kv_bkgnd => NULL(), & !< Viscosity from background diffusivity at interfaces [H Z T-1 ~> m2 s-1 or Pa s]
-    KT_extra => NULL(), & !< Double diffusion diffusivity for temperature [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
-    KS_extra => NULL(), & !< Double diffusion diffusivity for salinity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
-    drho_rat => NULL()    !< The density difference ratio used in double diffusion [nondim].
+    N2_3d     => NULL(), & !< squared buoyancy frequency at interfaces [T-2 ~> s-2]
+    Kd_user   => NULL(), & !< user-added diffusivity at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_BBL    => NULL(), & !< BBL diffusivity at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_work   => NULL(), & !< layer integrated work by diapycnal mixing [R Z3 T-3 ~> W m-2]
+    maxTKE    => NULL(), & !< energy required to entrain to h_max [H Z2 T-3 ~> m3 s-3 or W m-2]
+    Kd_bkgnd  => NULL(), & !< Background diffusivity at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kv_bkgnd  => NULL(), & !< Viscosity from background diffusivity at interfaces [H Z T-1 ~> m2 s-1 or Pa s]
+    KT_extra  => NULL(), & !< Double diffusion diffusivity for temperature [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    KS_extra  => NULL(), & !< Double diffusion diffusivity for salinity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    drho_rat  => NULL(), & !< The density difference ratio used in double diffusion [nondim].
+    Kd_leak   => NULL(), & !< internal tides leakage diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_quad   => NULL(), & !< internal tides bottom drag diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_itidal => NULL(), & !< internal tides wave drag diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_Froude => NULL(), & !< internal tides high Froude diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_slope  => NULL(), & !< internal tides critical slopes diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    prof_leak   => NULL(), & !< vertical profile for leakage [Z-1 ~> m-1]
+    prof_quad   => NULL(), & !< vertical profile for bottom drag [Z-1 ~> m-1]
+    prof_itidal => NULL(), & !< vertical profile for wave drag [Z-1 ~> m-1]
+    prof_Froude => NULL(), & !< vertical profile for Froude drag [Z-1 ~> m-1]
+    prof_slope  => NULL()    !< vertical profile for critical slopes [Z-1 ~> m-1]
+  real, pointer, dimension(:,:) ::  bbl_thick => NULL(), & !< bottom boundary layer thickness [Z ~> m]
+                                    kbbl => NULL() !< top of bottom boundary layer [nondim]
+
   real, pointer, dimension(:,:,:) :: TKE_to_Kd => NULL()
                           !< conversion rate (~1.0 / (G_Earth + dRho_lay)) between TKE
                           !! dissipated within a layer and Kd in that layer
@@ -259,11 +276,20 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
     T_f, S_f      ! Temperature and salinity [C ~> degC] and [S ~> ppt] with properties in massless layers
                   ! filled vertically by diffusion or the properties after full convective adjustment.
 
+  real, dimension(SZI_(G)) :: &
+    bbl_thick_1d  !< bottom boundary layer thickness [Z ~> m]
+  integer, dimension(SZI_(G)) :: &
+    kbbl_1d       !< index of the top of boundary layer [nondim]
   real, dimension(SZI_(G),SZK_(GV)) :: &
     N2_lay, &     !< Squared buoyancy frequency associated with layers [T-2 ~> s-2]
     Kd_lay_2d, &  !< The layer diffusivities [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
     dz, &         !< Height change across layers [Z ~> m]
     maxTKE, &     !< Energy required to entrain to h_max [H Z2 T-3 ~> m3 s-3 or W m-2]
+    prof_leak_2d, & !< vertical profile for leakage [Z-1 ~> m-1]
+    prof_quad_2d, & !< vertical profile for bottom drag [Z-1 ~> m-1]
+    prof_itidal_2d, & !< vertical profile for wave drag [Z-1 ~> m-1]
+    prof_Froude_2d, & !< vertical profile for Froude drag [Z-1 ~> m-1]
+    prof_slope_2d, & !< vertical profile for critical slopes [Z-1 ~> m-1]
     TKE_to_Kd     !< Conversion rate (~1.0 / (G_Earth + dRho_lay)) between
                   !< TKE dissipated within a layer and Kd in that layer
                   !< [H Z T-1 / H Z2 T-3 = T2 Z-1 ~> s2 m-1]
@@ -272,6 +298,11 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
     N2_int,   &   !< squared buoyancy frequency associated at interfaces [T-2 ~> s-2]
     Kd_int_2d, &  !< The interface diffusivities [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
     Kv_bkgnd, &   !< The background diffusion related interface viscosities [H Z T-1 ~> m2 s-1 or Pa s]
+    Kd_leak_2d, & !< internal tides leakage diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_quad_2d, & !< internal tides bottom drag diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_itidal_2d, & !< internal tides wave drag diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_Froude_2d, & !< internal tides high Froude diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
+    Kd_slope_2d, & !< internal tides critical slopes diffusivity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
     dRho_int, &   !< Locally referenced potential density difference across interfaces [R ~> kg m-3]
     KT_extra, &   !< Double diffusion diffusivity of temperature [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
     KS_extra      !< Double diffusion diffusivity of salinity [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
@@ -316,6 +347,7 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
                           "when USE_CVMIX_DDIFF or DOUBLE_DIFFUSION are true.")
 
   TKE_to_Kd_used = (CS%use_tidal_mixing .or. CS%ML_radiation .or. &
+                    CS%use_int_tides .or. &
                    (CS%bottomdraglaw .and. .not.CS%use_LOTW_BBL_diffusivity))
 
   ! Set Kd_lay, Kd_int and Kv_slow to constant values, mostly to fill the halos.
@@ -341,6 +373,20 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
 
   if (CS%id_Kd_bkgnd > 0) allocate(dd%Kd_bkgnd(isd:ied,jsd:jed,nz+1), source=0.)
   if (CS%id_Kv_bkgnd > 0) allocate(dd%Kv_bkgnd(isd:ied,jsd:jed,nz+1), source=0.)
+
+  if (CS%id_kbbl > 0) allocate(dd%kbbl(isd:ied,jsd:jed), source=0.)
+  if (CS%id_bbl_thick > 0) allocate(dd%bbl_thick(isd:ied,jsd:jed), source=0.)
+  if (CS%id_Kd_leak > 0) allocate(dd%Kd_leak(isd:ied,jsd:jed,nz+1), source=0.)
+  if (CS%id_Kd_quad > 0) allocate(dd%Kd_quad(isd:ied,jsd:jed,nz+1), source=0.)
+  if (CS%id_Kd_itidal > 0) allocate(dd%Kd_itidal(isd:ied,jsd:jed,nz+1), source=0.)
+  if (CS%id_Kd_Froude > 0) allocate(dd%Kd_Froude(isd:ied,jsd:jed,nz+1), source=0.)
+  if (CS%id_Kd_slope > 0) allocate(dd%Kd_slope(isd:ied,jsd:jed,nz+1), source=0.)
+
+  if (CS%id_prof_leak > 0) allocate(dd%prof_leak(isd:ied,jsd:jed,nz), source=0.)
+  if (CS%id_prof_quad > 0) allocate(dd%prof_quad(isd:ied,jsd:jed,nz), source=0.)
+  if (CS%id_prof_itidal > 0) allocate(dd%prof_itidal(isd:ied,jsd:jed,nz), source=0.)
+  if (CS%id_prof_Froude > 0) allocate(dd%prof_Froude(isd:ied,jsd:jed,nz), source=0.)
+  if (CS%id_prof_slope > 0) allocate(dd%prof_slope(isd:ied,jsd:jed,nz), source=0.)
 
   ! set up arrays for tidal mixing diagnostics
   if (CS%use_tidal_mixing) &
@@ -520,6 +566,55 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
                                   maxTKE, G, GV, US, CS%tidal_mixing, &
                                   CS%Kd_max, visc%Kv_slow, Kd_lay_2d, Kd_int_2d)
 
+    ! Add diffusivity from internal tides ray tracing
+    if (CS%use_int_tides) then
+
+      call thickness_to_dz(h, tv, dz, j, G, GV)
+
+      call get_lowmode_diffusivity(G, GV, h, tv, US, visc, dz, j, N2_lay, N2_int, TKE_to_Kd, CS%Kd_max, &
+                                   CS%int_tide_CSp, Kd_leak_2d, Kd_quad_2d, Kd_itidal_2d, Kd_Froude_2d, Kd_slope_2d, &
+                                   Kd_lay_2d, Kd_int_2d, prof_leak_2d, prof_quad_2d, prof_itidal_2d, prof_froude_2d, &
+                                   prof_slope_2d, bbl_thick_1d, kbbl_1d)
+
+      if (CS%id_kbbl > 0) then ; do i=is,ie
+        dd%kbbl(i,j) = kbbl_1d(i)
+      enddo ; endif
+      if (CS%id_bbl_thick > 0) then ; do i=is,ie
+        dd%bbl_thick(i,j) = bbl_thick_1d(i)
+      enddo ; endif
+      if (CS%id_Kd_leak > 0) then ; do K=1,nz+1 ; do i=is,ie
+        dd%Kd_leak(i,j,K) = Kd_leak_2d(i,K)
+      enddo ; enddo ; endif
+      if (CS%id_Kd_quad > 0) then ; do K=1,nz+1 ; do i=is,ie
+        dd%Kd_quad(i,j,K) = Kd_quad_2d(i,K)
+      enddo ; enddo ; endif
+      if (CS%id_Kd_itidal > 0) then ; do K=1,nz+1 ; do i=is,ie
+        dd%Kd_itidal(i,j,K) = Kd_itidal_2d(i,K)
+      enddo ; enddo ; endif
+      if (CS%id_Kd_Froude > 0) then ; do K=1,nz+1 ; do i=is,ie
+        dd%Kd_Froude(i,j,K) = Kd_Froude_2d(i,K)
+      enddo ; enddo ; endif
+      if (CS%id_Kd_slope > 0) then ; do K=1,nz+1 ; do i=is,ie
+        dd%Kd_slope(i,j,K) = Kd_slope_2d(i,K)
+      enddo ; enddo ; endif
+
+      if (CS%id_prof_leak > 0) then ; do k=1,nz; do i=is,ie
+        dd%prof_leak(i,j,k) = prof_leak_2d(i,k)
+      enddo ; enddo ; endif
+      if (CS%id_prof_quad > 0) then ; do k=1,nz; do i=is,ie
+        dd%prof_quad(i,j,k) = prof_quad_2d(i,k)
+      enddo ; enddo ; endif
+      if (CS%id_prof_itidal > 0) then ; do k=1,nz; do i=is,ie
+        dd%prof_itidal(i,j,k) = prof_itidal_2d(i,k)
+      enddo ; enddo ; endif
+      if (CS%id_prof_Froude > 0) then ; do k=1,nz; do i=is,ie
+        dd%prof_Froude(i,j,k) = prof_Froude_2d(i,k)
+      enddo ; enddo ; endif
+      if (CS%id_prof_slope > 0) then ; do k=1,nz; do i=is,ie
+        dd%prof_slope(i,j,k) = prof_slope_2d(i,k)
+      enddo ; enddo ; endif
+    endif
+
     ! This adds the diffusion sustained by the energy extracted from the flow by the bottom drag.
     if (CS%bottomdraglaw .and. (CS%BBL_effic > 0.0)) then
       if (CS%use_LOTW_BBL_diffusivity) then
@@ -624,12 +719,40 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
 
   endif
 
+  if (CS%debug) then
+    if (CS%id_prof_leak > 0) call hchksum(dd%prof_leak, "leakage_profile", G%HI, haloshift=0, scale=US%m_to_Z)
+    if (CS%id_prof_slope > 0) call hchksum(dd%prof_slope, "slope_profile", G%HI, haloshift=0, scale=US%m_to_Z)
+    if (CS%id_prof_Froude > 0) call hchksum(dd%prof_Froude, "Froude_profile", G%HI, haloshift=0, scale=US%m_to_Z)
+    if (CS%id_prof_quad > 0) call hchksum(dd%prof_quad, "quad_profile", G%HI, haloshift=0, scale=US%m_to_Z)
+    if (CS%id_prof_itidal > 0) call hchksum(dd%prof_itidal, "itidal_profile", G%HI, haloshift=0, scale=US%m_to_Z)
+    if (CS%id_TKE_to_Kd > 0) call hchksum(dd%TKE_to_Kd, "TKE_to_Kd", G%HI, haloshift=0, scale=US%m_to_Z*US%T_to_s**2)
+    if (CS%id_Kd_leak > 0) call hchksum(dd%Kd_leak,   "Kd_leak",   G%HI, haloshift=0, scale=GV%HZ_T_to_m2_s)
+    if (CS%id_Kd_quad > 0) call hchksum(dd%Kd_quad,   "Kd_quad",   G%HI, haloshift=0, scale=GV%HZ_T_to_m2_s)
+    if (CS%id_Kd_itidal > 0) call hchksum(dd%Kd_itidal, "Kd_itidal", G%HI, haloshift=0, scale=GV%HZ_T_to_m2_s)
+    if (CS%id_Kd_Froude > 0) call hchksum(dd%Kd_Froude, "Kd_Froude", G%HI, haloshift=0, scale=GV%HZ_T_to_m2_s)
+    if (CS%id_Kd_slope > 0) call hchksum(dd%Kd_slope,  "Kd_slope",  G%HI, haloshift=0, scale=GV%HZ_T_to_m2_s)
+  endif
+
   ! post diagnostics
   if (present(Kd_lay) .and. (CS%id_Kd_layer > 0)) call post_data(CS%id_Kd_layer, Kd_lay, CS%diag)
 
   ! background mixing
   if (CS%id_Kd_bkgnd > 0) call post_data(CS%id_Kd_bkgnd, dd%Kd_bkgnd, CS%diag)
   if (CS%id_Kv_bkgnd > 0) call post_data(CS%id_Kv_bkgnd, dd%Kv_bkgnd, CS%diag)
+
+  if (CS%id_kbbl > 0) call post_data(CS%id_kbbl, dd%kbbl, CS%diag)
+  if (CS%id_bbl_thick > 0) call post_data(CS%id_bbl_thick, dd%bbl_thick, CS%diag)
+  if (CS%id_Kd_leak > 0) call post_data(CS%id_Kd_leak, dd%Kd_leak, CS%diag)
+  if (CS%id_Kd_slope > 0) call post_data(CS%id_Kd_slope, dd%Kd_slope, CS%diag)
+  if (CS%id_Kd_Froude > 0) call post_data(CS%id_Kd_Froude, dd%Kd_Froude, CS%diag)
+  if (CS%id_Kd_quad > 0) call post_data(CS%id_Kd_quad, dd%Kd_quad, CS%diag)
+  if (CS%id_Kd_itidal > 0) call post_data(CS%id_Kd_itidal, dd%Kd_itidal, CS%diag)
+
+  if (CS%id_prof_leak > 0) call post_data(CS%id_prof_leak, dd%prof_leak, CS%diag)
+  if (CS%id_prof_slope > 0) call post_data(CS%id_prof_slope, dd%prof_slope, CS%diag)
+  if (CS%id_prof_Froude > 0) call post_data(CS%id_prof_Froude, dd%prof_Froude, CS%diag)
+  if (CS%id_prof_quad > 0) call post_data(CS%id_prof_quad, dd%prof_quad, CS%diag)
+  if (CS%id_prof_itidal > 0) call post_data(CS%id_prof_itidal, dd%prof_itidal, CS%diag)
 
   ! tidal mixing
   if (CS%use_tidal_mixing) &
@@ -664,6 +787,17 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
   if (associated(dd%Kd_BBL)) deallocate(dd%Kd_BBL)
   if (associated(dd%Kd_bkgnd)) deallocate(dd%Kd_bkgnd)
   if (associated(dd%Kv_bkgnd)) deallocate(dd%Kv_bkgnd)
+
+  if (associated(dd%Kd_leak)) deallocate(dd%Kd_leak)
+  if (associated(dd%Kd_quad)) deallocate(dd%Kd_quad)
+  if (associated(dd%Kd_itidal)) deallocate(dd%Kd_itidal)
+  if (associated(dd%Kd_Froude)) deallocate(dd%Kd_Froude)
+  if (associated(dd%Kd_slope)) deallocate(dd%Kd_slope)
+  if (associated(dd%prof_leak)) deallocate(dd%prof_leak)
+  if (associated(dd%prof_quad)) deallocate(dd%prof_quad)
+  if (associated(dd%prof_itidal)) deallocate(dd%prof_itidal)
+  if (associated(dd%prof_Froude)) deallocate(dd%prof_Froude)
+  if (associated(dd%prof_slope)) deallocate(dd%prof_slope)
 
   if (showCallTree) call callTree_leave("set_diffusivity()")
 
@@ -2071,7 +2205,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
   type(diag_ctrl), target,  intent(inout) :: diag !< A structure used to regulate diagnostic output.
   type(set_diffusivity_CS), pointer       :: CS   !< pointer set to point to the module control
                                                   !! structure.
-  type(int_tide_CS),        pointer       :: int_tide_CSp !< Internal tide control structure
+  type(int_tide_CS),        intent(in), target :: int_tide_CSp !< Internal tide control structure
   integer,                  intent(out)   :: halo_TS !< The halo size of tracer points that must be
                                                   !! valid for the calculations in set_diffusivity.
   logical,                  intent(out)   :: double_diffuse !< This indicates whether some version
@@ -2116,7 +2250,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   CS%diag => diag
-  if (associated(int_tide_CSp)) CS%int_tide_CSp  => int_tide_CSp
+  CS%int_tide_CSp  => int_tide_CSp
 
   ! These default values always need to be set.
   CS%BBL_mixing_as_max = .true.
@@ -2273,6 +2407,10 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                  "for an isopycnal layer-formulation.", &
                  default=.false., do_not_log=.not.TKE_to_Kd_used)
 
+   call get_param(param_file, mdl, "INTERNAL_TIDES", CS%use_int_tides, &
+                 "If true, use the code that advances a separate set of "//&
+                 "equations for the internal tide energy density.", default=.false.)
+
   ! set parameters related to the background mixing
   call bkgnd_mixing_init(Time, G, GV, US, param_file, CS%diag, CS%bkgnd_mixing_csp, physical_OBL_scheme)
 
@@ -2349,6 +2487,33 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
       'Background diffusivity added by MOM_bkgnd_mixing module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
   CS%id_Kv_bkgnd = register_diag_field('ocean_model', 'Kv_bkgnd', diag%axesTi, Time, &
       'Background viscosity added by MOM_bkgnd_mixing module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
+
+  if (CS%use_int_tides) then
+    CS%id_kbbl = register_diag_field('ocean_model', 'kbbl', diag%axesT1, Time, &
+        'BBL index at h points', 'nondim')
+    CS%id_bbl_thick = register_diag_field('ocean_model', 'bbl_thick', diag%axesT1, Time, &
+        'BBL thickness at h points', 'm', conversion=US%Z_to_m)
+    CS%id_Kd_leak = register_diag_field('ocean_model', 'Kd_leak', diag%axesTi, Time, &
+        'internal tides leakage viscosity added by MOM_internal tides module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
+    CS%id_Kd_Froude = register_diag_field('ocean_model', 'Kd_Froude', diag%axesTi, Time, &
+        'internal tides Froude viscosity added by MOM_internal tides module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
+    CS%id_Kd_itidal = register_diag_field('ocean_model', 'Kd_itidal', diag%axesTi, Time, &
+        'internal tides wave drag viscosity added by MOM_internal tides module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
+    CS%id_Kd_quad = register_diag_field('ocean_model', 'Kd_quad', diag%axesTi, Time, &
+        'internal tides bottom viscosity added by MOM_internal tides module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
+    CS%id_Kd_slope = register_diag_field('ocean_model', 'Kd_slope', diag%axesTi, Time, &
+        'internal tides slope viscosity added by MOM_internal tides module', 'm2/s', conversion=GV%HZ_T_to_m2_s)
+    CS%id_prof_leak = register_diag_field('ocean_model', 'prof_leak', diag%axesTl, Time, &
+        'internal tides leakage profile added by MOM_internal tides module', 'm-1', conversion=US%m_to_Z)
+    CS%id_prof_Froude = register_diag_field('ocean_model', 'prof_Froude', diag%axesTl, Time, &
+        'internal tides Froude profile added by MOM_internal tides module', 'm-1', conversion=US%m_to_Z)
+    CS%id_prof_itidal = register_diag_field('ocean_model', 'prof_itidal', diag%axesTl, Time, &
+        'internal tides wave drag profile added by MOM_internal tides module', 'm-1', conversion=US%m_to_Z)
+    CS%id_prof_quad = register_diag_field('ocean_model', 'prof_quad', diag%axesTl, Time, &
+        'internal tides bottom profile added by MOM_internal tides module', 'm-1', conversion=US%m_to_Z)
+    CS%id_prof_slope = register_diag_field('ocean_model', 'prof_slope', diag%axesTl, Time, &
+        'internal tides slope profile added by MOM_internal tides module', 'm-1', conversion=US%m_to_Z)
+  endif
 
   CS%id_Kd_layer = register_diag_field('ocean_model', 'Kd_layer', diag%axesTL, Time, &
       'Diapycnal diffusivity of layers (as set)', 'm2 s-1', conversion=GV%HZ_T_to_m2_s)

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1197,7 +1197,7 @@ subroutine find_N2(h, tv, T_f, S_f, fluxes, j, G, GV, US, CS, dRho_int, &
 
   ! Average over the larger of the envelope of the topography or a minimal distance.
   do i=is,ie ; dz_BBL_avg(i) = max(h_amp(i), CS%dz_BBL_avg_min) ; enddo
-  call find_rho_bottom(h, dz, pres, dz_BBL_avg, tv, j, G, GV, US, Rho_bot, h_bot, k_bot)
+  call find_rho_bottom(G, GV, US, tv, h, dz, pres, dz_BBL_avg, j, Rho_bot, h_bot, k_bot)
 
 end subroutine find_N2
 


### PR DESCRIPTION
For better readibility, the PR is split into 3 commits: the first deals with bugfixes and improvements relative to the internal tides energy (changes answers) while the second deals with refactoring of debugging infra. The third commit introduces the TKE loss to diffusivity part.

1st part:

    (*)bugfixes for internal tides
    
    - TKE_itidal_input values are set to zero where it is not applied to
      the model so that diagnostics are consistent
    
    - removed useless halo updates
    
    - diagnose energy loss terms as dE/dt instead of equivalent loss rate
      to properly close energy budget
    
    - tot_vel_btTide2 was already a velocity squared, no need to square again
    
    - Froude loss term was not properly initialized
    
    - add missing halo updates for internal tide speed
    
    - compute residual/critical slopes loss only where it has a meaning,
      allows to clean up noise in field
    
    - uh/vh in energy flux routines do not need to be inout
    
    - missing unit scaling for frequency
 
2nd part:

    Refactor debugging internal tides
    
    - put test for negative energy behind debug flag
    
    - do energy budget in debug mode
    
    - add flags to skip refraction, propagation for debugging
    
    - add option to input TKE only at first step for debugging
    
    - add checksums for unit scaling testing
    
    - rewrite terms in refraction to avoid substractions of velocities
    
    - rewrite gradient of coriolis in rotationally invariant form

last part:

    Add internal tides diffusivities
    
    - MOM_internal_tides gets new routine that converts
      TKE losses into diffusivities using the TKE_to_Kd array
    
    - MOM_set_diffusivities handles the diagnostics
