### PR TITLE
*Possibly initialize h_ML from MLD in restart file

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3270,17 +3270,18 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   CS%mixedlayer_restrat = mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, &
                                                   CS%mixedlayer_restrat_CSp, restart_CSp)
-  if (CS%mixedlayer_restrat) then
-    if (GV%Boussinesq .and. associated(CS%visc%h_ML)) then
-      ! This is here to allow for a transition of restart files between model versions.
-      call get_param(param_file, "MOM", "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
-                     default=.false., do_not_log=.true.)
-      if (MLE_use_PBL_MLD .and. .not.query_initialized(CS%visc%h_ML, "h_ML", restart_CSp) .and. &
-          associated(CS%visc%MLD)) then
-        do j=js,je ; do i=is,ie ; CS%visc%h_ML(i,j) = GV%Z_to_H * CS%visc%MLD(i,j) ; enddo ; enddo
-      endif
-    endif
 
+  if (GV%Boussinesq .and. associated(CS%visc%h_ML)) then
+    ! This is here to allow for a transition of restart files between model versions.
+    call get_param(param_file, "MOM", "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
+                   default=.false., do_not_log=.true.)
+    if (MLE_use_PBL_MLD .and. .not.query_initialized(CS%visc%h_ML, "h_ML", restart_CSp) .and. &
+        associated(CS%visc%MLD)) then
+      do j=js,je ; do i=is,ie ; CS%visc%h_ML(i,j) = GV%Z_to_H * CS%visc%MLD(i,j) ; enddo ; enddo
+    endif
+  endif
+
+  if (CS%mixedlayer_restrat) then
     if (.not.(bulkmixedlayer .or. CS%use_ALE_algorithm)) &
       call MOM_error(FATAL, "MOM: MIXEDLAYER_RESTRAT true requires a boundary layer scheme.")
     ! When DIABATIC_FIRST=False and using CS%visc%ML in mixedlayer_restrat we need to update after a restart


### PR DESCRIPTION
  Moved a check for whether to initialize an uninitialized `visc%h_ML` field from `visc%MLD` outside of the test for the value of `CS%mixedlayer_restart`.  This change will prevent answer changes between code versions for certain cases that initialize from a restart file, use the `surface_state%melt_potential` field and have `MLE_USE_PBL_MLD = True` but also have `MIXEDLAYER_RESTRAT = False`.  This commit corrects a very specific oversight that was introduced when the roles of `visc%h_ML` and `visc%MLD` were separated, and it can change answers (reverting them to answers from older versions of the main branch of MOM6) in very specific cases where MOM6 is initialized from a restart file from an older versions of the code, including the 5x5-degree test case in the dev/emc regression suite.