### PR TITLE
Fortran 2023 compliance and testing

### DIFF
--- a/.github/actions/ubuntu-setup/action.yml
+++ b/.github/actions/ubuntu-setup/action.yml
@@ -23,7 +23,7 @@ runs:
       run: |
         echo "::group::config.mk"
         cd .testing
-        echo "FCFLAGS_DEBUG = -g -O0 -Wextra -Wno-compare-reals -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds" >> config.mk
+        echo "FCFLAGS_DEBUG = -g -O0 -std=f2018 -Wextra -Wno-compare-reals -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds" >> config.mk
         echo "FCFLAGS_REPRO = -g -O2 -fbacktrace" >> config.mk
         echo "FCFLAGS_INIT = -finit-real=snan -finit-integer=2147483647 -finit-derived" >> config.mk
         echo "FCFLAGS_FMS = -g -fbacktrace -O0" >> config.mk

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -83,19 +83,21 @@ export FMS_URL
 # TODO: This needs more automated configuration
 MPIRUN ?= mpirun
 
-# Generic compiler variables are pass through to the builds
+# Generic compiler variables are passed through to the builds
 export CC
 export MPICC
 export FC
 export MPIFC
 
 # Builds are distinguished by FCFLAGS
-FCFLAGS_DEBUG ?= -g -O0
+FCFLAGS ?= -g -O0
+
+FCFLAGS_DEBUG ?= $(FCFLAGS)
 FCFLAGS_REPRO ?= -g -O2
 FCFLAGS_OPT ?= -g -O3 -mavx -fno-omit-frame-pointer
 FCFLAGS_INIT ?=
 FCFLAGS_COVERAGE ?= -g -O0 -fbacktrace --coverage
-FCFLAGS_FMS ?= $(FCFLAGS_DEBUG)
+FCFLAGS_FMS ?= $(FCFLAGS)
 # Additional notes:
 # - These default values are simple, minimalist flags, supported by nearly all
 #   compilers, and are somewhat analogous to GFDL's DEBUG and REPRO builds.

--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -1065,10 +1065,10 @@ subroutine ocean_model_data2D_get(OS, Ocean, name, array2D, isc, jsc)
   type(ocean_public_type),    intent(in) :: Ocean !< A structure containing various publicly
                                                   !! visible ocean surface fields.
   character(len=*)          , intent(in) :: name  !< The name of the field to extract
-  real, dimension(isc:,jsc:), intent(out):: array2D !< The values of the named field, it must
-                                                  !! cover only the computational domain [various]
   integer                   , intent(in) :: isc   !< The starting i-index of array2D
   integer                   , intent(in) :: jsc   !< The starting j-index of array2D
+  real, dimension(isc:,jsc:), intent(out):: array2D !< The values of the named field, it must
+                                                  !! cover only the computational domain [various]
 
   integer :: g_isc, g_iec, g_jsc, g_jec, g_isd, g_ied, g_jsd, g_jed, i, j
 
@@ -1188,10 +1188,10 @@ subroutine ocean_model_get_UV_surf(OS, Ocean, name, array2D, isc, jsc)
   type(ocean_public_type),    intent(in) :: Ocean !< A structure containing various publicly
                                                   !! visible ocean surface fields.
   character(len=*)          , intent(in) :: name  !< The name of the current (ua or va) to extract
-  real, dimension(isc:,jsc:), intent(out):: array2D !< The values of the named field, it must
-                                                  !! cover only the computational domain [L T-1 ~> m s-1]
   integer                   , intent(in) :: isc   !< The starting i-index of array2D
   integer                   , intent(in) :: jsc   !< The starting j-index of array2D
+  real, dimension(isc:,jsc:), intent(out):: array2D !< The values of the named field, it must
+                                                  !! cover only the computational domain [L T-1 ~> m s-1]
 
   type(ocean_grid_type) , pointer :: G            !< The ocean's grid structure
   type(surface),          pointer :: sfc_state    !< A structure containing fields that

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -2424,7 +2424,7 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
     tol_here = 0.5*tol*(abs(SpV_avg_a(1)) + abs(SpV_avg_q(1)))
     test_OK = (abs(SpV_avg_a(1) - SpV_avg_q(1)) < tol_here)
     if (verbose) then
