### PR TITLE
Add Option to Specify Tracer Advection Time Step

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2404,7 +2404,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "timesteps that can be longer than the coupling timestep. "//&
                  "The actual tracer advection timestep that is used in this "//&
                  "case is the largest integer multiple of the coupling "//&
-                 "timestep that is less than or equal to DT_TRACER_ADVECT.", & 
+                 "timestep that is less than or equal to DT_TRACER_ADVECT.", &
                  default=CS%thermo_spans_coupling)
   if ( CS%diabatic_first .and. (CS%dt_tr_adv /= CS%dt_therm) ) then
     call MOM_error(FATAL,"MOM: If using DIABATIC_FIRST, DT_TRACER_ADVECT must equal DT_THERM.")

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -944,7 +944,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
-
+      do_advection = .false.
       if (tradv_does_span_coupling .or. .not.do_thermo) then
         do_advection = (CS%t_dyn_rel_adv + 0.5*dt > dt_tr_adv)
         if (CS%t_dyn_rel_thermo + 0.5*dt > dt_therm) do_advection = .true.
@@ -2404,7 +2404,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "timesteps that can be longer than the coupling timestep. "//&
                  "The actual tracer advection timestep that is used in this "//&
                  "case is the largest integer multiple of the coupling "//&
-                 "timestep that is less than or equal to DT_TRACER_ADVECT.", default=.false.)
+                 "timestep that is less than or equal to DT_TRACER_ADVECT.", & 
+                 default=CS%thermo_spans_coupling)
   if ( CS%diabatic_first .and. (CS%dt_tr_adv /= CS%dt_therm) ) then
     call MOM_error(FATAL,"MOM: If using DIABATIC_FIRST, DT_TRACER_ADVECT must equal DT_THERM.")
   endif

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -963,6 +963,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     !===========================================================================
     ! This is the second place where the diabatic processes and remapping could occur.
     if (do_thermo) then
+      do_diabatic = .false.
       if (thermo_does_span_coupling .or. .not.do_dyn) then
         do_diabatic = (CS%t_dyn_rel_thermo + 0.5*dt > dt_therm)
       else

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2403,6 +2403,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "The actual tracer advection timestep that is used in this "//&
                  "case is the largest integer multiple of the coupling "//&
                  "timestep that is less than or equal to DT_TADVECT.", default=.false.)
+  if ( CS%diabatic_first .and. (CS%dt_tadvect /= CS%dt_therm) ) then
+    call MOM_error(FATAL,"MOM: If using DIABATIC_FIRST, DT_TADVECT must equal DT_THERM.")
+  endif
 
   if (bulkmixedlayer) then
     CS%Hmix = -1.0 ; CS%Hmix_UV = -1.0

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -275,9 +275,11 @@ type, public :: MOM_control_struct ; private
 
   type(time_type), pointer :: Time   !< pointer to the ocean clock
   real    :: dt                      !< (baroclinic) dynamics time step [T ~> s]
-  real    :: dt_therm                !< thermodynamics time step [T ~> s]
+  real    :: dt_therm                !< diabatic time step [T ~> s]
+  real    :: dt_tadvect              !< tracer advection time step [T ~> s]
   logical :: thermo_spans_coupling   !< If true, thermodynamic and tracer time
                                      !! steps can span multiple coupled time steps.
+  logical :: tadvect_spans_coupling   !< If true, thermodynamic and tracer time
   integer :: nstep_tot = 0           !< The total number of dynamic timesteps taken
                                      !! so far in this run segment
   logical :: count_calls = .false.   !< If true, count the calls to step_MOM, rather than the
@@ -534,7 +536,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   type(verticalGrid_type), pointer :: GV => NULL() ! Pointer to the vertical grid structure
   type(unit_scale_type),   pointer :: US => NULL() ! Pointer to a structure containing
                                                    ! various unit conversion factors
