### PR TITLE
CI: Consolidate unit test rules, codecov pathfix

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,6 @@ coverage:
             default:
                 threshold: 100%
                 base: parent
+
+fixes:
+  - "MOM6/::"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,17 +19,11 @@ jobs:
 
     - uses: ./.github/actions/testing-setup
 
-    - name: Compile file parser unit tests
-      run: make -j build/unit/test_MOM_file_parser
-
-    - name: Run file parser unit tests
-      run: make run.cov.unit
-
-    - name: Compile unit testing
+    - name: Compile unit tests
       run: make -j build.unit
 
-    - name: Run (single processor) unit tests
-      run: make run.unit
+    - name: Run unit tests
+      run: make run.cov.unit
 
     - name: Report unit test coverage to CI
       run: make report.cov.unit
@@ -40,7 +34,7 @@ jobs:
       run: make -j build/cov/MOM6
 
     - name: Run coverage tests
-      run: make -j -k run.cov
+      run: make -k run.cov
 
     - name: Report coverage to CI
       run: make report.cov

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -222,8 +222,6 @@ build.prof: $(foreach b,opt opt_target,$(BUILD)/$(b)/MOM6)
 # Compiler flags
 
 # .testing dependencies
-# TODO: We should probably build TARGET with the FMS that it was configured
-#   to use.  But for now we use the same FMS over all builds.
 FCFLAGS_DEPS = -I$(abspath $(DEPS)/include)
 LDFLAGS_DEPS = -L$(abspath $(DEPS)/lib)
 PATH_DEPS = PATH="${PATH}:$(abspath $(DEPS)/bin)"
@@ -661,7 +659,7 @@ test.summary:
 
 # NOTE: Using file parser gcov report as a proxy for test completion
 .PHONY: run.cov.unit
-run.cov.unit: $(BUILD)/unit/MOM_file_parser_tests.F90.gcov
+run.cov.unit: $(foreach t,$(UNIT_EXECS),$(BUILD)/unit/$(t).F90.gcov)
 
 .PHONY: build.unit
 build.unit: $(foreach f, $(UNIT_EXECS), $(BUILD)/unit/$(f))
@@ -702,6 +700,7 @@ $(WORK)/unit/%.out: $(BUILD)/unit/%
 	@mkdir -p $(@D)
 	cd $(@D) ; $(TIME) $(MPIRUN) -n 1 $(abspath $<) 2> >(tee $*.err) > $*.out
 
+# The file parser uses a separate rule to support two-core tests.
 $(WORK)/unit/test_MOM_file_parser.out: $(BUILD)/unit/test_MOM_file_parser
 	if [ $(REPORT_COVERAGE) ]; then \
 	  find $(BUILD)/unit -name *.gcda -exec rm -f '{}' \; ; \
@@ -721,15 +720,13 @@ $(WORK)/unit/test_MOM_file_parser.out: $(BUILD)/unit/test_MOM_file_parser
 	    cat p2.test_MOM_file_parser.err | tail -n 100 ; \
 	  )
 
-# NOTE: .gcov actually depends on .gcda, but .gcda is produced with std.out
-# TODO: Replace $(WORK)/unit/std.out with *.gcda?
-$(BUILD)/unit/MOM_file_parser_tests.F90.gcov: $(WORK)/unit/test_MOM_file_parser.out
+$(BUILD)/unit/test_%.F90.gcov: $(WORK)/unit/test_%.out
 	cd $(@D) \
 	  && gcov -b *.gcda > gcov.unit.out
 	find $(@D) -name "*.gcov" -exec sed -i -r 's/^( *[0-9]*)\*:/ \1:/g' {} \;
 
 .PHONY: report.cov.unit
-report.cov.unit: $(BUILD)/unit/MOM_file_parser_tests.F90.gcov codecov
+report.cov.unit: $(foreach t,$(UNIT_EXECS),$(BUILD)/unit/$(t).F90.gcov) codecov
 	./codecov $(CODECOV_TOKEN_ARG) -R $(BUILD)/unit -f "*.gcov" -Z -n "Unit tests" \
 	    > $(BUILD)/unit/codecov.out \
 	    2> $(BUILD)/unit/codecov.err \


### PR DESCRIPTION
This commit contains two changes to gcov report generation and codecov upload.

1. Separation of the file parser unit tests from the others was causing them to be exluded from report.cov.unit.

   This patch reworks the rules to replace MOM_file_parser_tests.F90.gcov with driver code, build/unit/test_%.F90.gcov.

   This does assume at all drivers will look the same (test_*.F90) but that part can be reworked if it ever becomes a problem in the future.

   Thanks to @adcroft for multiple suggestions in this PR.

2. Github appears to internally store all its repositories in another directory with the name as the repo (in this case MOM6/).

   Normally this is hidden to everyone, but it was causing some confusion with the codecov upload tool, and was unable to match the source code to the .gcov report.

   The .codecov.yml config file was modified to adjust for this path change, and should now correctly allow coverage to be reported alongside the file.

   (The GitHub Actions app likely makes this adjustment, but we need to do it manually since we upload directly to Codecov.io.)