-      write(mesg, '(ES24.16," and ",ES24.16," differ by ",ES16.8," (",ES10.2"), tol=",ES16.8)') &
+      write(mesg, '(ES24.16," and ",ES24.16," differ by ",ES16.8," (",ES10.2,"), tol=",ES16.8)') &
         SpV_avg_a(1), SpV_avg_q(1), SpV_avg_a(1) - SpV_avg_q(1), &
         2.0*(SpV_avg_a(1) - SpV_avg_q(1)) / (abs(SpV_avg_a(1)) + abs(SpV_avg_q(1)) + tiny(SpV_avg_a(1))), &
         tol_here
@@ -2504,8 +2504,7 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
 
     check_FD = ( abs(val_fd(1) - val) < (1.2*abs(val_fd(2) - val)/2**order + abs(tol)) )
 
-    ! write(mesg, '(ES16.8," and ",ES16.8," differ by ",ES16.8," (",ES10.2"), tol=",ES16.8)') &
-    write(mesg, '(ES24.16," and ",ES24.16," differ by ",ES16.8," (",ES10.2"), tol=",ES16.8)') &
+    write(mesg, '(ES24.16," and ",ES24.16," differ by ",ES16.8," (",ES10.2,"), tol=",ES16.8)') &
           val, val_fd(1), val - val_fd(1), &
           2.0*(val - val_fd(1)) / (abs(val) + abs(val_fd(1)) + tiny(val)), &
           (1.2*abs(val_fd(2) - val)/2**order + abs(tol))

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -680,10 +680,10 @@ subroutine write_auto_mask_file(mask_table, layout, npes, filename)
   true_num_masked_blocks = layout(1) * layout(2) - npes
 
   call open_ASCII_file(file_ascii, trim(filename), action=WRITEONLY_FILE)
-  write(file_ascii, '(I0)'), true_num_masked_blocks
-  write(file_ascii, '(I0,",",I0)'), layout(1), layout(2)
+  write(file_ascii, '(I0)') true_num_masked_blocks
+  write(file_ascii, '(I0,",",I0)') layout(1), layout(2)
   do p = 1, true_num_masked_blocks
-    write(file_ascii, '(I0,",",I0)'), mask_table(p,1), mask_table(p,2)
+    write(file_ascii, '(I0,",",I0)') mask_table(p,1), mask_table(p,2)
   enddo
   call close_file(file_ascii)
 end subroutine write_auto_mask_file

--- a/src/framework/posix.F90
+++ b/src/framework/posix.F90
@@ -437,6 +437,7 @@ function setjmp_missing(env) result(rc) bind(c)
   error stop
 
   ! NOTE: compilers may expect a return value, even if it is unreachable
+  read env%state
   rc = -1
 end function setjmp_missing
 
@@ -450,6 +451,9 @@ subroutine longjmp_missing(env, val) bind(c)
   print '(a)', 'ERROR: longjmp() is not implemented in this build.'
   print '(a)', 'Recompile with autoconf or -DLONGJMP_NAME=\"<symbol name>\".'
   error stop
+
+  read env%state
+  read char(val)
 end subroutine longjmp_missing
 
 !> Placeholder function for a missing or unconfigured sigsetjmp
@@ -466,6 +470,8 @@ function sigsetjmp_missing(env, savesigs) result(rc) bind(c)
   error stop
 
   ! NOTE: compilers may expect a return value, even if it is unreachable
+  read env%state
+  read char(savesigs)
   rc = -1
 end function sigsetjmp_missing
 
@@ -478,6 +484,8 @@ subroutine siglongjmp_missing(env, val) bind(c)
 
   print '(a)', 'ERROR: siglongjmp() is not implemented in this build.'
   print '(a)', 'Recompile with autoconf or -DSIGLONGJMP_NAME=\"<symbol name>\".'