-  integer       :: ntstep ! time steps between tracer updates or diabatic forcing
+  integer       :: ntstep  ! number of time steps between diabatic forcing updates
+  integer       :: ntastep ! number of time steps between tracer advection updates
   integer       :: n_max  ! number of steps to take in this call
   integer :: halo_sz, dynamics_stencil
 
@@ -544,6 +547,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   real :: time_interval   ! time interval covered by this run segment [T ~> s].
   real :: dt              ! baroclinic time step [T ~> s]
   real :: dtdia           ! time step for diabatic processes [T ~> s]
+  real :: dt_tadvect      ! time step for tracer advection [T ~> s]
   real :: dt_therm        ! a limited and quantized version of CS%dt_therm [T ~> s]
   real :: dt_therm_here   ! a further limited value of dt_therm [T ~> s]
 
@@ -554,9 +558,12 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
                           ! if it is not to be calculated anew [T ~> s].
   real :: rel_time = 0.0  ! relative time since start of this call [T ~> s].
 
-  logical :: do_advection              ! If true, it is time to advect tracers.
-  logical :: thermo_does_span_coupling ! If true, thermodynamic forcing spans
-                                       ! multiple dynamic timesteps.
+  logical :: do_advection    ! If true, do tracer advection.
+  logical :: do_diabatic     ! If true, do diabatic update.
+  logical :: thermo_does_span_coupling ! If true,thermodynamic (diabatic) forcing spans
+                                       ! multiple coupling timesteps.
+  logical :: tadvect_does_span_coupling ! If true, tracer advection spans
+                                       ! multiple coupling timesteps.
   logical :: do_dyn     ! If true, dynamics are updated with this call.
   logical :: do_thermo  ! If true, thermodynamics and remapping may be applied with this call.
   logical :: debug_redundant ! If true, check redundant values on PE boundaries when debugging.
@@ -662,6 +669,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     dt = time_interval / real(n_max)
     thermo_does_span_coupling = (CS%thermo_spans_coupling .and. &
                                 (CS%dt_therm > 1.5*cycle_time))
+    tadvect_does_span_coupling = (CS%tadvect_spans_coupling .and. &
+                                (CS%dt_tadvect > 1.5*cycle_time))
     if (thermo_does_span_coupling) then
       ! Set dt_therm to be an integer multiple of the coupling time step.
       dt_therm = cycle_time * floor(CS%dt_therm / cycle_time + 0.001)
@@ -673,6 +682,18 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     else
       ntstep = MAX(1, MIN(n_max, floor(CS%dt_therm/dt + 0.001)))
       dt_therm = dt*ntstep
+    endif
+    if (tadvect_does_span_coupling) then
+      ! Set dt_tadvect to be an integer multiple of the coupling time step.
+      dt_tadvect = cycle_time * floor(CS%dt_tadvect / cycle_time + 0.001)
+      ntastep = floor(dt_tadvect/dt + 0.001)
+    elseif (.not.do_thermo) then
+      dt_tadvect = CS%dt_tadvect
+      if (present(cycle_length)) dt_tadvect = min(CS%dt_tadvect, cycle_length)
+      ! ntstep is not used.
+    else
+      ntastep = MAX(1, MIN(n_max, floor(CS%dt_tadvect/dt + 0.001)))
+      dt_tadvect = dt*ntastep
     endif
 
     !---------- Initiate group halo pass of the forcing fields
@@ -924,10 +945,10 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       !===========================================================================
       ! This is the start of the tracer advection part of the algorithm.
 
-      if (thermo_does_span_coupling .or. .not.do_thermo) then
-        do_advection = (CS%t_dyn_rel_adv + 0.5*dt > dt_therm)
+      if (tadvect_does_span_coupling .or. .not.do_thermo) then
+        do_advection = (CS%t_dyn_rel_adv + 0.5*dt > dt_tadvect)
       else
-        do_advection = ((MOD(n,ntstep) == 0) .or. (n==n_max))
+        do_advection = ((MOD(n,ntastep) == 0) .or. (n==n_max))
       endif
 
       if (do_advection) then ! Do advective transport and lateral tracer mixing.
