### PR TITLE
+(*)Pressure gradient corrections under ice shelves

### DIFF
--- a/.testing/tc1/MOM_input
+++ b/.testing/tc1/MOM_input
@@ -278,6 +278,12 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
                                 ! have no effect on the SADOURNY Coriolis scheme if it
                                 ! were possible to use centered difference thickness fluxes.
 
+! === module MOM_PressureForce_FV ===
+MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolating T/S for integrals
+                                ! near the bathymetry in FV pressure gradient calculations.
+
+
 ! === module MOM_hor_visc ===
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
                                 ! The velocity scale which is multiplied by the cube of

--- a/.testing/tc2/MOM_input
+++ b/.testing/tc2/MOM_input
@@ -302,11 +302,16 @@ PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
                                 ! gradient in the deterministic part of the Stanley form of the Brankart
                                 ! correction. Negative values disable the scheme.
 
+! === module MOM_PressureForce_FV ===
+MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolating T/S for integrals
+                                ! near the bathymetry in FV pressure gradient calculations.
+
 ! === module MOM_hor_visc ===
 LAPLACIAN = True
 KH_VEL_SCALE = 0.05
 SMAGORINSKY_KH = True           !   [Boolean] default = False
-SMAG_LAP_CONST = 0.06            !   [nondim] default = 0.0
+SMAG_LAP_CONST = 0.06           !   [nondim] default = 0.0
 AH_VEL_SCALE = 0.05             !   [m s-1] default = 0.0
                                 ! The velocity scale which is multiplied by the cube of
                                 ! the grid spacing to calculate the Laplacian viscosity.

--- a/.testing/tc4/MOM_input
+++ b/.testing/tc4/MOM_input
@@ -269,6 +269,9 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 ! === module MOM_PressureForce ===
 
 ! === module MOM_PressureForce_FV ===
+MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolating T/S for integrals
+                                ! near the bathymetry in FV pressure gradient calculations.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = True
                                 ! If True, use vertical reconstruction of T & S within the integrals of the FV
                                 ! pressure gradient calculation. If False, use the constant-by-layer algorithm.

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -1028,6 +1028,7 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, SAL_CSp,
                            ! temperature variance [nondim]
   integer :: default_answer_date ! Global answer date
   logical :: useMassWghtInterp ! If true, use near-bottom mass weighting for T and S
+  logical :: MassWghtInterpTop ! If true, use near-surface mass weighting for T and S under ice shelves
   logical :: MassWghtInterp_NonBous_bug ! If true, use a buggy mass weighting when non-Boussinesq
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -1072,9 +1073,14 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, SAL_CSp,
                  "If True, use the ALE algorithm (regridding/remapping). "//&
                  "If False, use the layered isopycnal algorithm.", default=.false. )
   call get_param(param_file, mdl, "MASS_WEIGHT_IN_PRESSURE_GRADIENT", useMassWghtInterp, &
-                 "If true, use mass weighting when interpolating T/S for "//&
-                 "integrals near the bathymetry in FV pressure gradient "//&
-                 "calculations.", default=.false.)
+                 "If true, use mass weighting when interpolating T/S for integrals "//&
+                 "near the bathymetry in FV pressure gradient calculations.", &
+                 default=.false.)
+  call get_param(param_file, mdl, "MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP", MassWghtInterpTop, &
+                 "If true and MASS_WEIGHT_IN_PRESSURE_GRADIENT is true, use mass weighting when "//&
+                 "interpolating T/S for integrals near the top of the water column in FV "//&
+                 "pressure gradient calculations. ", &
+                 default=.false.) !### Change Default to MASS_WEIGHT_IN_PRESSURE_GRADIENT?
   call get_param(param_file, mdl, "MASS_WEIGHT_IN_PGF_NONBOUS_BUG", MassWghtInterp_NonBous_bug, &
                  "If true, use a masking bug in non-Boussinesq calculations with mass weighting "//&
                  "when interpolating T/S for integrals near the bathymetry in FV pressure "//&
@@ -1083,8 +1089,11 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, SAL_CSp,
   CS%MassWghtInterp = 0
   if (useMassWghtInterp) &
     CS%MassWghtInterp = ibset(CS%MassWghtInterp, 0) ! Same as CS%MassWghtInterp + 1
+  if (MassWghtInterpTop) &
+    CS%MassWghtInterp = ibset(CS%MassWghtInterp, 1) ! Same as CS%MassWghtInterp + 2
   if ((.not.GV%Boussinesq) .and. MassWghtInterp_NonBous_bug) &
     CS%MassWghtInterp = ibset(CS%MassWghtInterp, 3) ! Same as CS%MassWghtInterp + 8
+
   call get_param(param_file, mdl, "USE_INACCURATE_PGF_RHO_ANOM", CS%use_inaccurate_pgf_rho_anom, &
                  "If true, use a form of the PGF that uses the reference density "//&
                  "in an inaccurate way. This is not recommended.", default=.false.)

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -49,7 +49,11 @@ type, public :: PressureForce_FV_CS ; private
                             !! timing of diagnostic output.
   integer :: MassWghtInterp !< A flag indicating whether and how to use mass weighting in T/S interpolation
   logical :: correction_intxpa !< If true, apply a correction to surface intxpa under ice.
-  logical :: correction_intxpa_5pt ! Use 5 point quadrature to calculate surface intxpa
+  logical :: correction_intxpa_5pt !< Use 5 point quadrature to calculate surface intxpa
+  logical :: reset_intxpa_integral !< In the interior, reset intxpa at a trusted cell (for ice shelf)
+  real    :: h_nonvanished  !< A minimal layer thickness that indicates that a layer is thick enough
+                            !! to usefully reestimate the pressure integral across the interface
+                            !! below it [H ~> m or kg m-2]
   logical :: use_inaccurate_pgf_rho_anom !< If true, uses the older and less accurate
                             !! method to calculate density anomalies, as used prior to
                             !! March 2018.
@@ -661,7 +665,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer, dimension(2) :: EOSdom_h ! The i-computational domain for the equation of state at tracer points
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, nkmb
-  integer :: i, j, k, m
+  integer :: i, j, k, m, k2
   real :: T5(5), S5(5) ! Temperatures and salinities at five quadrature points [C ~> degC] and [S ~> ppt]
   real :: p5(5)        ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
   real :: r5(5)        ! Densities at five quadrature points [R ~> kg m-3]
@@ -669,6 +673,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   real, parameter :: C1_12 = 1.0/12.0  ! A rational constant [nondim]
   real :: wt_R       ! A weighting factor [nondim]
+  real :: rho_tr, rho_tl ! Store right and left densities in reset intxpa calculation [R ~> kg m-3]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   nkmb=GV%nk_rho_varies
@@ -952,12 +957,12 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm
           ! The pressure difference is at least half the size of the difference expected by hydrostatic
           ! balance.  This test gets rid of pressure differences that are small, e.g. open ocean.
           if (CS%correction_intxpa_5pt) then
-            !! Use 5 point quadrature to calculate intxpa 
+            ! Use 5 point quadrature to calculate intxpa
             T5(1) = T_t(I,j,1) ; T5(5) = T_t(I+1,j,1)
             S5(1) = S_t(I,j,1) ; S5(5) = S_t(I+1,j,1)
-            ! Pressure input to density EOS should be real pressure not rho_ref, I think
-            p5(1) = pa(I,j,1) - (rho_ref*GV%g_Earth)*(e(i,j,1) - G%Z_ref)
-            p5(5) = pa(I+1,j,1) - (rho_ref*GV%g_Earth)*(e(i,j,1) - G%Z_ref)
+            ! Pressure input to density EOS is the actual pressure not adjusted for rho_ref.
+            p5(1) = pa(i,j,1) - (rho_ref*GV%g_Earth)*(e(i,j,1) - G%Z_ref)
+            p5(5) = pa(i+1,j,1) - (rho_ref*GV%g_Earth)*(e(i,j,1) - G%Z_ref)
             do m=2,4
               wt_R =  0.25*real(m-1)
               T5(m) = T5(1)+(T5(5)-T5(1))*wt_R !Quadratic: + (T5(5)-T5(1))*B*wt_R*(wt_R-1);
@@ -996,11 +1001,11 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm
             0.25*((rho_top(i,j+1)+rho_top(i,j))-2.0*rho_ref) * dz_geo_sfc**2) then
           ! The pressure difference is at least half the size of the difference expected by hydrostatic
           ! balance.  This test gets rid of pressure differences that are small, e.g. open ocean.
