### PR TITLE
(*)+Restore USE_WRIGHT_2ND_DERIV_BUG functionality

### DIFF
--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1526,6 +1526,7 @@ subroutine EOS_init(param_file, EOS, US)
                  "If true, use a bug in the calculation of the second derivatives of density "//&
                  "with temperature and with temperature and pressure that causes some terms "//&
                  "to be only 2/3 of what they should be.", default=.false.)
+    call EOS_manual_init(EOS, form_of_EOS=EOS_WRIGHT, use_Wright_2nd_deriv_bug=EOS%use_Wright_2nd_deriv_bug)
   endif
 
   EOS_quad_default = .not.((EOS%form_of_EOS == EOS_LINEAR) .or. &
@@ -1645,6 +1646,8 @@ subroutine EOS_manual_init(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Co
     select type (t => EOS%type)
       type is (linear_EOS)
         call t%set_params_linear(Rho_T0_S0, dRho_dT, dRho_dS)
+      type is (buggy_Wright_EOS)
+        call t%set_params_buggy_Wright(use_Wright_2nd_deriv_bug)
     end select
   endif
   if (present(form_of_TFreeze))  EOS%form_of_TFreeze = form_of_TFreeze


### PR DESCRIPTION
  This commit restores the effectiveness of the runtime parameter `USE_WRIGHT_2ND_DERIV_BUG` in determining whether a bug is corrected in the calculation of two of the second derivative terms returned by `calculate_density_second_derivs_elem()` with the "WRIGHT" equation of state, recreating the behavior (and answers) that are currently on the main branch of MOM6.  To do this, it adds and calls the new routine `set_params_buggy_Wright()` when appropriate, and adds the new element "three" to the `buggy_Wright_EOS` type. When the bug is fixed, `buggy_Wright_EOS%three = 3`, but `...%three = 2` to recreate the bug.  This commit does change answers for cases using the "WRIGHT" equation of state and one of the "USE_STANLEY_..." parameterizations from those on the dev/gfdl branch of MOM6, but in so doing it restores the answers on the main branch of MOM6.  There is also a new publicly visible subroutine.