### PR TITLE
Adding documentation links for lateral parameterizations

### DIFF
--- a/docs/forcing.rst
+++ b/docs/forcing.rst
@@ -1,23 +1,23 @@
 Forcing
 =======
 Data Override
--------
+-------------
 When running MOM6 with the Flexible Modelling System (FMS) coupler, forcing can be specified by a `data_table` file. This is particularly useful when running MOM6 with a data atmosphere, as paths to the relevent atmospheric forcing products (eg. JRA55-do or ERA5) can be provided here. Each item in the data table must be separated by a new line, and contains the following information:
 
 | ``gridname``: The component of the model this data applies to. eg. `atm` `ocn` `lnd` `ice`.
 | ``fieldname_code``: The field name according to the model component. eg. `salt`
-| ``fieldname_file``: The name of the field within the source file. 
+| ``fieldname_file``: The name of the field within the source file.
 | ``file_name``: Path to the source file.
 | ``interpol_method``: Interpolation method eg. `bilinear`
-| ``factor``: A scalar by which to multiply the field ahead of passing it onto the model. This is a quick way to do unit conversions for example. 
+| ``factor``: A scalar by which to multiply the field ahead of passing it onto the model. This is a quick way to do unit conversions for example.
+|
 
-| 
 The data table is commonly formatted by specifying each of the fields in the order listed above, with a new line for each entry.
 
 Example Format:
     "ATM", "t_bot",  "t2m", "./INPUT/2t_ERA5.nc", "bilinear", 1.0
 
-A `yaml` format is also possible if you prefer. This is outlined in the `FMS data override <https://github.com/NOAA-GFDL/FMS/tree/main/data_override>`_ github page, along with other details. 
+A `yaml` format is also possible if you prefer. This is outlined in the `FMS data override <https://github.com/NOAA-GFDL/FMS/tree/main/data_override>`_ github page, along with other details.
 
 Speficying a constant value:
     Rather than overriding with data from a file, one can also set a field to constant. To do this, pass empty strings to `fieldname_file` and `file_name`. The `factor` now corresponds to the override value. For example, the following sets the temperature at the bottom of the atmosphere to 290 Kelvin.
@@ -26,7 +26,7 @@ Speficying a constant value:
     "ATM", "t_bot",  "", "", "bilinear", 290.0
 
 Which units do I need?
-    For configurations using SIS2 and MOM, a list of available surface flux variables along with the expected units can be found in the `flux_exchange <https://github.com/NOAA-GFDL/FMScoupler/blob/f4782c2c033df086eeac29fbbefb4a0bdac1649f/full/flux_exchange.F90>`_ file. 
+    For configurations using SIS2 and MOM, a list of available surface flux variables along with the expected units can be found in the `flux_exchange <https://github.com/NOAA-GFDL/FMScoupler/blob/f4782c2c033df086eeac29fbbefb4a0bdac1649f/full/flux_exchange.F90>`_ file.
 
 
 .. toctree::

--- a/docs/ocean.bib
+++ b/docs/ocean.bib
@@ -10,18 +10,6 @@
 	journal = {Ocean Modelling}
 }
 
-@article{Adcroft2019,
-	doi = {10.1029/2019ms001726},
-	year = 2019,
-	publisher = {American Geophysical Union ({AGU})},
-	volume = {11},
-	number = {10},
-	pages = {3167--3211},
-	author = {A. Adcroft and W. Anderson and V. Balaji and C. Blanton and M. Bushuk and C. O. Dufour and J. P. Dunne and S. M. Griffies and R. Hallberg and M. J. Harrison and I. M. Held and M. F. Jansen and J. G. John and J. P. Krasting and A. R. Langenhorst and S. Legg and Z. Liang and C. McHugh and A. Radhakrishnan and B. G. Reichl and T. Rosati and B. L. Samuels and A. Shao and R. Stouffer and M. Winton and A. T. Wittenberg and B. Xiang and N. Zadeh and R. Zhang},
-	title = {The {GFDL} Global Ocean and Sea Ice Model {OM}4.0: Model Description and Simulation Features},
-	journal = {J. Adv. Mod. Earth Sys.}
-}
-
 @article{Campin2004,
 	doi = {10.1016/s1463-5003(03)00009-x},
 	year = 2004,

--- a/docs/parameterizations_lateral.rst
+++ b/docs/parameterizations_lateral.rst
@@ -64,7 +64,7 @@ The Love numbers are stored internally in MOM_load_love_numbers:
 
     :ref:`namespacemom__load__love__numbers_1section_Love_numbers`
 
-While the self attraction and loading is computed in MOM_self_attr_load:
+while the self attraction and loading is computed in MOM_self_attr_load:
 
     :ref:`namespaceself__attr__load_1section_SAL`
 

--- a/docs/parameterizations_lateral.rst
+++ b/docs/parameterizations_lateral.rst
@@ -68,9 +68,6 @@ While the self attraction and loading is computed in MOM_self_attr_load:
 
     :ref:`namespaceself__attr__load_1section_SAL`
 
-Spherical Harmonics
--------------------
-
-The model needs spherical, computed in MOM_spherical_harmonics:
+The self attraction and loading needs spherical harmonics, computed in MOM_spherical_harmonics:
 
     :ref:`namespacemom__spherical__harmonics_1section_spherical_harmonics`

--- a/docs/parameterizations_lateral.rst
+++ b/docs/parameterizations_lateral.rst
@@ -32,7 +32,8 @@ Mixed layer restratification by sub-mesoscale eddies
 ----------------------------------------------------
 
 Mixed layer restratification from :cite:`fox-kemper2008` and
-:cite:`fox-kemper2008-2` is implemented in MOM_mixed_layer_restrat.
+:cite:`fox-kemper2008-2` is implemented in MOM_mixed_layer_restrat,
+which now also contains the mixed layer restratication comes from :cite: Bodner2023.
 
 Lateral diffusion
 -----------------

--- a/docs/parameterizations_lateral.rst
+++ b/docs/parameterizations_lateral.rst
@@ -56,9 +56,9 @@ See also :ref:`namespacemom__lateral__mixing__coeffs_1section_Resolution_Functio
 Tidal forcing
 -------------
 
-Astronomical tidal forcings and self-attraction and loading are implement in MOM_tidal_forcing.
-Tides can also be added via an open boundary tidal specification,
-see `OBC wiki page <https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions>`_.
+Astronomical tidal forcings and self-attraction and loading are implement in
+
+    :ref:`namespacetidal__forcing_1section_tides`
 
 The Love numbers are stored internally in MOM_load_love_numbers:
 
@@ -71,3 +71,6 @@ while the self attraction and loading is computed in MOM_self_attr_load:
 The self attraction and loading needs spherical harmonics, computed in MOM_spherical_harmonics:
 
     :ref:`namespacemom__spherical__harmonics_1section_spherical_harmonics`
+
+Tides can also be added via an open boundary tidal specification,
+see `OBC wiki page <https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions>`_.

--- a/docs/parameterizations_lateral.rst
+++ b/docs/parameterizations_lateral.rst
@@ -35,6 +35,8 @@ Mixed layer restratification from :cite:`fox-kemper2008` and
 :cite:`fox-kemper2008-2` is implemented in MOM_mixed_layer_restrat,
 which now also contains the mixed layer restratication comes from :cite: Bodner2023.
 
+    :ref:`namespacemom__mixed__layer__restrat_1section_mle`
+
 Lateral diffusion
 -----------------
 

--- a/docs/parameterizations_lateral.rst
+++ b/docs/parameterizations_lateral.rst
@@ -8,6 +8,8 @@ Lateral viscosity
 
 Laplacian and bi-harmonic viscosities with linear and Smagorinsky options are implemented in MOM_hor_visc.
 
+    :ref:`namespacemom__hor__visc_1section_horizontal_viscosity`
+
 Gent-McWilliams/TEM/isopycnal height diffusion
 ----------------------------------------------
 
@@ -20,7 +22,7 @@ scaling.
 A model of sub-grid scale Mesoscale Eddy Kinetic Energy (MEKE) is implement in MOM_MEKE and the associated diffusivity added in MOM_thickness_diffuse.
 See :cite:`jansen2015` and :cite:`marshall2010`.
 
-   :ref:`namespacemom__meke_1section_MEKE`
+    :ref:`namespacemom__meke_1section_MEKE`
 
 Backscatter
 -----------
@@ -37,15 +39,38 @@ which now also contains the mixed layer restratication comes from :cite: Bodner2
 
     :ref:`namespacemom__mixed__layer__restrat_1section_mle`
 
+Interface filtering
+-------------------
+
+For layer mode, one can filter the interface thicknesses:
+
+    :ref:`namespacemom__interface__filter_1section_interface_filter`
+
 Lateral diffusion
 -----------------
 
 See :ref:`Horizontal_Diffusion`.
+
+See also :ref:`namespacemom__lateral__mixing__coeffs_1section_Resolution_Function`
 
 Tidal forcing
 -------------
 
 Astronomical tidal forcings and self-attraction and loading are implement in MOM_tidal_forcing.
 Tides can also be added via an open boundary tidal specification,
-see [OBC wiki page](https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions).
+see `OBC wiki page <https://github.com/NOAA-GFDL/MOM6-examples/wiki/Open-Boundary-Conditions>`_.
 
+The Love numbers are stored internally in MOM_load_love_numbers:
+
+    :ref:`namespacemom__load__love__numbers_1section_Love_numbers`
+
+While the self attraction and loading is computed in MOM_self_attr_load:
+
+    :ref:`namespaceself__attr__load_1section_SAL`
+
+Spherical Harmonics
+-------------------
+
+The model needs spherical, computed in MOM_spherical_harmonics:
+
+    :ref:`namespacemom__spherical__harmonics_1section_spherical_harmonics`

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2873,28 +2873,15 @@
 	month=feb
 }
 
-@article{Wang2012,
-	author={Wang, H., Xiang, L., Jia, L., Jiang, L., Wang, Z., Hu, B. and Gao, P.},
+@article{Wang2012-2,
+	author={Wang, H. and Xiang, L. and Jia, L. and Jiang, L. and Wang, Z. and Hu, B.
+	and Gao, P.},
 	year={2012},
 	title={Load Love numbers and Green's functions
 for elastic Earth models PREM, iasp91, ak135, and modified models with refined crustal structure from Crust 2.0},
 	journal={Computers & Geosciences},
 	volume={49},
 	pages={190--199}
-}
-
-@article{Jansen2015,
-	title={Parameterization of eddy fluxes based on a mesoscale energy budget},
-	volume={92},
-	ISSN={1463-5003},
-	url={http://dx.doi.org/10.1016/j.ocemod.2015.05.007},
-	DOI={10.1016/j.ocemod.2015.05.007},
-	journal={Ocean Modelling},
-	publisher={Elsevier BV},
-	author={Jansen, Malte F. and Adcroft, Alistair J. and Hallberg, Robert and Held, Isaac M.},
-	year={2015},
-	month=aug,
-	pages={28–-41}
 }
 
 @inproceedings{Hallberg2003,

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2760,3 +2760,17 @@
 	journal = {J. Adv. Mod. Earth Sys.}
 }
 
+@article{Bodner2023,
+	title={Modifying the Mixed Layer Eddy Parameterization to Include Frontogenesis Arrest by Boundary Layer Turbulence},
+	volume={53},
+	ISSN={1520-0485},
+	url={http://dx.doi.org/10.1175/JPO-D-21-0297.1},
+	DOI={10.1175/jpo-d-21-0297.1},
+	number={1},
+	journal={Journal of Physical Oceanography},
+	publisher={American Meteorological Society},
+	author={Bodner, Abigail S. and Fox-Kemper, Baylor and Johnson, Leah and Van Roekel, Luke P. and McWilliams, James C. and Sullivan, Peter P. and Hall, Paul S. and Dong, Jihai},
+	year={2023},
+	month=jan,
+	pages={323–339}
+}

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2958,3 +2958,12 @@ for elastic Earth models PREM, iasp91, ak135, and modified models with refined c
 	month=mar,
 	pages={751-–758}
 }
+
+@article{Young1994,
+	author={Young, W.},
+	title={The subinertial mixed layer approximation},
+	journal={J. Phys. Oceanogr.},
+	volume={24},
+	pages={1812--1826},
+	year={1994}
+}

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -967,7 +967,7 @@
 	pages = {15669--15677}
 }
 
-@inproceedings{briegleb2007,
+@incollection{briegleb2007,
 	series = {Technical {Note}},
 	title = {A {Delta}-{Eddington} {Mutiple} {Scattering} {Parameterization} for {Solar} {Radiation} in the {Sea} {Ice} {Component} of the {Community} {Climate} {System} {Model} {\textbar} {OpenSky} {Repository}},
 	url = {http://opensky.ucar.edu/islandora/object/technotes:484},
@@ -2447,7 +2447,7 @@
 	doi = {10.1175/1520-0450(1981)020<1483:ANFDSF>2.0.CO;2}
 }
 
-@inproceedings{huynh1997,
+@incollection{huynh1997,
 	title = {Schemes and constraints for advection},
 	booktitle = {Fifteenth International Conference on Numerical
 	  Methods in Fluid Dynamics},
@@ -2564,7 +2564,7 @@
 	doi = {10.1016/j.ocemod.2010.02.001}
 }
 
-@inproceedings{millero1978,
+@incollection{millero1978,
 	author = {Millero, F.J.},
 	title = {Freezing point of seawater},
 	note = {Annex 6},
@@ -2820,7 +2820,7 @@
 	pages={518–536}
 }
 
-@inproceedings{Smagorinsky1993,
+@incollection{Smagorinsky1993,
 	author={Joseph Smagorinsky},
 	year={1993},
 	title={Some historical remarks on the use of non-linear viscosities},
@@ -2884,7 +2884,7 @@ for elastic Earth models PREM, iasp91, ak135, and modified models with refined c
 	pages={190--199}
 }
 
-@inproceedings{Hallberg2003,
+@incollection{Hallberg2003,
 	title={The ability of large-scale ocean models to accept parameterizations of boundary mixing, and a description of a refined bulk mixed-layer model},
 	author={Robert Hallberg},
 	year={2003},

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2524,7 +2524,7 @@
 }
 
 @article{visbeck1996,
-	author = {Viscbeck, M. and J.C. Marshall and H. Jones},
+	author = {Visbeck, M. and J.C. Marshall and H. Jones},
 	year = {1996},
 	title = {Dynamics of isolated convective regions in the ocean},
 	journal = {J. Phys. Oceanogr.},
@@ -2801,3 +2801,160 @@
 	pages={808–829}
 }
 
+@article{Smith2003,
+	title={Anisotropic horizontal viscosity for ocean models},
+	volume={5},
+	ISSN={1463-5003},
+	url={http://dx.doi.org/10.1016/s1463-5003(02)00016-1},
+	DOI={10.1016/s1463-5003(02)00016-1},
+	number={2},
+	journal={Ocean Modelling},
+	publisher={Elsevier BV},
+	author={Smith, Richard D. and McWilliams, James C.},
+	year={2003},
+	month=jan,
+	pages={129–156}
+}
+
+@article{Large2001,
+	title={Equatorial Circulation of a Global Ocean Climate Model with Anisotropic Horizontal Viscosity},
+	volume={31},
+	ISSN={1520-0485},
+	url={http://dx.doi.org/10.1175/1520-0485(2001)031<0518:ECOAGO>2.0.CO;2},
+	DOI={10.1175/1520-0485(2001)031<0518:ecoago>2.0.co;2},
+	number={2},
+	journal={Journal of Physical Oceanography},
+	publisher={American Meteorological Society},
+	author={Large, William G. and Danabasoglu, Gokhan and McWilliams, James C. and Gent, Peter R. and Bryan, Frank O.},
+	year={2001},
+	month=feb,
+	pages={518–536}
+}
+
+@inproceedings{Smagorinsky1993,
+	author={Joseph Smagorinsky},
+	year={1993},
+	title={Some historical remarks on the use of non-linear viscosities},
+	booktitle={Large Eddy Simulation of Complex Engineering and Geophysical Flows},
+	note={Proceedings of an International Workshop in Large Eddy Simulation},
+	address={Cambridge, UK},
+	publisher={Cambridge University Press},
+	pages={1--34}
+}
+
+@article{Barton2022,
+	title={Global Barotropic Tide Modeling Using Inline Self‐Attraction and Loading in MPAS‐Ocean},
+	volume={14},
+	ISSN={1942-2466},
+	url={http://dx.doi.org/10.1029/2022MS003207},
+	DOI={10.1029/2022ms003207},
+	number={11},
+	journal={Journal of Advances in Modeling Earth Systems},
+	publisher={American Geophysical Union (AGU)},
+	author={Barton, Kristin N. and Pal, Nairita and Brus, Steven R. and Petersen, Mark R. and Arbic, Brian K. and Engwirda, Darren and Roberts, Andrew F. and Westerink, Joannes J. and Wirasaet, Damrongsak and Schindelegger, Michael},
+	year={2022},
+	month=nov
+}
+
+@article{Brus2023,
+	title={Scalable self attraction and loading calculations for unstructured ocean tide models},
+	volume={182},
+	ISSN={1463-5003},
+	url={http://dx.doi.org/10.1016/j.ocemod.2023.102160},
+	DOI={10.1016/j.ocemod.2023.102160},
+	journal={Ocean Modelling},
+	publisher={Elsevier BV},
+	author={Brus, Steven R. and Barton, Kristin N. and Pal, Nairita and Roberts, Andrew F. and Engwirda, Darren and Petersen, Mark R. and Arbic, Brian K. and Wirasaet, Damrongsak and Westerink, Joannes J. and Schindelegger, Michael},
+	year={2023},
+	month=apr,
+	pages={102160}
+}
+
+@article{Blewitt2003,
+	title={Self‐consistency in reference frames, geocenter definition, and surface loading of the solid Earth},
+	volume={108},
+	ISSN={0148-0227},
+	url={http://dx.doi.org/10.1029/2002JB002082},
+	DOI={10.1029/2002jb002082},
+	number={B2},
+	journal={Journal of Geophysical Research: Solid Earth},
+	publisher={American Geophysical Union (AGU)},
+	author={Blewitt, Geoffrey},
+	year={2003},
+	month=feb
+}
+
+@article{Wang2012,
+	author={Wang, H., Xiang, L., Jia, L., Jiang, L., Wang, Z., Hu, B. and Gao, P.},
+	year={2012},
+	title={Load Love numbers and Green's functions
+for elastic Earth models PREM, iasp91, ak135, and modified models with refined crustal structure from Crust 2.0},
+	journal={Computers & Geosciences},
+	volume={49},
+	pages={190--199}
+}
+
+@article{Jansen2015,
+	title={Parameterization of eddy fluxes based on a mesoscale energy budget},
+	volume={92},
+	ISSN={1463-5003},
+	url={http://dx.doi.org/10.1016/j.ocemod.2015.05.007},
+	DOI={10.1016/j.ocemod.2015.05.007},
+	journal={Ocean Modelling},
+	publisher={Elsevier BV},
+	author={Jansen, Malte F. and Adcroft, Alistair J. and Hallberg, Robert and Held, Isaac M.},
+	year={2015},
+	month=aug,
+	pages={28–-41}
+}
+
+@inproceedings{Hallberg2003,
+	title={The ability of large-scale ocean models to accept parameterizations of boundary mixing, and a description of a refined bulk mixed-layer model},
+	author={Robert Hallberg},
+	year={2003},
+	booktitle={Internal Gravity Waves and Small-Scale Turbulence: Proc.‘Aha Huliko ‘a Hawaiian Winter Workshop},
+	pages={187--203}
+}
+
+@article{1978,
+	volume={290},
+	ISSN={2054-0272},
+	url={http://dx.doi.org/10.1098/rsta.1978.0083},
+	DOI={10.1098/rsta.1978.0083},
+	number={1368},
+	journal={Philosophical Transactions of the Royal Society of London. Series A, Mathematical and Physical Sciences},
+	publisher={The Royal Society},
+	year={1978},
+	month=nov,
+	pages={235-–266}
+}
+
+@article{Arbic2004,
+	title={The accuracy of surface elevations in forward global barotropic and baroclinic tide models},
+	volume={51},
+	ISSN={0967-0645},
+	url={http://dx.doi.org/10.1016/j.dsr2.2004.09.014},
+	DOI={10.1016/j.dsr2.2004.09.014},
+	number={25–26},
+	journal={Deep Sea Research Part II: Topical Studies in Oceanography},
+	publisher={Elsevier BV},
+	author={Arbic, Brian K. and Garner, Stephen T. and Hallberg, Robert W. and Simmons, Harper L.},
+	year={2004},
+	month=dec,
+	pages={3069-–3101}
+}
+
+@article{Schaeffer2013,
+	title={Efficient spherical harmonic transforms aimed at pseudospectral numerical simulations},
+	volume={14},
+	ISSN={1525-2027},
+	url={http://dx.doi.org/10.1002/ggge.20071},
+	DOI={10.1002/ggge.20071},
+	number={3},
+	journal={Geochemistry, Geophysics, Geosystems},
+	publisher={American Geophysical Union (AGU)},
+	author={Schaeffer, Nathanaël},
+	year={2013},
+	month=mar,
+	pages={751-–758}
+}

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2892,7 +2892,7 @@ for elastic Earth models PREM, iasp91, ak135, and modified models with refined c
 	pages={187--203}
 }
 
-@article{1978,
+@article{Accad1978,
 	volume={290},
 	ISSN={2054-0272},
 	url={http://dx.doi.org/10.1098/rsta.1978.0083},
@@ -2902,7 +2902,10 @@ for elastic Earth models PREM, iasp91, ak135, and modified models with refined c
 	publisher={The Royal Society},
 	year={1978},
 	month=nov,
-	pages={235-–266}
+	pages={235-–266},
+	author={Accad, Y. and Pekeris, C.L.},
+	title={Solution of the tidal equations for the M2 and S2 tides in the world oceans from a
+               knowledge of the tidal potential alone}
 }
 
 @article{Arbic2004,

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2775,7 +2775,7 @@
 	pages={323-–339}
 }
 
-@article{Oberhuber1993,
+@article{Oberhuber1993a,
 	title={Simulation of the Atlantic Circulation with a Coupled Sea Ice-Mixed Layer-Isopycnal General Circulation Model. Part I: Model Description},
 	volume={23},
 	ISSN={1520-0485},

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2775,17 +2775,6 @@
 	pages={323-–339}
 }
 
-@incollection{Niiler1977,
-	author={P. P. Niiler and E. B. Kraus},
-	title={One-dimensional models of the upper ocean},
-	booktitle={Modeling and Prediction of the Upper Layers of the Ocean},
-	editor={E. B. Kraus},
-	publisher={Pergamon},
-	address={New York},
-	pages={143-–172},
-	year={1977}
-}
-
 @article{Oberhuber1993,
 	title={Simulation of the Atlantic Circulation with a Coupled Sea Ice-Mixed Layer-Isopycnal General Circulation Model. Part I: Model Description},
 	volume={23},

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -2772,5 +2772,32 @@
 	author={Bodner, Abigail S. and Fox-Kemper, Baylor and Johnson, Leah and Van Roekel, Luke P. and McWilliams, James C. and Sullivan, Peter P. and Hall, Paul S. and Dong, Jihai},
 	year={2023},
 	month=jan,
-	pages={323–339}
+	pages={323-–339}
 }
+
+@incollection{Niiler1977,
+	author={P. P. Niiler and E. B. Kraus},
+	title={One-dimensional models of the upper ocean},
+	booktitle={Modeling and Prediction of the Upper Layers of the Ocean},
+	editor={E. B. Kraus},
+	publisher={Pergamon},
+	address={New York},
+	pages={143-–172},
+	year={1977}
+}
+
+@article{Oberhuber1993,
+	title={Simulation of the Atlantic Circulation with a Coupled Sea Ice-Mixed Layer-Isopycnal General Circulation Model. Part I: Model Description},
+	volume={23},
+	ISSN={1520-0485},
+	url={http://dx.doi.org/10.1175/1520-0485(1993)023<0808:SOTACW>2.0.CO;2},
+	DOI={10.1175/1520-0485(1993)023<0808:sotacw>2.0.co;2},
+	number={5},
+	journal={Journal of Physical Oceanography},
+	publisher={American Meteorological Society},
+	author={Oberhuber, Josef M.},
+	year={1993},
+	month=may,
+	pages={808–829}
+}
+

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1892,7 +1892,7 @@ end subroutine MEKE_end
 !! \f$ U_b \f$ is a constant background bottom velocity scale and is
 !! typically not used (i.e. set to zero).
 !!
-!! Following Jansen et al., 2015, the projection of eddy energy on to the bottom
+!! Following \cite jansen2015, the projection of eddy energy on to the bottom
 !! is given by the ratio of bottom energy to column mean energy:
 !! \f[
 !! \gamma_b^2  = \frac{E_b}{E} = \gamma_{d0}
@@ -1924,12 +1924,12 @@ end subroutine MEKE_end
 !! \f[  \kappa_M = \gamma_\kappa \sqrt{ \gamma_t^2 U_e^2 A_\Delta } \f]
 !!
 !! where \f$ A_\Delta \f$ is the area of the grid cell.
-!! Following Jansen et al., 2015, we now use
+!! Following \cite jansen2015, we now use
 !!
 !! \f[  \kappa_M = \gamma_\kappa l_M \sqrt{ \gamma_t^2 U_e^2 } \f]
 !!
 !! where \f$ \gamma_\kappa \in [0,1] \f$ is a non-dimensional factor and,
-!! following Jansen et al., 2015, \f$\gamma_t^2\f$ is the ratio of barotropic
+!! following \cite jansen2015, \f$\gamma_t^2\f$ is the ratio of barotropic
 !! eddy energy to column mean eddy energy given by
 !! \f[
 !! \gamma_t^2  = \frac{E_t}{E} = \left( 1 + c_{t} \frac{L_d}{L_f} \right)^{-\frac{1}{4}}

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -3193,24 +3193,24 @@ subroutine hor_visc_end(CS)
 end subroutine hor_visc_end
 !> \namespace mom_hor_visc
 !!
+!! \section section_horizontal_viscosity Horizontal viscosity in MOM
+!!
 !! This module contains the subroutine horizontal_viscosity() that calculates the
 !! effects of horizontal viscosity, including parameterizations of the value of
 !! the viscosity itself. horizontal_viscosity() calculates the acceleration due to
 !! some combination of a biharmonic viscosity and a Laplacian viscosity. Either or
 !! both may use a coefficient that depends on the shear and strain of the flow.
 !! All metric terms are retained. The Laplacian is calculated as the divergence of
-!! a stress tensor, using the form suggested by Smagorinsky (1993). The biharmonic
+!! a stress tensor, using the form suggested by \cite Smagorinsky1993. The biharmonic
 !! is calculated by twice applying the divergence of the stress tensor that is
 !! used to calculate the Laplacian, but without the dependence on thickness in the
 !! first pass. This form permits a variable viscosity, and indicates no
 !! acceleration for either resting fluid or solid body rotation.
 !!
-!! The form of the viscous accelerations is discussed extensively in Griffies and
-!! Hallberg (2000), and the implementation here follows that discussion closely.
-!! We use the notation of Smith and McWilliams (2003) with the exception that the
+!! The form of the viscous accelerations is discussed extensively in \cite griffies2000,
+!! and the implementation here follows that discussion closely.
+!! We use the notation of \cite Smith2003 with the exception that the
 !! isotropic viscosity is \f$\kappa_h\f$.
-!!
-!! \section section_horizontal_viscosity Horizontal viscosity in MOM
 !!
 !! In general, the horizontal stress tensor can be written as
 !! \f[
@@ -3357,7 +3357,7 @@ end subroutine hor_visc_end
 !!
 !! \subsection section_anisotropic_viscosity Anisotropic viscosity
 !!
-!! Large et al., 2001, proposed enhancing viscosity in a particular direction and the
+!! \cite Large2001, proposed enhancing viscosity in a particular direction and the
 !! approach was generalized in Smith and McWilliams, 2003. We use the second form of their
 !! two coefficient anisotropic viscosity (section 4.3). We also replace their
 !! \f$A^\prime\f$ and $D$ such that \f$2A^\prime = 2 \kappa_h + D\f$ and

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2044,9 +2044,9 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
 end subroutine horizontal_viscosity
 
-!> Allocates space for and calculates static variables used by horizontal_viscosity().
+!> Allocates space for and calculates static variables used by horizontal_viscosity.
 !! hor_visc_init calculates and stores the values of a number of metric functions that
-!! are used in horizontal_viscosity().
+!! are used in horizontal_viscosity.
 subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   type(time_type),         intent(in)    :: Time !< Current model time.
   type(ocean_grid_type),   intent(inout) :: G    !< The ocean's grid structure.
@@ -3259,7 +3259,7 @@ end subroutine hor_visc_end
 !! \f}
 !!
 !! The viscosity \f$\kappa_h\f$ may either be a constant or variable. For example,
-!! \f$\kappa_h\f$ may vary with the shear, as proposed by Smagorinsky (1993).
+!! \f$\kappa_h\f$ may vary with the shear, as proposed by \cite Smagorinsky1993.
 !!
 !! The accelerations resulting form the divergence of the stress tensor are
 !! \f{eqnarray*}{
@@ -3357,8 +3357,8 @@ end subroutine hor_visc_end
 !!
 !! \subsection section_anisotropic_viscosity Anisotropic viscosity
 !!
-!! \cite Large2001, proposed enhancing viscosity in a particular direction and the
-!! approach was generalized in Smith and McWilliams, 2003. We use the second form of their
+!! \cite Large2001 proposed enhancing viscosity in a particular direction and the
+!! approach was generalized in \cite Smith2003. We use the second form of their
 !! two coefficient anisotropic viscosity (section 4.3). We also replace their
 !! \f$A^\prime\f$ and $D$ such that \f$2A^\prime = 2 \kappa_h + D\f$ and
 !! \f$\kappa_a = D\f$ so that \f$\kappa_h\f$ can be considered the isotropic

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -3195,9 +3195,9 @@ end subroutine hor_visc_end
 !!
 !! \section section_horizontal_viscosity Horizontal viscosity in MOM
 !!
-!! This module contains the subroutine horizontal_viscosity() that calculates the
+!! This module contains the subroutine horizontal_viscosity that calculates the
 !! effects of horizontal viscosity, including parameterizations of the value of
-!! the viscosity itself. horizontal_viscosity() calculates the acceleration due to
+!! the viscosity itself. Subroutine horizontal_viscosity calculates the acceleration due to
 !! some combination of a biharmonic viscosity and a Laplacian viscosity. Either or
 !! both may use a coefficient that depends on the shear and strain of the flow.
 !! All metric terms are retained. The Laplacian is calculated as the divergence of

--- a/src/parameterizations/lateral/MOM_interface_filter.F90
+++ b/src/parameterizations/lateral/MOM_interface_filter.F90
@@ -480,7 +480,7 @@ end subroutine interface_filter_end
 !! filter, depending on the order of the filter, or to the slope for a Laplacian
 !! filter
 !! \f[
-!! \vec{\psi} = - \kappa_h {\nabla \eta - \eta_smooth}
+!! \vec{\psi} = - \kappa_h {\nabla \eta - \eta_{smooth}}
 !! \f]
 !!
 !! The result of the above expression is subsequently bounded by minimum and maximum values, including a

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1728,7 +1728,7 @@ end subroutine VarMix_end
 !! \f]
 !!
 !! \todo Check this reference to Bob on/off paper.
-!! The resolution function used in scaling diffusivities (Hallberg, 2010) is
+!! The resolution function used in scaling diffusivities (\cite hallberg2013) is
 !!
 !! \f[
 !! r(\Delta,L_d) = \frac{1}{1+(\alpha R)^p}

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -1734,8 +1734,8 @@ end subroutine VarMix_end
 !! r(\Delta,L_d) = \frac{1}{1+(\alpha R)^p}
 !! \f]
 !!
-!! The resolution function can be applied independently to thickness diffusion (module mom_thickness_diffuse),
-!! tracer diffusion (mom_tracer_hordiff) lateral viscosity (mom_hor_visc).
+!! The resolution function can be applied independently to thickness diffusion \(module mom_thickness_diffuse\),
+!! tracer diffusion \(mom_tracer_hordiff\) lateral viscosity \(mom_hor_visc\).
 !!
 !! Robert Hallberg, 2013: Using a resolution function to regulate parameterizations of oceanic mesoscale eddy effects.
 !! Ocean Modelling, 71, pp 92-103.  http://dx.doi.org/10.1016/j.ocemod.2013.08.007
@@ -1757,7 +1757,7 @@ end subroutine VarMix_end
 !! \section section_Vicbeck Visbeck diffusivity
 !!
 !! This module also calculates factors used in setting the thickness diffusivity similar to a Visbeck et al., 1997,
-!! scheme.  The factors are combined in mom_thickness_diffuse::thickness_diffuse() but calculated in this module.
+!! scheme.  The factors are combined in mom_thickness_diffuse::thickness_diffuse but calculated in this module.
 !!
 !! \f[
 !! \kappa_h = \alpha_s L_s^2 S N

--- a/src/parameterizations/lateral/MOM_load_love_numbers.F90
+++ b/src/parameterizations/lateral/MOM_load_love_numbers.F90
@@ -1460,7 +1460,7 @@ real, dimension(4, lmax+1), parameter :: &
 !!
 !! Variable Love_Data stores the Love numbers up to degree 1440. From left to right: degree, h, l, and k. Data in this
 !! module is imported from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los Alamos
-!! National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2022]. The load Love numbers
+!! National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023]. The load Love numbers
 !! are from \cite Wang2012, which are in the center of mass of total Earth system reference frame (CM). When used,
 !! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF) [\cite Blewitt2003],
 !! as in subroutine calc_love_scaling in MOM_tidal_forcing module.

--- a/src/parameterizations/lateral/MOM_load_love_numbers.F90
+++ b/src/parameterizations/lateral/MOM_load_love_numbers.F90
@@ -1462,8 +1462,8 @@ real, dimension(4, lmax+1), parameter :: &
 !! module is imported from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los Alamos
 !! National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023]. The load Love numbers
 !! are from \cite Wang2012, which are in the center of mass of total Earth system reference frame (CM). When used,
-!! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF) [\cite Blewitt2003],
-!! as in subroutine calc_love_scaling in MOM_tidal_forcing module.
+!! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF)
+!! [\cite Blewitt2003], as in subroutine calc_love_scaling in MOM_tidal_forcing module.
 !!
 !! References:
 !!

--- a/src/parameterizations/lateral/MOM_load_love_numbers.F90
+++ b/src/parameterizations/lateral/MOM_load_love_numbers.F90
@@ -1452,15 +1452,17 @@ real, dimension(4, lmax+1), parameter :: &
             /), (/4, lmax+1/)) !< Load Love numbers
 
 !> \namespace mom_load_love_numbers
+!! \section section_Love_numbers The Love numbers
+!!
 !! This module serves the sole purpose of storing load Love number. The Love numbers are used for the spherical harmonic
 !! self-attraction and loading (SAL) calculation in MOM_self_attr_load module. This separate module ensures readability
 !! of the SAL module.
 !!
 !! Variable Love_Data stores the Love numbers up to degree 1440. From left to right: degree, h, l, and k. Data in this
 !! module is imported from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los Alamos
-!! National Laboratory and University of Michigan [Barton et al. (2022) and Brus et al. (2022)]. The load Love numbers
-!! are from Wang et al. (2012), which are in the center of mass of total Earth system reference frame (CM). When used,
-!! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF) [Blewitt (2003)],
+!! National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2022]. The load Love numbers
+!! are from \cite Wang2012, which are in the center of mass of total Earth system reference frame (CM). When used,
+!! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF) [\cite Blewitt2003],
 !! as in subroutine calc_love_scaling in MOM_tidal_forcing module.
 !!
 !! References:

--- a/src/parameterizations/lateral/MOM_load_love_numbers.F90
+++ b/src/parameterizations/lateral/MOM_load_love_numbers.F90
@@ -1461,7 +1461,7 @@ real, dimension(4, lmax+1), parameter :: &
 !! Variable Love_Data stores the Love numbers up to degree 1440. From left to right: degree, h, l, and k. Data in this
 !! module is imported from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los Alamos
 !! National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023]. The load Love numbers
-!! are from \cite Wang2012, which are in the center of mass of total Earth system reference frame (CM). When used,
+!! are from \cite Wang2012-2, which are in the center of mass of total Earth system reference frame (CM). When used,
 !! Love numbers with degree<2 should be converted to center of mass solid Earth reference frame (CF)
 !! [\cite Blewitt2003], as in subroutine calc_love_scaling in MOM_tidal_forcing module.
 !!

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1971,15 +1971,15 @@ end function test_answer
 !! \cite Hallberg2003, which this new parameterization surpasses, which
 !! in turn is based on the sub-inertial mixed layer theory of \cite Young1994.
 !! There is no net horizontal volume transport due to this parameterization, and
-!! no direct effect below the mixed layer. A revised of the parameterization by
-!! \cite Bodner2023, is also available as an option.
+!! no direct effect below the mixed layer. A revised version of the parameterization by
+!! \cite Bodner2023 is also available as an option.
 !!
 !! This parameterization sets the restratification timescale to agree with
 !! high-resolution studies of mixed layer restratification.
 !!
-!! The run-time parameter FOX_KEMPER_ML_RESTRAT_COEF is a non-dimensional number of
+!! The run-time parameter <code>FOX_KEMPER_ML_RESTRAT_COEF</code> is a non-dimensional number of
 !! order a few tens, proportional to the ratio of the deformation radius or the
-!! grid scale (whichever is smaller to the dominant horizontal length-scale of the
+!! grid scale (whichever is smaller) to the dominant horizontal length-scale of the
 !! sub-meso-scale mixed layer instabilities.
 !!
 !! \subsection section_mle_nutshell "Sub-meso" in a nutshell
@@ -2011,14 +2011,15 @@ end function test_answer
 !! \f$ \tau \f$ is a time-scale for mixing momentum across the mixed layer.
 !! \f$ l_f \f$ is thought to be of order hundreds of meters.
 !!
-!! The upscaling factor \f$ \frac{\Delta s}{l_f} \f$ can be a global constant, model parameter FOX_KEMPER_ML_RESTRAT,
-!! so that in practice the parameterization is:
+!! The upscaling factor \f$ \frac{\Delta s}{l_f} \f$ can be a global constant, model parameter
+!! <code>FOX_KEMPER_ML_RESTRAT</code>, so that in practice the parameterization is:
 !! \f[
 !!    {\bf \Psi} = C_e \Gamma_\Delta \frac{ H^2 \nabla \bar{b} \times \hat{\bf z} }{ \sqrt{ f^2 + \tau^{-2}} } \mu(z)
 !! \f]
 !! with non-unity \f$ \Gamma_\Delta \f$.
 !!
 !! \f$ C_e \f$ is hard-coded as 0.0625. \f$ \tau \f$ is calculated from the surface friction velocity \f$ u^* \f$.
+!!
 !! \todo Explain expression for momentum mixing time-scale.
 !!
 !! | Symbol                       | Module parameter      |
@@ -2102,7 +2103,7 @@ end function test_answer
 !! | \f$ \tau_{h+} \f$            | MLE\%BLD_GROWING_TFILTER  |
 !! | \f$ \tau_{h-} \f$            | MLE\%BLD_DECAYING_TFILTER |
 !! | \f$ \tau_{H+} \f$            | MLE\%MLD_GROWING_TFILTER  |
-!! | \f$ \tau_{H-} \f$            | MLE\%BLD_DECAYING_TFILTER |
+!! | \f$ \tau_{H-} \f$            | MLE\%MLD_DECAYING_TFILTER |
 !!
 !! \subsection section_mle_ref References
 !!

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1704,7 +1704,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
              "mesoscale eddy kinetic energy to the large-scale "//&
              "geostrophic kinetic energy or 1 plus the square of the "//&
              "grid spacing over the deformation radius, as detailed "//&
-             "by Fox-Kemper et al. (2010)", units="nondim", default=0.0)
+             "by Fox-Kemper et al. (2011)", units="nondim", default=0.0)
     ! These parameters are only used in the OM4-era version of Fox-Kemper
     call get_param(param_file, mdl, "USE_STANLEY_ML", CS%use_Stanley_ML, &
                    "If true, turn on Stanley SGS T variance parameterization "// &
@@ -1750,7 +1750,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
         call get_param(param_file, mdl, "MLE_DENSITY_DIFF", CS%MLE_density_diff, &
              "Density difference used to detect the mixed-layer "//&
              "depth used for the mixed-layer eddy parameterization "//&
-             "by Fox-Kemper et al. (2010)", units="kg/m3", default=0.03, scale=US%kg_m3_to_R)
+             "by Fox-Kemper et al. (2011)", units="kg/m3", default=0.03, scale=US%kg_m3_to_R)
       endif
       call get_param(param_file, mdl, "MLE_TAIL_DH", CS%MLE_tail_dh, &
              "Fraction by which to extend the mixed-layer restratification "//&
@@ -1965,14 +1965,14 @@ end function test_answer
 !! \section section_mle Mixed-layer eddy parameterization module
 !!
 !! The subroutines in this module implement a parameterization of unresolved viscous
-!! mixed layer restratification of the mixed layer as described in Fox-Kemper et
-!! al., 2008, and whose impacts are described in Fox-Kemper et al., 2011.
+!! mixed layer restratification of the mixed layer as described in \cite fox-kemper2008,
+!! and whose impacts are described in \cite fox-kemper2011.
 !! This is derived in part from the older parameterization that is described in
-!! Hallberg (Aha Hulikoa, 2003), which this new parameterization surpasses, which
-!! in turn is based on the sub-inertial mixed layer theory of Young (JPO, 1994).
+!! \cite Hallberg2003, which this new parameterization surpasses, which
+!! in turn is based on the sub-inertial mixed layer theory of \cite Young1994.
 !! There is no net horizontal volume transport due to this parameterization, and
 !! no direct effect below the mixed layer. A revised of the parameterization by
-!! Bodner et al., 2023, is also available as an option.
+!! \cite Bodner2023, is also available as an option.
 !!
 !! This parameterization sets the restratification timescale to agree with
 !! high-resolution studies of mixed layer restratification.
@@ -1986,8 +1986,8 @@ end function test_answer
 !!
 !! The parameterization is colloquially referred to as "sub-meso".
 !!
-!! The original Fox-Kemper et al., (2008b) paper proposed a quasi-Stokes
-!! advection described by the stream function (eq. 5 of Fox-Kemper et al., 2011):
+!! The original \cite fox-kemper2008-2 paper proposed a quasi-Stokes
+!! advection described by the stream function (eq. 5 of \cite fox-kemper2011):
 !! \f[
 !!    {\bf \Psi}_o = C_e \frac{ H^2 \nabla \bar{b} \times \hat{\bf z} }{ |f| } \mu(z)
 !! \f]
@@ -2001,7 +2001,7 @@ end function test_answer
 !! \f$ \nabla \bar{b} \f$ is a depth mean buoyancy gradient averaged over the mixed layer.
 !!
 !! For use in coarse-resolution models, an upscaling of the buoyancy gradients and adaption for the equator
-!! leads to the following parameterization (eq. 6 of Fox-Kemper et al., 2011):
+!! leads to the following parameterization (eq. 6 of \cite fox-kemper2011):
 !! \f[
 !!    {\bf \Psi} = C_e \Gamma_\Delta \frac{\Delta s}{l_f} \frac{ H^2 \nabla \bar{b} \times \hat{\bf z} }
 !!                 { \sqrt{ f^2 + \tau^{-2}} } \mu(z)
@@ -2057,7 +2057,7 @@ end function test_answer
 !! available parameters.
 !! MLE_USE_PBL_MLD must be True to use the B23 modification.
 !!
-!! Bodner et al., 2023, (B23) use an expression for the frontal width which changes the scaling from \f$ H^2 \f$
+!! \cite Bodner2023, (B23) use an expression for the frontal width which changes the scaling from \f$ H^2 \f$
 !! to \f$ h H^2 \f$:
 !! \f[
 !!    {\bf \Psi} = C_r \frac{\Delta s |f| \bar{h} \bar{H}^2 \nabla \bar{b} \times \hat{\bf z} }

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -251,12 +251,12 @@ end subroutine SAL_end
 !! (rather, it should be bottom pressure anomaly). SAL is primarily used for fast evolving processes like tides or
 !! storm surges, but the effect applies to all motions.
 !!
-!!     If SAL_SCALAR_APPROX is true, a scalar approximation is applied (\cite Accad1978) and the SAL is simply
+!! If SAL_SCALAR_APPROX is true, a scalar approximation is applied [\cite Accad1978] and the SAL is simply
 !! a fraction (set by SAL_SCALAR_VALUE, usually around 10% for global tides) of local SSH . For tides, the scalar
 !! approximation can also be used to iterate the SAL to convergence [see USE_PREVIOUS_TIDES in MOM_tidal_forcing,
 !! \cite Arbic2004].
 !!
-!!    If SAL_HARMONICS is true, a more accurate online spherical harmonic transforms are used to calculate SAL.
+!! If SAL_HARMONICS is true, a more accurate online spherical harmonic transforms are used to calculate SAL.
 !! Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is set by
 !! SAL_HARMONICS_DEGREE. The algorithm is based on SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean
 !! developed by Los Alamos National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023].

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -251,14 +251,15 @@ end subroutine SAL_end
 !! (rather, it should be bottom pressure anomaly). SAL is primarily used for fast evolving processes like tides or
 !! storm surges, but the effect applies to all motions.
 !!
-!! If SAL_SCALAR_APPROX is true, a scalar approximation is applied [\cite Accad1978] and the SAL is simply
-!! a fraction (set by SAL_SCALAR_VALUE, usually around 10% for global tides) of local SSH . For tides, the scalar
-!! approximation can also be used to iterate the SAL to convergence [see USE_PREVIOUS_TIDES in MOM_tidal_forcing,
-!! \cite Arbic2004].
+!! If <code>SAL_SCALAR_APPROX</code> is true, a scalar approximation is applied (\cite Accad1978) and the SAL is simply
+!! a fraction (set by <code>SAL_SCALAR_VALUE</code>, usually around 10% for global tides) of local SSH.
+!! For tides, the scalar approximation can also be used to iterate the SAL to convergence [see
+!! <code>USE_PREVIOUS_TIDES</code> in MOM_tidal_forcing, \cite Arbic2004].
 !!
-!! If SAL_HARMONICS is true, a more accurate online spherical harmonic transforms are used to calculate SAL.
-!! Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is set by
-!! SAL_HARMONICS_DEGREE. The algorithm is based on SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean
+!! If <code>SAL_HARMONICS</code> is true, a more accurate online spherical harmonic transforms are used to calculate
+!! SAL. Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is
+!! set by <code>SAL_HARMONICS_DEGREE</code>. The algorithm is based on SAL calculation in Model for Prediction Across
+!! Scales (MPAS)-Ocean
 !! developed by Los Alamos National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023].
 !!
 !! References:

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -245,19 +245,21 @@ end subroutine SAL_end
 
 !> \namespace self_attr_load
 !!
+!! \section section_SAL Self attraction and loading
+!!
 !! This module contains methods to calculate self-attraction and loading (SAL) as a function of sea surface height (SSH)
 !! (rather, it should be bottom pressure anomaly). SAL is primarily used for fast evolving processes like tides or
 !! storm surges, but the effect applies to all motions.
 !!
-!!     If SAL_SCALAR_APPROX is true, a scalar approximation is applied (Accad and Pekeris 1978) and the SAL is simply
+!!     If SAL_SCALAR_APPROX is true, a scalar approximation is applied (\cite Accad1978) and the SAL is simply
 !! a fraction (set by SAL_SCALAR_VALUE, usually around 10% for global tides) of local SSH . For tides, the scalar
 !! approximation can also be used to iterate the SAL to convergence [see USE_PREVIOUS_TIDES in MOM_tidal_forcing,
-!! Arbic et al. (2004)].
+!! \cite Arbic2004].
 !!
 !!    If SAL_HARMONICS is true, a more accurate online spherical harmonic transforms are used to calculate SAL.
 !! Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is set by
 !! SAL_HARMONICS_DEGREE. The algorithm is based on SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean
-!! developed by Los Alamos National Laboratory and University of Michigan [Barton et al. (2022) and Brus et al. (2023)].
+!! developed by Los Alamos National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023].
 !!
 !! References:
 !!

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -361,7 +361,7 @@ end function order2index
 !! \f[
 !!  f^m_n = \sum^{Nj}_{0}\sum^{Ni}_{0}f(i,j)Y^m_n(i,j)A(i,j)/r_e^2
 !! \f]
-!! where $A$ is the area of the cell and $r_e$ is the radius of the Earth.
+!! where \f$A\f$ is the area of the cell and \f$r_e\f$ is the radius of the Earth.
 !!
 !! In inverse transform, the first N degree spherical harmonic coefficients are used to reconstruct a two-dimensional
 !! physical field:
@@ -374,10 +374,10 @@ end function order2index
 !! array vectorization.
 !!
 !! The maximum degree of the spherical harmonics is a runtime parameter and the maximum used by all SHT applications.
-!! At the moment, it is only decided by SAL_HARMONICS_DEGREE.
+!! At the moment, it is only decided by <code>SAL_HARMONICS_DEGREE</code>.
 !!
-!! The forward transforms involve a global summation. Runtime flag SHT_REPRODUCING_SUM controls whether this is done
-!! in a bit-wise reproducing way or not.
+!! The forward transforms involve a global summation. Runtime flag <code>SHT_REPRODUCING_SUM</code> controls
+!! whether this is done in a bit-wise reproducing way or not.
 !!
 !! References:
 !!

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -334,6 +334,8 @@ end function order2index
 
 !> \namespace mom_spherical_harmonics
 !!
+!! \section section_spherical_harmonics Spherical harmonics
+!!
 !! This module contains the subroutines to calculate spherical harmonic transforms (SHT), namely, forward transform
 !! of a two-dimensional field into a given number of spherical harmonic modes and its inverse transform.  This module
 !! is primarily used to but not limited to calculate self-attraction and loading (SAL) term, which is mostly relevant to
@@ -341,8 +343,8 @@ end function order2index
 !! Currently, the transforms are for t-cell fields only.
 !!
 !! This module is stemmed from SAL calculation in Model for Prediction Across Scales (MPAS)-Ocean developed by Los
-!! Alamos National Laboratory and University of Michigan [Barton et al. (2022) and Brus et al. (2023)]. The algorithm
-!! for forward and inverse transforms loosely follows Schaeffer (2013).
+!! Alamos National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023]. The algorithm
+!! for forward and inverse transforms loosely follows \cite Schaeffer2013.
 !!
 !! In forward transform, a two-dimensional physical field can be projected into a series of spherical harmonics. The
 !! spherical harmonic coefficient of degree n and order m for a field \f$f(\theta, \phi)\f$ is calculated as follows:

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -2460,7 +2460,7 @@ end subroutine thickness_diffuse_end
 !! since the quantity \f$\frac{M^2}{\sqrt{N^4 + M^4}}\f$ is bounded between $-1$ and $1$ and does not change sign
 !! if \f$N^2<0\f$.
 !!
-!! Optionally, the method of Ferrari et al, 2010, can be used to obtain the streamfunction which solves the
+!! Optionally, the method of \cite ferrari2010, can be used to obtain the streamfunction which solves the
 !! vertically elliptic equation:
 !! \f[
 !! \gamma_F \partial_z c^2 \partial_z \psi - N_*^2 \psi  = -( 1 + \gamma_F ) \kappa_h N_*^2 \frac{M^2}{\sqrt{N^4+M^4}}
@@ -2478,7 +2478,7 @@ end subroutine thickness_diffuse_end
 !! \f$ r(\Delta x,L_d) \f$ is a function of the local resolution (ratio of grid-spacing, \f$\Delta x\f$,
 !! to deformation radius, \f$L_d\f$). The length \f$L_s\f$ is provided by the mom_lateral_mixing_coeffs module
 !! (enabled with <code>USE_VARIABLE_MIXING=True</code> and the term \f$<SN>\f$ is the vertical average slope
-!! times the buoyancy frequency prescribed by Visbeck et al., 1996.
+!! times the buoyancy frequency prescribed by \cite visbeck1996.
 !!
 !! The result of the above expression is subsequently bounded by minimum and maximum values, including an upper
 !! diffusivity consistent with numerical stability (\f$ \kappa_{cfl} \f$ is calculated internally).

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -765,7 +765,7 @@ end subroutine tidal_forcing_end
 !! are provided. TIDAL_SAL_FROM_FILE can be set to read the phase and
 !! amplitude of the tidal SAL. USE_PREVIOUS_TIDES may be useful in
 !! combination with the scalar approximation to iterate the SAL to
-!! convergence (for details, see Arbic et al., 2004, DSR II). With
+!! convergence (for details, see \cite Arbic2004). With
 !! TIDAL_SAL_FROM_FILE or USE_PREVIOUS_TIDES, a list of input files
 !! must be provided to describe each constituent's properties from
 !! a previous solution. The online SAL calculations that are functions

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -744,6 +744,8 @@ end subroutine tidal_forcing_end
 
 !> \namespace tidal_forcing
 !!
+!! \section section_tides Tidal forcing
+!!
 !! Code by Robert Hallberg, August 2005, based on C-code by Harper
 !! Simmons, February, 2003, in turn based on code by Brian Arbic.
 !!
@@ -762,14 +764,14 @@ end subroutine tidal_forcing_end
 !!
 !!   In addition, approaches to calculate self-attraction and loading
 !! due to tides (harmonics of astronomical forcing frequencies)
-!! are provided. TIDAL_SAL_FROM_FILE can be set to read the phase and
-!! amplitude of the tidal SAL. USE_PREVIOUS_TIDES may be useful in
+!! are provided. <code>TIDAL_SAL_FROM_FILE</code> can be set to read the phase and
+!! amplitude of the tidal SAL. <code>USE_PREVIOUS_TIDES</code> may be useful in
 !! combination with the scalar approximation to iterate the SAL to
 !! convergence (for details, see \cite Arbic2004). With
-!! TIDAL_SAL_FROM_FILE or USE_PREVIOUS_TIDES, a list of input files
-!! must be provided to describe each constituent's properties from
+!! <code>TIDAL_SAL_FROM_FILE</code> or <code>USE_PREVIOUS_TIDES</code>, a list of input
+!! files must be provided to describe each constituent's properties from
 !! a previous solution. The online SAL calculations that are functions
 !! of SSH (rather should be bottom pressure anmoaly), either a scalar
 !! approximation or with spherical harmonic transforms, are located in
-!! MOM_self_attr_load.
+!! <code>MOM_self_attr_load</code>.
 end module MOM_tidal_forcing

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -4257,7 +4257,7 @@ end function EF4
 !!   This file contains the subroutine (bulkmixedlayer) that
 !! implements a Kraus-Turner-like bulk mixed layer, based on the work
 !! of various people, as described in the review paper by \cite niiler1977,
-!! with particular attention to the form proposed by \cite Oberhuber1993,
+!! with particular attention to the form proposed by \cite Oberhuber1993a,
 !! with an extension to a refined bulk mixed layer as described in
 !! Hallberg (\cite muller2003). The physical processes portrayed in
 !! this subroutine include convective adjustment and mixed layer entrainment

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -4256,7 +4256,7 @@ end function EF4
 !!
 !!   This file contains the subroutine (bulkmixedlayer) that
 !! implements a Kraus-Turner-like bulk mixed layer, based on the work
-!! of various people, as described in the review paper by \cite Niiler1977,
+!! of various people, as described in the review paper by \cite niiler1977,
 !! with particular attention to the form proposed by \cite Oberhuber1993,
 !! with an extension to a refined bulk mixed layer as described in
 !! Hallberg (\cite muller2003). The physical processes portrayed in


### PR DESCRIPTION
There is documentation under lateral parameterizations, but it isn't directly linked under the appropriate Readthedocs page. I am hoping this cleans up a few things. Should not change any answers.