-           if (CS%correction_intxpa_5pt) then
-            !! Use 5 point quadrature to calculate intxpa
+          if (CS%correction_intxpa_5pt) then
+            ! Use 5 point quadrature to calculate intypa
             T5(1) = T_t(I,j,1) ; T5(5) = T_t(i,j+1,1)
             S5(1) = S_t(I,j,1) ; S5(5) = S_t(i,j+1,1)
-            ! Pressure input to density EOS should be real pressure not rho_ref, I think
+            ! Pressure input to density EOS is the actual pressure not adjusted for rho_ref.
             p5(1) = pa(i,j,1) - (rho_ref*GV%g_Earth)*(e(i,j,1) - G%Z_ref)
             p5(5) = pa(i,j+1,1) - (rho_ref*GV%g_Earth)*(e(i,j,1) - G%Z_ref)
             do m=2,4
@@ -1058,6 +1063,62 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, p_atm
       inty_pa(i,J,K+1) = inty_pa(i,J,K) + inty_dpa(i,J,k)
     enddo ; enddo
   enddo
+
+  ! Having stored the pressure gradient info, we can work out where the first nonvanished layers is
+  ! reset intxpa there, then adjust intxpa above and below using the same increments between interfaces as above.
+  ! Note: This currently assumes pressure varies quadratically along the bottom of the topmost non-vanished,
+  ! non-mass-weighted layer.  Possibly 5 pt quadrature should be implemented as for the surface.
+  if (CS%reset_intxpa_integral) then
+    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      kloop: do k=1,nz-1
+        ! Check if both sides are nonvanished and mass-weighting is not activated in the subgrid interpolation.
+        if ((h(i,j,k)>CS%h_nonvanished) .and. (h(i+1,j,k)>CS%h_nonvanished)) then
+          if (.not. (max(0., e(i+1,j,K+1)-e(i,j,1), e(i,j,K+1)-e(i+1,j,1)) > 0.0)) then
+            ! Calculate pressure at the bottom of this cell (pa are known)
+            ! then we have a "good estimate" for intxpa (it might have quadratic pressure dependence if sloped)
+            ! now we recalculate intx_pa and PFu at each level working up and then down
+            call calculate_density(T_t(i,j,k+1), S_t(i,j,k+1), pa(i,j,K+1), rho_tl, &
+                                   tv%eqn_of_state, rho_ref=rho_ref)
+            call calculate_density(T_t(i+1,j,k+1), S_t(i+1,j,k+1), pa(i+1,j,K+1), rho_tr, &
+                                   tv%eqn_of_state, rho_ref=rho_ref)
+            inty_pa_cor(I,j) = C1_12 * (rho_tr-rho_tl)*GV%g_Earth * (e(i+1,j,K+1)-e(i,j,K+1))
+            intx_pa(i,j,K+1) = 0.5*(pa(i,j,K+1) + pa(i+1,j,K+1)) + inty_pa_cor(I,j)
+            do k2=1,k
+              intx_pa(I,j,K-K2+1) = intx_pa(I,j,(K-K2+2)) - intx_dpa(i,j,k-k2+1)
+            enddo
+            do k2=k+2,nz
+              intx_pa(I,j,K2) = intx_pa(I,j,K2-1) + intx_dpa(i,j,k2-1)
+            enddo
+            exit kloop
+        endif ; endif
+      enddo kloop
+    enddo ; enddo
+
+    do J=Jsq,Jeq+1 ; do i=is,ie+1
+      kloop2: do k=1,nz-1
+        ! Check if both sides are nonvanished and mass-weighting is not activated in the subgrid interpolation.
+        if ((h(i,j,k)>CS%h_nonvanished) .and. (h(i,j+1,k)>CS%h_nonvanished)) then
+          if (.not. (max(0., e(i,j+1,K+1)-e(i,j,1), e(i,j,K+1)-e(i,j+1,1)) > 0.0)) then
+            ! calculate pressure at the bottom of this cell (pa are known)
+            ! then we have a "good estimate" for intxpa (it might have quadratic pressure dependence if sloped)
+            ! now we recalculate intx_pa and PFu at each level working up and then down
+            call calculate_density(T_t(i,j,k+1), S_t(i,j,k+1), pa(i,j,K+1), rho_tl, &
+                                   tv%eqn_of_state, rho_ref=rho_ref)
+            call calculate_density(T_t(i,j+1,k+1), S_t(i,j+1,k+1), pa(i,j+1,K+1), rho_tr, &
+                                   tv%eqn_of_state, rho_ref=rho_ref)
+            inty_pa_cor(i,J) = C1_12 * (rho_tr-rho_tl) * GV%g_Earth * (e(i,j+1,K+1)-e(i,j,K+1))
+            inty_pa(i,J,K+1) = 0.5*(pa(i,j,K+1) + pa(i,j+1,K+1)) + inty_pa_cor(i,J)
+            do k2=1,k
+              inty_pa(i,J,K-K2+1) = inty_pa(i,J,(K-K2+2)) - inty_dpa(i,J,k-k2+1)
+            enddo
+            do k2=k+2,nz
+              inty_pa(i,J,K2) = inty_pa(i,J,K2-1) + inty_dpa(i,J,k2-1)
+            enddo
+            exit kloop2
+        endif ; endif
+      enddo kloop2
+    enddo ; enddo
+  endif ! intx_pa and inty_pa are now reset and should be correct
 
   ! Compute pressure gradient in x direction
   !$OMP parallel do default(shared)
@@ -1292,9 +1353,16 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, SAL_CSp,
   call get_param(param_file, mdl, "CORRECTION_INTXPA",CS%correction_intxpa, &
                  "If true, use a correction for surface pressure curvature in intx_pa.", &
                  default = .false.)
