### PR TITLE
+Make h_neglect argument mandatory in 28 routines

### DIFF
--- a/config_src/drivers/timing_tests/time_MOM_remapping.F90
+++ b/config_src/drivers/timing_tests/time_MOM_remapping.F90
@@ -17,8 +17,9 @@ real, dimension(nschemes) :: tstd ! Standard deviation of time for a call [s]
 real, dimension(nschemes) :: tmin ! Shortest time for a call [s]
 real, dimension(nschemes) :: tmax ! Longest time for a call [s]
 real, dimension(:,:), allocatable :: u0, u1 ! Source/target values [arbitrary but same units as each other]
-real, dimension(:,:), allocatable :: h0, h1 ! Source target thicknesses [0..1]
+real, dimension(:,:), allocatable :: h0, h1 ! Source target thicknesses [0..1] [nondim]
 real :: start, finish ! Times [s]
+real :: h_neglect    ! A negligible thickness [nondim]
 real :: h0sum, h1sum ! Totals of h0 and h1 [nondim]
 integer :: ij, k, isamp, iter, ischeme ! Indices and counters
 integer :: seed_size ! Number of integers used by seed
@@ -50,6 +51,7 @@ do ij = 1, nij
   h0(:,ij) = h0(:,ij) / h0sum
   h1(:,ij) = h1(:,ij) / h1sum
 enddo
+h_neglect = 1.0-30
 
 ! Loop over many samples of timing loop to collect statistics
 tmean(:) = 0.
@@ -63,7 +65,7 @@ do isamp = 1, nsamp
     call cpu_time(start)
     do iter = 1, nits ! Make many passes to reduce sampling error
       do ij = 1, nij ! Calling nij times to make similar to cost in MOM_ALE()
-        call remapping_core_h(CS, nk, h0(:,ij), u0(:,ij), nk, h1(:,ij), u1(:,ij))
+        call remapping_core_h(CS, nk, h0(:,ij), u0(:,ij), nk, h1(:,ij), u1(:,ij), h_neglect)
       enddo
     enddo
     call cpu_time(finish)

--- a/src/ALE/P1M_functions.F90
+++ b/src/ALE/P1M_functions.F90
@@ -31,7 +31,7 @@ subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answe
   real, dimension(:,:), intent(inout) :: edge_values !< Potentially modified edge values [A]
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Potentially modified
                                            !! piecewise polynomial coefficients, mainly [A]
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables

--- a/src/ALE/PLM_functions.F90
+++ b/src/ALE/PLM_functions.F90
@@ -12,8 +12,6 @@ public PLM_reconstruction
 public PLM_slope_wa
 public PLM_slope_cw
 
-real, parameter :: hNeglect_dflt = 1.E-30 !< Default negligible cell thickness
-
 contains
 
 !> Returns a limited PLM slope following White and Adcroft, 2008, in the same arbitrary
@@ -195,7 +193,7 @@ subroutine PLM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect )
                                            !! with the same units as u [A].
   real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly
                                            !! with the same units as u [A].
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
+  real,                 intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions
                                            !! in the same units as h [H]
 
@@ -208,15 +206,12 @@ subroutine PLM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect )
   real          :: almost_one  ! A value that is slightly smaller than 1 [nondim]
   real, dimension(N) :: slp    ! The first guess at the normalized tracer slopes [A]
   real, dimension(N) :: mslp   ! The monotonized normalized tracer slopes [A]
-  real    :: hNeglect          ! A negligibly small width used in cell reconstructions [H]
-
-  hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   almost_one = 1. - epsilon(slope)
 
   ! Loop on interior cells
   do k = 2,N-1
-    slp(k) = PLM_slope_wa(h(k-1), h(k), h(k+1), hNeglect, u(k-1), u(k), u(k+1))
+    slp(k) = PLM_slope_wa(h(k-1), h(k), h(k+1), h_neglect, u(k-1), u(k), u(k+1))
   enddo ! end loop on interior cells
 
   ! Boundary cells use PCM. Extrapolation is handled after monotonization.
@@ -277,17 +272,14 @@ subroutine PLM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
                                            !! with the same units as u [A].
   real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly
                                            !! with the same units as u [A].
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
+  real,                 intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions
                                            !! in the same units as h [H]
   ! Local variables
   real    :: slope     ! retained PLM slope for a normalized cell width [A]
