### PR TITLE
Bug fix for subroutine `write_energy` when `DT`<2

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -21,9 +21,9 @@ use MOM_io,            only : axis_info, set_axis_info, delete_axis_info, get_fi
 use MOM_io,            only : attribute_info, set_attribute_info, delete_attribute_info
 use MOM_io,            only : APPEND_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_spatial_means, only : array_global_min_max
-use MOM_time_manager,  only : time_type, get_time, get_date, set_time, operator(>)
+use MOM_time_manager,  only : time_type, get_time, get_date, set_time
 use MOM_time_manager,  only : operator(+), operator(-), operator(*), operator(/)
-use MOM_time_manager,  only : operator(/=), operator(<=), operator(>=), operator(<)
+use MOM_time_manager,  only : operator(/=), operator(<=), operator(>=), operator(<), operator(>)
 use MOM_time_manager,  only : get_calendar_type, time_type_to_real, NO_CALENDAR
 use MOM_tracer_flow_control, only : tracer_flow_control_CS, call_tracer_stocks
 use MOM_unit_scaling,  only : unit_scale_type
@@ -489,7 +489,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
       CS%write_energy_time = CS%Start_time + CS%energysavedays * &
         (1 + (day - CS%Start_time) / CS%energysavedays)
     endif
-  elseif (day + (dt_force/2) <= CS%write_energy_time) then
+  elseif (day + (dt_force/2) < CS%write_energy_time) then
     return  ! Do not write this step
   else ! Determine the next write time before proceeding
     if (CS%energysave_geometric) then


### PR DESCRIPTION
This PR fixes a bug with subroutine `write_energy` when using a DT<2. 

Otherwise, the energy outputs could be written at wrong time steps with extremely small time stepping size. 

The reason was that time type divide is essentially a floor. So in the line in question, dt_force/2 = 0 if dt_force<2. And energy is always written at the following time step, rather than when day==CS%write_energy_time.

The patch is a bit ugly. 
1. I believe both `dt_force/2` and  `<=` (rather than <) are necessary for round-off considerations.
2. There is no real divide for `time_type` and a real number. (operator(//) is between `time_type` variables and operator(*) is for a `time_type` and an integer) 