-  call get_param(param_file, mdl, "CORRECTION_INTXPA_5PT",CS%correction_intxpa_5pt, &
+  call get_param(param_file, mdl, "CORRECTION_INTXPA_5PT", CS%correction_intxpa_5pt, &
                  "If true, use 5point quadrature to calculate intxpa. This requires "//&
                  "CORRECTION_INTXPA = True.",default = .false.)
+  call get_param(param_file, mdl, "RESET_INTXPA_INTEGRAL", CS%reset_intxpa_integral, &
+                 "If true, reset INTXPA to match pressures at first nonvanished cell. "//&
+                 "Includes pressure correction. ", default = .false.)
+  call get_param(param_file, mdl, "RESET_INTXPA_H_NONVANISHED", CS%h_nonvanished, &
+                 "A minimal layer thickness that indicates that a layer is thick enough to usefully "//&
+                 "reestimate the pressure integral across the interface below.", &
+                 default=1.0e-6, units="m", scale=GV%m_to_H, do_not_log=.not.CS%reset_intxpa_integral)
   call get_param(param_file, mdl, "USE_INACCURATE_PGF_RHO_ANOM", CS%use_inaccurate_pgf_rho_anom, &
                  "If true, use a form of the PGF that uses the reference density "//&
                  "in an inaccurate way. This is not recommended.", default=.false.)

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -40,7 +40,7 @@ contains
 !! required for calculating the finite-volume form pressure accelerations in a
 !! Boussinesq model.
 subroutine int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, US, dpa, &
-                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp, Z_0p)
+                          intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, MassWghtInterp, Z_0p)
   type(hor_index_type), intent(in)  :: HI  !< Ocean horizontal index structures for the arrays
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [C ~> degC]
@@ -77,6 +77,8 @@ subroutine int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, US, dpa,
                                           !! layer divided by the y grid spacing [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(in)  :: bathyT !< The depth of the bathymetry [Z ~> m]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+              optional, intent(in)  :: SSH !< The sea surface height [Z ~> m]
   real,       optional, intent(in)  :: dz_neglect !< A minuscule thickness change [Z ~> m]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
                                            !! mass weighting to interpolate T/S in integrals
@@ -85,10 +87,10 @@ subroutine int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, US, dpa,
 
   if (EOS_quadrature(EOS)) then
     call int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, US, dpa, &
-                                    intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp, Z_0p=Z_0p)
+                                    intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, MassWghtInterp, Z_0p=Z_0p)
   else
     call analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, dpa, &
-                                 intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp, Z_0p=Z_0p)
+                                 intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, MassWghtInterp, Z_0p=Z_0p)
   endif
 
 end subroutine int_density_dz
@@ -97,7 +99,7 @@ end subroutine int_density_dz
 !> Calculates (by numerical quadrature) integrals of pressure anomalies across layers, which
 !! are required for calculating the finite-volume form pressure accelerations in a Boussinesq model.
 subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                      EOS, US, dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                      EOS, US, dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                       dz_neglect, MassWghtInterp, use_inaccurate_form, Z_0p)
   type(hor_index_type), intent(in)  :: HI  !< Horizontal index type for input variables.
   real, dimension(SZI_(HI),SZJ_(HI)), &
@@ -135,6 +137,8 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                           !! layer divided by the y grid spacing [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(in)  :: bathyT !< The depth of the bathymetry [Z ~> m]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+              optional, intent(in)  :: SSH !< The sea surface height [Z ~> m]
   real,       optional, intent(in)  :: dz_neglect !< A minuscule thickness change [Z ~> m]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
                                            !! mass weighting to interpolate T/S in integrals
@@ -169,7 +173,8 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real :: wtT_L, wtT_R ! The weights for tracers from the left and right columns [nondim]
   real :: intz(5)    ! The gravitational acceleration times the integrals of density
                      ! with height at the 5 sub-column locations [R L2 T-2 ~> Pa]
-  logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: do_massWeight ! Indicates whether to do mass weighting near bathymetry
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   logical :: use_rho_ref ! Pass rho_ref to the equation of state for more accurate calculation
                          ! of density anomalies.
   integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
@@ -198,13 +203,16 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     if (use_inaccurate_form) use_rho_ref = .not. use_inaccurate_form
   endif
 
-  do_massWeight = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  if (do_massWeight) then
-    if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-        "bathyT must be present if MassWghtInterp is present and true.")
-    if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-        "dz_neglect must be present if MassWghtInterp is present and true.")
+  do_massWeight = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+    if (do_massWeight .and. .not.present(bathyT)) call MOM_error(FATAL, &
+        "int_density_dz_generic: bathyT must be present if near-bottom mass weighting is in use.")
+    if (top_massWeight .and. .not.present(SSH)) call MOM_error(FATAL, &
+        "int_density_dz_generic: SSH must be present if near-surface mass weighting is in use.")
+    if ((do_massWeight .or. top_massWeight) .and. .not.present(dz_neglect)) call MOM_error(FATAL, &
+        "int_density_dz_generic: dz_neglect must be present if mass weighting is in use.")
   endif
 
   ! Set the loop ranges for equation of state calculations at various points.
@@ -248,6 +256,8 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
       hWght = 0.0
       if (do_massWeight) &
         hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
+      if (top_massWeight) &
+        hWght = max(hWght, z_b(i+1,j)-SSH(i,j), z_b(i,j)-SSH(i+1,j))
       if (hWght > 0.) then
         hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
         hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
@@ -314,6 +324,8 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
       hWght = 0.0
       if (do_massWeight) &
         hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
+      if (top_massWeight) &
+        hWght = max(hWght, z_b(i,j+1)-SSH(i,j), z_b(i,j)-SSH(i,j+1))
       if (hWght > 0.) then
         hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
         hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
@@ -470,8 +482,8 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   real :: dz(HI%iscB:HI%iecB+1)   ! Layer thicknesses at tracer points [Z ~> m]
   real :: dz_x(5,HI%iscB:HI%iecB) ! Layer thicknesses along an x-line of subgrid locations [Z ~> m]
   real :: dz_y(5,HI%isc:HI%iec)   ! Layer thicknesses along a y-line of subgrid locations [Z ~> m]
-  real :: massWeightToggle          ! A non-dimensional toggle factor (0 or 1) [nondim]
-  real :: TopWeightToggle           ! A non-dimensional toggle factor (0 or 1) [nondim]
+  real :: massWeightToggle          ! A non-dimensional toggle factor for near-bottom mass weighting (0 or 1) [nondim]
+  real :: TopWeightToggle           ! A non-dimensional toggle factor for near-surface mass weighting (0 or 1) [nondim]
   real :: Ttl, Tbl, Ttr, Tbr        ! Temperatures at the velocity cell corners [C ~> degC]
   real :: Stl, Sbl, Str, Sbr        ! Salinities at the velocity cell corners [S ~> ppt]
   real :: z0pres(HI%isd:HI%ied,HI%jsd:HI%jed) ! The height at which the pressure is zero [Z ~> m]
@@ -900,7 +912,8 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: dz ! Layer thicknesses at tracer points [Z ~> m]
   real :: dz_x(5,HI%iscB:HI%iecB) ! Layer thicknesses along an x-line of subgrid locations [Z ~> m]
   real :: dz_y(5,HI%isc:HI%iec)   ! Layer thicknesses along a y-line of subgrid locations [Z ~> m]