+  read env%state
+  read char(val)
   error stop
 end subroutine siglongjmp_missing
 

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -1122,7 +1122,7 @@ subroutine write_ice_shelf_energy(CS, G, US, mass, area, day, time_step)
     else
       call open_ASCII_file(CS%IS_fileenergy_ascii, trim(CS%IS_energyfile), action=WRITEONLY_FILE)
       if (abs(CS%timeunit - 86400.0) < 1.0) then
-        write(CS%IS_fileenergy_ascii,'("  Step,",7x,"Day,"8x,"Energy/Mass,",13x,"Total Mass")')
+        write(CS%IS_fileenergy_ascii,'("  Step,",7x,"Day,",8x,"Energy/Mass,",13x,"Total Mass")')
         write(CS%IS_fileenergy_ascii,'(12x,"[days]",10x,"[m2 s-2]",17x,"[kg]")')
       else
         if ((CS%timeunit >= 0.99) .and. (CS%timeunit < 1.01)) then
@@ -1137,7 +1137,7 @@ subroutine write_ice_shelf_energy(CS, G, US, mass, area, day, time_step)
           write(time_units,'(9x,"[",es8.2," s]    ")') CS%timeunit
         endif
 
-        write(CS%IS_fileenergy_ascii,'("  Step,",7x,"Time,"7x,"Energy/Mass,",13x,"Total Mass")')
+        write(CS%IS_fileenergy_ascii,'("  Step,",7x,"Time,",7x,"Energy/Mass,",13x,"Total Mass")')
         write(CS%IS_fileenergy_ascii,'(A25,3x,"[m2 s-2]",17x,"[kg]")') time_units
       endif
     endif

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -510,7 +510,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af halo", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after forcing')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after forcing', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after forcing', CS%En_sum
     enddo ; enddo
   endif
 
@@ -537,7 +537,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af refr", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after 1/2 refraction')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after 1/2 refraction', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after 1/2 refraction', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
     do m=1,CS%nMode ; do fr=1,CS%Nfreq ; do a=1,CS%nAngle
@@ -567,7 +567,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af halo R", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after correct halo rotation')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after correct halo rotation', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after correct halo rotation', CS%En_sum
     enddo ; enddo
   endif
 
@@ -598,7 +598,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af prop", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after propagate')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after propagate', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after propagate', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
     do m=1,CS%nMode ; do fr=1,CS%Nfreq ; do a=1,CS%nAngle
@@ -640,7 +640,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides af refr2", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after 2/2 refraction')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after 2/2 refraction', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after 2/2 refraction', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
     do m=1,CS%nMode ; do fr=1,CS%Nfreq ; do a=1,CS%nAngle
@@ -696,9 +696,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after leak", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after background drag')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after background drag', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after background drag', CS%En_sum
       call sum_En(G, GV, US, CS, CS%TKE_leak_loss(:,:,:,fr,m) * dt, 'prop_int_tide: loss after background drag')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: loss after background drag', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: loss after background drag', CS%En_sum
     enddo ; enddo
     ! Check for En<0 - for debugging, delete later
     do m=1,CS%nMode ; do fr=1,CS%Nfreq ; do a=1,CS%nAngle
@@ -867,7 +867,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after wave", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: before Froude drag')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: before Froude drag', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: before Froude drag', CS%En_sum
     enddo ; enddo
     ! save loss term for online budget, may want to add a debug flag later
     do m=1,CS%nMode ; do fr=1,CS%nFreq
@@ -941,9 +941,9 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
     call hchksum(CS%En(:,:,:,1,1), "EnergyIntTides after froude", G%HI, haloshift=0, scale=HZ2_T2_to_J_m2)
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'prop_int_tide: after Froude drag')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: after Froude drag', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: after Froude drag', CS%En_sum
       call sum_En(G, GV, US, CS, CS%TKE_Froude_loss(:,:,:,fr,m) * dt, 'prop_int_tide: loss after Froude drag')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'prop_int_tide: loss after Froude drag', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'prop_int_tide: loss after Froude drag', CS%En_sum
     enddo ; enddo
     ! save loss term for online budget, may want to add a debug flag later
     do m=1,CS%nMode ; do fr=1,CS%nFreq
