### PR TITLE
Correct 10 do-loop index cases

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2533,7 +2533,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
     if (CS%BT_OBC%apply_v_OBCs) then  ! copy back the value for v-points on the boundary.
       !GOMP parallel do default(shared)
-      do J=js-1,je ; do I=is,ie
+      do J=js-1,je ; do i=is,ie
         l_seg = OBC%segnum_v(i,J)
         if (l_seg == OBC_NONE) cycle
 

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -395,7 +395,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$OMP                                  drho_dT_dT_hr,pres_hr,T_hr,S_hr,             &
   !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
   !$OMP                                  drdy,mag_grad2,slope,l_seg)
-  do j=js-1,je ; do K=nz,2,-1
+  do J=js-1,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
       drdjA = 0.0 ; drdjB = 0.0
       drdkL = GV%Rlay(k)-GV%Rlay(k-1) ; drdkR = GV%Rlay(k)-GV%Rlay(k-1)

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -970,9 +970,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
 
   if (.not.(CS%KE_term_on .or. (CS%id_KE > 0))) return
 
-  do j=js-1,je ; do i=is-1,ie
-    KE_u(I,j) = 0.0 ; KE_v(i,J) = 0.0
-  enddo ; enddo
+  KE_u(:,:) = 0. ; KE_v(:,:) = 0.
 
   do k=1,nz ; do j=js,je ; do i=is,ie
     KE(i,j,k) = ((u(I,j,k) * u(I,j,k) + u(I-1,j,k) * u(I-1,j,k)) &

--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -103,7 +103,7 @@ function global_area_mean_v(var, G, tmp_scale)
   scalefac = G%US%L_to_m**2*temp_scale
 
   tmpForSumming(:,:) = 0.
-  do J=js,je ; do i=is,ie
+  do j=js,je ; do i=is,ie
     tmpForSumming(i,j) = G%areaT(i,j) * scalefac * &
              (var(i,J) * G%mask2dCv(i,J) + var(i,J-1) * G%mask2dCv(i,J-1)) / &
              max(1.e-20, G%mask2dCv(i,J)+G%mask2dCv(i,J-1))

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2045,7 +2045,7 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
       ! This call to set_up_sponge_ML_density registers the target values of the
       ! mixed layer density, which is used in determining which layers can be
       ! inflated without causing static instabilities.
-      do i=is-1,ie ; pres(i) = tv%P_Ref ; enddo
+      do i=is,ie ; pres(i) = tv%P_Ref ; enddo
       EOSdom(:) = EOS_domain(G%HI)
 
       call MOM_read_data(filename, potemp_var, tmp(:,:,:), G%Domain, scale=US%degC_to_C)

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1096,7 +1096,7 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
 
   cnmask(:,:) = merge(0., 1., cn(:,:) == 0.)
 
-  do j=js,je ; do i=is-1,ie
+  do j=js,je ; do I=is-1,ie
     ! wgt = 0 if local cn == 0, wgt = 0.5 if both contiguous values != 0
     ! and wgt = 1 if neighbour cn == 0
     wgt1 = cnmask(i,j) - 0.5 * cnmask(i,j) * cnmask(i+1,j)
@@ -1104,7 +1104,7 @@ subroutine refract(En, cn, freq, dt, G, US, NAngle, use_PPMang)
     cn_u(I,j) = wgt1*cn(i,j) + wgt2*cn(i+1,j)
   enddo ; enddo
 
-  do j=js-1,je ; do i=is,ie
+  do J=js-1,je ; do i=is,ie
     wgt1 = cnmask(i,j) - 0.5 * cnmask(i,j) * cnmask(i,j+1)
     wgt2 = cnmask(i,j+1) - 0.5 * cnmask(i,j) * cnmask(i,j+1)
     cn_v(i,J) = wgt1*cn(i,j) + wgt2*cn(i,j+1)

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -703,7 +703,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
     if (CS%id_vDml          > 0) call post_data(CS%id_vDml, vDml_diag, CS%diag)
 
     if (CS%id_uml > 0) then
-      do J=js,je ; do i=is-1,ie
+      do j=js,je ; do I=is-1,ie
         h_vel = 0.5*((htot_fast(i,j) + htot_fast(i+1,j)) + h_neglect)
         uDml_diag(I,j) = uDml_diag(I,j) / (0.01*h_vel) * G%IdyCu(I,j) * (mu(0.,0.)-mu(-.01,0.))
       enddo ; enddo
@@ -1164,7 +1164,7 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
     if (CS%id_lfbod  > 0) call post_data(CS%id_lfbod, lf_bodner_diag, CS%diag)
 
     if (CS%id_uml > 0) then
-      do J=js,je ; do i=is-1,ie
+      do j=js,je ; do I=is-1,ie
         h_vel = 0.5*((htot(i,j) + htot(i+1,j)) + h_neglect)
         uDml_diag(I,j) = uDml_diag(I,j) / (0.01*h_vel) * G%IdyCu(I,j) * (mu(0.,0.)-mu(-.01,0.))
       enddo ; enddo

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -221,7 +221,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
       (dt * (G%IdxCu(I,j)*G%IdxCu(I,j) + G%IdyCu(I,j)*G%IdyCu(I,j)))
   enddo ; enddo
   !$OMP parallel do default(shared)
-  do j=js-1,je ; do I=is,ie
+  do J=js-1,je ; do i=is,ie
     KH_v_CFL(i,J) = (0.25*CS%max_Khth_CFL) / &
       (dt * (G%IdxCv(i,J)*G%IdxCv(i,J) + G%IdyCv(i,J)*G%IdyCv(i,J)))
   enddo ; enddo
@@ -426,7 +426,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     if (CS%MEKE_GEOMETRIC) then
       if (CS%MEKE_GEOM_answer_date < 20190101) then
         !$OMP do
-        do j=js,je ; do I=is,ie
+        do j=js,je ; do i=is,ie
           ! This does not give bitwise rotational symmetry.
           MEKE%Kh(i,j) = CS%MEKE_GEOMETRIC_alpha * MEKE%MEKE(i,j) / &
                          (0.25*(VarMix%SN_u(I,j)+VarMix%SN_u(I-1,j) + &
@@ -435,7 +435,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
         enddo ; enddo
       else
         !$OMP do
-        do j=js,je ; do I=is,ie
+        do j=js,je ; do i=is,ie
           ! With the additional parentheses this gives bitwise rotational symmetry.
           MEKE%Kh(i,j) = CS%MEKE_GEOMETRIC_alpha * MEKE%MEKE(i,j) / &
                          (0.25*((VarMix%SN_u(I,j)+VarMix%SN_u(I-1,j)) + &

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -183,7 +183,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
     !   This call to set_up_sponge_ML_density registers the target values of the
     ! mixed layer density, which is used in determining which layers can be
     ! inflated without causing static instabilities.
-      do i=is-1,ie ; pres(i) = tv%P_Ref ; enddo
+      do i=is,ie ; pres(i) = tv%P_Ref ; enddo
       EOSdom(:) = EOS_domain(G%HI)
       do j=js,je
         call calculate_density(T(:,j,1), S(:,j,1), pres, rho(:,j), tv%eqn_of_state, EOSdom)


### PR DESCRIPTION
  Corrected the case of the do-loop index variable in 10 places in 6 files, initialized two whole diagnostic arrays to 0 instead of having shared loops initializing u- and v-point arrays, and shortened two loops initializing pressures to the size that is actually used in the corresponding equation of state calls.  With these changes, there are no i- or j- loops with extents that are inconsistent with the stagger-based index case convention used throughout the MOM6 code.  All answers are bitwise identical in all cases.