-  real :: massWeightToggle ! A non-dimensional toggle factor (0 or 1) [nondim]
+  real :: massWeightToggle        ! A non-dimensional toggle factor for near-bottom mass weighting (0 or 1) [nondim]
+  real :: TopWeightToggle         ! A non-dimensional toggle factor for near-surface mass weighting (0 or 1) [nondim]
   real :: Ttl, Tbl, Tml, Ttr, Tbr, Tmr ! Temperatures at the velocity cell corners [C ~> degC]
   real :: Stl, Sbl, Sml, Str, Sbr, Smr ! Salinities at the velocity cell corners [S ~> ppt]
   real :: s6 ! PPM curvature coefficient for S [S ~> ppt]
@@ -909,6 +922,7 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: S_top, S_mn, S_bot ! Left edge, cell mean and right edge values used in PPM reconstructions of S [S ~> ppt]
   real :: z0pres(HI%isd:HI%ied,HI%jsd:HI%jed) ! The height at which the pressure is zero [Z ~> m]
   real :: hWght  ! A topographically limited thickness weight [Z ~> m]
+  real :: hWghtTop ! A surface displacement limited thickness weight [Z ~> m]
   real :: hL, hR ! Thicknesses to the left and right [Z ~> m]
   real :: iDenom ! The denominator of the thickness weight expressions [Z-2 ~> m-2]
   integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
@@ -929,8 +943,11 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   else
     z0pres(:,:) = 0.0
   endif
-  massWeightToggle = 0.
-  if (present(MassWghtInterp)) then ; if (BTEST(MassWghtInterp, 0)) massWeightToggle = 1. ; endif
+  massWeightToggle = 0. ; TopWeightToggle = 0.
+  if (present(MassWghtInterp)) then
+    if (BTEST(MassWghtInterp, 0)) massWeightToggle = 1.
+    if (BTEST(MassWghtInterp, 1)) TopWeightToggle = 1.
+  endif
 
   ! In event PPM calculation is bypassed with use_PPM=False
   s6 = 0.
@@ -1017,6 +1034,9 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
       ! this distance by the layer thickness to replicate other models.
       hWght = massWeightToggle * &
               max(0., -bathyT(i,j)-e(i+1,j,K), -bathyT(i+1,j)-e(i,j,K))
+      hWghtTop = TopWeightToggle * &
+              max(0., e(i+1,j,K+1)-e(i,j,1), e(i,j,K+1)-e(i+1,j,1))
+      hWght = max(hWght, hWghtTop)
       if (hWght > 0.) then
         hL = (e(i,j,K) - e(i,j,K+1)) + dz_subroundoff
         hR = (e(i+1,j,K) - e(i+1,j,K+1)) + dz_subroundoff
@@ -1122,6 +1142,9 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
       ! this distance by the layer thickness to replicate other models.
       hWght = massWeightToggle * &
               max(0., -bathyT(i,j)-e(i,j+1,K), -bathyT(i,j+1)-e(i,j,K))
+      hWghtTop = TopWeightToggle * &
+              max(0., e(i,j+1,K+1)-e(i,j,1), e(i,j,K+1)-e(i,j+1,1))
+      hWght = max(hWght, hWghtTop)
       if (hWght > 0.) then
         hL = (e(i,j,K) - e(i,j,K+1)) + dz_subroundoff
         hR = (e(i,j+1,K) - e(i,j+1,K+1)) + dz_subroundoff
@@ -1223,7 +1246,7 @@ end subroutine int_density_dz_generic_ppm
 !! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
 subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, US, &
                                dza, intp_dza, intx_dza, inty_dza, halo_size, &
-                               bathyP, dP_tiny, MassWghtInterp)
+                               bathyP, P_surf, dP_tiny, MassWghtInterp)
   type(hor_index_type), intent(in)  :: HI  !< The horizontal index structure
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [C ~> degC]
@@ -1257,6 +1280,8 @@ subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, US, &
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(in)  :: bathyP  !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+              optional, intent(in)  :: P_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_tiny !< A minuscule pressure change with
                             !! the same units as p_t [R L2 T-2 ~> Pa]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
@@ -1265,11 +1290,11 @@ subroutine int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, US, &
   if (EOS_quadrature(EOS)) then
     call int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, &
                                      dza, intp_dza, intx_dza, inty_dza, halo_size, &
-                                     bathyP, dP_tiny, MassWghtInterp)
+                                     bathyP, P_surf, dP_tiny, MassWghtInterp)
   else
     call analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                                       dza, intp_dza, intx_dza, inty_dza, halo_size, &
-                                      bathyP, dP_tiny, MassWghtInterp)
+                                      bathyP, P_surf, dP_tiny, MassWghtInterp)
   endif
 
 end subroutine int_specific_vol_dp
@@ -1281,7 +1306,7 @@ end subroutine int_specific_vol_dp
 !! no free assumptions, apart from the use of Boole's rule quadrature to do the integrals.
 subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, dza, &
                                        intp_dza, intx_dza, inty_dza, halo_size, &
-                                       bathyP, dP_neglect, MassWghtInterp)
+                                       bathyP, P_surf, dP_neglect, MassWghtInterp)
   type(hor_index_type), intent(in)  :: HI !< A horizontal index type structure.
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: T  !< Potential temperature of the layer [C ~> degC]
@@ -1316,6 +1341,8 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
   real, dimension(SZI_(HI),SZJ_(HI)), &
               optional, intent(in)  :: bathyP !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+              optional, intent(in)  :: P_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A minuscule pressure change with
                                            !! the same units as p_t [R L2 T-2 ~> Pa]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
@@ -1352,6 +1379,7 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   real :: intp(5)    ! The integrals of specific volume with pressure at the
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
@@ -1365,14 +1393,17 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
   if (present(intx_dza)) then ; ish = MIN(Isq,ish) ; ieh = MAX(Ieq+1,ieh); endif
   if (present(inty_dza)) then ; jsh = MIN(Jsq,jsh) ; jeh = MAX(Jeq+1,jeh); endif
 
-  do_massWeight = .false. ; massWeight_bug = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
-  if (do_massWeight) then
-    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-        "bathyP must be present if MassWghtInterp is present and true.")
-    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-        "dP_neglect must be present if MassWghtInterp is present and true.")
+  do_massWeight = .false. ; massWeight_bug = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+    massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+    if (do_massWeight .and. .not.present(bathyP)) call MOM_error(FATAL, &
+        "int_spec_vol_dp_generic_pcm: bathyP must be present if near-bottom mass weighting is in use.")
+    if (top_massWeight .and. .not.present(P_surf)) call MOM_error(FATAL, &
+        "int_spec_vol_dp_generic_pcm: P_surf must be present if near-surface mass weighting is in use.")
+    if ((do_massWeight .or. top_massWeight) .and. .not.present(dP_neglect)) call MOM_error(FATAL, &
+        "int_spec_vol_dp_generic_pcm: dP_neglect must be present if mass weighting is in use.")
   endif
 
   ! Set the loop ranges for equation of state calculations at various points.
@@ -1417,6 +1448,8 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
       elseif (do_massWeight) then
         hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
       endif
