### PR TITLE
change CMOR names, fixes #709

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2706,7 +2706,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     CS%tv%T => CS%T ; CS%tv%S => CS%S
     if (CS%tv%T_is_conT) then
       vd_T = var_desc(name="contemp", units="Celsius", longname="Conservative Temperature", &
-                      cmor_field_name="thetao", cmor_longname="Sea Water Potential Temperature", &
+                      cmor_field_name="bigthetao", cmor_longname="Sea Water Conservative Temperature", &
                       conversion=US%Q_to_J_kg*CS%tv%C_p)
     else
       vd_T = var_desc(name="temp", units="degC", longname="Potential Temperature", &
@@ -2715,7 +2715,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     endif
     if (CS%tv%S_is_absS) then
       vd_S = var_desc(name="abssalt", units="g kg-1", longname="Absolute Salinity", &
-                      cmor_field_name="so", cmor_longname="Sea Water Salinity", &
+                      cmor_field_name="absso", cmor_longname="Sea Water Absolute Salinity", &
                       conversion=0.001*US%S_to_ppt)
     else
       vd_S = var_desc(name="salt", units="psu", longname="Salinity", &


### PR DESCRIPTION
bigthetao refers the the uppercase greek letter theta used for conservative temperature. Salinity so uses the roman alphabet and a bigso is ambiguous as many papers use S for salinity hence absso seems like the most unambiguous.