### PR TITLE
*+Fix non-Boussinesq MASS_WEIGHT_IN_PGF bug

### DIFF
--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1226,7 +1226,7 @@ end function EOS_domain
 !! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
 subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                                dza, intp_dza, intx_dza, inty_dza, halo_size, &
-                               bathyP, dP_tiny, useMassWghtInterp)
+                               bathyP, dP_tiny, MassWghtInterp)
   type(hor_index_type), intent(in)  :: HI  !< The horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [C ~> degC]
@@ -1261,8 +1261,8 @@ subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
               optional, intent(in)  :: bathyP  !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_tiny !< A miniscule pressure change with
                             !! the same units as p_t [R L2 T-2 ~> Pa]
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
-                            !! to interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                            !! mass weighting to interpolate T/S in integrals
 
   ! Local variables
   real :: dRdT_scale ! A factor to convert drho_dT to the desired units [R degC m3 C-1 kg-1 ~> 1]
@@ -1280,20 +1280,20 @@ subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
       call int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, EOS%kg_m3_to_R*EOS%Rho_T0_S0, &
                                 dRdT_scale*EOS%dRho_dT, dRdS_scale*EOS%dRho_dS, dza, &
                                 intp_dza, intx_dza, inty_dza, halo_size, &
-                                bathyP, dP_tiny, useMassWghtInterp)
+                                bathyP, dP_tiny, MassWghtInterp)
     case (EOS_WRIGHT)
       call int_spec_vol_dp_wright(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
-                                  inty_dza, halo_size, bathyP, dP_tiny, useMassWghtInterp, &
+                                  inty_dza, halo_size, bathyP, dP_tiny, MassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
     case (EOS_WRIGHT_FULL)
       call int_spec_vol_dp_wright_full(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
-                                  inty_dza, halo_size, bathyP, dP_tiny, useMassWghtInterp, &
+                                  inty_dza, halo_size, bathyP, dP_tiny, MassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
     case (EOS_WRIGHT_REDUCED)
       call int_spec_vol_dp_wright_red(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
-                                  inty_dza, halo_size, bathyP, dP_tiny, useMassWghtInterp, &
+                                  inty_dza, halo_size, bathyP, dP_tiny, MassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
     case default
@@ -1306,7 +1306,7 @@ end subroutine analytic_int_specific_vol_dp
 !! pressure anomalies across layers, which are required for calculating the
 !! finite-volume form pressure accelerations in a Boussinesq model.
 subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, dpa, &
-                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp, Z_0p)
+                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp, Z_0p)
   type(hor_index_type), intent(in)  :: HI !< Ocean horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [C ~> degC]
@@ -1343,8 +1343,8 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT !< The depth of the bathymetry [Z ~> m]
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m]
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
-                                           !! interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                          !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: Z_0p !< The height at which the pressure is 0 [Z ~> m]
 
   ! Local variables
@@ -1366,11 +1366,11 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (dRdT_scale /= 1.0) .or. (dRdS_scale /= 1.0)) then
         call int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                          rho_scale*EOS%Rho_T0_S0, dRdT_scale*EOS%dRho_dT, dRdS_scale*EOS%dRho_dS, &
-                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp)
+                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp)
       else
         call int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                          EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, &
-                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, useMassWghtInterp)
+                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp)
       endif
     case (EOS_WRIGHT)
       rho_scale = EOS%kg_m3_to_R
@@ -1378,12 +1378,12 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale, &
+                                   dz_neglect, MassWghtInterp, rho_scale, pres_scale, &
                                    temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt, Z_0p=Z_0p)
       else
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, Z_0p=Z_0p)
+                                   dz_neglect, MassWghtInterp, Z_0p=Z_0p)
       endif
     case (EOS_WRIGHT_FULL)
       rho_scale = EOS%kg_m3_to_R
@@ -1391,12 +1391,12 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
         call int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale, &
+                                   dz_neglect, MassWghtInterp, rho_scale, pres_scale, &
                                    temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt, Z_0p=Z_0p)
       else
         call int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, Z_0p=Z_0p)