+      if (top_massWeight) &
+        hWght = max(hWght, P_surf(i,j)-p_b(i+1,j), P_surf(i+1,j)-p_b(i,j))
       if (hWght > 0.) then
         hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
         hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -1475,6 +1508,8 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
       elseif (do_massWeight) then
         hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
       endif
+      if (top_massWeight) &
+        hWght = max(hWght, P_surf(i,j)-p_b(i,j+1), P_surf(i,j+1)-p_b(i,j))
       if (hWght > 0.) then
         hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
         hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
@@ -1530,7 +1565,7 @@ end subroutine int_spec_vol_dp_generic_pcm
 !! no free assumptions, apart from the use of Boole's rule quadrature to do the integrals.
 subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, &
                              dP_neglect, bathyP, HI, EOS, US, dza, &
-                             intp_dza, intx_dza, inty_dza, MassWghtInterp)
+                             intp_dza, intx_dza, inty_dza, P_surf, MassWghtInterp)
   type(hor_index_type), intent(in)  :: HI !< A horizontal index type structure.
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: T_t  !< Potential temperature at the top of the layer [C ~> degC]
@@ -1570,6 +1605,8 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
               optional, intent(inout) :: inty_dza  !< The integral in y of the difference between
                             !! the geopotential anomaly at the top and bottom of the layer divided
                             !! by the y grid spacing [L2 T-2 ~> m2 s-2]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+              optional, intent(in)  :: P_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
                             !! mass weighting to interpolate T/S in integrals
 
@@ -1608,6 +1645,7 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
   integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
@@ -1616,9 +1654,14 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
 
-  do_massWeight = .false. ; massWeight_bug = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+  do_massWeight = .false. ; massWeight_bug = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+    massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+    if (top_massWeight .and. .not.present(P_surf)) call MOM_error(FATAL, &
+        "int_spec_vol_dp_generic_plm: P_surf must be present if near-surface mass weighting is in use.")
+  endif
 
   do n = 1, 5 ! Note that these are reversed from int_density_dz.
     wt_t(n) = 0.25 * real(n-1)
@@ -1666,6 +1709,8 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
       elseif (do_massWeight) then
         hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
       endif
+      if (top_massWeight) &
+        hWght = max(hWght, P_surf(i,j)-p_b(i+1,j), P_surf(i+1,j)-p_b(i,j))
       if (hWght > 0.) then
         hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
         hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -1730,6 +1775,8 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
       elseif (do_massWeight) then
         hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
       endif
+      if (top_massWeight) &
+        hWght = max(hWght, P_surf(i,j)-p_b(i,j+1), P_surf(i,j+1)-p_b(i,j))
       if (hWght > 0.) then
         hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
         hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
@@ -1787,71 +1834,87 @@ end subroutine int_spec_vol_dp_generic_plm
 
 
 !> Diagnose the fractional mass weighting in a layer that might be used with a Boussinesq calculation.
-subroutine diagnose_mass_weight_Z(z_t, z_b, dz_neglect, bathyT, HI, MassWt_u, MassWt_v)
+subroutine diagnose_mass_weight_Z(z_t, z_b, bathyT, SSH, dz_neglect, MassWghtInterp, HI, &
+                                  MassWt_u, MassWt_v)
   type(hor_index_type), intent(in)  :: HI !< A horizontal index type structure.
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: z_t !< Height at the top of the layer in depth units [Z ~> m]
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: z_b !< Height at the bottom of the layer [Z ~> m]
-  real,                 intent(in)  :: dz_neglect !< A minuscule thickness change [Z ~> m]
-
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: bathyT !< The depth of the bathymetry [Z ~> m]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+                        intent(in)  :: SSH !< The sea surface height [Z ~> m]
+  real,                 intent(in)  :: dz_neglect !< A minuscule thickness change [Z ~> m]
+  integer,              intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                           !! mass weighting to interpolate T/S in integrals
   real, dimension(SZIB_(HI),SZJ_(HI)), &
-              optional, intent(inout) :: MassWt_u  !< The fractional mass weighting at u-points [nondim]
+                        intent(inout) :: MassWt_u  !< The fractional mass weighting at u-points [nondim]
   real, dimension(SZI_(HI),SZJB_(HI)), &
-              optional, intent(inout) :: MassWt_v  !< The fractional mass weighting at v-points [nondim]
+                        intent(inout) :: MassWt_v  !< The fractional mass weighting at v-points [nondim]
 
   ! Local variables
   real :: hWght      ! A pressure-thickness below topography [Z ~> m]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [Z ~> m]
   real :: iDenom     ! The inverse of the denominator in the weights [Z-2 ~> m-2]
+  logical :: do_massWeight  ! Indicates whether to do mass weighting near bathymetry
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   integer :: Isq, Ieq, Jsq, Jeq, i, j
 
   Isq = HI%IscB ; Ieq = HI%IecB
   Jsq = HI%JscB ; Jeq = HI%JecB
 
-  if (present(MassWt_u)) then
-    do j=HI%jsc,HI%jec ; do I=Isq,Ieq
-      ! hWght is the distance measure by which the cell is violation of
-      ! hydrostatic consistency. For large hWght we bias the interpolation
-      ! of T,S along the top and bottom integrals, like thickness weighting.
-      hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
-      if (hWght > 0.) then
-        hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
-        hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
-        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-        MassWt_u(I,j) = (hWght*hR + hWght*hL) * iDenom
-      else
-        MassWt_u(I,j) = 0.0
-      endif
-    enddo ; enddo
-  endif
+  do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
 
-  if (present(MassWt_v)) then
-    do J=Jsq,Jeq ; do i=HI%isc,HI%iec
-      ! hWght is the distance measure by which the cell is violation of
-      ! hydrostatic consistency. For large hWght we bias the interpolation
-      ! of T,S along the top and bottom integrals, like thickness weighting.
+  ! Calculate MassWt_u
+  do j=HI%jsc,HI%jec ; do I=Isq,Ieq
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation
+    ! of T,S along the top and bottom integrals, like thickness weighting.
+    hWght = 0.0
+    if (do_massWeight) &
+      hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
+    if (top_massWeight) &
+      hWght = max(hWght, z_b(i+1,j)-SSH(i,j), z_b(i,j)-SSH(i+1,j))
+    if (hWght > 0.) then
+      hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
+      hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      MassWt_u(I,j) = (hWght*hR + hWght*hL) * iDenom
+    else
+      MassWt_u(I,j) = 0.0
+    endif
+  enddo ; enddo
+
+  ! Calculate MassWt_v
+  do J=Jsq,Jeq ; do i=HI%isc,HI%iec
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation
+    ! of T,S along the top and bottom integrals, like thickness weighting.
+    hWght = 0.0
+    if (do_massWeight) &
       hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
-      if (hWght > 0.) then
-        hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
-        hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
-        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-        MassWt_v(i,J) = (hWght*hR + hWght*hL) * iDenom
-      else
-        MassWt_v(i,J) = 0.0
-      endif
-    enddo ; enddo
-  endif
+    if (top_massWeight) &
+      hWght = max(hWght, z_b(i,j+1)-SSH(i,j), z_b(i,j)-SSH(i,j+1))
+    if (hWght > 0.) then
+      hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
+      hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      MassWt_v(i,J) = (hWght*hR + hWght*hL) * iDenom
+    else
+      MassWt_v(i,J) = 0.0
+    endif
+  enddo ; enddo
 
 end subroutine diagnose_mass_weight_Z
 
 
 !> Diagnose the fractional mass weighting in a layer that might be used with a non-Boussinesq calculation.