@@ -940,7 +961,12 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     !===========================================================================
     ! This is the second place where the diabatic processes and remapping could occur.
-    if ((CS%t_dyn_rel_adv==0.0) .and. do_thermo .and. (.not.CS%diabatic_first)) then
+    if (thermo_does_span_coupling .or. .not.do_dyn) then
+      do_diabatic = (CS%t_dyn_rel_thermo + 0.5*dt > dt_therm)
+    else
+      do_diabatic = ((MOD(n,ntstep) == 0) .or. (n==n_max))
+    endif
+    if ((CS%t_dyn_rel_adv==0.0) .and. do_thermo .and. (.not.CS%diabatic_first) .and. do_diabatic) then
 
       dtdia = CS%t_dyn_rel_thermo
       ! If the MOM6 dynamic and thermodynamic time stepping is being orchestrated
@@ -2350,7 +2376,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "coupling timestep in coupled mode.)", units="s", scale=US%s_to_T, &
                  fail_if_missing=.true.)
   call get_param(param_file, "MOM", "DT_THERM", CS%dt_therm, &
-                 "The thermodynamic and tracer advection time step. "//&
+                 "The thermodynamic time step. "//&
                  "Ideally DT_THERM should be an integer multiple of DT "//&
                  "and less than the forcing or coupling time-step, unless "//&
                  "THERMO_SPANS_COUPLING is true, in which case DT_THERM "//&
@@ -2358,11 +2384,25 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "default DT_THERM is set to DT.", &
                  units="s", scale=US%s_to_T, default=US%T_to_s*CS%dt)
   call get_param(param_file, "MOM", "THERMO_SPANS_COUPLING", CS%thermo_spans_coupling, &
-                 "If true, the MOM will take thermodynamic and tracer "//&
+                 "If true, the MOM will take thermodynamic "//&
                  "timesteps that can be longer than the coupling timestep. "//&
                  "The actual thermodynamic timestep that is used in this "//&
                  "case is the largest integer multiple of the coupling "//&
                  "timestep that is less than or equal to DT_THERM.", default=.false.)
+  call get_param(param_file, "MOM", "DT_TADVECT", CS%dt_tadvect, &
+                 "The tracer advection time step. "//&
+                 "Ideally DT_TADVECT should be an integer multiple of DT "//&
+                 "and less than the forcing or coupling time-step, unless "//&
+                 "TADVECT_SPANS_COUPLING is true, in which case DT_TADVECT "//&
+                 "can be an integer multiple of the coupling timestep.  By "//&
+                 "default DT_TADVECT is set to DT_THERM.", &
+                 units="s", scale=US%s_to_T, default=US%T_to_s*CS%dt_therm)
+  call get_param(param_file, "MOM", "TADVECT_SPANS_COUPLING", CS%tadvect_spans_coupling, &
+                 "If true, the MOM will take tracer advection "//&
+                 "timesteps that can be longer than the coupling timestep. "//&
+                 "The actual tracer advection timestep that is used in this "//&
+                 "case is the largest integer multiple of the coupling "//&
+                 "timestep that is less than or equal to DT_TADVECT.", default=.false.)
 
   if (bulkmixedlayer) then
     CS%Hmix = -1.0 ; CS%Hmix_UV = -1.0

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -962,10 +962,12 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     !===========================================================================
     ! This is the second place where the diabatic processes and remapping could occur.
-    if (thermo_does_span_coupling .or. .not.do_dyn) then
-      do_diabatic = (CS%t_dyn_rel_thermo + 0.5*dt > dt_therm)
-    else
-      do_diabatic = ((MOD(n,ntstep) == 0) .or. (n==n_max))
+    if (do_thermo) then
+      if (thermo_does_span_coupling .or. .not.do_dyn) then
+        do_diabatic = (CS%t_dyn_rel_thermo + 0.5*dt > dt_therm)
+      else
+        do_diabatic = ((MOD(n,ntstep) == 0) .or. (n==n_max))
+      endif
     endif
     if ((CS%t_dyn_rel_adv==0.0) .and. do_thermo .and. (.not.CS%diabatic_first) .and. do_diabatic) then
 


