### PR TITLE
In generic_tracer_source call, perform unit conversion for internal heat only when it is applicable

### DIFF
--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -584,13 +584,24 @@ contains
                optics%nbands, optics%max_wavelength_band, optics%sw_pen_band, optics%opacity_band, &
                internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga)
     else
-      call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
+      ! tv%internal_heat is a null pointer unless DO_GEOTHERMAL = True,
+      ! so we have to check and only do the scaling if it is associated.
+      if(associated(tv%internal_heat)) then
+        call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
                optics%nbands, optics%max_wavelength_band, &
                sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
                opacity_band=G%US%m_to_Z*optics%opacity_band(:,:,:,:), &
                internal_heat=G%US%RZ_to_kg_m2*US%C_to_degC*tv%internal_heat(:,:), &
                frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga)
+      else
+        call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
+               G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
+               optics%nbands, optics%max_wavelength_band, &
+               sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
+               opacity_band=G%US%m_to_Z*optics%opacity_band(:,:,:,:), &
+               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga)
+      endif
     endif
 
     ! This uses applyTracerBoundaryFluxesInOut to handle the change in tracer due to freshwater fluxes


### PR DESCRIPTION
This PR is related to another [PR](https://github.com/NOAA-GFDL/ocean_BGC/pull/34) made in the NOAA-GFDL/ocean_BGC repo.

In the past, setting `DO_GEOTHERMAL = True` was necessary for COBALT to function correctly. Failure to enable geothermal heating will lead to segmentation faults if someone turned it off accidently.

We have now made `internal_heat` an [optional argument](https://github.com/NOAA-GFDL/ocean_BGC/blob/048ac6811232c006a6ff2d63f7063911822ba3ef/generic_tracers/generic_COBALT.F90#L6455) in the `generic_COBALT_update_from_source`. The `if(present())` [check](https://github.com/NOAA-GFDL/ocean_BGC/blob/048ac6811232c006a6ff2d63f7063911822ba3ef/generic_tracers/generic_COBALT.F90#L7856) will determine if `internal_heating` is a null pointer. However, in the unit conversion case, the scaling operation `G%US%RZ_to_kg_m2*US%C_to_degC*tv%internal_heat(:,:)` occurs before passing the data to `generic_tracer_source`. This will cause a segmentation fault if `internal_heat` [is null](https://github.com/NOAA-GFDL/MOM6/blob/2c1a9d32fce72828b7091e6f623c0ec20069e637/src/core/MOM.F90#L2811-L28135).

This PR (proposed by @andrew-c-ross originally) fixes this issue by omitting this argument if `internal_heat` is not associated.