-subroutine diagnose_mass_weight_p(p_t, p_b, dP_neglect, bathyP, HI, MassWt_u, MassWt_v)
+subroutine diagnose_mass_weight_p(p_t, p_b, bathyP, P_surf, dP_neglect, MassWghtInterp, HI, &
+                                  MassWt_u, MassWt_v)
   type(hor_index_type), intent(in)  :: HI !< A horizontal index type structure.
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: p_t !< Pressure atop the layer [R L2 T-2 ~> Pa]
@@ -1861,55 +1924,78 @@ subroutine diagnose_mass_weight_p(p_t, p_b, dP_neglect, bathyP, HI, MassWt_u, Ma
                                            !! the same units as p_t [R L2 T-2 ~> Pa]
   real, dimension(SZI_(HI),SZJ_(HI)), &
                         intent(in)  :: bathyP !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real, dimension(SZI_(HI),SZJ_(HI)), &
+                        intent(in)  :: P_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
+  integer,              intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
+                                           !! mass weighting to interpolate T/S in integrals
   real, dimension(SZIB_(HI),SZJ_(HI)), &
-              optional, intent(inout) :: MassWt_u  !< The fractional mass weighting at u-points [nondim]
+                        intent(inout) :: MassWt_u  !< The fractional mass weighting at u-points [nondim]
   real, dimension(SZI_(HI),SZJB_(HI)), &
-              optional, intent(inout) :: MassWt_v  !< The fractional mass weighting at v-points [nondim]
+                        intent(inout) :: MassWt_v  !< The fractional mass weighting at v-points [nondim]
 
   ! Local variables
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa]
   real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2]
+  logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
+  logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   integer :: Isq, Ieq, Jsq, Jeq, i, j
 
   Isq = HI%IscB ; Ieq = HI%IecB
   Jsq = HI%JscB ; Jeq = HI%JecB
 
-  if (present(MassWt_u)) then
-    do j=HI%jsc,HI%jec ; do I=Isq,Ieq
-      ! hWght is the distance measure by which the cell is violation of
-      ! hydrostatic consistency. For large hWght we bias the interpolation
-      ! of T,S along the top and bottom integrals, like thickness weighting.
-      hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
-      if (hWght > 0.) then
-        hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
-        hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
-        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-        MassWt_u(I,j) = (hWght*hR + hWght*hL) * iDenom
-      else
-        MassWt_u(I,j) = 0.0
-      endif
-    enddo ; enddo
-  endif
+  do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+  top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+  massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
 
-  if (present(MassWt_v)) then
-    do J=Jsq,Jeq ; do i=HI%isc,HI%iec
-      ! hWght is the distance measure by which the cell is violation of
-      ! hydrostatic consistency. For large hWght we bias the interpolation
-      ! of T,S along the top and bottom integrals, like thickness weighting.
+  ! Calculate MassWt_u
+  do j=HI%jsc,HI%jec ; do I=Isq,Ieq
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation
+    ! of T,S along the top and bottom integrals, like thickness weighting.
+    hWght = 0.0
+    if (do_massWeight .and. massWeight_bug) then
+      hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+    elseif (do_massWeight) then
+      hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
+    endif
+    if (top_massWeight) &
+      hWght = max(hWght, P_surf(i,j)-p_b(i+1,j), P_surf(i+1,j)-p_b(i,j))
+    if (hWght > 0.) then
+      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+      hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      MassWt_u(I,j) = (hWght*hR + hWght*hL) * iDenom
+    else
+      MassWt_u(I,j) = 0.0
+    endif
+  enddo ; enddo
+
+  ! Calculate MassWt_v
+  do J=Jsq,Jeq ; do i=HI%isc,HI%iec
+    ! hWght is the distance measure by which the cell is violation of
+    ! hydrostatic consistency. For large hWght we bias the interpolation
+    ! of T,S along the top and bottom integrals, like thickness weighting.
+    hWght = 0.0
+    if (do_massWeight .and. massWeight_bug) then
+      hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+    elseif (do_massWeight) then
       hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
-      if (hWght > 0.) then
-        hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
-        hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
-        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-        MassWt_v(i,J) = (hWght*hR + hWght*hL) * iDenom
-      else
-        MassWt_v(i,J) = 0.0
-      endif
-    enddo ; enddo
-  endif
+    endif
+    if (top_massWeight) &
+      hWght = max(hWght, P_surf(i,j)-p_b(i,j+1), P_surf(i,j+1)-p_b(i,j))
+    if (hWght > 0.) then
+      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+      hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
+      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+      MassWt_v(i,J) = (hWght*hR + hWght*hL) * iDenom
+    else
+      MassWt_v(i,J) = 0.0
+    endif
+  enddo ; enddo
 
 end subroutine diagnose_mass_weight_p
 

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1226,7 +1226,7 @@ end function EOS_domain
 !! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
 subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
                                dza, intp_dza, intx_dza, inty_dza, halo_size, &
-                               bathyP, dP_tiny, MassWghtInterp)
+                               bathyP, P_surf, dP_tiny, MassWghtInterp)
   type(hor_index_type), intent(in)  :: HI  !< The horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [C ~> degC]
@@ -1259,6 +1259,8 @@ subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
   integer,    optional, intent(in)  :: halo_size !< The width of halo points on which to calculate dza.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyP  !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: P_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_tiny !< A miniscule pressure change with
                             !! the same units as p_t [R L2 T-2 ~> Pa]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
@@ -1280,20 +1282,20 @@ subroutine analytic_int_specific_vol_dp(T, S, p_t, p_b, alpha_ref, HI, EOS, &
       call int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, EOS%kg_m3_to_R*EOS%Rho_T0_S0, &
                                 dRdT_scale*EOS%dRho_dT, dRdS_scale*EOS%dRho_dS, dza, &
                                 intp_dza, intx_dza, inty_dza, halo_size, &
-                                bathyP, dP_tiny, MassWghtInterp)
+                                bathyP, P_surf, dP_tiny, MassWghtInterp)
     case (EOS_WRIGHT)
       call int_spec_vol_dp_wright(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
-                                  inty_dza, halo_size, bathyP, dP_tiny, MassWghtInterp, &
+                                  inty_dza, halo_size, bathyP, P_surf, dP_tiny, MassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
     case (EOS_WRIGHT_FULL)
       call int_spec_vol_dp_wright_full(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
-                                  inty_dza, halo_size, bathyP, dP_tiny, MassWghtInterp, &
+                                  inty_dza, halo_size, bathyP, P_surf, dP_tiny, MassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
     case (EOS_WRIGHT_REDUCED)
       call int_spec_vol_dp_wright_red(T, S, p_t, p_b, alpha_ref, HI, dza, intp_dza, intx_dza, &
-                                  inty_dza, halo_size, bathyP, dP_tiny, MassWghtInterp, &
+                                  inty_dza, halo_size, bathyP, P_surf, dP_tiny, MassWghtInterp, &
                                   SV_scale=EOS%R_to_kg_m3, pres_scale=EOS%RL2_T2_to_Pa, &
                                   temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt)
     case default
@@ -1306,7 +1308,7 @@ end subroutine analytic_int_specific_vol_dp
 !! pressure anomalies across layers, which are required for calculating the
 !! finite-volume form pressure accelerations in a Boussinesq model.
 subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS, dpa, &
-                          intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp, Z_0p)
+                          intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, MassWghtInterp, Z_0p)
   type(hor_index_type), intent(in)  :: HI !< Ocean horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: T   !< Potential temperature referenced to the surface [C ~> degC]