-  real    :: hNeglect  ! A negligibly small width used in cell reconstructions [H]
-
-  hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! Extrapolate from 2 to 1 to estimate slope
-  slope = - PLM_extrapolate_slope( h(2), h(1), hNeglect, u(2), u(1) )
+  slope = - PLM_extrapolate_slope( h(2), h(1), h_neglect, u(2), u(1) )
 
   edge_values(1,1) = u(1) - 0.5 * slope
   edge_values(1,2) = u(1) + 0.5 * slope
@@ -296,7 +288,7 @@ subroutine PLM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
   ppoly_coef(1,2) = edge_values(1,2) - edge_values(1,1)
 
   ! Extrapolate from N-1 to N to estimate slope
-  slope = PLM_extrapolate_slope( h(N-1), h(N), hNeglect, u(N-1), u(N) )
+  slope = PLM_extrapolate_slope( h(N-1), h(N), h_neglect, u(N-1), u(N) )
 
   edge_values(N,1) = u(N) - 0.5 * slope
   edge_values(N,2) = u(N) + 0.5 * slope

--- a/src/ALE/PPM_functions.F90
+++ b/src/ALE/PPM_functions.F90
@@ -15,13 +15,6 @@ implicit none ; private
 
 public PPM_reconstruction, PPM_boundary_extrapolation, PPM_monotonicity
 
-!> A tiny width that is so small that adding it to cell widths does not
-!! change the value due to a computational representation. It is used
-!! to avoid division by zero.
-!! @note This is a dimensional parameter and should really include a unit
-!!       conversion.
-real, parameter :: hNeglect_dflt = 1.E-30
-
 contains
 
 !> Builds quadratic polynomials coefficients from cell mean and edge values.
@@ -31,7 +24,7 @@ subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answ
   real, dimension(N),   intent(in)    :: u !< Cell averages in arbitrary coordinates [A]
   real, dimension(N,2), intent(inout) :: edge_values !< Edge values [A]
   real, dimension(N,3), intent(inout) :: ppoly_coef !< Polynomial coefficients, mainly [A]
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -64,7 +57,7 @@ subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answer_date )
   real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
   real, dimension(:),   intent(in)    :: u !< cell average properties (size N) [A]
   real, dimension(:,:), intent(inout) :: edge_values !< Potentially modified edge values [A]
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -190,7 +183,7 @@ subroutine PPM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
   real, dimension(:),   intent(in)    :: u !< cell averages (size N) [A]
   real, dimension(:,:), intent(inout) :: edge_values    !< edge values of piecewise polynomials [A]
   real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly [A]
-  real,       optional, intent(in)    :: h_neglect  !< A negligibly small width for
+  real,                 intent(in)    :: h_neglect  !< A negligibly small width for
                                            !! the purpose of cell reconstructions [H]
 
   ! Local variables
@@ -204,9 +197,6 @@ subroutine PPM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
                         ! the cell being worked on [A]
   real    :: slope      ! The normalized slope [A]
   real    :: exp1, exp2 ! Temporary expressions [A2]
-  real    :: hNeglect   ! A negligibly small width used in cell reconstructions [H]
-
-  hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
   ! ----- Left boundary -----
   i0 = 1
@@ -219,7 +209,7 @@ subroutine PPM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
   ! Compute the left edge slope in neighboring cell and express it in
   ! the global coordinate system
   b = ppoly_coef(i1,2)
-  u1_r = b *((h0+hNeglect)/(h1+hNeglect))     ! derivative evaluated at xi = 0.0,
+  u1_r = b *((h0+h_neglect)/(h1+h_neglect))     ! derivative evaluated at xi = 0.0,
                         ! expressed w.r.t. xi (local coord. system)
 
   ! Limit the right slope by the PLM limited slope
@@ -273,7 +263,7 @@ subroutine PPM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
   b = ppoly_coef(i0,2)
   c = ppoly_coef(i0,3)
   u1_l = (b + 2*c)                  ! derivative evaluated at xi = 1.0
