### PR TITLE
Revert a bug fix with visc_rem in continuity solver

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -178,7 +178,8 @@ type, public :: MOM_dyn_split_RK2_CS ; private
   logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
   logical :: fpmix = .false.                 !< If true, applies profiles of momentum flux magnitude and direction.
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
-  logical :: visc_rem_dt_fix = .false. !<If true, use dt rather than dt_pred for vertvisc_rem at the end of predictor.
+  logical :: visc_rem_dt_bug = .true. !< If true, recover a bug that uses dt_pred rather than dt for vertvisc_rem
+                                      !! at the end of predictor.
 
   !>@{ Diagnostic IDs
   integer :: id_uold   = -1, id_vold   = -1
@@ -736,10 +737,10 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call start_group_pass(CS%pass_uvp, G%Domain, clock=id_clock_pass)
     call cpu_clock_begin(id_clock_vertvisc)
   endif
-  if (CS%visc_rem_dt_fix) then
-    call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
-  else
+  if (CS%visc_rem_dt_bug) then
     call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt_pred, G, GV, US, CS%vertvisc_CSp)
+  else
+    call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
   endif
   call cpu_clock_end(id_clock_vertvisc)
 
@@ -1439,16 +1440,14 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
                  default=.false.)
   call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, &
                  "If true, visc_rem_[uv] in split mode is incorrectly calculated or accounted "//&
-                 "for in three places. This parameter controls the defaults of three individual "//&
-                 "flags, VISC_REM_TIMESTEP_FIX in MOM_dynamics_split_RK2(b), "//&
-                 "VISC_REM_BT_WEIGHT_FIX in MOM_barotropic, and VISC_REM_CONT_HVEL_FIX in "//&
-                 "MOM_continuity_PPM. Eventually, the three individual flags should be removed "//&
-                 "after tests and the default of VISC_REM_BUG should be to False.", default=.true.)
-  call get_param(param_file, mdl, "VISC_REM_TIMESTEP_FIX", CS%visc_rem_dt_fix, &
-                 "If true, use dt rather than dt_pred in vertvisc_remnant() at the end of "//&
-                 "predictor stage for the following continuity() call and btstep() call "//&
-                 "in the corrector step. This flag should be used with "//&
-                 "VISC_REM_BT_WEIGHT_FIX.", default=.not.visc_rem_bug)
+                 "for in two places. This parameter controls the defaults of two individual "//&
+                 "flags, VISC_REM_TIMESTEP_BUG in MOM_dynamics_split_RK2(b) and "//&
+                 "VISC_REM_BT_WEIGHT_BUG in MOM_barotropic.", default=.true.)
+  call get_param(param_file, mdl, "VISC_REM_TIMESTEP_BUG", CS%visc_rem_dt_bug, &
+                 "If true, recover a bug that uses dt_pred rather than dt in "//&
+                 "vertvisc_remnant() at the end of predictor stage for the following "//&
+                 "continuity() and btstep() calls in the corrector step. Default of this flag "//&
+                 "is set by VISC_REM_BUG", default=visc_rem_bug)
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed), source=0.0)
   allocate(CS%tauy_bot(isd:ied,JsdB:JedB), source=0.0)

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -175,7 +175,8 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
   logical :: fpmix = .false.                 !< If true, applies profiles of momentum flux magnitude and direction.
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
-  logical :: visc_rem_dt_fix = .false. !<If true, use dt rather than dt_pred for vertvisc_rem at the end of predictor.
+  logical :: visc_rem_dt_bug = .true. !< If true, recover a bug that uses dt_pred rather than dt for vertvisc_rem
+                                      !! at the end of predictor.
 
   !>@{ Diagnostic IDs
   !  integer :: id_uold   = -1, id_vold   = -1
@@ -754,10 +755,10 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
     call start_group_pass(CS%pass_uvp, G%Domain, clock=id_clock_pass)
     call cpu_clock_begin(id_clock_vertvisc)
   endif
-  if (CS%visc_rem_dt_fix) then
-    call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
-  else
+  if (CS%visc_rem_dt_bug) then
     call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt_pred, G, GV, US, CS%vertvisc_CSp)
+  else
+    call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
   endif
   call cpu_clock_end(id_clock_vertvisc)
 
@@ -1355,16 +1356,15 @@ subroutine initialize_dyn_split_RK2b(u, v, h, tv, uh, vh, eta, Time, G, GV, US, 
                  default=.false.)
   call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, &
                  "If true, visc_rem_[uv] in split mode is incorrectly calculated or accounted "//&
-                 "for in three places. This parameter controls the defaults of three individual "//&
-                 "flags, VISC_REM_TIMESTEP_FIX in MOM_dynamics_split_RK2(b), "//&
-                 "VISC_REM_BT_WEIGHT_FIX in MOM_barotropic, and VISC_REM_CONT_HVEL_FIX in "//&
-                 "MOM_continuity_PPM. Eventually, the three individual flags should be removed "//&
-                 "after tests and the default of VISC_REM_BUG should be to False.", default=.true.)
-  call get_param(param_file, mdl, "VISC_REM_TIMESTEP_FIX", CS%visc_rem_dt_fix, &
-                 "If true, use dt rather than dt_pred in vertvisc_remnant() at the end of "//&
-                 "predictor stage for the following continuity() call and btstep() call "//&
-                 "in the corrector step. Default of this flag is set by VISC_REM_BUG. "//&
-                 "This flag should be used with VISC_REM_BT_WEIGHT_FIX.", default=.not.visc_rem_bug)
+                 "for in two places. This parameter controls the defaults of two individual "//&
+                 "flags, VISC_REM_TIMESTEP_BUG in MOM_dynamics_split_RK2(b) and "//&
+                 "VISC_REM_BT_WEIGHT_BUG in MOM_barotropic.", default=.true.)
+  call get_param(param_file, mdl, "VISC_REM_TIMESTEP_BUG", CS%visc_rem_dt_bug, &
+                 "If true, recover a bug that uses dt_pred rather than dt in "//&
+                 "vertvisc_remnant() at the end of predictor stage for the following "//&
+                 "continuity() and btstep() calls in the corrector step. Default of this flag "//&
+                 "is set by VISC_REM_BUG", default=visc_rem_bug)
+
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed), source=0.0)
   allocate(CS%tauy_bot(isd:ied,JsdB:JedB), source=0.0)


### PR DESCRIPTION
This PR reverts a bug fix introduced previously https://github.com/NOAA-GFDL/MOM6/pull/639, related to using `visc_rem_[uv]` for vertical weights `frhat[uv]` in barotropic solver. The change (controlled by runtime parameter `VISC_REM_CONT_HVEL_FIX`),  was demonstrated to be incorrect. Therefore the "fix" is unnecessary.

The other two bug fixes introduced at the same time are still valid. Corresponding runtime parameter names are changed with a suffix "_bug" for consistency. 

This PR introduces no answer changes. There are changes in runtime parameters with one removal and three name/description changes.