@@ -1342,6 +1344,8 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
                                           !! layer divided by the y grid spacing [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT !< The depth of the bathymetry [Z ~> m]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: SSH !< The sea surface height [Z ~> m]
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
                                           !! mass weighting to interpolate T/S in integrals
@@ -1367,23 +1371,23 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       if ((rho_scale /= 1.0) .or. (dRdT_scale /= 1.0) .or. (dRdS_scale /= 1.0)) then
         call int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                          rho_scale*EOS%Rho_T0_S0, dRdT_scale*EOS%dRho_dT, dRdS_scale*EOS%dRho_dS, &
-                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp)
+                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, MassWghtInterp)
       else
         call int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                          EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, &
-                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, MassWghtInterp)
+                         dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, MassWghtInterp)
       endif
     case (EOS_WRIGHT)
       rho_scale = EOS%kg_m3_to_R
       pres_scale = EOS%RL2_T2_to_Pa
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                    dz_neglect, MassWghtInterp, rho_scale, pres_scale, &
                                    temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt, Z_0p=Z_0p)
       else
         call int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                    dz_neglect, MassWghtInterp, Z_0p=Z_0p)
       endif
     case (EOS_WRIGHT_FULL)
@@ -1391,12 +1395,12 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       pres_scale = EOS%RL2_T2_to_Pa
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
         call int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                    dz_neglect, MassWghtInterp, rho_scale, pres_scale, &
                                    temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt, Z_0p=Z_0p)
       else
         call int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                    dz_neglect, MassWghtInterp, Z_0p=Z_0p)
       endif
     case (EOS_WRIGHT_REDUCED)
@@ -1404,12 +1408,12 @@ subroutine analytic_int_density_dz(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, EOS,
       pres_scale = EOS%RL2_T2_to_Pa
       if ((rho_scale /= 1.0) .or. (pres_scale /= 1.0) .or. (EOS%C_to_degC /= 1.0) .or. (EOS%S_to_ppt /= 1.0)) then
         call int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                    dz_neglect, MassWghtInterp, rho_scale, pres_scale, &
                                    temp_scale=EOS%C_to_degC, saln_scale=EOS%S_to_ppt, Z_0p=Z_0p)
       else
         call int_density_dz_wright_red(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, &
+                                   dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, &
                                    dz_neglect, MassWghtInterp, Z_0p=Z_0p)
       endif
     case default

--- a/src/equation_of_state/MOM_EOS_Wright.F90
+++ b/src/equation_of_state/MOM_EOS_Wright.F90
@@ -387,7 +387,7 @@ end subroutine EoS_fit_range_buggy_Wright
 !! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
 !! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                 dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
+                                 dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, &
                                  MassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
   type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
@@ -424,6 +424,8 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                                 !! layer divided by the y grid spacing [R L2 T-2 ~> Pa].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT   !< The depth of the bathymetry [Z ~> m].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: SSH       !< The sea surface height [Z ~> m]
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
                                                  !! mass weighting to interpolate T/S in integrals
@@ -481,6 +483,7 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m
@@ -531,14 +534,11 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  ! if (do_massWeight) then
-  !   if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !       "bathyT must be present if MassWghtInterp is present and true.")
-  !   if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !      "dz_neglect must be present if MassWghtInterp is present and true.")
-  ! endif
+  do_massWeight = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+  endif
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     al0_2d(i,j) = (a0 + a1s*T(i,j)) + a2s*S(i,j)
@@ -571,6 +571,8 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     hWght = 0.0
     if (do_massWeight) &
       hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
+    if (top_massWeight) &
+      hWght = max(hWght, z_b(i+1,j)-SSH(i,j), z_b(i,j)-SSH(i+1,j))
     if (hWght > 0.) then
       hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
       hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
@@ -613,6 +615,8 @@ subroutine int_density_dz_wright(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     hWght = 0.0
     if (do_massWeight) &
       hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
+    if (top_massWeight) &
+      hWght = max(hWght, z_b(i,j+1)-SSH(i,j), z_b(i,j)-SSH(i,j+1))
     if (hWght > 0.) then
       hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
       hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
@@ -656,7 +660,7 @@ end subroutine int_density_dz_wright
 !! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
 !! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
-                                  intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
+                                  intp_dza, intx_dza, inty_dza, halo_size, bathyP, P_surf, dP_neglect, &
                                   MassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
   type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
@@ -693,6 +697,8 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
                                                  !! dza.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: P_surf    !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
                                                  !! the same units as p_t [R L2 T-2 ~> Pa]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
@@ -743,6 +749,7 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
@@ -780,15 +787,12 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false. ; massWeight_bug = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
-!  if (do_massWeight) then
-!    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "bathyP must be present if MassWghtInterp is present and true.")
-!    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "dP_neglect must be present if MassWghtInterp is present and true.")
-!  endif
+  do_massWeight = .false. ; massWeight_bug = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+    massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+  endif
 
   !  alpha(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
   do j=jsh,jeh ; do i=ish,ieh
@@ -818,6 +822,8 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     elseif (do_massWeight) then
       hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
     endif
+    if (top_massWeight) &
+      hWght = max(hWght, P_surf(i,j)-p_b(i+1,j), P_surf(i+1,j)-p_b(i,j))
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -862,6 +868,8 @@ subroutine int_spec_vol_dp_wright(T, S, p_t, p_b, spv_ref, HI, dza, &
     elseif (do_massWeight) then
       hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
     endif
+    if (top_massWeight) &
+      hWght = max(hWght, P_surf(i,j)-p_b(i,j+1), P_surf(i,j+1)-p_b(i,j))
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -393,7 +393,7 @@ end subroutine EoS_fit_range_Wright_full
 !! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
 !! that assumes that |eps| < 0.34.
 subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
-                                 dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, dz_neglect, &
+                                 dpa, intz_dpa, intx_dpa, inty_dpa, bathyT, SSH, dz_neglect, &
                                  MassWghtInterp, rho_scale, pres_scale, temp_scale, saln_scale, Z_0p)
   type(hor_index_type), intent(in)  :: HI       !< The horizontal index type for the arrays.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
@@ -430,6 +430,8 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
                                                 !! layer divided by the y grid spacing [R L2 T-2 ~> Pa].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyT   !< The depth of the bathymetry [Z ~> m].
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: SSH       !< The sea surface height [Z ~> m]
   real,       optional, intent(in)  :: dz_neglect !< A miniscule thickness change [Z ~> m].
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
                                                  !! mass weighting to interpolate T/S in integrals
@@ -487,6 +489,7 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m
@@ -537,14 +540,11 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  ! if (do_massWeight) then
-  !   if (.not.present(bathyT)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !       "bathyT must be present if MassWghtInterp is present and true.")
-  !   if (.not.present(dz_neglect)) call MOM_error(FATAL, "int_density_dz_generic: "//&
-  !       "dz_neglect must be present if MassWghtInterp is present and true.")
-  ! endif
+  do_massWeight = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+  endif
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     al0_2d(i,j) = a0 + (a1s*T(i,j) + a2s*S(i,j))
@@ -576,6 +576,8 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     hWght = 0.0
     if (do_massWeight) &
       hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
+    if (top_massWeight) &
+      hWght = max(hWght, z_b(i+1,j)-SSH(i,j), z_b(i,j)-SSH(i+1,j))
     if (hWght > 0.) then
       hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
       hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
@@ -618,6 +620,8 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     hWght = 0.0
     if (do_massWeight) &
       hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
+    if (top_massWeight) &
+      hWght = max(hWght, z_b(i,j+1)-SSH(i,j), z_b(i,j)-SSH(i,j+1))
     if (hWght > 0.) then
       hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
       hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
@@ -661,7 +665,7 @@ end subroutine int_density_dz_wright_full
 !! rule to do the horizontal integrals, and from a truncation in the series for log(1-eps/1+eps)
 !! that assumes that |eps| < 0.34.
 subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
-                                  intp_dza, intx_dza, inty_dza, halo_size, bathyP, dP_neglect, &
+                                  intp_dza, intx_dza, inty_dza, halo_size, bathyP, P_surf, dP_neglect, &
                                   MassWghtInterp, SV_scale, pres_scale, temp_scale, saln_scale)
   type(hor_index_type), intent(in)  :: HI        !< The ocean's horizontal index type.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
