### PR TITLE
Tidal angular frequency has units [rad s-1]

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5270,7 +5270,7 @@ subroutine register_barotropic_restarts(HI, GV, US, param_file, CS, restart_CS)
   character(len=40)  :: mdl = "MOM_barotropic"  ! This module's name.
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   real :: am2, ak1      !< Bandwidth parameters of the M2 and K1 streaming filters [nondim]
-  real :: om2, ok1      !< Target frequencies of the M2 and K1 streaming filters [T-1 ~> s-1]
+  real :: om2, ok1      !< Target frequencies of the M2 and K1 streaming filters [rad T-1 ~> rad s-1]
 
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
   IsdB = HI%IsdB ; IedB = HI%IedB ; JsdB = HI%JsdB ; JedB = HI%JedB
@@ -5301,13 +5301,13 @@ subroutine register_barotropic_restarts(HI, GV, US, param_file, CS, restart_CS)
                  "Frequency of the M2 tidal constituent. "//&
                  "This is only used if TIDES and TIDE_M2"// &
                  " are true, or if OBC_TIDE_N_CONSTITUENTS > 0 and M2"// &
-                 " is in OBC_TIDE_CONSTITUENTS.", units="s-1", default=tidal_frequency("M2"), &
+                 " is in OBC_TIDE_CONSTITUENTS.", units="rad s-1", default=tidal_frequency("M2"), &
                  scale=US%T_to_s, do_not_log=.true.)
   call get_param(param_file, mdl, "TIDE_K1_FREQ", ok1, &
                  "Frequency of the K1 tidal constituent. "//&
                  "This is only used if TIDES and TIDE_K1"// &
                  " are true, or if OBC_TIDE_N_CONSTITUENTS > 0 and K1"// &
-                 " is in OBC_TIDE_CONSTITUENTS.", units="s-1", default=tidal_frequency("K1"), &
+                 " is in OBC_TIDE_CONSTITUENTS.", units="rad s-1", default=tidal_frequency("K1"), &
                  scale=US%T_to_s, do_not_log=.true.)
 
   ALLOC_(CS%ubtav(IsdB:IedB,jsd:jed))      ; CS%ubtav(:,:) = 0.0

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -320,7 +320,8 @@ type, public :: ocean_OBC_type
   logical :: add_tide_constituents = .false.          !< If true, add tidal constituents to the boundary elevation
                                                       !! and velocity. Will be set to true if n_tide_constituents > 0.
   character(len=2), allocatable, dimension(:) :: tide_names  !< Names of tidal constituents to add to the boundary data.
-  real, allocatable, dimension(:) :: tide_frequencies !< Angular frequencies of chosen tidal constituents [rad T-1 ~> rad s-1].
+  real, allocatable, dimension(:) :: tide_frequencies !< Angular frequencies of chosen tidal
+                                                      !! constituents [rad T-1 ~> rad s-1].
   real, allocatable, dimension(:) :: tide_eq_phases   !< Equilibrium phases of chosen tidal constituents [rad].
   real, allocatable, dimension(:) :: tide_fn          !< Amplitude modulation of boundary tides by nodal cycle [nondim].
   real, allocatable, dimension(:) :: tide_un          !< Phase modulation of boundary tides by nodal cycle [rad].

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -320,7 +320,7 @@ type, public :: ocean_OBC_type
   logical :: add_tide_constituents = .false.          !< If true, add tidal constituents to the boundary elevation
                                                       !! and velocity. Will be set to true if n_tide_constituents > 0.
   character(len=2), allocatable, dimension(:) :: tide_names  !< Names of tidal constituents to add to the boundary data.
-  real, allocatable, dimension(:) :: tide_frequencies !< Angular frequencies of chosen tidal constituents [T-1 ~> s-1].
+  real, allocatable, dimension(:) :: tide_frequencies !< Angular frequencies of chosen tidal constituents [rad T-1 ~> rad s-1].
   real, allocatable, dimension(:) :: tide_eq_phases   !< Equilibrium phases of chosen tidal constituents [rad].
   real, allocatable, dimension(:) :: tide_fn          !< Amplitude modulation of boundary tides by nodal cycle [nondim].
   real, allocatable, dimension(:) :: tide_un          !< Phase modulation of boundary tides by nodal cycle [rad].
@@ -1234,7 +1234,7 @@ subroutine initialize_obc_tides(OBC, US, param_file)
         "This is only used if TIDES and TIDE_"//trim(OBC%tide_names(c))// &
         " are true, or if OBC_TIDE_N_CONSTITUENTS > 0 and "//trim(OBC%tide_names(c))//&
         " is in OBC_TIDE_CONSTITUENTS.", &
-        units="s-1", default=tidal_frequency(trim(OBC%tide_names(c))), scale=US%T_to_s)
+        units="rad s-1", default=tidal_frequency(trim(OBC%tide_names(c))), scale=US%T_to_s)
 
     ! Find equilibrium phase if needed
     if (OBC%add_eq_phase) then

--- a/src/parameterizations/lateral/MOM_streaming_filter.F90
+++ b/src/parameterizations/lateral/MOM_streaming_filter.F90
@@ -15,7 +15,7 @@ public Filt_register, Filt_accum
 !> The control structure for storing the filter infomation of a particular field
 type, public :: Filter_CS ; private
   real       :: a, &                   !< Parameter that determines the bandwidth [nondim]