-  u1_l = u1_l * ((h1+hNeglect)/(h0+hNeglect))
+  u1_l = u1_l * ((h1+h_neglect)/(h0+h_neglect))
 
   ! Limit the left slope by the PLM limited slope
   slope = 2.0 * ( u1 - u0 )

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -119,7 +119,7 @@ subroutine build_hycom1_column(CS, remapCS, eqn_of_state, nz, depth, h, T, S, p_
   real, optional,        intent(in)    :: zScale !< Scaling factor from the input coordinate thicknesses in [Z ~> m]
                                                 !! to desired units for zInterface, perhaps GV%Z_to_H in which
                                                 !! case this has units of [H Z-1 ~> nondim or kg m-3]
-  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the purpose of
+  real,                  intent(in)    :: h_neglect !< A negligibly small width for the purpose of
                                                 !! cell reconstruction [H ~> m or kg m-2]
   real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width for the purpose of
                                                 !! edge value calculation [H ~> m or kg m-2]
@@ -225,7 +225,7 @@ subroutine build_hycom1_target_anomaly(CS, remapCS, eqn_of_state, nz, depth, h, 
   real, dimension(nz+1), intent(out) :: RiAnom !< The interface density anomaly
                                                !! w.r.t. the interface target
                                                !! densities [R ~> kg m-3]
-  real,        optional, intent(in)  :: h_neglect !< A negligibly small width for the purpose of
+  real,                  intent(in)  :: h_neglect !< A negligibly small width for the purpose of
                                                !! cell reconstruction [H ~> m or kg m-2]
   real,        optional, intent(in)  :: h_neglect_edge !< A negligibly small width for the purpose of
                                                 !! edge value calculation [H ~> m or kg m-2]

--- a/src/ALE/coord_rho.F90
+++ b/src/ALE/coord_rho.F90
@@ -105,7 +105,7 @@ subroutine build_rho_column(CS, nz, depth, h, T, S, eqn_of_state, z_interface, &
                                              !! units as depth) [H ~> m or kg m-2]
   real, optional,      intent(in)    :: eta_orig !< The actual original height of the top in the same
                                                    !! units as depth) [H ~> m or kg m-2]
-  real,      optional, intent(in)    :: h_neglect !< A negligibly small width for the purpose
+  real,                intent(in)    :: h_neglect !< A negligibly small width for the purpose
                                              !! of cell reconstructions [H ~> m or kg m-2]
   real,      optional, intent(in)    :: h_neglect_edge !< A negligibly small width for the purpose
                                              !! of edge value calculations [H ~> m or kg m-2]
@@ -201,7 +201,7 @@ subroutine build_rho_column_iteratively(CS, remapCS, nz, depth, h, T, S, eqn_of_
   real, dimension(nz),   intent(in)    :: S  !< S for column [S ~> ppt]
   type(EOS_type),        intent(in)    :: eqn_of_state !< Equation of state structure
   real, dimension(nz+1), intent(inout) :: zInterface !< Absolute positions of interfaces [Z ~> m]
-  real,        optional, intent(in)    :: h_neglect !< A negligibly small width for the
+  real,                  intent(in)    :: h_neglect !< A negligibly small width for the
                                              !! purpose of cell reconstructions
                                              !! in the same units as h [Z ~> m]
   real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -18,15 +18,10 @@ public edge_values_explicit_h2, edge_values_explicit_h4, edge_values_explicit_h4
 public edge_values_implicit_h4, edge_values_implicit_h6
 public edge_slopes_implicit_h3, edge_slopes_implicit_h5
 
-! The following parameters are used to avoid singular matrices for boundary
-! extrapolation. The are needed only in the case where thicknesses vanish
+! The following parameter is used to avoid singular matrices for boundary
+! extrapolation. It is needed only in the case where thicknesses vanish
 ! to a small enough values such that the eigenvalues of the matrix can not
 ! be separated.
-!   Specifying a dimensional parameter value, as is done here, is a terrible idea.
-real, parameter :: hNeglect_edge_dflt = 1.e-10 !< The default value for cut-off minimum
-                                          !! thickness for sum(h) in edge value inversions
-real, parameter :: hNeglect_dflt = 1.e-30 !< The default value for cut-off minimum
-                                          !! thickness for sum(h) in other calculations
 real, parameter :: hMinFrac      = 1.e-5  !< A minimum fraction for min(h)/sum(h) [nondim]
 
 contains
@@ -47,20 +42,16 @@ subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answer_date )
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val !< Potentially modified edge values [A]; the
                                            !! second index is for the two edges of each cell.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
   real    :: sigma_l, sigma_c, sigma_r    ! left, center and right van Leer slopes [A H-1] or [A]
   real    :: slope_x_h     ! retained PLM slope times  half grid step [A]
-  real    :: hNeglect      ! A negligible thickness [H].
   logical :: use_2018_answers  ! If true use older, less accurate expressions.
   integer :: k, km1, kp1   ! Loop index and the values to either side.
 
   use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
-  if (use_2018_answers) then
-    hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-  endif
 
   ! Loop on cells to bound edge value
   do k = 1,N
@@ -73,9 +64,9 @@ subroutine bound_edge_values( N, h, u, edge_val, h_neglect, answer_date )
 
     slope_x_h = 0.0
     if (use_2018_answers) then
-      sigma_l = 2.0 * ( u(k) - u(km1) ) / ( h(k) + hNeglect )
-      sigma_c = 2.0 * ( u(kp1) - u(km1) ) / ( h(km1) + 2.0*h(k) + h(kp1) + hNeglect )
-      sigma_r = 2.0 * ( u(kp1) - u(k) ) / ( h(k) + hNeglect )
+      sigma_l = 2.0 * ( u(k) - u(km1) ) / ( h(k) + h_neglect )
+      sigma_c = 2.0 * ( u(kp1) - u(km1) ) / ( h(km1) + 2.0*h(k) + h(kp1) + h_neglect )
+      sigma_r = 2.0 * ( u(kp1) - u(k) ) / ( h(k) + h_neglect )
 
       ! The limiter is used in the local coordinate system to each cell, so for convenience store
       ! the slope times a half grid spacing.  (See White and Adcroft JCP 2008 Eqs 19 and 20)
@@ -225,7 +216,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val !< Returned edge values [A]; the second index
                                            !! is for the two edges of each cell.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -248,16 +239,10 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   real, dimension(4)    :: B     ! The right hand side of the system to solve for C [A H]
   real, dimension(4)    :: C     ! The coefficients of a fit polynomial in units that vary
                                  ! with the index (j) as [A H^(j-1)]
-  real      :: hNeglect ! A negligible thickness in the same units as h [H].
   integer               :: i, j
   logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
   use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
-  if (use_2018_answers) then
-    hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-  else
-    hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-  endif
 
   ! Loop on interior cells
   do i = 3,N-1
@@ -270,9 +255,9 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
     ! Avoid singularities when consecutive pairs of h vanish
     if (h0+h1==0.0 .or. h1+h2==0.0 .or. h2+h3==0.0) then
       if (use_2018_answers) then
-        h_min = hMinFrac*max( hNeglect, h0+h1+h2+h3 )
+        h_min = hMinFrac*max( h_neglect, h0+h1+h2+h3 )
       else
-        h_min = hMinFrac*max( hNeglect, (h0+h1)+(h2+h3) )
+        h_min = hMinFrac*max( h_neglect, (h0+h1)+(h2+h3) )
       endif
       h0 = max( h_min, h(i-2) )
       h1 = max( h_min, h(i-1) )
@@ -307,7 +292,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
 
   ! Determine first two edge values
   if (use_2018_answers) then
-    h_min = max( hNeglect, hMinFrac*sum(h(1:4)) )
+    h_min = max( h_neglect, hMinFrac*sum(h(1:4)) )
     x(1) = 0.0
     do i = 1,4
       dx = max(h_min, h(i) )
@@ -322,7 +307,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
     edge_val(1,1) = evaluation_polynomial( C, 4, x(1) )
     edge_val(1,2) = evaluation_polynomial( C, 4, x(2) )
   else  ! Use expressions with less sensitivity to roundoff
-    do i=1,4 ; dz(i) = max(hNeglect, h(i) ) ; u_tmp(i) = u(i) ; enddo
+    do i=1,4 ; dz(i) = max(h_neglect, h(i) ) ; u_tmp(i) = u(i) ; enddo
     call end_value_h4(dz, u_tmp, C)
 
     ! Set the edge values of the first cell
@@ -333,7 +318,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
 
   ! Determine two edge values of the last cell
   if (use_2018_answers) then
-    h_min = max( hNeglect, hMinFrac*sum(h(N-3:N)) )
+    h_min = max( h_neglect, hMinFrac*sum(h(N-3:N)) )
 
     x(1) = 0.0
     do i = 1,4
@@ -351,7 +336,7 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   else
     ! Use expressions with less sensitivity to roundoff, including using a coordinate
     ! system that sets the origin at the last interface in the domain.
-    do i=1,4 ; dz(i) = max(hNeglect, h(N+1-i) ) ; u_tmp(i) = u(N+1-i) ; enddo
+    do i=1,4 ; dz(i) = max(h_neglect, h(N+1-i) ) ; u_tmp(i) = u(N+1-i) ; enddo
     call end_value_h4(dz, u_tmp, C)
 
     ! Set the last and second to last edge values
@@ -384,11 +369,10 @@ subroutine edge_values_explicit_h4cw( N, h, u, edge_val, h_neglect )
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val  !< Returned edge values [A]; the second index
                                                    !! is for the two edges of each cell.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
 
   ! Local variables
   real :: dp(N) ! Input grid layer thicknesses, but with a minimum thickness [H ~> m or kg m-2]
-  real :: hNeglect  ! A negligible thickness in the same units as h [H]
   real :: da        ! Difference between the unlimited scalar edge value estimates [A]
   real :: a6        ! Scalar field differences that are proportional to the curvature [A]
   real :: slk, srk  ! Differences between adjacent cell averages of scalars [A]
@@ -403,10 +387,8 @@ subroutine edge_values_explicit_h4cw( N, h, u, edge_val, h_neglect )
   real :: h23_h122(N+1) ! A ratio of sums of adjacent thicknesses [nondim], 2/3 in the limit of uniform thicknesses.
   integer :: k
 
-  hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-
   ! Set the thicknesses for very thin layers to some minimum value.
-  do k=1,N ; dp(k) = max(h(k), hNeglect) ; enddo
+  do k=1,N ; dp(k) = max(h(k), h_neglect) ; enddo
 
   !compute grid metrics
   do k=2,N
@@ -494,7 +476,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val !< Returned edge values [A]; the second index
                                            !! is for the two edges of each cell.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -524,15 +506,9 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
                            tri_u, &     ! tridiagonal system (upper diagonal) [nondim]
                            tri_b, &     ! tridiagonal system (right hand side) [A]
                            tri_x        ! tridiagonal system (solution vector) [A]
-  real      :: hNeglect          ! A negligible thickness [H]
   logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
   use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
-  if (use_2018_answers) then
-    hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-  else
-    hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-  endif
 
   ! Loop on cells (except last one)
   do i = 1,N-1
@@ -542,8 +518,8 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
       h1 = h(i+1)
       ! Avoid singularities when h0+h1=0
       if (h0+h1==0.) then
-        h0 = hNeglect
-        h1 = hNeglect
+        h0 = h_neglect
+        h1 = h_neglect
       endif
 
       ! Auxiliary calculations
@@ -562,8 +538,8 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
       tri_d(i+1) = 1.0
     else  ! Use expressions with less sensitivity to roundoff
       ! Get cell widths
-      h0 = max(h(i), hNeglect)
-      h1 = max(h(i+1), hNeglect)
+      h0 = max(h(i), h_neglect)
+      h1 = max(h(i+1), h_neglect)
       ! The 1e-12 here attempts to balance truncation errors from the differences of
       ! large numbers against errors from approximating thin layers as non-vanishing.
       if (abs(h0) < 1.0e-12*abs(h1)) h0 = 1.0e-12*h1
@@ -587,7 +563,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
 
   ! Boundary conditions: set the first boundary value
   if (use_2018_answers) then
-    h_min = max( hNeglect, hMinFrac*sum(h(1:4)) )
+    h_min = max( h_neglect, hMinFrac*sum(h(1:4)) )
     x(1) = 0.0
     do i = 1,4
       dx = max(h_min, h(i) )
@@ -601,7 +577,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
     tri_b(1) = evaluation_polynomial( Csys, 4, x(1) )  ! Set the first edge value
     tri_d(1) = 1.0
   else ! Use expressions with less sensitivity to roundoff
-    do i=1,4 ; dz(i) = max(hNeglect, h(i) ) ; u_tmp(i) = u(i) ; enddo
+    do i=1,4 ; dz(i) = max(h_neglect, h(i) ) ; u_tmp(i) = u(i) ; enddo
     call end_value_h4(dz, u_tmp, Csys)
 
     tri_b(1) = Csys(1)  ! Set the first edge value.
@@ -611,7 +587,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
 
   ! Boundary conditions: set the last boundary value
   if (use_2018_answers) then
-    h_min = max( hNeglect, hMinFrac*sum(h(N-3:N)) )
+    h_min = max( h_neglect, hMinFrac*sum(h(N-3:N)) )
     x(1) = 0.0
     do i=1,4
       dx = max(h_min, h(N-4+i) )
@@ -629,7 +605,7 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   else
     ! Use expressions with less sensitivity to roundoff, including using a coordinate
     ! system that sets the origin at the last interface in the domain.
-    do i=1,4 ; dz(i) = max(hNeglect, h(N+1-i) ) ; u_tmp(i) = u(N+1-i) ; enddo
+    do i=1,4 ; dz(i) = max(h_neglect, h(N+1-i) ) ; u_tmp(i) = u(N+1-i) ; enddo
     call end_value_h4(dz, u_tmp, Csys)
 
     tri_b(N+1) = Csys(1) ! Set the last edge value
@@ -806,7 +782,7 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_slopes !< Returned edge slopes [A H-1]; the
                                            !! second index is for the two edges of each cell.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -837,12 +813,10 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date
                            tri_u, &     ! tridiagonal system (upper diagonal) [nondim]
                            tri_b, &     ! tridiagonal system (right hand side) [A H-1]
                            tri_x        ! tridiagonal system (solution vector) [A H-1]
-  real      :: hNeglect  ! A negligible thickness [H].
   real      :: hNeglect3 ! hNeglect^3 [H3].
   logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
-  hNeglect = hNeglect_dflt ; if (present(h_neglect))  hNeglect = h_neglect
-  hNeglect3 = hNeglect**3
+  hNeglect3 = h_neglect**3
   use_2018_answers = .true. ; if (present(answer_date)) use_2018_answers = (answer_date < 20190101)
 
   ! Loop on cells (except last one)
@@ -875,8 +849,8 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date
       tri_b(i+1) = a * u(i) + b * u(i+1)
     else
       ! Get cell widths
-      h0 = max(h(i), hNeglect)
-      h1 = max(h(i+1), hNeglect)
+      h0 = max(h(i), h_neglect)
+      h1 = max(h(i+1), h_neglect)
 
       I_h = 1.0 / (h0 + h1)
       h0 = h0 * I_h ; h1 = h1 * I_h
@@ -917,7 +891,7 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date
     tri_b(1) = evaluation_polynomial( Dsys, 3, x(1) )  ! Set the first edge slope
     tri_d(1) = 1.0
   else ! Use expressions with less sensitivity to roundoff
-    do i=1,4 ; dz(i) = max(hNeglect, h(i) ) ; u_tmp(i) = u(i) ; enddo
+    do i=1,4 ; dz(i) = max(h_neglect, h(i) ) ; u_tmp(i) = u(i) ; enddo
     call end_value_h4(dz, u_tmp, Csys)
 
     ! Set the first edge slope
@@ -945,7 +919,7 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date
   else
     ! Use expressions with less sensitivity to roundoff, including using a coordinate
     ! system that sets the origin at the last interface in the domain.
-    do i=1,4 ; dz(i) = max(hNeglect, h(N+1-i) ) ; u_tmp(i) = u(N+1-i) ; enddo
+    do i=1,4 ; dz(i) = max(h_neglect, h(N+1-i) ) ; u_tmp(i) = u(N+1-i) ; enddo
 
     call end_value_h4(dz, u_tmp, Csys)
 
@@ -980,7 +954,7 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   real, dimension(N),   intent(in)    :: u !< cell average properties in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_slopes !< Returned edge slopes [A H-1]; the
                                            !! second index is for the two edges of each cell.
-  real, optional,       intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
 ! -----------------------------------------------------------------------------
@@ -1021,7 +995,6 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   real :: hMin                 ! The minimum thickness used in these calculations [H]
   real :: h01, h01_2           ! Summed thicknesses to various powers [H^n ~> m^n or kg^n m-2n]
   real :: h23, h23_2           ! Summed thicknesses to various powers [H^n ~> m^n or kg^n m-2n]
-  real :: hNeglect             ! A negligible thickness [H].
   real :: h1_2, h2_2           ! Squares of thicknesses [H2]
   real :: h1_3, h2_3           ! Cubes of thicknesses [H3]
   real :: h1_4, h2_4           ! Fourth powers of thicknesses [H4]
@@ -1045,12 +1018,10 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   real :: h_Min_Frac = 1.0e-4  ! A minimum fractional thickness [nondim]
   integer :: i, k   ! loop indexes
 
-  hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-
   ! Loop on cells (except the first and last ones)
   do k = 2,N-2
     ! Store temporary cell widths, avoiding singularities from zero thicknesses or extreme changes.
-    hMin = max(hNeglect, h_Min_Frac*((h(k-1) + h(k)) + (h(k+1) + h(k+2))))
+    hMin = max(h_neglect, h_Min_Frac*((h(k-1) + h(k)) + (h(k+1) + h(k+2))))
     h0 = max(h(k-1), hMin) ; h1 = max(h(k), hMin)
     h2 = max(h(k+1), hMin) ; h3 = max(h(k+2), hMin)
 
@@ -1091,7 +1062,7 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   ! Use a right-biased stencil for the second row, as described in Eq. (53) of White and Adcroft (2009).
 
   ! Store temporary cell widths, avoiding singularities from zero thicknesses or extreme changes.
-  hMin = max(hNeglect, h_Min_Frac*((h(1) + h(2)) + (h(3) + h(4))))
+  hMin = max(h_neglect, h_Min_Frac*((h(1) + h(2)) + (h(3) + h(4))))
   h0 = max(h(1), hMin) ; h1 = max(h(2), hMin)
   h2 = max(h(3), hMin) ; h3 = max(h(4), hMin)
 
@@ -1147,7 +1118,7 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   ! Use a left-biased stencil for the second to last row, as described in Eq. (54) of White and Adcroft (2009).
 
   ! Store temporary cell widths, avoiding singularities from zero thicknesses or extreme changes.
-  hMin = max(hNeglect, h_Min_Frac*((h(N-3) + h(N-2)) + (h(N-1) + h(N))))
+  hMin = max(h_neglect, h_Min_Frac*((h(N-3) + h(N-2)) + (h(N-1) + h(N))))
   h0 = max(h(N-3), hMin) ; h1 = max(h(N-2), hMin)
   h2 = max(h(N-1), hMin) ; h3 = max(h(N), hMin)
 
@@ -1255,7 +1226,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   real, dimension(N),   intent(in)    :: u !< cell average properties (size N) in arbitrary units [A]
   real, dimension(N,2), intent(inout) :: edge_val  !< Returned edge values [A]; the second index
                                            !! is for the two edges of each cell.
-  real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
+  real,                 intent(in)    :: h_neglect !< A negligibly small width [H]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
 
   ! Local variables
@@ -1263,7 +1234,6 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   real :: hMin                 ! The minimum thickness used in these calculations [H]
   real :: h01, h01_2, h01_3  ! Summed thicknesses to various powers [H^n ~> m^n or kg^n m-2n]
   real :: h23, h23_2, h23_3  ! Summed thicknesses to various powers [H^n ~> m^n or kg^n m-2n]
-  real :: hNeglect             ! A negligible thickness [H].
   real :: h1_2, h2_2, h1_3, h2_3 ! Cell widths raised to the 2nd and 3rd powers [H2] or [H3]
   real :: h1_4, h2_4, h1_5, h2_5 ! Cell widths raised to the 4th and 5th powers [H4] or [H5]
   real :: alpha, beta          ! stencil coefficients [nondim]
@@ -1286,12 +1256,10 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
                            tri_x        ! trid. system (unknowns vector) [A]
   integer :: i, k   ! loop indexes
 
-  hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
-
   ! Loop on interior cells
   do k = 2,N-2
     ! Store temporary cell widths, avoiding singularities from zero thicknesses or extreme changes.
-    hMin = max(hNeglect, hMinFrac*((h(k-1) + h(k)) + (h(k+1) + h(k+2))))
+    hMin = max(h_neglect, hMinFrac*((h(k-1) + h(k)) + (h(k+1) + h(k+2))))
     h0 = max(h(k-1), hMin) ; h1 = max(h(k), hMin)
     h2 = max(h(k+1), hMin) ; h3 = max(h(k+2), hMin)
 
@@ -1329,7 +1297,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   ! Use a right-biased stencil for the second row, as described in Eq. (49) of White and Adcroft (2009).
 
   ! Store temporary cell widths, avoiding singularities from zero thicknesses or extreme changes.
-  hMin = max(hNeglect, hMinFrac*((h(1) + h(2)) + (h(3) + h(4))))
+  hMin = max(h_neglect, hMinFrac*((h(1) + h(2)) + (h(3) + h(4))))
   h0 = max(h(1), hMin) ; h1 = max(h(2), hMin)
   h2 = max(h(3), hMin) ; h3 = max(h(4), hMin)
 
@@ -1364,7 +1332,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   tri_b(2) = Csys(3) * u(1) + Csys(4) * u(2) + Csys(5) * u(3) + Csys(6) * u(4)
 
   ! Boundary conditions: left boundary
-  hMin = max( hNeglect, hMinFrac*((h(1)+h(2)) + (h(5)+h(6)) + (h(3)+h(4))) )
+  hMin = max( h_neglect, hMinFrac*((h(1)+h(2)) + (h(5)+h(6)) + (h(3)+h(4))) )
   x(1) = 0.0
   do i = 1,6
     dx = max( hMin, h(i) )
@@ -1386,7 +1354,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   ! Use a left-biased stencil for the second to last row, as described in Eq. (50) of White and Adcroft (2009).
 
   ! Store temporary cell widths, avoiding singularities from zero thicknesses or extreme changes.
-  hMin = max(hNeglect, hMinFrac*((h(N-3) + h(N-2)) + (h(N-1) + h(N))))
+  hMin = max(h_neglect, hMinFrac*((h(N-3) + h(N-2)) + (h(N-1) + h(N))))
   h0 = max(h(N-3), hMin) ; h1 = max(h(N-2), hMin)
   h2 = max(h(N-1), hMin) ; h3 = max(h(N), hMin)
 
@@ -1421,7 +1389,7 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   tri_b(N) = Csys(3) * u(N-3) + Csys(4) * u(N-2) + Csys(5) * u(N-1) + Csys(6) * u(N)
 
   ! Boundary conditions: right boundary
-  hMin = max( hNeglect, hMinFrac*(h(N-3) + h(N-2)) + ((h(N-1) + h(N)) + (h(N-5) + h(N-4))) )
+  hMin = max( h_neglect, hMinFrac*(h(N-3) + h(N-2)) + ((h(N-1) + h(N)) + (h(N-5) + h(N-4))) )
   x(1) = 0.0
   do i = 1,6
     dx = max( hMin, h(N+1-i) )


### PR DESCRIPTION
  Made the `h_neglect` argument non-optional to 28 routines, because there is no way to provide a consistent hard-coded default for a dimensional parameter.  The routines where this change was made include `remapping_core_h()`, `remapping_core_w()`, `build_reconstructions_1d()`, `P1M_interpolation()`, `P3M_interpolation()`, `P3M_boundary_extrapolation()`, `PLM_reconstruction()`, `PLM_boundary_extrapolation()`, `PPM_reconstruction()`, `PPM_limiter_standard()`, `PPM_boundary_extrapolation()`, `PQM_reconstruction()`, `PQM_limiter()`, `PQM_boundary_extrapolation_v1()`, `build_hycom1_column()`, `build_rho_column()`, `bound_edge_values()`, `edge_values_explicit_h4()`, `edge_values_explicit_h4cw()`, `edge_values_implicit_h4()`, `edge_slopes_implicit_h3()`, `edge_slopes_implicit_h5()`, `edge_values_implicit_h6()`, `regridding_set_ppolys()`, `build_and_interpolate_grid()`, `remapByProjection()`, `remapByDeltaZ()`, and `integrateReconOnInterval()`.

  In those cases that also have an optional `h_neglect_edge` argument, the default is now set to `h_neglect`.  Improperly hard-coded dimensional default values for` h_neglect` or `h_neglect_edge` were eliminated in 15 places as a result of this change, but they were added back in 3 unit testing routines (one of these is archaic and unused) that do not use exercise dimensional rescaling tests.

  Because these previously optional arguments were already present in all calls from the dev/gfdl or main branches of the MOM6 code, all answers are bitwise identical in the regression tests, but this change in interfaces could impact other code that is not in the main branch of MOM6.

  These changes were discussed and agreed to at the consortium wide MOM6 dev call on July 29, 2024.