### PR TITLE
Improve MOM_surface_chksum

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -4028,7 +4028,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
     endif
   endif
 
-  if (CS%debug) call MOM_surface_chksum("Post extract_sfc", sfc_state, G, US, haloshift=0)
+  if (CS%debug) call MOM_surface_chksum("Post extract_sfc", sfc_state, G, US, haloshift=0, symmetric=.true.)
 
   ! Rotate sfc_state back onto the input grid, sfc_state_in
   if (CS%rotate_index) then

--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -167,7 +167,7 @@ subroutine MOM_surface_chksum(mesg, sfc_state, G, US, haloshift, symmetric)
   logical :: sym
 
   sym = .false. ; if (present(symmetric)) sym = symmetric
-  hs = 1 ; if (present(haloshift)) hs = haloshift
+  hs = 0 ; if (present(haloshift)) hs = haloshift
 
   if (allocated(sfc_state%SST)) call hchksum(sfc_state%SST, mesg//" SST", G%HI, haloshift=hs, &
                                              scale=US%C_to_degC)
@@ -182,6 +182,14 @@ subroutine MOM_surface_chksum(mesg, sfc_state, G, US, haloshift, symmetric)
                   scale=US%L_T_to_m_s)
   if (allocated(sfc_state%frazil)) call hchksum(sfc_state%frazil, mesg//" frazil", G%HI, &
                                                 haloshift=hs, scale=US%Q_to_J_kg*US%RZ_to_kg_m2)
+  if (allocated(sfc_state%melt_potential)) call hchksum(sfc_state%melt_potential, mesg//" melt_potential", &
+                      G%HI, haloshift=hs, scale=US%Q_to_J_kg*US%RZ_to_kg_m2)
+  if (allocated(sfc_state%ocean_mass)) call hchksum(sfc_state%ocean_mass, mesg//" ocean_mass", &
+                      G%HI, haloshift=hs, scale=US%RZ_to_kg_m2)
+  if (allocated(sfc_state%ocean_heat)) call hchksum(sfc_state%ocean_heat, mesg//" ocean_heat", &
+                      G%HI, haloshift=hs, scale=US%C_to_degC*US%RZ_to_kg_m2)
+  if (allocated(sfc_state%ocean_salt)) call hchksum(sfc_state%ocean_salt, mesg//" ocean_salt", &
+                      G%HI, haloshift=hs, scale=US%S_to_ppt*US%RZ_to_kg_m2)
 
 end subroutine MOM_surface_chksum
 


### PR DESCRIPTION
  Added checksum calls for the `melt_potential`, `ocean_mass`, `ocean_heat` and `ocean_salt` elements of the surface state in `MOM_surface_chksum()` if these fields are allocated for more comprehensive debugging.  Also added the symmetric optional argument to the call to `MOM_surface_chksum()` from `extract_surface_state()` so that all of the surface velocity values that could contribute to the ocean surface velocities that are seen by the coupler are checksummed.  All solutions are bitwise identical, but there are enhancements to the MOM6 debugging capabilities.