@@ -1024,7 +1024,7 @@ subroutine propagate_int_tide(h, tv, Nb, Rho_bot, dt, G, GV, US, inttide_input_C
                             CS%TKE_quad_loss_glo_dt(fr,m) - CS%TKE_itidal_loss_glo_dt(fr,m) - &
                             CS%TKE_Froude_loss_glo_dt(fr,m) - CS%TKE_residual_loss_glo_dt(fr,m) - &
                             CS%En_end_glo(fr,m)
-    if (is_root_pe()) write(stdout,'(A,F18.10)'), "error in Energy budget", CS%error_mode(fr,m)
+    if (is_root_pe()) write(stdout,'(A,F18.10)') "error in Energy budget", CS%error_mode(fr,m)
     enddo ; enddo
   endif
 
@@ -1612,23 +1612,23 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
          enddo
 
          if (abs(verif_N -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)'), i, j, verif_N
+           write(stdout,'(I5,I5,F18.10)') i, j, verif_N
            call MOM_error(FATAL, "mismatch integral for N profile")
          endif
          if (abs(verif_N2 -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)'), i, j, verif_N2
+           write(stdout,'(I5,I5,F18.10)') i, j, verif_N2
            call MOM_error(FATAL, "mismatch integral for N2 profile")
          endif
          if (abs(verif_bbl -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)'), i, j, verif_bbl
+           write(stdout,'(I5,I5,F18.10)') i, j, verif_bbl
            call MOM_error(FATAL, "mismatch integral for bbl profile")
          endif
          if (abs(verif_stl1 -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)'), i, j, verif_stl1
+           write(stdout,'(I5,I5,F18.10)') i, j, verif_stl1
            call MOM_error(FATAL, "mismatch integral for stl1 profile")
          endif
          if (abs(verif_stl2 -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)'), i, j, verif_stl2
+           write(stdout,'(I5,I5,F18.10)') i, j, verif_stl2
            call MOM_error(FATAL, "mismatch integral for stl2 profile")
          endif
 
@@ -2108,7 +2108,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
   if (CS%debug) then
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: top of routine')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'propagate: top of routine', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'propagate: top of routine', CS%En_sum
     enddo ; enddo
   endif
 
@@ -2180,7 +2180,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
     if (CS%debug) then
       do m=1,CS%nMode ; do fr=1,CS%Nfreq
         call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: after propagate_x')
-        if (is_root_pe()) write(stdout,'(A,E18.10)'), 'propagate: after propagate_x', CS%En_sum
+        if (is_root_pe()) write(stdout,'(A,E18.10)') 'propagate: after propagate_x', CS%En_sum
       enddo ; enddo
     endif
 
@@ -2191,7 +2191,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
     if (CS%debug) then
       do m=1,CS%nMode ; do fr=1,CS%Nfreq
         call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: after halo update')
-        if (is_root_pe()) write(stdout,'(A,E18.10)'), 'propagate: after halo update', CS%En_sum
+        if (is_root_pe()) write(stdout,'(A,E18.10)') 'propagate: after halo update', CS%En_sum
       enddo ; enddo
     endif
     ! Apply propagation in y-direction (reflection included)
@@ -2210,7 +2210,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
     if (CS%debug) then
       do m=1,CS%nMode ; do fr=1,CS%Nfreq
         call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: after propagate_y')
-        if (is_root_pe()) write(stdout,'(A,E18.10)'), 'propagate: after propagate_y', CS%En_sum
+        if (is_root_pe()) write(stdout,'(A,E18.10)') 'propagate: after propagate_y', CS%En_sum
       enddo ; enddo
     endif
 
@@ -2219,7 +2219,7 @@ subroutine propagate(En, cn, freq, dt, G, GV, US, CS, NAngle, residual_loss)
   if (CS%debug) then
     do m=1,CS%nMode ; do fr=1,CS%Nfreq
       call sum_En(G, GV, US, CS, CS%En(:,:,:,fr,m), 'propagate: bottom of routine')
-      if (is_root_pe()) write(stdout,'(A,E18.10)'), 'propagate: bottom of routine', CS%En_sum
+      if (is_root_pe()) write(stdout,'(A,E18.10)') 'propagate: bottom of routine', CS%En_sum
     enddo ; enddo
   endif
 

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1953,10 +1953,10 @@ logical function test_answer(verbose, u, u_true, label, tol)
   if (abs(u - u_true) > tolerance) test_answer = .true.
   if (test_answer .or. verbose) then
     if (test_answer) then
-      print '(3(a,1pe24.16),x,a,x,a)','computed =',u,' correct =',u_true, &
+      print '(3(a,1pe24.16),1x,a,1x,a)','computed =',u,' correct =',u_true, &
             ' err=',u-u_true,' < wrong',label
     else
-      print '(2(a,1pe24.16),x,a)','computed =',u,' correct =',u_true,label
+      print '(2(a,1pe24.16),1x,a)','computed =',u,' correct =',u_true,label
     endif
   endif
 

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -344,10 +344,10 @@ end subroutine find_N2_bottom
 !> Returns TKE_itidal_input
 subroutine get_input_TKE(G, TKE_itidal_input, nFreq, CS)
   type(ocean_grid_type), intent(in)    :: G !< The ocean's grid structure (in).
+  integer, intent(in) :: nFreq !< number of frequencies
   real, dimension(SZI_(G),SZJ_(G),nFreq), &
                          intent(out) :: TKE_itidal_input !< The energy input to the internal waves
                                                          !! [H Z2 T-3 ~> m3 s-3 or W m-2].
-  integer, intent(in) :: nFreq !< number of frequencies
   type(int_tide_input_CS),   target       :: CS !< A pointer that is set to point to the control
                                                  !! structure for the internal tide input module.
   integer :: i,j,fr
@@ -361,9 +361,9 @@ end subroutine get_input_TKE
 !> Returns barotropic tidal velocities
 subroutine get_barotropic_tidal_vel(G, vel_btTide, nFreq, CS)
   type(ocean_grid_type), intent(in)    :: G !< The ocean's grid structure (in).
+  integer, intent(in) :: nFreq !< number of frequencies
   real, dimension(SZI_(G),SZJ_(G),nFreq), &
                          intent(out) :: vel_btTide !< Barotropic velocity read from file [L T-1 ~> m s-1].
-  integer, intent(in) :: nFreq !< number of frequencies
   type(int_tide_input_CS),   target       :: CS !< A pointer that is set to point to the control
                                                  !! structure for the internal tide input module.
   integer :: i,j,fr

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -342,8 +342,8 @@ subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   if (CS%use_real_BL_depth .and. .not. present(Hbl)) then
-    call MOM_error(FATAL,"Attempting to use real boundary layer depth for ideal age tracers, &
-         but no valid boundary layer scheme was found")
+    call MOM_error(FATAL, "Attempting to use real boundary layer depth for ideal age tracers, " &
+         // "but no valid boundary layer scheme was found")
   endif
 
   if (CS%use_real_BL_depth .and. present(Hbl)) then


### PR DESCRIPTION
This PR contains several commits to ensure Fortran 2023 compliance.

Most changes are related to missing or redundant commas in I/O statements.  Others were related to the ordering of input-dependent arguments in functions.

This should help improve support on other compilers which have more strict I/O syntax requirements.  It will also help prepare us to turn on additional warnings and improve the overall testing of the model.

It also includes modifications to the GitHub CI to provide F2018 testing.  (Unfortunately our compiler of choice is a bit out of day and cannot yet provide 2023 compliance testing.)