### PR TITLE
Add SQG vertical structure to eddy diffusivities

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -750,7 +750,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     if (CS%VarMix%use_variable_mixing) then
       call enable_averages(cycle_time, Time_start + real_to_time(US%T_to_s*cycle_time), CS%diag)
-      call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE)
+      call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, dt)
       call calc_depth_function(G, CS%VarMix)
       call disable_averaging(CS%diag)
     endif
@@ -1898,7 +1898,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         if (.not. skip_diffusion) then
           if (CS%VarMix%use_variable_mixing) then
             call pass_var(CS%h, G%Domain)
-            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE)
+            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, dt_offline)
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif
@@ -1925,7 +1925,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         if (.not. skip_diffusion) then
           if (CS%VarMix%use_variable_mixing) then
             call pass_var(CS%h, G%Domain)
-            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE)
+            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, dt_offline)
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -750,7 +750,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     if (CS%VarMix%use_variable_mixing) then
       call enable_averages(cycle_time, Time_start + real_to_time(US%T_to_s*cycle_time), CS%diag)
-      call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix)
+      call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE)
       call calc_depth_function(G, CS%VarMix)
       call disable_averaging(CS%diag)
     endif
@@ -1898,7 +1898,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         if (.not. skip_diffusion) then
           if (CS%VarMix%use_variable_mixing) then
             call pass_var(CS%h, G%Domain)
-            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix)
+            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE)
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif
@@ -1925,7 +1925,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         if (.not. skip_diffusion) then
           if (CS%VarMix%use_variable_mixing) then
             call pass_var(CS%h, G%Domain)
-            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix)
+            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE)
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -124,6 +124,7 @@ type, public :: MEKE_CS ; private
   logical :: debug      !< If true, write out checksums of data for debugging
   integer :: eke_src !< Enum specifying whether EKE is stepped forward prognostically (default),
                      !! read in from a file, or inferred via a neural network
+  logical :: sqg_use_MEKE !< If True, use MEKE%Le for the SQG vertical structure. 
   type(diag_ctrl), pointer :: diag => NULL() !< A type that regulates diagnostics output
   !>@{ Diagnostic handles
   integer :: id_MEKE = -1, id_Ue = -1, id_Kh = -1, id_src = -1
@@ -398,6 +399,13 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       call hchksum(bottomFac2, 'MEKE bottomFac2', G%HI)
       call hchksum(barotrFac2, 'MEKE barotrFac2', G%HI)
       call hchksum(LmixScale, 'MEKE LmixScale', G%HI, unscale=US%L_to_m)
+    endif
+
+    if (allocated(MEKE%Le)) then
+      !$OMP parallel do default(shared)
+      do j=js,je ; do i=is,ie
+        MEKE%Le(i,j) = LmixScale(i,j)
+      enddo ; enddo
     endif
 
     ! Aggregate sources of MEKE (background, frictional and GM)
@@ -757,7 +765,8 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
     enddo ; enddo
   endif
 
-  if (allocated(MEKE%Kh) .or. allocated(MEKE%Ku) .or. allocated(MEKE%Au)) then
+  if (allocated(MEKE%Kh) .or. allocated(MEKE%Ku) .or. allocated(MEKE%Au) &
+     .or. allocated(MEKE%Le)) then
     call cpu_clock_begin(CS%id_clock_pass)
     call do_group_pass(CS%pass_Kh, G%Domain)
     call cpu_clock_end(CS%id_clock_pass)
@@ -1425,6 +1434,9 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
                  "computing beta in the expression of Rhines scale. Use 1 if full "//&
                  "topographic beta effect is considered; use 0 if it's completely ignored.", &
                  units="nondim", default=0.0)
+  call get_param(param_file, mdl, "SQG_USE_MEKE", CS%sqg_use_MEKE, &
+                 "If true, the eddy scale of MEKE is used for the SQG vertical structure ",&
+                 default=.false.)
 
   ! Nonlocal module parameters
   call get_param(param_file, mdl, "CDRAG", cdrag, &
@@ -1531,6 +1543,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
 
   CS%id_clock_pass = cpu_clock_id('(Ocean continuity halo updates)', grain=CLOCK_ROUTINE)
 
+
   ! Detect whether this instance of MEKE_init() is at the beginning of a run
   ! or after a restart. If at the beginning, we will initialize MEKE to a local
   ! equilibrium.
@@ -1538,6 +1551,12 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   if (coldStart) CS%initialize = .false.
   if (CS%initialize) call MOM_error(WARNING, &
                        "MEKE_init: Initializing MEKE with a local equilibrium balance.")
+  if (.not.query_initialized(MEKE%Le, "MEKE_Le", restart_CS) .and. allocated(MEKE%Le)) then
+    !$OMP parallel do default(shared)
+    do j=js,je ; do i=is,ie
+      MEKE%Le(i,j) = sqrt(G%areaT(i,j))
+    enddo ; enddo
+  endif
 
   ! Set up group passes.  In the case of a restart, these fields need a halo update now.
   if (allocated(MEKE%MEKE)) then
@@ -1548,8 +1567,10 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   if (allocated(MEKE%Kh)) call create_group_pass(CS%pass_Kh, MEKE%Kh, G%Domain)
   if (allocated(MEKE%Ku)) call create_group_pass(CS%pass_Kh, MEKE%Ku, G%Domain)
   if (allocated(MEKE%Au)) call create_group_pass(CS%pass_Kh, MEKE%Au, G%Domain)
+  if (allocated(MEKE%Le)) call create_group_pass(CS%pass_Kh, MEKE%Le, G%Domain)
 
-  if (allocated(MEKE%Kh) .or. allocated(MEKE%Ku) .or. allocated(MEKE%Au)) &
+  if (allocated(MEKE%Kh) .or. allocated(MEKE%Ku) .or. allocated(MEKE%Au) &
+     .or. allocated(MEKE%Le)) &
     call do_group_pass(CS%pass_Kh, G%Domain)
 
 end function MEKE_init
@@ -1839,6 +1860,7 @@ subroutine MEKE_alloc_register_restart(HI, US, param_file, MEKE, restart_CS)
   real :: MEKE_KHCoeff, MEKE_viscCoeff_Ku, MEKE_viscCoeff_Au  ! Coefficients for various terms [nondim]
   logical :: Use_KH_in_MEKE
   logical :: useMEKE
+  logical :: sqg_use_MEKE
   integer :: isd, ied, jsd, jed
 
 ! Determine whether this module will be used
@@ -1853,6 +1875,7 @@ subroutine MEKE_alloc_register_restart(HI, US, param_file, MEKE, restart_CS)
   MEKE_viscCoeff_Ku = 0. ; call read_param(param_file,"MEKE_VISCOSITY_COEFF_KU",MEKE_viscCoeff_Ku)
   MEKE_viscCoeff_Au = 0. ; call read_param(param_file,"MEKE_VISCOSITY_COEFF_AU",MEKE_viscCoeff_Au)
   Use_KH_in_MEKE = .false. ; call read_param(param_file,"USE_KH_IN_MEKE", Use_KH_in_MEKE)
+  sqg_use_MEKE = .false. ; call read_param(param_file,"SQG_USE_MEKE", sqg_use_MEKE)
 
   if (.not. useMEKE) return
 
@@ -1884,6 +1907,12 @@ subroutine MEKE_alloc_register_restart(HI, US, param_file, MEKE, restart_CS)
              longname="Lateral viscosity from Mesoscale Eddy Kinetic Energy", &
              units="m2 s-1", conversion=US%L_to_m**2*US%s_to_T)
   endif
+  if (sqg_use_MEKE) then
+    allocate(MEKE%Le(isd:ied,jsd:jed), source=0.0)
+    call register_restart_field(MEKE%Le, "MEKE_Le", .false., restart_CS, &
+             longname="Eddy length scale from Mesoscale Eddy Kinetic Energy", &
+             units="m", conversion=US%L_to_m)
+  endif    
   if (Use_Kh_in_MEKE) then
     allocate(MEKE%Kh_diff(isd:ied,jsd:jed), source=0.0)
     call register_restart_field(MEKE%Kh_diff, "MEKE_Kh_diff", .false., restart_CS, &
@@ -1918,6 +1947,7 @@ subroutine MEKE_end(MEKE)
   if (allocated(MEKE%mom_src_bh)) deallocate(MEKE%mom_src_bh)
   if (allocated(MEKE%GM_src)) deallocate(MEKE%GM_src)
   if (allocated(MEKE%MEKE)) deallocate(MEKE%MEKE)
+  if (allocated(MEKE%Le)) deallocate(MEKE%Le)
 end subroutine MEKE_end
 
 !> \namespace mom_meke

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -124,7 +124,7 @@ type, public :: MEKE_CS ; private
   logical :: debug      !< If true, write out checksums of data for debugging
   integer :: eke_src !< Enum specifying whether EKE is stepped forward prognostically (default),
                      !! read in from a file, or inferred via a neural network
-  logical :: sqg_use_MEKE !< If True, use MEKE%Le for the SQG vertical structure. 
+  logical :: sqg_use_MEKE !< If True, use MEKE%Le for the SQG vertical structure.
   type(diag_ctrl), pointer :: diag => NULL() !< A type that regulates diagnostics output
   !>@{ Diagnostic handles
   integer :: id_MEKE = -1, id_Ue = -1, id_Kh = -1, id_src = -1
@@ -1912,7 +1912,7 @@ subroutine MEKE_alloc_register_restart(HI, US, param_file, MEKE, restart_CS)
     call register_restart_field(MEKE%Le, "MEKE_Le", .false., restart_CS, &
              longname="Eddy length scale from Mesoscale Eddy Kinetic Energy", &
              units="m", conversion=US%L_to_m)
-  endif    
+  endif
   if (Use_Kh_in_MEKE) then
     allocate(MEKE%Kh_diff(isd:ied,jsd:jed), source=0.0)
     call register_restart_field(MEKE%Kh_diff, "MEKE_Kh_diff", .false., restart_CS, &

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -766,7 +766,7 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
   endif
 
   if (allocated(MEKE%Kh) .or. allocated(MEKE%Ku) .or. allocated(MEKE%Au) &
-     .or. allocated(MEKE%Le)) then
+      .or. allocated(MEKE%Le)) then
     call cpu_clock_begin(CS%id_clock_pass)
     call do_group_pass(CS%pass_Kh, G%Domain)
     call cpu_clock_end(CS%id_clock_pass)
@@ -1570,7 +1570,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   if (allocated(MEKE%Le)) call create_group_pass(CS%pass_Kh, MEKE%Le, G%Domain)
 
   if (allocated(MEKE%Kh) .or. allocated(MEKE%Ku) .or. allocated(MEKE%Au) &
-     .or. allocated(MEKE%Le)) &
+      .or. allocated(MEKE%Le)) &
     call do_group_pass(CS%pass_Kh, G%Domain)
 
 end function MEKE_init

--- a/src/parameterizations/lateral/MOM_MEKE_types.F90
+++ b/src/parameterizations/lateral/MOM_MEKE_types.F90
@@ -24,6 +24,7 @@ type, public :: MEKE_type
                                     !! backscatter from unresolved eddies (see Jansen and Held, 2014).
   real, allocatable :: Au(:,:)      !< The MEKE-derived lateral biharmonic viscosity
                                     !! coefficient [L4 T-1 ~> m4 s-1].
+  real, allocatable :: Le(:,:)      !< Eddy length scale [L m]
 
   ! Parameters
   real :: KhTh_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTh [nondim]

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -446,6 +446,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   logical :: use_MEKE_Ku
   logical :: use_MEKE_Au
   logical :: use_cont_huv
+  logical :: use_kh_struct
   integer :: is_vort, ie_vort, js_vort, je_vort  ! Loop ranges for vorticity terms
   integer :: is_Kh, ie_Kh, js_Kh, je_Kh  ! Loop ranges for thickness point viscosities
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -502,6 +503,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   if (CS%id_FrictWorkIntz > 0) find_FrictWork = .true.
 
   if (allocated(MEKE%mom_src)) find_FrictWork = .true.
+  use_kh_struct = allocated(VarMix%BS_struct)
   backscat_subround = 0.0
   if (find_FrictWork .and. allocated(MEKE%mom_src) .and. (MEKE%backscatter_Ro_c > 0.0) .and. &
       (MEKE%backscatter_Ro_Pow /= 0.0)) &
@@ -663,7 +665,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
   !$OMP   is_vort, ie_vort, js_vort, je_vort, &
   !$OMP   is_Kh, ie_Kh, js_Kh, je_Kh, &
-  !$OMP   apply_OBC, rescale_Kh, legacy_bound, find_FrictWork, &
+  !$OMP   apply_OBC, rescale_Kh, legacy_bound, find_FrictWork, use_kh_struct, &
   !$OMP   use_MEKE_Ku, use_MEKE_Au, u_smooth, v_smooth, use_cont_huv, slope_x, slope_y, dz, &
   !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
   !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
@@ -1181,14 +1183,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         ! *Add* the MEKE contribution (which might be negative)
-        if (CS%res_scale_MEKE) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
-          enddo ; enddo
+        if (use_kh_struct) then
+          if (CS%res_scale_MEKE) then
+            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
+            enddo ; enddo
+          else
+            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+            enddo ; enddo
+          endif
         else
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-          enddo ; enddo
+          if (CS%res_scale_MEKE) then
+            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
+            enddo ; enddo
+          else
+            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j)
+            enddo ; enddo
+          endif
         endif
       endif
 
@@ -1443,7 +1457,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         if (visc_limit_h_flag(i,j,k) > 0) then
           Kh_BS(i,j) = 0.
         else
-          Kh_BS(i,j) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+          if (use_kh_struct) then
+            Kh_BS(i,j) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+          else
+            Kh_BS(i,j) = MEKE%Ku(i,j)
+          endif
         endif
       enddo ; enddo
 
@@ -1618,10 +1636,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
         if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
           ! *Add* the MEKE contribution (might be negative)
-          Kh(I,J) = Kh(I,J) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
-                                     (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
-                                     ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
-                                     (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
+          if (use_kh_struct) then
+            Kh(I,J) = Kh(I,J) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+                                       (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
+                                       ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
+                                       (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
+          else
+            Kh(I,J) = Kh(I,J) + 0.25*( (MEKE%Ku(i,j) + &
+                                       MEKE%Ku(i+1,j+1)) + &
+                                       (MEKE%Ku(i+1,j) + &
+                                        MEKE%Ku(i,j+1)) ) * meke_res_fn
+          endif
         endif
 
         if (CS%anisotropic) &
@@ -1789,10 +1814,17 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         if (visc_limit_q_flag(I,J,k) > 0) then
           Kh_BS(I,J) = 0.
         else
-          Kh_BS(I,J) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
-                       (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
-                       ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
-                       (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
+          if (use_kh_struct) then
+            Kh_BS(I,J) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+                         (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
+                         ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
+                         (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
+          else
+            Kh_BS(I,J) = 0.25*( (MEKE%Ku(i,j) + &
+                         MEKE%Ku(i+1,j+1)) + &
+                         (MEKE%Ku(i+1,j) + &
+                         MEKE%Ku(i,j+1)) )
+          endif
         endif
       enddo ; enddo
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -129,8 +129,8 @@ type, public :: VarMix_CS
   real, allocatable :: khtr_struct(:,:,:) !< Vertical structure function used in tracer diffusivity [nondim]
   real, allocatable :: kdgl90_struct(:,:,:) !< Vertical structure function used in GL90 diffusivity [nondim]
   real :: BS_EBT_power                !< Power to raise EBT vertical structure to. Default 0.0.
-  real :: sqg_expo     !< Exponent for SQG vertical structure [nondim]. Default 0.0
-  logical :: BS_use_sqg   !< If true, use sqg_stuct for backscatter vertical structure.
+  real :: sqg_expo     !< Exponent for SQG vertical structure [nondim]. Default 1.0
+  logical :: BS_use_sqg_struct   !< If true, use sqg_stuct for backscatter vertical structure.
 
 
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_) :: &
@@ -282,31 +282,23 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, dt)
     call create_group_pass(CS%pass_cg1, CS%cg1, G%Domain)
     call do_group_pass(CS%pass_cg1, G%Domain)
   endif
-  if (CS%BS_use_sqg .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
+  if (CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
       .or. CS%kdgl90_use_sqg_struct .or. CS%id_sqg_struct>0) then
     call calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE)
     call pass_var(CS%sqg_struct, G%Domain)
   endif
 
-  if (CS%BS_EBT_power>0. .and. CS%BS_use_sqg) then
-    call MOM_error(FATAL, &
-      "calc_resoln_function: BS_EBT_POWER>0. &
-      and BS_USE_SQG=True cannot be set together")
-  elseif (CS%BS_EBT_power>0.) then
+  if (CS%BS_EBT_power>0.) then
     do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
       CS%BS_struct(i,j,k) = CS%ebt_struct(i,j,k)**CS%BS_EBT_power
     enddo ; enddo ; enddo
-  elseif (CS%BS_use_sqg) then
+  elseif (CS%BS_use_sqg_struct) then
     do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
       CS%BS_struct(i,j,k) = CS%sqg_struct(i,j,k)
     enddo ; enddo ; enddo
   endif
 
-  if (CS%khth_use_ebt_struct .and. CS%khth_use_sqg_struct) then
-    call MOM_error(FATAL, &
-      "calc_resoln_function: Only one of KHTH_USE_EBT_STRUCT &
-      and KHTH_USE_SQG_STRUCT can be true")
-  elseif (CS%khth_use_ebt_struct) then
+  if (CS%khth_use_ebt_struct) then
     do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
       CS%khth_struct(i,j,k) = CS%ebt_struct(i,j,k)
     enddo ; enddo ; enddo
@@ -316,11 +308,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, dt)
     enddo ; enddo ; enddo
   endif
 
-  if (CS%khtr_use_ebt_struct .and. CS%khtr_use_sqg_struct) then
-    call MOM_error(FATAL, &
-      "calc_resoln_function: Only one of KHTR_USE_EBT_STRUCT &
-      and KHTR_USE_SQG_STRUCT can be true")
-  elseif (CS%khtr_use_ebt_struct) then
+  if (CS%khtr_use_ebt_struct) then
     do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
       CS%khtr_struct(i,j,k) = CS%ebt_struct(i,j,k)
     enddo ; enddo ; enddo
@@ -330,11 +318,7 @@ subroutine calc_resoln_function(h, tv, G, GV, US, CS, MEKE, dt)
     enddo ; enddo ; enddo
   endif
 
-  if (CS%kdgl90_use_ebt_struct .and. CS%kdgl90_use_sqg_struct) then
-    call MOM_error(FATAL, &
-      "calc_resoln_function: Only one of KD_GL90_USE_EBT_STRUCT &
-      and KD_GL90_USE_SQG_STRUCT can be true")
-  elseif (CS%kdgl90_use_ebt_struct) then
+  if (CS%kdgl90_use_ebt_struct) then
     do k=1,nz ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
       CS%kdgl90_struct(i,j,k) = CS%ebt_struct(i,j,k)
     enddo ; enddo ; enddo
@@ -561,8 +545,6 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE)
    real,                                      intent(in)    :: dt !< Time increment [T ~> s]
   type(VarMix_CS),                           intent(inout) :: CS !< Variable mixing control struct
   type(MEKE_type),                           intent(in)     :: MEKE !< MEKE struct
-  !  type(ocean_OBC_type),                      pointer       :: OBC !< Open
-!  boundaries control structure.
 
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G),SZK_(GV)+1) :: &
@@ -574,13 +556,14 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE)
   real, dimension(SZIB_(G), SZJ_(G),SZK_(GV)+1) :: dzSxN ! |Sx| N times dz at u-points [Z T-1 ~> m s-1]
   real, dimension(SZI_(G), SZJB_(G),SZK_(GV)+1) :: dzSyN ! |Sy| N times dz at v-points [Z T-1 ~> m s-1]
   real, dimension(SZI_(G), SZJ_(G)) :: f  ! Absolute value of the Coriolis parameter at h point [T-1 ~> s-1]
-  real :: N2  ! Positive buoyancy frequency square or zero [L2 Z-2 T-2 ~> s-2]
-  real :: dzc  ! Spacing between two adjacent layers in stretched vertical coordinate [m]
-!  real, dimension(SZK_(GV)) :: zs  ! Stretched vertical coordinate [m]
+  real :: N2             ! Positive buoyancy frequency square or zero [L2 Z-2 T-2 ~> s-2]
+  real :: dzc            ! Spacing between two adjacent layers in stretched vertical coordinate [m]
+  real :: f_subround     ! The minimal resolved value of Coriolis parameter to prevent division by zero [T-1 ~> s-1]
   real, dimension(SZI_(G), SZJ_(G)) :: Le  ! Eddy length scale [m]
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  f_subround = 1.0e-40 * US%s_to_T
 
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_slope_functions: "//&
          "Module must be initialized before it is used.")
@@ -590,34 +573,32 @@ subroutine calc_sqg_struct(h, tv, G, GV, US, CS, dt, MEKE)
                                   CS%slope_x, CS%slope_y, N2_u=N2_u, N2_v=N2_v,dzu=dzu, dzv=dzv, &
                                   dzSxN=dzSxN, dzSyN=dzSyN, halo=1)
 
-  do j=js,je ; do i=is,ie
-    CS%sqg_struct(i,j,1) = 1.0
-  enddo ; enddo
-  if (allocated(MEKE%Le)) then
-    do j=js,je ; do i=is,ie
-      Le(i,j) = MEKE%Le(i,j)
-      f(i,j) = max(0.25*abs(G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J-1) + &
-                       G%CoriolisBu(I-1,J) + G%CoriolisBu(I,J-1)), 1.0e-8/US%T_to_s)
-    enddo ; enddo
+  if (CS%sqg_expo<=0.) then
+    CS%sqg_struct(:,:,:) = 1.
   else
     do j=js,je ; do i=is,ie
-      Le(i,j) = sqrt(G%areaT(i,j))
-      f(i,j) = max(0.25*abs(G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J-1) + &
-                       G%CoriolisBu(I-1,J) + G%CoriolisBu(I,J-1)), 1.0e-8*US%T_to_s)
+      CS%sqg_struct(i,j,1) = 1.0
     enddo ; enddo
+    if (allocated(MEKE%Le)) then
+      do j=js,je ; do i=is,ie
+        Le(i,j) = MEKE%Le(i,j)
+        f(i,j) = max(0.25 * abs((G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J-1)) + &
+                         (G%CoriolisBu(I-1,J) + G%CoriolisBu(I,J-1))), f_subround)
+      enddo ; enddo
+    else
+      do j=js,je ; do i=is,ie
+        Le(i,j) = sqrt(G%areaT(i,j))
+        f(i,j) = max(0.25 * abs((G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J-1)) + &
+                         (G%CoriolisBu(I-1,J) + G%CoriolisBu(I,J-1))), f_subround)
+      enddo ; enddo
+    endif
+    do k=2,nz ; do j=js,je ; do i=is,ie
+      N2 = max(0.25 * ((N2_u(I-1,j,k) + N2_u(I,j,k)) + (N2_v(i,J-1,k) + N2_v(i,J,k))), 0.0)
+      dzc = 0.25 * ((dzu(I-1,j,k) + dzu(I,j,k)) + (dzv(i,J-1,k) + dzv(i,J,k)))
+      CS%sqg_struct(i,j,k) = CS%sqg_struct(i,j,k-1) * &
+              exp(-CS%sqg_expo * (dzc * sqrt(N2)/(f(i,j) * Le(i,j))))
+    enddo ; enddo ; enddo
   endif
-  if (CS%debug) then
-    call hchksum(Le, 'SQG length scale', G%HI, unscale=US%L_to_m)
-    call hchksum(f, 'Coriolis at h point', G%HI, unscale=US%s_to_T)
-    call uvchksum( 'MEKE LmixScale', dzu, dzv, G%HI, unscale=US%Z_to_m, scalar_pair=.true.)
-  endif
-  do k=2,nz ; do j=js,je ; do i=is,ie
-    N2 = max(0.25*(N2_u(I-1,j,k) + N2_u(I,j,k) + N2_v(i,J-1,k) + N2_v(i,J,k)),0.0)
-    dzc = 0.25*(dzu(I-1,j,k) + dzu(I,j,k) + dzv(i,J-1,k) + dzv(i,J,k)) * &
-            N2**0.5/f(i,j)*US%Z_to_L
-!    dzs = -N2**0.5/f(i,j)*dzc
-    CS%sqg_struct(i,j,k) = CS%sqg_struct(i,j,k-1)*exp(-CS%sqg_expo*dzc/Le(i,j))
-  enddo ; enddo ; enddo
 
 
   if (query_averaging_enabled(CS%diag)) then
@@ -1418,7 +1399,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   call get_param(param_file, mdl, "BACKSCAT_EBT_POWER", CS%BS_EBT_power, &
                  "Power to raise EBT vertical structure to when backscatter "// &
                  "has vertical structure.", units="nondim", default=0.0)
-  call get_param(param_file, mdl, "BS_USE_SQG", CS%BS_use_sqg, &
+  call get_param(param_file, mdl, "BS_USE_SQG_STRUCT", CS%BS_use_sqg_struct, &
                  "If true, the SQG vertical structure is used for backscatter "//&
                  "on the condition that BS_EBT_power=0", &
                  default=.false.)
@@ -1503,8 +1484,33 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   endif
 
 
-  allocate(CS%BS_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
-  CS%BS_struct(:,:,:) = 1.0
+  if (CS%BS_EBT_power>0. .and. CS%BS_use_sqg_struct) then
+    call MOM_error(FATAL, &
+                   "calc_resoln_function: BS_EBT_POWER>0. &
+                   & and BS_USE_SQG=True cannot be set together")
+  endif
+
+  if (CS%khth_use_ebt_struct .and. CS%khth_use_sqg_struct) then
+    call MOM_error(FATAL, &
+                   "calc_resoln_function: Only one of KHTH_USE_EBT_STRUCT &
+                   & and KHTH_USE_SQG_STRUCT can be true")
+  endif
+
+  if (CS%khtr_use_ebt_struct .and. CS%khtr_use_sqg_struct) then
+    call MOM_error(FATAL, &
+                   "calc_resoln_function: Only one of KHTR_USE_EBT_STRUCT &
+                   & and KHTR_USE_SQG_STRUCT can be true")
+  endif
+
+  if (CS%kdgl90_use_ebt_struct .and. CS%kdgl90_use_sqg_struct) then
+    call MOM_error(FATAL, &
+                   "calc_resoln_function: Only one of KD_GL90_USE_EBT_STRUCT &
+                   & and KD_GL90_USE_SQG_STRUCT can be true")
+  endif
+
+  if (CS%BS_EBT_power>0. .or. CS%BS_use_sqg_struct) then
+    allocate(CS%BS_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
+  endif
 
   if (CS%khth_use_ebt_struct .or. CS%khth_use_sqg_struct) then
     allocate(CS%khth_struct(isd:ied, jsd:jed, gv%ke), source=0.0)
@@ -1615,13 +1621,15 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
 
   CS%id_sqg_struct = register_diag_field('ocean_model', 'sqg_struct', diag%axesTl, Time, &
             'Vertical structure of SQG mode', 'nondim')
-  if (CS%BS_use_sqg .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
-    .or. CS%kdgl90_use_sqg_struct .or. CS%id_sqg_struct>0) then
+  if (CS%BS_use_sqg_struct .or. CS%khth_use_sqg_struct .or. CS%khtr_use_sqg_struct &
+      .or. CS%kdgl90_use_sqg_struct .or. CS%id_sqg_struct>0) then
     allocate(CS%sqg_struct(isd:ied,jsd:jed,GV%ke), source=0.0)
   endif
 
-  CS%id_BS_struct = register_diag_field('ocean_model', 'BS_struct', diag%axesTl, Time, &
-            'Vertical structure of backscatter', 'nondim')
+  if (CS%BS_EBT_power>0. .or. CS%BS_use_sqg_struct) then
+    CS%id_BS_struct = register_diag_field('ocean_model', 'BS_struct', diag%axesTl, Time, &
+              'Vertical structure of backscatter', 'nondim')
+  endif
   if (CS%khth_use_ebt_struct .or. CS%khth_use_sqg_struct) then
     CS%id_khth_struct = register_diag_field('ocean_model', 'khth_struct', diag%axesTl, Time, &
             'Vertical structure of thickness diffusivity', 'nondim')
@@ -1888,7 +1896,7 @@ subroutine VarMix_end(CS)
   type(VarMix_CS), intent(inout) :: CS
 
   if (CS%Resoln_use_ebt .or. CS%khth_use_ebt_struct .or. CS%kdgl90_use_ebt_struct &
-     .or. CS%BS_EBT_power>0. .or. CS%khtr_use_ebt_struct) deallocate(CS%ebt_struct)
+      .or. CS%BS_EBT_power>0. .or. CS%khtr_use_ebt_struct) deallocate(CS%ebt_struct)
   if (allocated(CS%sqg_struct)) deallocate(CS%sqg_struct)
   if (allocated(CS%BS_struct)) deallocate(CS%BS_struct)
   if (CS%khth_use_ebt_struct .or. CS%khth_use_sqg_struct) deallocate(CS%khth_struct)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -179,7 +179,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
                                     ! to layer centers [L2 T-1 ~> m2 s-1]
   real :: KH_v_lay(SZI_(G),SZJ_(G)) ! Diagnostic of isopycnal height diffusivities at v-points averaged
                                     ! to layer centers [L2 T-1 ~> m2 s-1]
-  logical :: use_VarMix, Resoln_scaled, Depth_scaled, use_stored_slopes, khth_use_ebt_struct, use_Visbeck
+  logical :: use_VarMix, Resoln_scaled, Depth_scaled, use_stored_slopes, khth_use_vert_struct, use_Visbeck
   logical :: use_QG_Leith
   integer :: i, j, k, is, ie, js, je, nz
 
@@ -198,7 +198,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   use_VarMix = .false. ; Resoln_scaled = .false. ; use_stored_slopes = .false.
-  khth_use_ebt_struct = .false. ; use_Visbeck = .false. ; use_QG_Leith = .false.
+  khth_use_vert_struct = .false. ; use_Visbeck = .false. ; use_QG_Leith = .false.
   Depth_scaled = .false.
 
   if (VarMix%use_variable_mixing) then
@@ -206,7 +206,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     Resoln_scaled = VarMix%Resoln_scaled_KhTh
     Depth_scaled = VarMix%Depth_scaled_KhTh
     use_stored_slopes = VarMix%use_stored_slopes
-    khth_use_ebt_struct = VarMix%khth_use_ebt_struct
+    khth_use_vert_struct = allocated(VarMix%khth_struct)
     use_Visbeck = VarMix%use_Visbeck
     use_QG_Leith = VarMix%use_QG_Leith_GM
     if (allocated(VarMix%cg1)) cg1 => VarMix%cg1
@@ -298,10 +298,10 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     KH_u(I,j,1) = min(KH_u_CFL(I,j), Khth_loc_u(I,j))
   enddo ; enddo
 
-  if (khth_use_ebt_struct) then
+  if (khth_use_vert_struct) then
     !$OMP do
     do K=2,nz+1 ; do j=js,je ; do I=is-1,ie
-      KH_u(I,j,K) = KH_u(I,j,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i+1,j,k-1) )
+      KH_u(I,j,K) = KH_u(I,j,1) * 0.5 * ( VarMix%khth_struct(i,j,k-1) + VarMix%khth_struct(i+1,j,k-1) )
     enddo ; enddo ; enddo
   else
     !$OMP do
@@ -394,10 +394,10 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     enddo ; enddo
   endif
 
-  if (khth_use_ebt_struct) then
+  if (khth_use_vert_struct) then
     !$OMP do
     do K=2,nz+1 ; do J=js-1,je ; do i=is,ie
-      KH_v(i,J,K) = KH_v(i,J,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i,j+1,k-1) )
+      KH_v(i,J,K) = KH_v(i,J,1) * 0.5 * ( VarMix%khth_struct(i,j,k-1) + VarMix%khth_struct(i,j+1,k-1) )
     enddo ; enddo ; enddo
   else
     !$OMP do

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -616,7 +616,7 @@ subroutine find_coupling_coef_gl90(a_cpl_gl90, hvel, do_i, z_i, j, G, GV, CS, Va
                                                                      !! otherwise they are v-points.
 
   ! local variables
-  logical :: kdgl90_use_ebt_struct
+  logical :: kdgl90_use_vert_struct  ! use vertical structure for GL90 coefficient
   integer :: i, k, is, ie, nz, Isq, Ieq
   real    :: f2         !< Squared Coriolis parameter at a velocity grid point [T-2 ~> s-2].
   real    :: h_neglect  ! A vertical distance that is so small it is usually lost in roundoff error
@@ -629,9 +629,9 @@ subroutine find_coupling_coef_gl90(a_cpl_gl90, hvel, do_i, z_i, j, G, GV, CS, Va
   nz = GV%ke
 
   h_neglect = GV%dZ_subroundoff
-  kdgl90_use_ebt_struct = .false.
+  kdgl90_use_vert_struct = .false.
   if (VarMix%use_variable_mixing) then
-    kdgl90_use_ebt_struct = VarMix%kdgl90_use_ebt_struct
+    kdgl90_use_vert_struct = allocated(VarMix%kdgl90_struct)
   endif
 
   if (work_on_u) then
@@ -647,8 +647,9 @@ subroutine find_coupling_coef_gl90(a_cpl_gl90, hvel, do_i, z_i, j, G, GV, CS, Va
           else
             a_cpl_gl90(I,K) = f2 * CS%kappa_gl90 / GV%g_prime(K)
           endif
-          if (kdgl90_use_ebt_struct) then
-            a_cpl_gl90(I,K) = a_cpl_gl90(I,K) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i+1,j,k-1) )
+          if (kdgl90_use_vert_struct) then
+            a_cpl_gl90(I,K) = a_cpl_gl90(I,K) * 0.5 * &
+                    ( VarMix%kdgl90_struct(i,j,k-1) + VarMix%kdgl90_struct(i+1,j,k-1) )
           endif
         endif
         ! botfn determines when a point is within the influence of the GL90 bottom boundary layer,
@@ -671,8 +672,9 @@ subroutine find_coupling_coef_gl90(a_cpl_gl90, hvel, do_i, z_i, j, G, GV, CS, Va
           else
             a_cpl_gl90(i,K) = f2 * CS%kappa_gl90 / GV%g_prime(K)
           endif
-          if (kdgl90_use_ebt_struct) then
-            a_cpl_gl90(i,K) = a_cpl_gl90(i,K) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i,j+1,k-1) )
+          if (kdgl90_use_vert_struct) then
+            a_cpl_gl90(i,K) = a_cpl_gl90(i,K) * 0.5 * &
+                    ( VarMix%kdgl90_struct(i,j,k-1) + VarMix%kdgl90_struct(i,j+1,k-1) )
           endif
         endif
         ! botfn determines when a point is within the influence of the GL90 bottom boundary layer,

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -57,8 +57,8 @@ type, public :: neutral_diffusion_CS ; private
   logical :: tapering = .false. !< If true, neutral diffusion linearly decays towards zero within a
                       !! transition zone defined using boundary layer depths. Only available when
                       !! interior_only=true.
-  logical :: KhTh_use_ebt_struct !< If true, uses the equivalent barotropic structure
-                                 !! as the vertical structure of tracer diffusivity.
+  logical :: KhTh_use_vert_struct !< If true, uses vertical structure
+                                 !! for tracer diffusivity.
   logical :: use_unmasked_transport_bug !< If true, use an older form for the accumulation of
                       !! neutral-diffusion transports that were unmasked, as used prior to Jan 2018.
   real,    allocatable, dimension(:,:)  :: hbl    !< Boundary layer depth [H ~> m or kg m-2]
@@ -67,7 +67,7 @@ type, public :: neutral_diffusion_CS ; private
                                                   !! at cell interfaces [nondim]
   real,    allocatable, dimension(:) :: coeff_r   !< Non-dimensional coefficient in the right column,
                                                   !! at cell interfaces [nondim]
-  ! Array used when KhTh_use_ebt_struct is true
+  ! Array used when KhTh_use_vert_struct is true
   real,    allocatable, dimension(:,:,:) :: Coef_h !< Coef_x and Coef_y averaged at t-points [L2 ~> m2]
   ! Positions of neutral surfaces in both the u, v directions
   real,    allocatable, dimension(:,:,:) :: uPoL  !< Non-dimensional position with left layer uKoL-1, u-point [nondim]
@@ -153,6 +153,7 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
   logical :: boundary_extrap      ! Indicate whether high-order boundary
                                   !! extrapolation should be used within boundary cells.
   logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
+  logical :: KhTh_use_ebt_struct, KhTh_use_sqg_struct
 
   if (associated(CS)) then
     call MOM_error(FATAL, "neutral_diffusion_init called with associated control structure.")
@@ -197,8 +198,12 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
                    "a transition zone defined using boundary layer depths.    "//&
                    "Only applicable when NDIFF_INTERIOR_ONLY=True", default=.false.)
   endif
-  call get_param(param_file, mdl, "KHTR_USE_EBT_STRUCT", CS%KhTh_use_ebt_struct, &
+  call get_param(param_file, mdl, "KHTR_USE_EBT_STRUCT", KhTh_use_ebt_struct, &
                  "If true, uses the equivalent barotropic structure "//&
+                 "as the vertical structure of the tracer diffusivity.",&
+                 default=.false.,do_not_log=.true.)
+  call get_param(param_file, mdl, "KHTR_USE_SQG_STRUCT", KhTh_use_sqg_struct, &
+                 "If true, uses the surface geostrophic structure "//&
                  "as the vertical structure of the tracer diffusivity.",&
                  default=.false.,do_not_log=.true.)
   call get_param(param_file, mdl, "NDIFF_USE_UNMASKED_TRANSPORT_BUG", CS%use_unmasked_transport_bug, &
@@ -296,7 +301,8 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
     endif
   endif
 
-  if (CS%KhTh_use_ebt_struct) &
+  CS%KhTh_use_vert_struct = KhTh_use_ebt_struct .or. KhTh_use_sqg_struct
+  if (CS%KhTh_use_vert_struct) &
      allocate(CS%Coef_h(G%isd:G%ied,G%jsd:G%jed,SZK_(GV)+1), source=0.)
 
   ! Store a rescaling factor for use in diagnostic messages.
@@ -624,11 +630,11 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
   real, dimension(SZIB_(G),SZJ_(G),CS%nsurf-1) :: uFlx        ! Zonal flux of tracer in units that vary between a
                         ! thickness times a concentration ([C H ~> degC m or degC kg m-2] for temperature) or a
                         ! volume or mass times a concentration ([C H L2 ~> degC m3 or degC kg] for temperature),
-                        ! depending on the setting of CS%KhTh_use_ebt_struct.
+                        ! depending on the setting of CS%KhTh_use_vert_struct.
   real, dimension(SZI_(G),SZJB_(G),CS%nsurf-1) :: vFlx        ! Meridional flux of tracer in units that vary between a
                         ! thickness times a concentration ([C H ~> degC m or degC kg m-2] for temperature) or a
                         ! volume or mass times a concentration ([C H L2 ~> degC m3 or degC kg] for temperature),
-                        ! depending on the setting of CS%KhTh_use_ebt_struct.
+                        ! depending on the setting of CS%KhTh_use_vert_struct.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))    :: tendency    ! tendency array for diagnostics
                                                               ! [H conc T-1 ~> m conc s-1 or kg m-2 conc s-1]
                                                               ! For temperature these units are
@@ -673,7 +679,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
     endif
   endif
 
-  if (CS%KhTh_use_ebt_struct) then
+  if (CS%KhTh_use_vert_struct) then
     ! Compute Coef at h points
     CS%Coef_h(:,:,:) = 0.
     do j = G%jsc,G%jec ; do i = G%isc,G%iec
@@ -706,7 +712,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
     vFlx(:,:,:) = 0.
 
     ! x-flux
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTh_use_vert_struct) then
       if (CS%tapering) then
         do j = G%jsc,G%jec ; do I = G%isc-1,G%iec
           if (G%mask2dCu(I,j)>0.) then
@@ -770,7 +776,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
     endif
 
     ! y-flux
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTh_use_vert_struct) then
       if (CS%tapering) then
         do J = G%jsc-1,G%jec ; do i = G%isc,G%iec
           if (G%mask2dCv(i,J)>0.) then
@@ -837,7 +843,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
 
     ! Update the tracer concentration from divergence of neutral diffusive flux components, noting
     ! that uFlx and vFlx use an unexpected sign convention.
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTh_use_vert_struct) then
       do j = G%jsc,G%jec ; do i = G%isc,G%iec
         if (G%mask2dT(i,j)>0.) then
           if (CS%ndiff_answer_date <= 20240330) then
@@ -940,7 +946,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
     ! Note sign corresponds to downgradient flux convention.
     if (tracer%id_dfx_2d > 0) then
 
-      if (CS%KhTh_use_ebt_struct) then
+      if (CS%KhTh_use_vert_struct) then
         do j = G%jsc,G%jec ; do I = G%isc-1,G%iec
           trans_x_2d(I,j) = 0.
           if (G%mask2dCu(I,j)>0.) then
@@ -969,7 +975,7 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
     ! Note sign corresponds to downgradient flux convention.
     if (tracer%id_dfy_2d > 0) then
 
-      if (CS%KhTh_use_ebt_struct) then
+      if (CS%KhTh_use_vert_struct) then
         do J = G%jsc-1,G%jec ; do i = G%isc,G%iec
           trans_y_2d(i,J) = 0.
           if (G%mask2dCv(i,J)>0.) then

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -52,7 +52,7 @@ type, public :: tracer_hor_diff_CS ; private
   real    :: max_diff_CFL         !< If positive, locally limit the along-isopycnal
                                   !! tracer diffusivity to keep the diffusive CFL
                                   !! locally at or below this value [nondim].
-  logical :: KhTh_use_ebt_struct  !< If true, uses the equivalent barotropic structure
+  logical :: KhTr_use_vert_struct  !< If true, uses the equivalent barotropic structure
                                   !! as the vertical structure of tracer diffusivity.
   logical :: Diffuse_ML_interior  !< If true, diffuse along isopycnals between
                                   !! the mixed layer and the interior.
@@ -218,6 +218,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
     use_VarMix = VarMix%use_variable_mixing
     Resoln_scaled = VarMix%Resoln_scaled_KhTr
     use_Eady = CS%KhTr_Slope_Cff > 0.
+    CS%KhTr_use_vert_struct = allocated(VarMix%khtr_struct)
   endif
 
   call cpu_clock_begin(id_clock_pass)
@@ -422,18 +423,18 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
         enddo
       enddo
     enddo
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTr_use_vert_struct) then
       do K=2,nz+1
         do J=js-1,je
           do i=is,ie
-            Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i,j+1,k-1) )
+            Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
           enddo
         enddo
       enddo
       do k=2,nz+1
         do j=js,je
           do I=is-1,ie
-            Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i+1,j,k-1) )
+            Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
           enddo
         enddo
       enddo
@@ -478,18 +479,18 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
         enddo
       enddo
     enddo
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTr_use_vert_struct) then
       do K=2,nz+1
         do J=js-1,je
           do i=is,ie
-            Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i,j+1,k-1) )
+            Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
           enddo
         enddo
       enddo
       do k=2,nz+1
         do j=js,je
           do I=is-1,ie
-            Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i+1,j,k-1) )
+            Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
           enddo
         enddo
       enddo
@@ -605,11 +606,11 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
     do j=js,je ; do I=is-1,ie
       Kh_u(I,j,:) = G%mask2dCu(I,j)*Kh_u(I,j,1)
     enddo ; enddo
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTr_use_vert_struct) then
       do K=2,nz+1
         do j=js,je
           do I=is-1,ie
