### PR TITLE
*+Add ePBL bottom boundary layer mixing option

### DIFF
--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -858,7 +858,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
     endif
 
     call find_uv_at_h(u, v, h, u_h, v_h, G, GV, US)
-    call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, GV, US, &
+    call energetic_PBL(h, u_h, v_h, tv, fluxes, visc, dt, Kd_ePBL, G, GV, US, &
                        CS%ePBL, stoch_CS, dSV_dT, dSV_dS, cTKE, SkinBuoyFlux, waves=waves)
 
     call energetic_PBL_get_MLD(CS%ePBL, BLD(:,:), G, US)
@@ -1410,7 +1410,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
     endif
 
     call find_uv_at_h(u, v, h, u_h, v_h, G, GV, US)
-    call energetic_PBL(h, u_h, v_h, tv, fluxes, dt, Kd_ePBL, G, GV, US, &
+    call energetic_PBL(h, u_h, v_h, tv, fluxes, visc, dt, Kd_ePBL, G, GV, US, &
                        CS%ePBL, stoch_CS, dSV_dT, dSV_dS, cTKE, SkinBuoyFlux, waves=waves)
 
     call energetic_PBL_get_MLD(CS%ePBL, BLD(:,:), G, US)

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -1378,7 +1378,7 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
                          dT_to_dPE_a(k-1), dS_to_dPE_a(k-1), dT_to_dPE(k), dS_to_dPE(k), &
                          pres_Z(K), dT_to_dColHt_a(k-1), dS_to_dColHt_a(k-1), &
                          dT_to_dColHt(k), dS_to_dColHt(k), &
-                         PE_chg=dPE_conv, dPEc_dKd=dPEc_dKd)
+                         PE_chg=PE_chg, dPEc_dKd=dPEc_dKd)
               endif
               MKE_src = dMKE_max * (1.0 - exp(-MKE2_Hharm * Kddt_h_guess))
               dMKE_src_dK = dMKE_max * MKE2_Hharm * exp(-MKE2_Hharm * Kddt_h_guess)


### PR DESCRIPTION
  This series of six commits adds the option to do energetically consistent bottom boundary layer mixing with the new routine `ePBL_BBL_column()`. `ePBL_BBL_column()` is closely based on the surface-focused ePBL mixing in `ePBL_column()`, but without adding convective instability driven mixing or mean-TKE driven mixing to avoid possible double-counting.  This new option is enabled by setting the new runtime parameter `EPBL_BBL_EFFIC` to be positive.  The changes include the addition of a new mandatory `vertvisc_type` argument to the publicly visible routine `energetic_PBL()`.  If both EPBL_BBL_EFFIC and BBL_EFFIC are set to positive values, there is a risk of double-counting, but this case is not being trapped for now.  The changes that actually adds `ePBL_BBL_column()` is in the fifth of the commits in this PR.

  The first commit in this series corrects a bug that causes ePBL column to set the wrong variable and then use an uninitialized variable when `EPBL_ORIGINAL_PE_CALC` is set to false.  This bug was present when the `EPBL_ORIGINAL_PE_CALC` was first added on Sept. 30, 2016, but it was not detected because only the default case with `EPBL_ORIGINAL_PE_CALC = True` appears to being used or tested.  Any runs that used this code with debugging compile options would have trapped it immediately.  This will change answers when `EPBL_ORIGINAL_PE_CALC is false`.

  The second commit corrects an unlikely bug when iterating to determine the mixed layer depth, that arises when the change between iterations exactly matches the tolerance.  This bug is fixed by setting the new runtime parameter `EPBL_MLD_ITER_BUG = False`.

  The third commit adds the ability to passively run `ePBL_column()` twice in a diagnostic mode and then provide diagnostics of the differences in the diffusivities and boundary layer depths that are generated with the two options.  This is controlled by the new runtime parameter `EPBL_OPTIONS_DIFF`, which is an integer that specifies which options to change or 0 (the default) to
