### PR TITLE
Frequency-dependent internal wave drag

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -626,6 +626,10 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                   ! spacing [H L ~> m2 or kg m-1].
   real, dimension(:,:), pointer :: um2, uk1, vm2, vk1
                   ! M2 and K1 velocities from the output of streaming filters [m s-1]
+  real, dimension(SZIBW_(CS),SZJW_(CS)), target :: zero_u
+                  ! Zero array on u grid [nondim]
+  real, dimension(SZIW_(CS),SZJBW_(CS)), target :: zero_v
+                  ! Zero array on v grid [nondim]
   real, dimension(SZIBW_(CS),SZJW_(CS)) :: Drag_u
                   ! The zonal acceleration due to frequency-dependent drag [m s-2]
   real, dimension(SZIW_(CS),SZJBW_(CS)) :: Drag_v
@@ -1449,13 +1453,18 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
 
   ! Compute the instantaneous M2 and K1 velocities
   ! Note here the filtering is applied to the velocity fields at the previous time step.
+  zero_u(:,:) = 0.0 ; zero_v(:,:) = 0.0
   if (CS%use_filter_m2) then
     call Filt_accum(ubt, um2, CS%Time, US, CS%Filt_CS_um2)
     call Filt_accum(vbt, vm2, CS%Time, US, CS%Filt_CS_vm2)
+  else
+    um2 => zero_u ; vm2 => zero_v
   endif
   if (CS%use_filter_k1) then
     call Filt_accum(ubt, uk1, CS%Time, US, CS%Filt_CS_uk1)
     call Filt_accum(vbt, vk1, CS%Time, US, CS%Filt_CS_vk1)
+  else
+    uk1 => zero_u ; vk1 => zero_v
   endif
 
   ! Apply frequency-dependent linear wave drag

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5128,11 +5128,9 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
       if (len_trim(wave_drag_u) > 0 .and. len_trim(wave_drag_v) > 0) then
         call MOM_read_data(wave_drag_file, wave_drag_u, CS%lin_drag_u, G%Domain, &
                            position=EAST_FACE, scale=wave_drag_scale*GV%m_to_H*US%T_to_s)
-        call pass_var(CS%lin_drag_u, G%Domain)
-
         call MOM_read_data(wave_drag_file, wave_drag_v, CS%lin_drag_v, G%Domain, &
                            position=NORTH_FACE, scale=wave_drag_scale*GV%m_to_H*US%T_to_s)
-        call pass_var(CS%lin_drag_v, G%Domain)
+        call pass_vector(CS%lin_drag_u, CS%lin_drag_v, G%domain, direction=To_All+SCALAR_PAIR)
 
       elseif (len_trim(wave_drag_var) > 0) then
         allocate(lin_drag_h(isd:ied,jsd:jed), source=0.0)
@@ -5168,11 +5166,9 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
         if (len_trim(m2_drag_u) > 0 .and. len_trim(m2_drag_v) > 0) then
           call MOM_read_data(wave_drag_file, m2_drag_u, CS%lin_drag_um2, G%Domain, &
                              position=EAST_FACE, scale=m2_drag_scale*GV%m_to_H*US%T_to_s)
-          call pass_var(CS%lin_drag_um2, G%Domain)
-
           call MOM_read_data(wave_drag_file, m2_drag_v, CS%lin_drag_vm2, G%Domain, &
                              position=NORTH_FACE, scale=m2_drag_scale*GV%m_to_H*US%T_to_s)
-          call pass_var(CS%lin_drag_vm2, G%Domain)
+          call pass_vector(CS%lin_drag_um2, CS%lin_drag_vm2, G%domain, direction=To_All+SCALAR_PAIR)
 
         elseif (len_trim(m2_drag_var) > 0) then
           allocate(lin_drag_h(isd:ied,jsd:jed), source=0.0)
@@ -5194,11 +5190,9 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
         if (len_trim(k1_drag_u) > 0 .and. len_trim(k1_drag_v) > 0) then
           call MOM_read_data(wave_drag_file, k1_drag_u, CS%lin_drag_uk1, G%Domain, &
                              position=EAST_FACE, scale=k1_drag_scale*GV%m_to_H*US%T_to_s)
-          call pass_var(CS%lin_drag_uk1, G%Domain)
-
           call MOM_read_data(wave_drag_file, k1_drag_v, CS%lin_drag_vk1, G%Domain, &
                              position=NORTH_FACE, scale=k1_drag_scale*GV%m_to_H*US%T_to_s)
-          call pass_var(CS%lin_drag_vk1, G%Domain)
+          call pass_vector(CS%lin_drag_uk1, CS%lin_drag_vk1, G%domain, direction=To_All+SCALAR_PAIR)
 
         elseif (len_trim(k1_drag_var) > 0) then
           allocate(lin_drag_h(isd:ied,jsd:jed), source=0.0)


### PR DESCRIPTION
Utilizing streaming bandpass filters, the linear wave drag can now be applied to the M2 and K1 velocities independently, without affecting the broadband barotropic velocity fields. This implementation would be particularly useful (and perhaps necessary) for correctly representing tides in climate simulations, because if the linear drag is applied to the broadband barotropic velocity, the low-frequency, non-tidal motions would also be damped.