@@ -698,6 +702,8 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                                                  !! dza.
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
               optional, intent(in)  :: bathyP    !< The pressure at the bathymetry [R L2 T-2 ~> Pa]
+  real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
+              optional, intent(in)  :: P_surf    !< The pressure at the ocean surface [R L2 T-2 ~> Pa]
   real,       optional, intent(in)  :: dP_neglect !< A miniscule pressure change with
                                                  !! the same units as p_t [R L2 T-2 ~> Pa]
   integer,    optional, intent(in)  :: MassWghtInterp !< A flag indicating whether and how to use
@@ -749,6 +755,7 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
   real :: c4s        ! Partly rescaled version of c4 [m2 s-2 S-1 ~> m2 s-2 PSU-1]
   real :: c5s        ! Partly rescaled version of c5 [m2 s-2 C-1 S-1 ~> m2 s-2 degC-1 PSU-1]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  logical :: top_massWeight ! Indicates whether to do mass weighting the sea surface
   logical :: massWeight_bug ! If true, use an incorrect expression to determine where to apply mass weighting
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0    ! Rational constants [nondim]
   real, parameter :: C1_9 = 1.0/9.0, C1_90 = 1.0/90.0  ! Rational constants [nondim]
@@ -786,15 +793,12 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
     c4s = c4s * saln_scale ; c5s = c5s * saln_scale
   endif ; endif
 
-  do_massWeight = .false. ; massWeight_bug = .false.
-  if (present(MassWghtInterp)) do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
-  if (present(MassWghtInterp)) massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
-!  if (do_massWeight) then
-!    if (.not.present(bathyP)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "bathyP must be present if MassWghtInterp is present and true.")
-!    if (.not.present(dP_neglect)) call MOM_error(FATAL, "int_spec_vol_dp_generic: "//&
-!        "dP_neglect must be present if MassWghtInterp is present and true.")
-!  endif
+  do_massWeight = .false. ; massWeight_bug = .false. ; top_massWeight = .false.
+  if (present(MassWghtInterp)) then
+    do_massWeight = BTEST(MassWghtInterp, 0) ! True for odd values
+    top_massWeight = BTEST(MassWghtInterp, 1) ! True if the 2 bit is set
+    massWeight_bug = BTEST(MassWghtInterp, 3) ! True if the 8 bit is set
+  endif
 
   !  alpha = (lambda + al0*(pressure + p0)) / (pressure + p0)
   do j=jsh,jeh ; do i=ish,ieh
@@ -825,6 +829,8 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
     elseif (do_massWeight) then
       hWght = max(0., p_t(i+1,j)-bathyP(i,j), p_t(i,j)-bathyP(i+1,j))
     endif
+    if (top_massWeight) &
+      hWght = max(hWght, P_surf(i,j)-p_b(i+1,j), P_surf(i+1,j)-p_b(i,j))
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
@@ -870,6 +876,8 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
     elseif (do_massWeight) then
       hWght = max(0., p_t(i,j+1)-bathyP(i,j), p_t(i,j)-bathyP(i,j+1))
     endif
+    if (top_massWeight) &
+      hWght = max(hWght, P_surf(i,j)-p_b(i,j+1), P_surf(i,j+1)-p_b(i,j))
     if (hWght > 0.) then
       hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
       hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect


### PR DESCRIPTION
  This series of 10 commits adds options for correcting the pressure gradient forces in ice-shelf cavities or massive sea-ice or icebergs.  These changes include adding the option of using mass-weighting when interpolating the sub-gridscale distributions of temperature and salinity under ice, analogously to what is done near the topography, along with several different options for changing which interface has an distribution of pressure as a function of depth (or vice-versa in non-Boussinesq mode) that can be determined from a combination of hydrostatic changes and a linear large-scale gradient.  The new runtime parameters that impact this behavior include `CORRECTION_INTX_PA`, `RESET_INTXPA_INTEGRAL`, `RESET_INTXPA_H_NONVANISHED` and `MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP`.  There are both Boussinesq and non-Boussinesq versions of all these added capabilities, and all the new options have been tested to confirm that they satisfy rotational symmetry and dimensional consistency.  By default, these new options are not used and all answers are bitwise identical, but there are new runtime parameters in multiple MOM_parameter_doc files.

  The commits in this PR include:

- NOAA-GFDL/MOM6@64628f710 +(*)Eliminate CORRECTION_INTXPA_5PT
- NOAA-GFDL/MOM6@3a7e4a177 +(*)Add 5-point quadrature in RESET_INTXPA_INTEGRAL
- NOAA-GFDL/MOM6@c6ec94874 *Non-Boussinesq code for RESET_INTXPA_INTEGRAL
- NOAA-GFDL/MOM6@65d998879 *Refactor CORRECTION_INTX_PA
- NOAA-GFDL/MOM6@3c9bdfe44 Revisions of sub-ice pressure gradient fixes
- NOAA-GFDL/MOM6@37418fc70 +Add RESET_INTXPA_INTEGRAL
- NOAA-GFDL/MOM6@e0870a826 +Add CORRECTION_INTXPA_5PT
- NOAA-GFDL/MOM6@94e4db0a9 +Add CORRECTION_INTXPA
- NOAA-GFDL/MOM6@4b9a8c00b +Add top mass_weight_in_PGF option to 13 integrals
- NOAA-GFDL/MOM6@ecb365e33 +Add MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP
