### PR TITLE
Use bottom pressure anomaly for self-attraction and loading

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1506,7 +1506,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
-  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%calculate_SAL) call SAL_init(G, GV, US, param_file, CS%SAL_CSp)
   if (CS%use_tides) then
     call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp, CS%HA_CSp)
     HA_CSp => CS%HA_CSp

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -1419,7 +1419,7 @@ subroutine initialize_dyn_split_RK2b(u, v, h, tv, uh, vh, eta, Time, G, GV, US, 
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
-  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%calculate_SAL) call SAL_init(G, GV, US, param_file, CS%SAL_CSp)
   if (CS%use_tides) then
     call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp, CS%HA_CSp)
     HA_CSp => CS%HA_CSp

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -707,7 +707,7 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
-  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%calculate_SAL) call SAL_init(G, GV, US, param_file, CS%SAL_CSp)
   if (CS%use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
                           CS%SAL_CSp, CS%tides_CSp)

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -671,7 +671,7 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
-  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%calculate_SAL) call SAL_init(G, GV, US, param_file, CS%SAL_CSp)
   if (CS%use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
                           CS%SAL_CSp, CS%tides_CSp)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -5470,7 +5470,7 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
           endif
           I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
           if (allocated(segment%tr_Reg%Tr(m)%tres)) then ; do k=1,nz
-            ! Calculate weights. Both a and u_L are nodim. Adding them together has no meaning.
+            ! Calculate weights. Both a and u_L are nondim. Adding them together has no meaning.
             ! However, since they cannot be both non-zero, adding them works like a switch.
             ! When InvLscale_out is 0 and outflow, only interior data is applied to reservoirs
             ! When InvLscale_in is 0 and inflow, only nudged data is applied to reservoirs

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -41,7 +41,7 @@ type, public :: SAL_CS ; private
   integer :: sal_sht_Nd
     !< Maximum degree for spherical harmonic transforms [nodim]
   real, allocatable :: ebot_ref(:,:)
-    !< Reference bottom pressure normalized by Rho_0 and G_Earth[Z ~> m]
+    !< Reference bottom pressure scaled by Rho_0 and G_Earth[Z ~> m]
   real, allocatable :: Love_scaling(:)
     !< Dimensional coefficients for harmonic SAL, which are functions of Love numbers
     !! [nondim or L2 Z-1 T-2 ~> m s-2 or R-1 ~> m3 kg-1 or L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
@@ -56,16 +56,15 @@ contains
 !> This subroutine calculates seawater self-attraction and loading based on either sea surface height (SSH) or bottom
 !! pressure anomaly.  Note that the SAL calculation applies to all motions across the spectrum. Tidal-specific methods
 !! that assume periodicity, i.e. iterative and read-in SAL, are stored in MOM_tidal_forcing module.
-!!     The input field is always assume to have the unit of [Z ~> m], which can be either SSH or total bottom pressure
-!! normalized by mean seawater density Rho_0 and earth gravity G_Earth. For spherical harmonic method, the mean
-!! seawater density would be cancelled by the same parameter in Love Number scalings. If total bottom pressure is used
-!! as input, bottom pressure anomaly is calculated in the subroutine by subtracting a reference pressure from the
-!! input bottom pressure.
-!!     The output field is expressed as geopotential height anomaly, and therefore has the unit of [Z ~> m].
+!! The input field is always assume to have the unit of [Z ~> m], which can be either SSH or total bottom pressure
+!! scaled by mean seawater density Rho_0 and earth gravity G_Earth. For spherical harmonics, the mean seawater density
+!! would be cancelled by the same parameter in Love number scalings. If total bottom pressure is used as input, bottom
+!! pressure anomaly is calculated in the subroutine by subtracting a reference pressure from the input bottom pressure.
+!! The output field is expressed as geopotential height anomaly, and therefore has the unit of [Z ~> m].
 subroutine calc_SAL(eta, eta_sal, G, CS, tmp_scale)
   type(ocean_grid_type), intent(in)  :: G  !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: eta     !< The sea surface height anomaly from
-              !! a time-mean geoid or total bottom pressure normalized by mean density [Z ~> m].
+              !! a time-mean geoid or total bottom pressure scaled by mean density and earth gravity [Z ~> m].
   real, dimension(SZI_(G),SZJ_(G)), intent(out) :: eta_sal !< The geopotential height anomaly from
               !! self-attraction and loading [Z ~> m].
   type(SAL_CS), intent(inout) :: CS !< The control structure returned by a previous call to SAL_init.

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -45,8 +45,8 @@ type, public :: SAL_CS ; private
   real, allocatable :: Love_scaling(:)
     !< Dimensional coefficients for harmonic SAL, which are functions of Love numbers
     !! [nondim or L2 Z-1 T-2 ~> m s-2 or R-1 ~> m3 kg-1 or L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
-  real, allocatable :: Snm_Re(:), Snm_Im(:)
-    !< Real and imaginary coefficients for harmonic SAL [Z ~> m or L2 T-2 ~> m2 s-2]
+  real, allocatable :: Snm_Re(:), &    !< Real SHT coefficient for SHT SAL [Z ~> m]
+                       Snm_Im(:)       !< Imaginary SHT coefficient for SHT SAL [Z ~> m]
 end type SAL_CS
 
 integer :: id_clock_SAL   !< CPU clock for self-attraction and loading

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -1,16 +1,18 @@
 module MOM_self_attr_load
 
-use MOM_cpu_clock,       only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_MODULE
-use MOM_domains,         only : pass_var
-use MOM_error_handler,   only : MOM_error, FATAL, WARNING
-use MOM_file_parser,     only : read_param, get_param, log_version, param_file_type
+use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_MODULE
+use MOM_domains, only : pass_var
+use MOM_error_handler, only : MOM_error, FATAL, WARNING
+use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
+use MOM_grid, only : ocean_grid_type
+use MOM_io, only : slasher, MOM_read_data
+use MOM_load_love_numbers, only : Love_Data
 use MOM_obsolete_params, only : obsolete_logical, obsolete_int
-use MOM_grid,            only : ocean_grid_type
-use MOM_unit_scaling,    only : unit_scale_type
 use MOM_spherical_harmonics, only : spherical_harmonics_init, spherical_harmonics_end
 use MOM_spherical_harmonics, only : spherical_harmonics_forward, spherical_harmonics_inverse
 use MOM_spherical_harmonics, only : sht_CS, order2index, calc_lmax
-use MOM_load_love_numbers,   only : Love_Data
+use MOM_unit_scaling, only : unit_scale_type
+use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private
 
@@ -27,61 +29,81 @@ type, public :: SAL_CS ; private
   logical :: use_tidal_sal_prev = .false.
     !< If true, read the tidal SAL from the previous iteration of the tides to
     !! facilitate convergence.
-  real    :: sal_scalar_value   !< The constant of proportionality between sea surface height
-                                !! (really it should be bottom pressure) anomalies and bottom
-                                !! geopotential anomalies [nondim].
-  type(sht_CS), allocatable :: sht  !< Spherical harmonic transforms (SHT) control structure
-  integer :: sal_sht_Nd         !< Maximum degree for SHT [nodim]
-  real, allocatable :: Love_Scaling(:) !< Love number for each SHT mode [nodim]
-  real, allocatable :: Snm_Re(:), &    !< Real SHT coefficient for SHT SAL [Z ~> m]
-                       Snm_Im(:)       !< Imaginary SHT coefficient for SHT SAL [Z ~> m]
+  logical :: use_bpa = .false.
+    !< If true, use bottom pressure anomaly instead of SSH to calculate SAL.
+  real :: eta_prop
+    !< The partial derivative of eta_sal with the local value of eta [nondim].
+  real :: linear_scaling
+    !< A dimensional coefficient for scalar approximation SAL, equal to eta_prop * unit_convert
+    !! [nondim or L2 Z-1 T-2 ~> m s-2 or R-1 ~> m3 kg-1 or L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+  type(sht_CS), allocatable :: sht
+    !< Spherical harmonic transforms (SHT) control structure
+  integer :: sal_sht_Nd
+    !< Maximum degree for spherical harmonic transforms [nodim]
+  real, allocatable :: ebot_ref(:,:)
+    !< Reference bottom pressure normalized by Rho_0 and G_Earth[Z ~> m]
+  real, allocatable :: Love_scaling(:)
+    !< Dimensional coefficients for harmonic SAL, which are functions of Love numbers
+    !! [nondim or L2 Z-1 T-2 ~> m s-2 or R-1 ~> m3 kg-1 or L2 Z-1 T-2 R-1 ~> m4 s-2 kg-1]
+  real, allocatable :: Snm_Re(:), Snm_Im(:)
+    !< Real and imaginary coefficients for harmonic SAL [Z ~> m or L2 T-2 ~> m2 s-2]
 end type SAL_CS
 
 integer :: id_clock_SAL   !< CPU clock for self-attraction and loading
 
 contains
 
-!> This subroutine calculates seawater self-attraction and loading based on sea surface height. This should
-!! be changed into bottom pressure anomaly in the future. Note that the SAL calculation applies to all motions
-!! across the spectrum. Tidal-specific methods that assume periodicity, i.e. iterative and read-in SAL, are
-!! stored in MOM_tidal_forcing module.
+!> This subroutine calculates seawater self-attraction and loading based on either sea surface height (SSH) or bottom
+!! pressure anomaly.  Note that the SAL calculation applies to all motions across the spectrum. Tidal-specific methods
+!! that assume periodicity, i.e. iterative and read-in SAL, are stored in MOM_tidal_forcing module.
+!!     The input field is always assume to have the unit of [Z ~> m], which can be either SSH or total bottom pressure
+!! normalized by mean seawater density Rho_0 and earth gravity G_Earth. For spherical harmonic method, the mean
+!! seawater density would be cancelled by the same parameter in Love Number scalings. If total bottom pressure is used
+!! as input, bottom pressure anomaly is calculated in the subroutine by subtracting a reference pressure from the
+!! input bottom pressure.
+!!     The output field is expressed as geopotential height anomaly, and therefore has the unit of [Z ~> m].
 subroutine calc_SAL(eta, eta_sal, G, CS, tmp_scale)
   type(ocean_grid_type), intent(in)  :: G  !< The ocean's grid structure.
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: eta     !< The sea surface height anomaly from
-                                                           !! a time-mean geoid [Z ~> m].
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: eta_sal !< The sea surface height anomaly from
-                                                           !! self-attraction and loading [Z ~> m].
+              !! a time-mean geoid or total bottom pressure normalized by mean density [Z ~> m].
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: eta_sal !< The geopotential height anomaly from
+              !! self-attraction and loading [Z ~> m].
   type(SAL_CS), intent(inout) :: CS !< The control structure returned by a previous call to SAL_init.
-  real,                   optional, intent(in)  :: tmp_scale !< A rescaling factor to temporarily convert eta
-                                                            !! to MKS units in reproducing sumes [m Z-1 ~> 1]
+  real, optional, intent(in)  :: tmp_scale !< A rescaling factor to temporarily convert eta
+              !! to MKS units in reproducing sumes [m Z-1 ~> 1]
 
   ! Local variables
   integer :: n, m, l
+  real, dimension(SZI_(G),SZJ_(G)) :: bpa ! [Z ~> m]
   integer :: Isq, Ieq, Jsq, Jeq
   integer :: i, j
-  real :: eta_prop ! The scalar constant of proportionality between eta and eta_sal [nondim]
 
   call cpu_clock_begin(id_clock_SAL)
 
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
+  if (CS%use_bpa) then ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    bpa(i,j) = eta(i,j) - CS%ebot_ref(i,j)
+  enddo ; enddo ; else ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    bpa(i,j) = eta(i,j)
+  enddo ; enddo ; endif
+
   ! use the scalar approximation and/or iterative tidal SAL
   if (CS%use_sal_scalar .or. CS%use_tidal_sal_prev) then
-    call scalar_SAL_sensitivity(CS, eta_prop)
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      eta_sal(i,j) = eta_prop*eta(i,j)
+      eta_sal(i,j) = CS%eta_prop * bpa(i,j)
     enddo ; enddo
 
   ! use the spherical harmonics method
   elseif (CS%use_sal_sht) then
-    call spherical_harmonics_forward(G, CS%sht, eta, CS%Snm_Re, CS%Snm_Im, CS%sal_sht_Nd, tmp_scale=tmp_scale)
+    call spherical_harmonics_forward(G, CS%sht, bpa, CS%Snm_Re, CS%Snm_Im, CS%sal_sht_Nd, tmp_scale=tmp_scale)
 
     ! Multiply scaling factors to each mode
     do m = 0,CS%sal_sht_Nd
       l = order2index(m, CS%sal_sht_Nd)
       do n = m,CS%sal_sht_Nd
-        CS%Snm_Re(l+n-m) = CS%Snm_Re(l+n-m) * CS%Love_Scaling(l+n-m)
-        CS%Snm_Im(l+n-m) = CS%Snm_Im(l+n-m) * CS%Love_Scaling(l+n-m)
+        CS%Snm_Re(l+n-m) = CS%Snm_Re(l+n-m) * CS%Love_scaling(l+n-m)
+        CS%Snm_Im(l+n-m) = CS%Snm_Im(l+n-m) * CS%Love_scaling(l+n-m)
       enddo
     enddo
 
@@ -98,36 +120,32 @@ subroutine calc_SAL(eta, eta_sal, G, CS, tmp_scale)
   call cpu_clock_end(id_clock_SAL)
 end subroutine calc_SAL
 
-!>   This subroutine calculates the partial derivative of the local geopotential height with the input
-!! sea surface height due to the scalar approximation of self-attraction and loading.
+!>   This subroutine returns eta_prop member of SAL_CS type, which is the non-dimensional partial
+!! derivative of the local geopotential height with the input sea surface height due to the scalar
+!! approximation of self-attraction and loading.
 subroutine scalar_SAL_sensitivity(CS, deta_sal_deta)
   type(SAL_CS), intent(in)  :: CS !< The control structure returned by a previous call to SAL_init.
   real,         intent(out) :: deta_sal_deta !< The partial derivative of eta_sal with
                                              !! the local value of eta [nondim].
-
-  if (CS%use_sal_scalar .and. CS%use_tidal_sal_prev) then
-    deta_sal_deta = 2.0*CS%sal_scalar_value
-  elseif (CS%use_sal_scalar .or. CS%use_tidal_sal_prev) then
-    deta_sal_deta = CS%sal_scalar_value
-  else
-    deta_sal_deta = 0.0
-  endif
+  deta_sal_deta = CS%eta_prop
 end subroutine scalar_SAL_sensitivity
 
 !> This subroutine calculates coefficients of the spherical harmonic modes for self-attraction and loading.
 !! The algorithm is based on the SAL implementation in MPAS-ocean, which was modified by Kristin Barton from
 !! routine written by K. Quinn (March 2010) and modified by M. Schindelegger (May 2017).
-subroutine calc_love_scaling(nlm, rhoW, rhoE, Love_Scaling)
+subroutine calc_love_scaling(nlm, rhoW, rhoE, Love_scaling)
   integer, intent(in) :: nlm  !< Maximum spherical harmonics degree [nondim]
   real,    intent(in) :: rhoW !< The average density of sea water [R ~> kg m-3]
   real,    intent(in) :: rhoE !< The average density of Earth [R ~> kg m-3]
-  real, dimension(:), intent(out) :: Love_Scaling !< Scaling factors for inverse SHT [nondim]
+  real, dimension(:), intent(out) :: Love_scaling !< Scaling factors for inverse spherical harmonic
+    !! transforms [nondim]
 
   ! Local variables
   real, dimension(:), allocatable :: HDat, LDat, KDat ! Love numbers converted in CF reference frames [nondim]
   real :: H1, L1, K1 ! Temporary variables to store degree 1 Love numbers [nondim]
   integer :: n_tot ! Size of the stored Love numbers
   integer :: n, m, l
+  real :: unit
 
   n_tot = size(Love_Data, dim=2)
 
@@ -148,34 +166,40 @@ subroutine calc_love_scaling(nlm, rhoW, rhoE, Love_Scaling)
 
   do m=0,nlm ; do n=m,nlm
     l = order2index(m,nlm)
-    Love_Scaling(l+n-m) = (3.0 / real(2*n+1)) * (rhoW / rhoE) * (1.0 + KDat(n+1) - HDat(n+1))
+    Love_scaling(l+n-m) = (3.0 / real(2*n+1)) * (rhoW / rhoE) * (1.0 + KDat(n+1) - HDat(n+1))
   enddo ; enddo
 end subroutine calc_love_scaling
 
 !> This subroutine initializes the self-attraction and loading control structure.
-subroutine SAL_init(G, US, param_file, CS)
-  type(ocean_grid_type),  intent(inout) :: G    !< The ocean's grid structure.
-  type(unit_scale_type),  intent(in)    :: US   !< A dimensional unit scaling type
-  type(param_file_type),  intent(in)    :: param_file !< A structure to parse for run-time parameters.
+subroutine SAL_init(G, GV, US, param_file, CS)
+  type(ocean_grid_type),   intent(inout) :: G  !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
+  type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters.
   type(SAL_CS), intent(inout) :: CS   !< Self-attraction and loading control structure
 
   ! Local variables
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_self_attr_load" ! This module's name.
   integer :: lmax ! Total modes of the real spherical harmonics [nondim]
-  real :: rhoW    ! The average density of sea water [R ~> kg m-3].
   real :: rhoE    ! The average density of Earth [R ~> kg m-3].
+  character(len=200) :: filename, ebot_ref_file, inputdir ! Strings for file/path
+  character(len=200) :: ebot_ref_varname                  ! Variable name in file
+  real :: I_g_rho  ! The inverse of the density times the gravitational acceleration [Z T2 L-2 R-1 ~> m Pa-1]
+  logical :: calculate_sal=.false.
+  logical :: tides=.false., use_tidal_sal_file=.false., bq_sal_tides_bug=.false.
+  integer :: tides_answer_date=99991203 ! Recover old answers with tides
+  real :: sal_scalar_value, tide_sal_scalar_value ! Scaling SAL factors [nondim]
 
-  logical :: calculate_sal
-  logical :: tides, use_tidal_sal_file
-  real :: tide_sal_scalar_value ! Scaling SAL factor [nondim]
+  integer :: isd, ied, jsd, jed
+  integer :: i, j
+  isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, '', "TIDES", tides, default=.false., do_not_log=.True.)
-  call get_param(param_file, mdl, "CALCULATE_SAL", calculate_sal, "If true, calculate "//&
-                 " self-attraction and loading.", default=tides, do_not_log=.True.)
+  call get_param(param_file, '', "CALCULATE_SAL", calculate_sal, default=tides, do_not_log=.True.)
   if (.not. calculate_sal) return
 
   if (tides) then
@@ -183,17 +207,51 @@ subroutine SAL_init(G, US, param_file, CS)
                    default=.false., do_not_log=.True.)
     call get_param(param_file, '', "TIDAL_SAL_FROM_FILE", use_tidal_sal_file, &
                    default=.false., do_not_log=.True.)
+    call get_param(param_file, '', "TIDES_ANSWER_DATE", tides_answer_date, &
+                   default=20230630, do_not_log=.True.)
   endif
 
+  call get_param(param_file, mdl, "SAL_USE_BPA", CS%use_bpa, &
+                 "If true, use bottom pressure anomaly to calculate self-attraction and "// &
+                 "loading (SAL). Otherwise sea surface height anomaly is used, which is "// &
+                 "only correct for homogenous flow.", default=.False.)
+  if (CS%use_bpa) then
+    call get_param(param_file, '', "INPUTDIR", inputdir, default=".", do_not_log=.True.)
+    inputdir = slasher(inputdir)
+    call get_param(param_file, mdl, "REF_BOT_PRES_FILE", ebot_ref_file, &
+                   "Reference bottom pressure file used by self-attraction and loading (SAL).", &
+                   default="pbot.nc")
+    call get_param(param_file, mdl, "REF_BOT_PRES_VARNAME", ebot_ref_varname, &
+                   "The name of the variable in REF_BOT_PRES_FILE with reference bottom "//&
+                   "pressure.  The variable should have the unit of Pa.", &
+                   default="pbot")
+    filename = trim(inputdir)//trim(ebot_ref_file)
+    call log_param(param_file, mdl, "INPUTDIR/REF_BOT_PRES_FILE", filename)
+
+    allocate(CS%ebot_ref(isd:ied, jsd:jed), source=0.0)
+    call MOM_read_data(filename, trim(ebot_ref_varname), CS%ebot_ref, G%Domain,&
+                       scale=US%Pa_to_RL2_T2)
+    I_g_rho = 1.0 / (GV%g_Earth * GV%Rho0)
+    do j=jsd,jed ; do i=isd,ied
+      CS%ebot_ref(i,j) = CS%ebot_ref(i,j) * I_g_rho
+    enddo ; enddo
+    call pass_var(CS%ebot_ref, G%Domain)
+  endif
+  if (tides_answer_date<=20230630 .and. CS%use_bpa) &
+    call MOM_error(FATAL, trim(mdl) // ", SAL_init: SAL_USE_BPA needs to be false to recover "//&
+                   "tide answers before 20230630.")
   call get_param(param_file, mdl, "SAL_SCALAR_APPROX", CS%use_sal_scalar, &
                  "If true, use the scalar approximation to calculate self-attraction and "//&
                  "loading.", default=tides .and. (.not. use_tidal_sal_file))
+  ! if (CS%use_sal_scalar .and. CS%use_bpa) &
+  !   call MOM_error(WARNING, trim(mdl) // ", SAL_init: Using bottom pressure anomaly for scalar "//&
+  !                  "approximation SAL is unsubstantiated.")
   call get_param(param_file, '', "TIDE_SAL_SCALAR_VALUE", tide_sal_scalar_value, &
                  units="m m-1", default=0.0, do_not_log=.True.)
   if (tide_sal_scalar_value/=0.0) &
     call MOM_error(WARNING, "TIDE_SAL_SCALAR_VALUE is a deprecated parameter. "//&
                    "Use SAL_SCALAR_VALUE instead." )
-  call get_param(param_file, mdl, "SAL_SCALAR_VALUE", CS%sal_scalar_value, &
+  call get_param(param_file, mdl, "SAL_SCALAR_VALUE", sal_scalar_value, &
                  "The constant of proportionality between sea surface "//&
                  "height (really it should be bottom pressure) anomalies "//&
                  "and bottom geopotential anomalies. This is only used if "//&
@@ -207,20 +265,28 @@ subroutine SAL_init(G, US, param_file, CS)
                  "The maximum degree of the spherical harmonics transformation used for "// &
                  "calculating the self-attraction and loading term.", &
                  default=0, do_not_log=(.not. CS%use_sal_sht))
-  call get_param(param_file, '', "RHO_0", rhoW, default=1035.0, scale=US%kg_m3_to_R, &
-                 units="kg m-3", do_not_log=.True.)
   call get_param(param_file, mdl, "RHO_SOLID_EARTH", rhoE, &
                  "The mean solid earth density.  This is used for calculating the "// &
                  "self-attraction and loading term.", units="kg m-3", &
                  default=5517.0, scale=US%kg_m3_to_R, do_not_log=(.not. CS%use_sal_sht))
 
+  ! Set scaling coefficients for scalar approximation
+  if (CS%use_sal_scalar .and. CS%use_tidal_sal_prev) then
+    CS%eta_prop = 2.0 * sal_scalar_value
+  elseif (CS%use_sal_scalar .or. CS%use_tidal_sal_prev) then
+    CS%eta_prop = sal_scalar_value
+  else
+    CS%eta_prop = 0.0
+  endif
+
+  ! Set scaling coefficients for spherical harmonics
   if (CS%use_sal_sht) then
     lmax = calc_lmax(CS%sal_sht_Nd)
     allocate(CS%Snm_Re(lmax)); CS%Snm_Re(:) = 0.0
     allocate(CS%Snm_Im(lmax)); CS%Snm_Im(:) = 0.0
 
-    allocate(CS%Love_Scaling(lmax)); CS%Love_Scaling(:) = 0.0
-    call calc_love_scaling(CS%sal_sht_Nd, rhoW, rhoE, CS%Love_Scaling)
+    allocate(CS%Love_scaling(lmax)); CS%Love_scaling(:) = 0.0
+    call calc_love_scaling(CS%sal_sht_Nd, GV%Rho0, rhoE, CS%Love_scaling)
 
     allocate(CS%sht)
     call spherical_harmonics_init(G, param_file, CS%sht)
@@ -234,8 +300,11 @@ end subroutine SAL_init
 subroutine SAL_end(CS)
   type(SAL_CS), intent(inout) :: CS !< The control structure returned by a previous call
                                     !! to SAL_init; it is deallocated here.
+
+  if (allocated(CS%ebot_ref)) deallocate(CS%ebot_ref)
+
   if (CS%use_sal_sht) then
-    if (allocated(CS%Love_Scaling)) deallocate(CS%Love_Scaling)
+    if (allocated(CS%Love_scaling)) deallocate(CS%Love_scaling)
     if (allocated(CS%Snm_Re)) deallocate(CS%Snm_Re)
     if (allocated(CS%Snm_Im)) deallocate(CS%Snm_Im)
     call spherical_harmonics_end(CS%sht)
@@ -245,22 +314,20 @@ end subroutine SAL_end
 
 !> \namespace self_attr_load
 !!
-!! \section section_SAL Self attraction and loading
-!!
-!! This module contains methods to calculate self-attraction and loading (SAL) as a function of sea surface height (SSH)
-!! (rather, it should be bottom pressure anomaly). SAL is primarily used for fast evolving processes like tides or
-!! storm surges, but the effect applies to all motions.
+!! This module contains methods to calculate self-attraction and loading (SAL) as a function of sea surface height or
+!! bottom pressure anomaly. SAL is primarily used for fast evolving processes like tides or storm surges, but the
+!! effect applies to all motions.
 !!
 !! If <code>SAL_SCALAR_APPROX</code> is true, a scalar approximation is applied (\cite Accad1978) and the SAL is simply
-!! a fraction (set by <code>SAL_SCALAR_VALUE</code>, usually around 10% for global tides) of local SSH.
-!! For tides, the scalar approximation can also be used to iterate the SAL to convergence [see
-!! <code>USE_PREVIOUS_TIDES</code> in MOM_tidal_forcing, \cite Arbic2004].
+!! a fraction (set by <code>SAL_SCALAR_VALUE</code>, usually around 10% for global tides) of local SSH. For tides, the
+!! scalar approximation can also be used to iterate the SAL to convergence [see <code>USE_PREVIOUS_TIDES</code> in
+!! MOM_tidal_forcing, \cite Arbic2004].
 !!
 !! If <code>SAL_HARMONICS</code> is true, a more accurate online spherical harmonic transforms are used to calculate
-!! SAL. Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is
-!! set by <code>SAL_HARMONICS_DEGREE</code>. The algorithm is based on SAL calculation in Model for Prediction Across
-!! Scales (MPAS)-Ocean
-!! developed by Los Alamos National Laboratory and University of Michigan [\cite Barton2022 and \cite Brus2023].
+!! SAL. Subroutines in module MOM_spherical_harmonics are called and the degree of spherical harmonic transforms is set
+!! by <code>SAL_HARMONICS_DEGREE</code>. The algorithm is based on SAL calculation in Model for Prediction Across
+!! Scales (MPAS)-Ocean developed by Los Alamos National Laboratory and University of Michigan
+!! [\cite Barton2022 and \cite Brus2023].
 !!
 !! References:
 !!

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -187,7 +187,7 @@ subroutine SAL_init(G, GV, US, param_file, CS)
   character(len=200) :: ebot_ref_varname                  ! Variable name in file
   logical :: calculate_sal=.false.
   logical :: tides=.false., use_tidal_sal_file=.false., bq_sal_tides_bug=.false.
-  integer :: tides_answer_date=99991203 ! Recover old answers with tides
+  integer :: tides_answer_date=99991231 ! Recover old answers with tides
   real :: sal_scalar_value, tide_sal_scalar_value ! Scaling SAL factors [nondim]
   integer :: isd, ied, jsd, jed
 
@@ -231,9 +231,9 @@ subroutine SAL_init(G, GV, US, param_file, CS)
                        scale=US%Pa_to_RL2_T2)
     call pass_var(CS%ebot_ref, G%Domain)
   endif
-  if (tides_answer_date<=20230630 .and. CS%use_bpa) &
+  if (tides_answer_date<=20250131 .and. CS%use_bpa) &
     call MOM_error(FATAL, trim(mdl) // ", SAL_init: SAL_USE_BPA needs to be false to recover "//&
-                   "tide answers before 20230630.")
+                   "tide answers before 20250131.")
   call get_param(param_file, mdl, "SAL_SCALAR_APPROX", CS%use_sal_scalar, &
                  "If true, use the scalar approximation to calculate self-attraction and "//&
                  "loading.", default=tides .and. (.not. use_tidal_sal_file))

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -1,12 +1,12 @@
 !> Laplace's spherical harmonic transforms (SHT)
 module MOM_spherical_harmonics
+use MOM_coms_infra,    only : sum_across_PEs
+use MOM_coms,          only : reproducing_sum
 use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, &
                               CLOCK_MODULE, CLOCK_ROUTINE, CLOCK_LOOP
 use MOM_error_handler, only : MOM_error, FATAL
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
-use MOM_coms_infra,    only : sum_across_PEs
-use MOM_coms,          only : reproducing_sum
 
 implicit none ; private
 

--- a/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
+++ b/src/parameterizations/vertical/MOM_diapyc_energy_req.F90
@@ -73,7 +73,7 @@ subroutine diapyc_energy_req_test(h_3d, dt, tv, G, GV, US, CS, Kd_int)
     Kd, &        ! A column of diapycnal diffusivities at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1].
     h_top, h_bot ! Distances from the top or bottom [H ~> m or kg m-2].
   real :: dz_h_int  ! The ratio of the vertical distances across the layers surrounding an interface
-                 ! over the layer thicknesses [H Z-1 ~> nonodim or kg m-3]
+                 ! over the layer thicknesses [H Z-1 ~> nondim or kg m-3]
   real :: ustar  ! The local friction velocity [Z T-1 ~> m s-1]
   real :: absf   ! The absolute value of the Coriolis parameter [T-1 ~> s-1]
   real :: htot   ! The sum of the thicknesses [H ~> m or kg m-2].


### PR DESCRIPTION
This PR adds the option of using bottom pressure anomaly to calculate self-attraction and loading (SAL). Currently, sea surface height (SSH) is used for SAL, which is only accurate for barotropic flows. (SSH is the barotropic equivalent of bottom pressure anomaly.) 

* A new runtime parameter `SAL_USE_BPA` is added to use bottom pressure anomaly. The option requires an input file for long term mean reference bottom pressure. 
  * The reference bottom pressure field is stored with `SAL_CS` rather than `PressureForce_FV_CS`. 
  * When `SAL_USE_BPA` is true, total bottom pressure field is used as the input for subroutine `calc_SAL`(), the reference pressure is subtracted within the subroutine.

* SAL calculation in Boussinesq mode is refactored in order to
  1. calculate SAL after bottom pressure is calculated.
  2. fix a longstand bug that SAL and tides geopotential height anomaly is added to interface height *before* density is calculated. Note that even though the newly-added parameter `SSH_IN_EOS_PRESSURE_FOR_PGF` also fix this bug, the refactor avoids having SAL code appear in multiple places.

* Add an alternative method for SAL and tides in Boussinesq mode, controlled by runtime parameter `BOUSSINESQ_SAL_TIDES` (default=False). The current method in Boussinesq mode has a baroclinic component of tidal forcing and SAL. While it is arguably consistent with the Boussinesq approximation, it might also be confusing. The alternative method directly calculate the gradients of tidal forcing and SAL and add them to `PF[uv]`.

* ~~Old answers with `TIDES_ANSWER_DATE`<=20230630 are not changed. But answers with `TIDES_ANSWER_DATE`>20230630 in Boussinesq mode are changed at bit-level. Since the default of `TIDES_ANSWER_DATE` is currently 20230630, there is probably no compelling reason to preserve answers after that date.~~

* All old answers are preserved with the correct answer date value. 