+                                   dz_neglect, MassWghtInterp, Z_0p=Z_0p)
       endif
     case (EOS_WRIGHT_REDUCED)
       rho_scale = EOS%kg_m3_to_R
@@ -1404,12 +1404,12 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
         call int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, rho_scale, pres_scale, &
+                                   dz_neglect, MassWghtInterp, rho_scale, pres_scale, &
                                    temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt, Z_0p=Z_0p)
       else
         call int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                    dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
-                                   dz_neglect, useMassWghtInterp, Z_0p=Z_0p)
+                                   dz_neglect, MassWghtInterp, Z_0p=Z_0p)
       endif
     case default
       call MOM_error(FATAL, "No analytic integration option is available with this EOS!")

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -380,7 +380,7 @@ end subroutine EoS_fit_range_buggy_Wright
 !! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
-                                 useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
+                                 MassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
   type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T        !< Potential temperature relative to the surface
@@ -417,8 +417,8 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT   !< The depth of the bathymetry [Z ~> m].
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
-                                                !! interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                                 !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: rho_scale !< A multiplicative factor by which to scale density
                                                  !! from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
@@ -517,13 +517,13 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   endif ; endif
 
   do_massWeight = .false.
-  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
-    do_massWeight = .true.
-  ! if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !     "bathyT must be present if useMassWghtInterp is present and true.")
-  ! if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !     "dz_neglect must be present if useMassWghtInterp is present and true.")
-  endif ; endif
+  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  ! if (do_massWeight) then
+  !   if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !       "bathyT must be present if MassWghtInterp is present and true.")
+  !   if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !      "dz_neglect must be present if MassWghtInterp is present and true.")
+  ! endif
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     al0_2d(i,j) = (a0 + a1s*T(i,j)) + a2s*S(i,j)
@@ -640,7 +640,7 @@ end subroutine int_density_dz_wright
 !! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
-                                  useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
+                                  MassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
   type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T         !< Potential temperature relative to the surface
@@ -678,8 +678,8 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
               optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
                                                  !! the same units as p_t [R L2 T-2 ~> Pa]
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
-                            !! to interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                                 !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: SV_scale  !< A multiplicative factor by which to scale specific
                             !! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
   real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
@@ -726,6 +726,7 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
   integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, halo
@@ -762,14 +763,15 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false.
-  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
-    do_massWeight = .true.
+  do_massWeight = .false. ; massWeight_bug = .false.
+  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+!  if (do_massWeight) then
 !    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "bathyP must be present if useMassWghtInterp is present and true.")
+!        "bathyP must be present if MassWghtInterp is present and true.")
 !    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "dP_neglect must be present if useMassWghtInterp is present and true.")
-  endif ; endif
+!        "dP_neglect must be present if MassWghtInterp is present and true.")
+!  endif
 
   !  alpha(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
   do j=jsh,jeh ; do i=ish,ieh
@@ -794,8 +796,11 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     ! hydrostatic consistency. For large hWght we bias the interpolation of
     ! T & S along the top and bottom integrals, akin to thickness weighting.
     hWght = 0.0
-    if (do_massWeight) &
+    if (do_massWeight .and. massWeight_bug) then
       hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
+    endif
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -835,8 +840,11 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     ! hydrostatic consistency. For large hWght we bias the interpolation of
     ! T & S along the top and bottom integrals, akin to thickness weighting.
     hWght = 0.0
-    if (do_massWeight) &
+    if (do_massWeight .and. massWeight_bug) then
       hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
+    endif
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -394,7 +394,7 @@ end subroutine EoS_fit_range_Wright_full
 !! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
-                                 useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
+                                 MassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
   type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T        !< Potential temperature relative to the surface
@@ -431,8 +431,8 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT   !< The depth of the bathymetry [Z ~> m].
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
-                                                !! interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                                 !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: rho_scale !< A multiplicative factor by which to scale density
                                                  !! from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
@@ -531,13 +531,13 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   endif ; endif
 
   do_massWeight = .false.
-  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
-    do_massWeight = .true.
-  ! if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !     "bathyT must be present if useMassWghtInterp is present and true.")
-  ! if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !     "dz_neglect must be present if useMassWghtInterp is present and true.")
-  endif ; endif
+  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  ! if (do_massWeight) then
+  !   if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !       "bathyT must be present if MassWghtInterp is present and true.")
+  !   if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !       "dz_neglect must be present if MassWghtInterp is present and true.")
+  ! endif
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     al0_2d(i,j) = a0 + (a1s*T(i,j) + a2s*S(i,j))
@@ -653,7 +653,7 @@ end subroutine int_density_dz_wright_full
 !! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