### PR DESCRIPTION
### Introduction
MOM6 separates dynamic and thermodynamic, or diabatic, processes and users have the option to specify a dynamic time step (`DT`) and a thermodynamic time step (`DT_THERM`).  The dynamic time step is limited by the CLF, but`DT_THERM` is not and therefore is often longer than `DT`. Tracer advection is done using accumulated fluxes from one or more dynamic steps, such that the tracers are advected for the length of a thermodynamic step.

However, in higher resolution regional domains we have found that a tracer advective CFL may be providing a practical limit on tracer advection and therefore `DT_THERM`. We also know that model results are depend on the choice of `DT_THERM` (such as in [Issue #773](https://github.com/NOAA-GFDL/MOM6/issues/733)). 

This PR introduces a new time step for tracer advection which can be less than or equal to the time step for diabatic processes. The tracer advection time step is `DT_TRACER_ADVECT` and can be an integer multiple of `DT`; `DT_THERM` should be an integer multiple of `DT_TRACER_ADVECT`. If `DT_THERM` is greater than the coupling time step, `DT_TRACER_ADVECT` can also be greater than the coupling time step. If `DIABATIC_FIRST` is true, `DT_TRACER_ADVECT` must equal `DT_THERM`, this limitation will be addressed in the near future. By default, `DT_TRACER_ADVECT` equals `DT_THERM`, which recovers old answers. The comments describing `DT_THERM` and `DT_TRACER_ADVECT` have been modified to reflect this change. Because the thermodynamics and tracer advection routines were already called separately there were no changes to those routines.

### Results in NWA12
The sensitivity to `DT_THERM` can be clearly observed in the regional Northwest Atlantic 1/12th degree domain. These experiments all use shorter time steps in the first year, with `DT`=400s, and `DT_THERM`=800s. After the first year, `DT`=600s and `DT_THERM` is set to 1800s, or 3600s. Using a tracer advection time step shorter than 3600s improved the Gulf Stream position with `DT_THERM`=3600, but more detailed analysis is needed. Here the position of the Gulf Stream is shown for the different combinations of timesteps.

**Experiment 1:   `DT`=600, `DT_THERM`=1800**
![gulfstream_eval](https://github.com/user-attachments/assets/b74832fb-f328-4278-b68e-baa93f1ff660)

**Experiment 2:   `DT`=600, `DT_THERM`=3600**
![gulfstream_eval](https://github.com/user-attachments/assets/d993454f-b100-4f40-90e9-662c4f052901)

**Experiment 3:   `DT`=600, `DT_TRACER_ADVECT`=1800, `DT_THERM`=3600**
![gulfstream_eval](https://github.com/user-attachments/assets/dd1c9e14-ca60-43c4-838c-c83c026b151a)

**Experiment 4:   `DT`=600, `DT_TRACER_ADVECT`=1200, `DT_THERM`=3600**
![gulfstream_eval](https://github.com/user-attachments/assets/7ffbfcf5-39c3-4166-a7e2-373058ed8a5c)

### Testing
This change was tested in the 0.25 degree Baltic domain for reproducibility across restarts for a combination of time step options:
- `DT` = 300, `DT_TRACER_ADVECT` = 600, `DT_THERM` = 1200, `DT_coupled` = 2400
- `DT` = 300, `DT_TRACER_ADVECT` = 600, `DT_coupled` = 1200, `DT_THERM` = 2400
- `DT` = 300, `DT_coupled` = 600, `DT_TRACER_ADVECT` = 1200, `DT_THERM` = 2400

Note that the new option `TRADV_SPANS_COUPLING` has been added, and should be used where appropriate. Because grid generation and remapping are done in `step_MOM_thermo` at the end of every thermodynamic time step, `DT_TRACER_ADVECT` must be less than `DT_THERM`. 