### PR TITLE
Set truncation file handle check from < 0 to == -1

### DIFF
--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -121,11 +121,11 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
     do_k(:) = .false.
 
   ! Open up the file for output if this is the first call.
-    if (CS%u_file < 0) then
+    if (CS%u_file == -1) then
       if (len_trim(CS%u_trunc_file) < 1) return
       call open_ASCII_file(CS%u_file, trim(CS%u_trunc_file), action=APPEND_FILE, &
                            threading=MULTIPLE, fileset=SINGLE_FILE)
-      if (CS%u_file < 0) then
+      if (CS%u_file == -1) then
         call MOM_error(NOTE, 'Unable to open file '//trim(CS%u_trunc_file)//'.')
         return
       endif
@@ -462,11 +462,11 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
     do_k(:) = .false.
 
   ! Open up the file for output if this is the first call.
-    if (CS%v_file < 0) then
+    if (CS%v_file == -1) then
       if (len_trim(CS%v_trunc_file) < 1) return
       call open_ASCII_file(CS%v_file, trim(CS%v_trunc_file), action=APPEND_FILE, &
                            threading=MULTIPLE, fileset=SINGLE_FILE)
-      if (CS%v_file < 0) then
+      if (CS%v_file == -1) then
         call MOM_error(NOTE, 'Unable to open file '//trim(CS%v_trunc_file)//'.')
         return
       endif


### PR DESCRIPTION
This patch replaces the `CS%[uv]_file < 0` checks with `CS%[uv]_file == -1`.  FMS1 returns negative file handles for missing or otherwise error-prone files, but the FMS2 IO framework relies on `newunit=` to autogenerate handle IDs, which are always negative and cannot be used with checks for negative values.

The check is replaced with equality with -1.  `newunit` is guaranteed to never return -1 for a valid file, so this is a valid check for a missing file.  It also lets us continue to use -1 as the initial (unopened) value.

Behavior is compatible with `mpp_open()` output, so this can also be used with the FMS1 API.

A better solution would be to introduce some validation function which is defined by each API, but there is not yet any need for such sophistication.