-                                  useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
+                                  MassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
   type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T         !< Potential temperature relative to the surface
@@ -691,8 +691,8 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
               optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
                                                  !! the same units as p_t [R L2 T-2 ~> Pa]
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
-                            !! to interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                                 !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: SV_scale  !< A multiplicative factor by which to scale specific
                             !! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
   real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
@@ -740,6 +740,7 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
   integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, halo
@@ -776,14 +777,15 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false.
-  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
-    do_massWeight = .true.
+  do_massWeight = .false. ; massWeight_bug = .false.
+  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+!  if (do_massWeight) then
 !    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "bathyP must be present if useMassWghtInterp is present and true.")
+!        "bathyP must be present if MassWghtInterp is present and true.")
 !    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "dP_neglect must be present if useMassWghtInterp is present and true.")
-  endif ; endif
+!        "dP_neglect must be present if MassWghtInterp is present and true.")
+!  endif
 
   !  alpha = (lambda + al0*(pressure + p0)) / (pressure + p0)
   do j=jsh,jeh ; do i=ish,ieh
@@ -809,8 +811,11 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
     ! hydrostatic consistency. For large hWght we bias the interpolation of
     ! T & S along the top and bottom integrals, akin to thickness weighting.
     hWght = 0.0
-    if (do_massWeight) &
+    if (do_massWeight .and. massWeight_bug) then
       hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
+    endif
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -851,8 +856,11 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
     ! hydrostatic consistency. For large hWght we bias the interpolation of
     ! T & S along the top and bottom integrals, akin to thickness weighting.
     hWght = 0.0
-    if (do_massWeight) &
+    if (do_massWeight .and. massWeight_bug) then
       hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
+    endif
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -396,7 +396,7 @@ end subroutine EoS_fit_range_Wright_red
 !! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                  dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
-                                 useMassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
+                                 MassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
   type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T        !< Potential temperature relative to the surface
@@ -433,8 +433,8 @@ subroutine int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT   !< The depth of the bathymetry [Z ~> m].
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting to
-                                                !! interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                                !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: rho_scale !< A multiplicative factor by which to scale density
                                                  !! from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
@@ -533,13 +533,13 @@ subroutine int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   endif ; endif
 
   do_massWeight = .false.
-  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
-    do_massWeight = .true.
-  ! if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !     "bathyT must be present if useMassWghtInterp is present and true.")
-  ! if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !     "dz_neglect must be present if useMassWghtInterp is present and true.")
-  endif ; endif
+  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  ! if (do_massWeight) then
+  !   if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !       "bathyT must be present if MassWghtInterp is present and true.")
+  !   if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
+  !       "dz_neglect must be present if MassWghtInterp is present and true.")
+  ! endif
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     al0_2d(i,j) = a0 + (a1s*T(i,j) + a2s*S(i,j))
@@ -655,7 +655,7 @@ end subroutine int_density_dz_wright_red
 !! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
                                   intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
-                                  useMassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
+                                  MassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
   type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T         !< Potential temperature relative to the surface
@@ -693,8 +693,8 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
               optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
                                                  !! the same units as p_t [R L2 T-2 ~> Pa]