-            Kh_u(I,j,K) = Kh_u(I,j,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i+1,j,k-1) )
+            Kh_u(I,j,K) = Kh_u(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
           enddo
         enddo
       enddo
@@ -621,11 +622,11 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
     do J=js-1,je ; do i=is,ie
       Kh_v(i,J,:) = G%mask2dCv(i,J)*Kh_v(i,J,1)
     enddo ; enddo
-    if (CS%KhTh_use_ebt_struct) then
+    if (CS%KhTr_use_vert_struct) then
       do K=2,nz+1
         do J=js-1,je
           do i=is,ie
-            Kh_v(i,J,K) = Kh_v(i,J,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i,j+1,k-1) )
+            Kh_v(i,J,K) = Kh_v(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
           enddo
         enddo
       enddo
@@ -647,9 +648,9 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
                          (G%mask2dCv(i,J-1)+G%mask2dCv(i,J)) + 1.0e-37)
       Kh_h(i,j,:) = normalize*G%mask2dT(i,j)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
                                              (Kh_v(i,J-1,1)+Kh_v(i,J,1)))
-      if (CS%KhTh_use_ebt_struct) then
+      if (CS%KhTr_use_vert_struct) then
         do K=2,nz+1
-          Kh_h(i,j,K) = normalize*G%mask2dT(i,j)*VarMix%ebt_struct(i,j,k-1)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
+          Kh_h(i,j,K) = normalize*G%mask2dT(i,j)*VarMix%khtr_struct(i,j,k-1)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
                                                                             (Kh_v(i,J-1,1)+Kh_v(i,J,1)))
         enddo
       endif
@@ -1630,10 +1631,10 @@ subroutine tracer_hor_diff_init(Time, G, GV, US, param_file, diag, EOS, diabatic
   call get_param(param_file, mdl, "KHTR", CS%KhTr, &
                  "The background along-isopycnal tracer diffusivity.", &
                  units="m2 s-1", default=0.0, scale=US%m_to_L**2*US%T_to_s)
-  call get_param(param_file, mdl, "KHTR_USE_EBT_STRUCT", CS%KhTh_use_ebt_struct, &
-                 "If true, uses the equivalent barotropic structure "//&
-                 "as the vertical structure of the tracer diffusivity.",&
-                 default=.false.)
+!  call get_param(param_file, mdl, "KHTR_USE_EBT_STRUCT", CS%KhTh_use_ebt_struct, &
+!                 "If true, uses the equivalent barotropic structure "//&
+!                 "as the vertical structure of the tracer diffusivity.",&
+!                 default=.false.)
   call get_param(param_file, mdl, "KHTR_SLOPE_CFF", CS%KhTr_Slope_Cff, &
                  "The scaling coefficient for along-isopycnal tracer "//&
                  "diffusivity using a shear-based (Visbeck-like) "//&


### PR DESCRIPTION
This commit added an surface quasigeostrophy (SQG) vertical structure (sqg_struct) in Varmix (MOM_lateral_mixing_coeffs) to provide a vertical profile for eddy diffusivities. The SQG vertical structure and its parameterization is given by Zhang et al. (2024): https://journals.ametsoc.org/view/journals/phoc/54/6/JPO-D-23-0203.1.xml. 
Also, the vertical structure of all eddy diffusivities/viscosities, including khth, khtr, kh, and kdgl90, are reorganized in Varmix. Two vertical structures are optional for each diffusivity: the equivalent barotropic (ebt_struct) and surface quasigeostrophy (sqg_struct) structures. For example, if one wants to use the SQG structure for the thickness diffusivity Khth, they can set KHTH_USE_SQG_STRUCT=True. 
Detailed changes are summarized below:
- KHTH_USE_EBT_STRUCT, KHTR_USE_EBT_STRUCT, KDGL90_USE_EBT_STRUCT and BS_EBT_POWER parameters, which already existed, still control whether to use the EBT structure for khth, khtr, kdgl90, and kh, respectively
- Added KHTH_USE_SQG_STRUCT, KHTR_USE_SQG_STRUCT, KDGL90_USE_SQG_STRUCT and BS_USE_SQG parameters to control whether to use the SQG structure for khth, khtr, kdgl90, and kh, respectively
- Added function calc_sqg_struct in MOM_lateral_mixing_coeffs to compute sqg_struct
- The sqg_struct can be tuned by the exponent sqg_expo, default is 1.0, suggested range is 0.5-3.0
- If SQG_USE_MEKE=True, the eddy length scale from MEKE will be used to compute sqg_struct
- The eddy length scale, Le, will be added into MEKE and registered as a restart variable, MEKE_LE, if SQG_USE_MEKE=True
- MEKE and dt are added in Varmix to compute sqg_struct