disable this capability.   Associated with this are the new diagnostics `ePBL_opt_diff_Kd_ePBL`, `ePBL_opt_maxdiff_Kd_ePBL` and `ePBL_opt_diff_h_ML`, which only are registered when the differencing is enabled.

  There was also some refactoring for code clarity and clean-up of some typos as a part of this third commit.  Within `ePBL_column()`, the `hp_a` variable was converted from a scalar into a 1-d array to emphasize where these variables are
located and to bring `ePBL_column()` closer to what would be required if the new diffusivities were being applied on top of diffusivities from other processes, as is the case in `ePBL_BBL_column()`.   As a part of these changes, there were some other reforms to the way that `MOM_energetic_PBL()` handles diagnostics, with the 2-d and 3-d arrays changed from allocatable arrays with enduring memory commitments in the `energetic_PBL_CS` type into simple arrays in `energetic_PBL()`,
relying on the fact that compilers will be smart enough to avoid actually allocating this memory when it is unused to avoid expanding the overall memory requirements of MOM6.  A number of allocate and deallocate calls were eliminated
by these changes.  In addition, explicit 'units=' descriptors were added to numerous `register_diag_field()` calls to help identify inconsistent conversion factors. Also, the diagnostic of the number of boundary layer depth iterations
was added to the `ePBL_column_diags`, which enabled the intent of the `CS` and `G` arguments to `ePBL_column()` to be changed to `intent(in)`.  The unnecessary extra logic associated with the use of the `OBL_converged` variable in `ePBL_column()` was eliminated, but the results are unaltered.  Because the MOM_parameter_doc files were changing anyway, and because this commit is only a diagnostic change, about 6 spelling errors were corrected in ePBL parameter descriptions as a part of
this commit.

  The fourth commit adds the new internal subroutine `find_Kd_from_PE_chg()` inside of the `MOM_energetic_PBL` module to directly calculate an increment in the diapycnal diffusivity from an energy input.  This can be used when ePBL does not convert
released mean kinetic energy into turbulent kinetic energy (i.e., if `MKE_TO_TKE_EFFIC = 0`.) and is more efficient than the more general iterative approach.  To preserve old answers, this new option is only enabled for the surface boundary layer when the new runtime parameter `DIRECT_EPBL_MIXING_CALC` is set to true.  This new option can be tested passively by setting
`EPBL_OPTIONS_DIFF = 3` in a run that uses ePBL.  `ePBL_BBL_column()` also has the option to use `find_Kd_from_PE_chg()`, and to verify its correctness for the bottom boundary layer by setting `EPBL_OPTIONS_DIFF = 4`.

  The sixth and final commit adds the ability to modify the bottom boundary layer TKE budget to account for an exponential decay of TKE away from the boundary and the fact that when the diffusivity is increased at an interface, it causes an increased buoyancy flux that varies linearly throughout a well mixed bottom boundary layer and through the layer above.  This new capability is enabled by the new runtime parameter DECAY_ADJUSTED_BBL_TKE and is implemented via the new internal function exp_decay_TKE_adjust.  It also adds 9 bottom-boundary layer specific run-time parameters that are analogous to parameters that set the properties of the surface-driven mixing, and take their defaults from them, but can now be set independently for the bottom boundary layer.

  This PR makes several new diagnostics available that are related to bottom boundary layer mixing or the sensitivity of ePBL mixing to several parameter changes. The MOM_parameter_doc files are altered by the addition of up to 15 new runtime parameters, and by the correction of several spelling errors in the descriptions of other ePBL parameters.  By default, all answers are bitwise identical.

  This commits in this PR include:

- NOAA-GFDL/MOM6@80c2fc560 +Add DECAY_ADJUSTED_BBL_TKE option for ePBL BBL
- NOAA-GFDL/MOM6@0c17f5fb2 +(*)Add ePBL bottom boundary mixing option
- NOAA-GFDL/MOM6@6f2c5fd35 +Add and test find_Kd_from_PE_chg
- NOAA-GFDL/MOM6@92f30322e +Add run-time ability to debug ePBL sensitivities
- NOAA-GFDL/MOM6@972f8e3ee +Add EPBL_MLD_ITER_BUG runtime parameter
- NOAA-GFDL/MOM6@49414ac36 *Fix a bug when EPBL_ORIGINAL_PE_CALC is false