-  logical,    optional, intent(in)  :: useMassWghtInterp !< If true, uses mass weighting
-                            !! to interpolate T/S for top and bottom integrals.
+  integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                                 !! mass weighting to interpolate T/S in integrals
   real,       optional, intent(in)  :: SV_scale  !< A multiplicative factor by which to scale specific
                             !! volume from m3 kg-1 to the desired units [kg m-3 R-1 ~> 1]
   real,       optional, intent(in)  :: pres_scale !< A multiplicative factor to convert pressure
@@ -742,6 +742,7 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
   integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, halo
@@ -778,14 +779,15 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false.
-  if (present(useMassWghtInterp)) then ; if (useMassWghtInterp) then
-    do_massWeight = .true.
+  do_massWeight = .false. ; massWeight_bug = .false.
+  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+!  if (do_massWeight) then
 !    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "bathyP must be present if useMassWghtInterp is present and true.")
+!        "bathyP must be present if MassWghtInterp is present and true.")
 !    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "dP_neglect must be present if useMassWghtInterp is present and true.")
-  endif ; endif
+!        "dP_neglect must be present if MassWghtInterp is present and true.")
+!  endif
 
   !  alpha(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
   do j=jsh,jeh ; do i=ish,ieh
@@ -811,8 +813,11 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
     ! hydrostatic consistency. For large hWght we bias the interpolation of
     ! T & S along the top and bottom integrals, akin to thickness weighting.
     hWght = 0.0
-    if (do_massWeight) &
+    if (do_massWeight .and. massWeight_bug) then
       hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
+    endif
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -853,8 +858,11 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
     ! hydrostatic consistency. For large hWght we bias the interpolation of
     ! T & S along the top and bottom integrals, akin to thickness weighting.
     hWght = 0.0
-    if (do_massWeight) &
+    if (do_massWeight .and. massWeight_bug) then
       hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
+    endif
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect


### PR DESCRIPTION
  Optionally corrected a bug (essentially a sign error) in the selection of where `MASS_WEIGHT_IN_PRESSURE_GRADIENT` is applied in non-Boussinesq test cases. The (incorrect) non-Boussinesq version of the test for where interfaces are outside of the range of hydrostatic consistency due to interactions with bathymetry was converted from the (correct) Boussinesq version without properly taking into account that pressure increases downward while height increases upward.  This bug is repeated 12 times in 6 different specific volume integral routines, including in the analytical specific volume integrals with 4 equations of state.

  To accommodate these corrections as well as a future expansion of the mass weighting to apply near the surface under ice-shelves or icebergs, the previous optional logical argument (`useMassWghtInterp`) was replaced with a new optional integer argument (`MassWghtInterp`) that can be used to encode information about where this weighting is applied as well as whether to fix this bug.

  This combination of settings (`MASS_WEIGHT_IN_PRESSURE_GRADIENT = True` and non-Boussinesq) does not seem to be widely used yet (it is not used in the GFDL regression suite), so rather than preserving the old (incorrect) solutions by default, this bug is corrected by default.  However, the previous answers can be recovered by setting the new runtime parameter `MASS_WEIGHT_IN_PGF_NONBOUS_BUG` to true.  This parameter that is only used (and logged) for non-Boussinesq cases with `MASS_WEIGHT_IN_PRESSURE_GRADIENT` set to true.  It is intended that this new runtime bug-fix parameter will be obsoleted with an aggressive schedule if it is not needed to recreate any production runs.

  In addition, there are two new diagnostics, `MassWt_u` and `MassWt_v`, that show the fractional (0 to 1) effects of the mass weighting in the pressure gradient forces at the velocity points, along with the new diagnostic subroutines `diagnose_mass_weight_Z()` and `diagnose_mass_weight_p()` that calculate these diagnostics by layer in code that replicates the 13 copies for various equations of state and vertical structures within layers.

  By default, this commit does change answers in non-Boussinesq cases that use `MASS_WEIGHT_IN_PRESSURE_GRADIENT = True`, and there is a new runtime parameter in such cases.  There are also two new diagnostics.  Answers are bitwise identical in all Boussinesq cases.