### PR TITLE
Set logicals in MOM_tracer_advect.F90

### DIFF
--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -1133,14 +1133,16 @@ subroutine tracer_advect_init(Time, G, US, param_file, diag, CS)
            "Unknown TRACER_ADVECTION_SCHEME = "//trim(mesg))
   end select
 
-  if (CS%useHuynh) then
-    call get_param(param_file, mdl, "USE_HUYNH_STENCIL_BUG", &
+  if (CS%usePPM) then
+    if (CS%useHuynh) then
+      call get_param(param_file, mdl, "USE_HUYNH_STENCIL_BUG", &
         CS%useHuynhStencilBug, &
         desc="If true, use a stencil width of 2 in PPM:H3 tracer advection. " &
         // "This is incorrect and will produce regressions in certain " &
         // "configurations, but may be required to reproduce results in " &
         // "legacy simulations.", &
         default=.false.)
+    endif
   endif
 
   id_clock_advect = cpu_clock_id('(Ocean advect tracer)', grain=CLOCK_MODULE)


### PR DESCRIPTION
Two logicals can be unset when using PLM in MOM_tracer_advect.F90. This was leading to random behavior in the doc files because a third parameter was only being read and logged depending on whether PLM:H3 was used.

This commit sets `CS%usePPM = .false.` and `CS%useHuynh = .false.` before processing the run-time parameter.