-                om, &                  !< Target frequency of the filter [T-1 ~> s-1]
+                om, &                  !< Target frequency of the filter [rad T-1 ~> rad s-1]
                 old_time = -1.0        !< The time of the previous accumulating step [T ~> s]
   real, allocatable, dimension(:,:) :: s1, & !< Dummy variable [A]
                                        u1    !< Filtered data [A]
@@ -29,7 +29,7 @@ contains
 !> This subroutine registers each of the fields to be filtered.
 subroutine Filt_register(a, om, grid, HI, CS)
   real,                      intent(in)    :: a      !< Parameter that determines the bandwidth [nondim]
-  real,                      intent(in)    :: om     !< Target frequency of the filter [T-1 ~> s-1]
+  real,                      intent(in)    :: om     !< Target frequency of the filter [rad T-1 ~> rad s-1]
   character(len=*),          intent(in)    :: grid   !< Horizontal grid location: h, u, or v
   type(hor_index_type),      intent(in)    :: HI     !< Horizontal index type structure
   type(Filter_CS),           intent(out)   :: CS     !< Control structure for the current field

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -50,7 +50,7 @@ type, public :: tidal_forcing_CS ; private
                       !! and bottom geopotential anomalies [nondim].
   integer :: nc       !< The number of tidal constituents in use.
   real, dimension(MAX_CONSTITUENTS) :: &
-    freq, &           !< The frequency of a tidal constituent [T-1 ~> s-1].
+    freq, &           !< The frequency of a tidal constituent [rad T-1 ~> rad s-1].
     phase0, &         !< The phase of a tidal constituent at time 0 [rad].
     amp, &            !< The amplitude of a tidal constituent at time 0 [Z ~> m].
     love_no           !< The Love number of a tidal constituent at time 0 [nondim].
@@ -151,7 +151,7 @@ end function eq_phase
 !! Values used here are from previous versions of MOM.
 function tidal_frequency(constit)
   character (len=2), intent(in) :: constit !> Constituent to look up
-  real :: tidal_frequency                  !> Angular frequency [s-1]
+  real :: tidal_frequency                  !> Angular frequency [rad s-1]
 
   select case (constit)
     case ("M2")
@@ -246,7 +246,7 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS, HA_CS)
     phase, &          ! The phase of some tidal constituent [radians].
     lat_rad, lon_rad  ! Latitudes and longitudes of h-points [radians].
   real :: deg_to_rad  ! A conversion factor from degrees to radians [radian degree-1]
-  real, dimension(MAX_CONSTITUENTS) :: freq_def ! Default frequency for each tidal constituent [s-1]
+  real, dimension(MAX_CONSTITUENTS) :: freq_def ! Default frequency for each tidal constituent [rad s-1]
   real, dimension(MAX_CONSTITUENTS) :: phase0_def ! Default reference phase for each tidal constituent [rad]
   real, dimension(MAX_CONSTITUENTS) :: amp_def  ! Default amplitude for each tidal constituent [m]
   real, dimension(MAX_CONSTITUENTS) :: love_def ! Default love number for each constituent [nondim]
@@ -480,7 +480,8 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS, HA_CS)
                    "Frequency of the "//trim(CS%const_name(c))//" tidal constituent. "//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &
                    " are true, or if OBC_TIDE_N_CONSTITUENTS > 0 and "//trim(CS%const_name(c))// &
-                   " is in OBC_TIDE_CONSTITUENTS.", units="s-1", default=freq_def(c), scale=US%T_to_s)
+                   " is in OBC_TIDE_CONSTITUENTS.", units="rad s-1", default=freq_def(c), &
+                   scale=US%T_to_s)
     call get_param(param_file, mdl, "TIDE_"//trim(CS%const_name(c))//"_AMP", CS%amp(c), &
                    "Amplitude of the "//trim(CS%const_name(c))//" tidal constituent. "//&
                    "This is only used if TIDES and TIDE_"//trim(CS%const_name(c))// &


### PR DESCRIPTION
Tidal frequencies are always angular frequencies to simplify applying sine and cosine.  These have MKS units [rad s-1] but they are all currently listed as [s-1].

Updated dOxygen comments for variables, e.g. [T-1 ~> s-1] becomes [rad T-1 ~> rad s-1].  Updated get_param units. e.g. units="s-1" becomes units="rad s-1".

No answers are changed, but the logged parameter units are different.

There are frequencies in MOM_internal_tides.F90 but these have not been updated because they may be specified incorrectly.  They are used as if they are [T-1] but they are calculated as 2PI/period [rad T-1].

  real, allocatable, dimension(:) :: frequency  !< The frequency of each band [T-1 ~> s-1].

  real    :: period             ! A tidal period read from namelist [T ~> s]

  ! The periods of the tidal constituents for internal tides raytracing
  call read_param(param_file, "TIDAL_PERIODS", periods)

  do fr=1,num_freq
    period = US%s_to_T*extract_real(periods, " ,", fr, 0.)
    CS%frequency(fr) = 8.0*atan(1.0)/period
  enddo

All MOM6-examples cases have INTERNAL_TIDES=False and so can't resolve this issue.