### PR TITLE
Update version of github checkout action (@v4)

### DIFF
--- a/.github/workflows/coupled-api.yml
+++ b/.github/workflows/coupled-api.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/documentation-and-style.yml
+++ b/.github/workflows/documentation-and-style.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/expression.yml
+++ b/.github/workflows/expression.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/perfmon.yml
+++ b/.github/workflows/perfmon.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/stencil.yml
+++ b/.github/workflows/stencil.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: .testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 


### PR DESCRIPTION
Other than staying up to date, this purportedly fixes a "Node.js deprecation" message we first noticed in the coverage workflow but has appeared elsewhere intermittently.