### PR TITLE
+Add and use optional unscale args to reproducing_sum

### DIFF
--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -332,9 +332,9 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   if (CS%id_masso > 0) then
     mass_cell(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do i=is,ie
-      mass_cell(i,j) = mass_cell(i,j) + (GV%H_to_kg_m2*h(i,j,k)) * US%L_to_m**2*G%areaT(i,j)
+      mass_cell(i,j) = mass_cell(i,j) + (GV%H_to_RZ*h(i,j,k)) * G%areaT(i,j)
     enddo ; enddo ; enddo
-    masso = reproducing_sum(mass_cell)
+    masso = reproducing_sum(mass_cell, unscale=US%RZL2_to_kg)
     call post_data(CS%id_masso, masso, CS%diag)
   endif
 
@@ -1644,8 +1644,9 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
       Time, 'Mass per unit area of liquid ocean grid cell', 'kg m-2', conversion=GV%H_to_kg_m2, &
       standard_name='sea_water_mass_per_unit_area', v_extensive=.true.)
 
-  CS%id_masso = register_scalar_field('ocean_model', 'masso', Time, &
-      diag, 'Mass of liquid ocean', 'kg', standard_name='sea_water_mass')
+  CS%id_masso = register_scalar_field('ocean_model', 'masso', Time, diag, &
+      'Mass of liquid ocean', units='kg', conversion=US%RZL2_to_kg, &
+      standard_name='sea_water_mass')
 
   CS%id_thkcello = register_diag_field('ocean_model', 'thkcello', diag%axesTL, Time, &
       long_name='Cell Thickness', standard_name='cell_thickness', &

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -51,7 +51,8 @@ logical :: overflow_error = .false. !< This becomes true if an overflow is encou
 logical :: NaN_error = .false.      !< This becomes true if a NaN is encountered.
 logical :: debug = .false.          !< Making this true enables debugging output.
 
-!> Find an accurate and order-invariant sum of a distributed 2d or 3d field
+!> Find an accurate and order-invariant sum of a distributed 2d or 3d field, in some cases after
+!! undoing the scaling of the input array and restoring that scaling in the returned value
 interface reproducing_sum
   module procedure reproducing_sum_2d, reproducing_sum_3d
 end interface reproducing_sum
@@ -91,8 +92,9 @@ contains
 !! the result returned as an extended fixed point type that can be converted back to a real number
 !! using EFP_to_real.  This technique is described in Hallberg & Adcroft, 2014, Parallel Computing,
 !! doi:10.1016/j.parco.2014.04.007.
-function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, only_on_PE) result(EFP_sum)
-  real, dimension(:,:),     intent(in)  :: array   !< The array to be summed in arbitrary units [a]
+function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, only_on_PE, unscale) result(EFP_sum)
+  real, dimension(:,:),     intent(in)  :: array   !< The array to be summed in arbitrary units [a], or in
+                                                   !! arbitrary scaled units [A ~> a] if unscale is present
   integer,        optional, intent(in)  :: isr     !< The starting i-index of the sum, noting
                                                    !! that the array indices starts at 1
   integer,        optional, intent(in)  :: ier     !< The ending i-index of the sum, noting
@@ -102,15 +104,17 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
   integer,        optional, intent(in)  :: jer     !< The ending j-index of the sum, noting
                                                    !! that the array indices starts at 1
   logical,        optional, intent(in)  :: overflow_check !< If present and false, disable
-                                                !! checking for overflows in incremental results.
-                                                !! This can speed up calculations if the number
-                                                !! of values being summed is small enough
-  integer,        optional, intent(out) :: err  !< If present, return an error code instead of
-                                                !! triggering any fatal errors directly from
-                                                !! this routine.
+                                                   !! checking for overflows in incremental results.
+                                                   !! This can speed up calculations if the number
+                                                   !! of values being summed is small enough
+  integer,        optional, intent(out) :: err     !< If present, return an error code instead of
+                                                   !! triggering any fatal errors directly from
+                                                   !! this routine.
   logical,        optional, intent(in)  :: only_on_PE !< If present and true, do not do the sum
-                                                !! across processors, only reporting the local sum
-  type(EFP_type)                        :: EFP_sum  !< The result in extended fixed point format
+                                                   !! across processors, only reporting the local sum
+  real,           optional, intent(in)  :: unscale !< A factor that is used to undo scaling of array before it is
+                                                   !! summed, often to compensate for the scaling in [a A-1 ~> 1]
+  type(EFP_type)                        :: EFP_sum !< The result in extended fixed point format
 
   !   This subroutine uses a conversion to an integer representation
   ! of real numbers to give order-invariant sums that will reproduce
@@ -120,7 +124,8 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
   integer(kind=int64) :: ival, prec_error
   real    :: rs ! The remaining value to add, in arbitrary units [a]
   real    :: max_mag_term ! A running maximum magnitude of the values in arbitrary units [a]
-  logical :: over_check, do_sum_across_PEs
+  real    :: descale    ! A local copy of unscale if it is present [a A-1 ~> 1] or 1
+  logical :: over_check, do_sum_across_PEs, do_unscale
   character(len=256) :: mesg
   integer :: i, j, n, is, ie, js, je, sgn
 
@@ -130,7 +135,7 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
 
   prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
 
-  is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2 )
+  is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2)
   if (present(isr)) then
     if (isr < is) call MOM_error(FATAL, "Value of isr too small in reproducing_EFP_sum_2d.")
     is = isr
@@ -150,32 +155,40 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
 
   over_check = .true. ; if (present(overflow_check)) over_check = overflow_check
   do_sum_across_PEs = .true. ; if (present(only_on_PE)) do_sum_across_PEs = .not.only_on_PE
+  do_unscale = .false. ; if (present(unscale)) do_unscale = (unscale /= 1.0)
+  descale = 1.0 ; if (do_unscale) descale = unscale
 
   overflow_error = .false. ; NaN_error = .false. ; max_mag_term = 0.0
   ints_sum(:) = 0
   if (over_check) then
     if ((je+1-js)*(ie+1-is) < max_count_prec) then
-      do j=js,je ; do i=is,ie
-        call increment_ints_faster(ints_sum, array(i,j), max_mag_term)
-      enddo ; enddo
+      ! This is the most common case, so handle the do_unscale case separately for efficiency.
+      if (do_unscale) then
+        do j=js,je ; do i=is,ie
+          call increment_ints_faster(ints_sum, unscale*array(i,j), max_mag_term)
+        enddo ; enddo
+      else
+        do j=js,je ; do i=is,ie
+          call increment_ints_faster(ints_sum, array(i,j), max_mag_term)
+        enddo ; enddo
+      endif
       call carry_overflow(ints_sum, prec_error)
     elseif ((ie+1-is) < max_count_prec) then
       do j=js,je
         do i=is,ie
-          call increment_ints_faster(ints_sum, array(i,j), max_mag_term)
+          call increment_ints_faster(ints_sum, descale*array(i,j), max_mag_term)
         enddo
         call carry_overflow(ints_sum, prec_error)
       enddo
     else
       do j=js,je ; do i=is,ie
-        call increment_ints(ints_sum, real_to_ints(array(i,j), prec_error), &
-                            prec_error)
+        call increment_ints(ints_sum, real_to_ints(descale*array(i,j), prec_error), prec_error)
       enddo ; enddo
     endif
   else
     do j=js,je ; do i=is,ie
       sgn = 1 ; if (array(i,j)<0.0) sgn = -1
-      rs = abs(array(i,j))
+      rs = abs(descale*array(i,j))
       do n=1,ni
         ival = int(rs*I_pr(n), kind=int64)
         rs = rs - ival*pr(n)
@@ -213,13 +226,15 @@ function reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, 
 
 end function reproducing_EFP_sum_2d
 
+
 !> This subroutine uses a conversion to an integer representation of real numbers to give an
 !! order-invariant sum of distributed 2-D arrays that reproduces across domain decomposition.
 !! This technique is described in Hallberg & Adcroft, 2014, Parallel Computing,
 !! doi:10.1016/j.parco.2014.04.007.
 function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
-                            overflow_check, err, only_on_PE) result(sum)
-  real, dimension(:,:),     intent(in)  :: array   !< The array to be summed in arbitrary units [a]
+                            overflow_check, err, only_on_PE, unscale) result(sum)
+  real, dimension(:,:),     intent(in)  :: array   !< The array to be summed in arbitrary units [a], or in
+                                                   !! arbitrary scaled units [A ~> a] if unscale is present
   integer,        optional, intent(in)  :: isr     !< The starting i-index of the sum, noting
                                                    !! that the array indices starts at 1
   integer,        optional, intent(in)  :: ier     !< The ending i-index of the sum, noting
@@ -228,7 +243,7 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
                                                    !! that the array indices starts at 1
   integer,        optional, intent(in)  :: jer     !< The ending j-index of the sum, noting
                                                    !! that the array indices starts at 1
-  type(EFP_type), optional, intent(out) :: EFP_sum  !< The result in extended fixed point format
+  type(EFP_type), optional, intent(out) :: EFP_sum !< The result in extended fixed point format
   logical,        optional, intent(in)  :: reproducing !< If present and false, do the sum
                                                 !! using the naive non-reproducing approach
   logical,        optional, intent(in)  :: overflow_check !< If present and false, disable
@@ -240,16 +255,18 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
                                                 !! this routine.
   logical,        optional, intent(in)  :: only_on_PE !< If present and true, do not do the sum
                                                 !! across processors, only reporting the local sum
-  real                                  :: sum  !< The sum of the values in array in arbitrary units [a]
+  real,           optional, intent(in)  :: unscale !< A factor that is used to undo scaling of array before it is
+                                                   !! summed, often to compensate for the scaling in [a A-1 ~> 1]
+  real                                  :: sum     !< The sum of the values in array in the same
+                                                   !! arbitrary units as array [a] or [A ~> a]
 
-  !   This subroutine uses a conversion to an integer representation
-  ! of real numbers to give order-invariant sums that will reproduce
-  ! across PE count.  This idea comes from R. Hallberg and A. Adcroft.
-
+  ! Local variables
   integer(kind=int64), dimension(ni)  :: ints_sum
   integer(kind=int64) :: prec_error
-  real    :: rsum(1) ! The running sum, in arbitrary units [a]
-  logical :: repro, do_sum_across_PEs
+  real    :: rsum(1)    ! The running sum, in arbitrary units [a]
+  real    :: descale    ! A local copy of unscale if it is present [a A-1 ~> 1] or 1
+  real    :: I_unscale  ! The reciprocal of unscale [A a-1 ~> 1]
+  logical :: repro, do_sum_across_PEs, do_unscale
   character(len=256) :: mesg
   type(EFP_type) :: EFP_val ! An extended fixed point version of the sum
   integer :: i, j, is, ie, js, je
@@ -260,7 +277,7 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
 
   prec_error = ((2_int64)**62 + ((2_int64)**62 - 1)) / num_PEs()
 
-  is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2 )
+  is = 1 ; ie = size(array,1) ; js = 1 ; je = size(array,2)
   if (present(isr)) then
     if (isr < is) call MOM_error(FATAL, "Value of isr too small in reproducing_sum_2d.")
     is = isr
@@ -280,19 +297,25 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
 
   repro = .true. ; if (present(reproducing)) repro = reproducing
   do_sum_across_PEs = .true. ; if (present(only_on_PE)) do_sum_across_PEs = .not.only_on_PE
+  do_unscale = .false. ; if (present(unscale)) do_unscale = (unscale /= 1.0)
+  descale = 1.0 ;  I_unscale = 1.0
+  if (do_unscale) then
+    descale = unscale
+    if (abs(unscale) > 0.0) I_unscale = 1.0 / unscale
+  endif
 
   if (repro) then
-    EFP_val = reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, only_on_PE)
-    sum = ints_to_real(EFP_val%v)
+    EFP_val = reproducing_EFP_sum_2d(array, isr, ier, jsr, jer, overflow_check, err, only_on_PE, unscale)
+    sum = ints_to_real(EFP_val%v) * I_unscale
     if (present(EFP_sum)) EFP_sum = EFP_val
     if (debug) ints_sum(:) = EFP_sum%v(:)
   else
     rsum(1) = 0.0
     do j=js,je ; do i=is,ie
-      rsum(1) = rsum(1) + array(i,j)
+      rsum(1) = rsum(1) + descale*array(i,j)
     enddo ; enddo
     if (do_sum_across_PEs) call sum_across_PEs(rsum,1)
-    sum = rsum(1)
+    sum = rsum(1) * I_unscale
 
     if (present(err)) then ; err = 0 ; endif
 
@@ -312,7 +335,7 @@ function reproducing_sum_2d(array, isr, ier, jsr, jer, EFP_sum, reproducing, &
   endif
 
   if (debug) then
-    write(mesg,'("2d RS: ", ES24.16, 6 Z17.16)') sum, ints_sum(1:ni)
+    write(mesg,'("2d RS: ", ES24.16, 6 Z17.16)') sum*descale, ints_sum(1:ni)
     call MOM_mesg(mesg, 3)
   endif
 
@@ -322,9 +345,10 @@ end function reproducing_sum_2d
 !! order-invariant sum of distributed 3-D arrays that reproduces across domain decomposition.
 !! This technique is described in Hallberg & Adcroft, 2014, Parallel Computing,
 !! doi:10.1016/j.parco.2014.04.007.
-function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_sums, err, only_on_PE) &
+function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_sums, err, only_on_PE, unscale) &
                             result(sum)
-  real, dimension(:,:,:),       intent(in)  :: array   !< The array to be summed in arbitrary units [a]
+  real, dimension(:,:,:),       intent(in)  :: array   !< The array to be summed in arbitrary units [a], or in
+                                                       !! arbitrary scaled units [A ~> a] if unscale is present
   integer,            optional, intent(in)  :: isr     !< The starting i-index of the sum, noting
                                                        !! that the array indices starts at 1
   integer,            optional, intent(in)  :: ier     !< The ending i-index of the sum, noting
@@ -333,28 +357,31 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
                                                        !! that the array indices starts at 1
   integer,            optional, intent(in)  :: jer     !< The ending j-index of the sum, noting
                                                        !! that the array indices starts at 1
-  real, dimension(:), optional, intent(out) :: sums    !< The sums by vertical layer in abitrary units [a]
+  real, dimension(:), optional, intent(out) :: sums    !< The sums by vertical layer in the same
+                                                       !! abitrary units as array [a] or [A ~> a]
   type(EFP_type),     optional, intent(out) :: EFP_sum !< The result in extended fixed point format
   type(EFP_type), dimension(:), &
                       optional, intent(out) :: EFP_lay_sums !< The sums by vertical layer in EFP format
-  integer,            optional, intent(out) :: err  !< If present, return an error code instead of
-                                                    !! triggering any fatal errors directly from
-                                                    !! this routine.
+  integer,            optional, intent(out) :: err     !< If present, return an error code instead of
+                                                       !! triggering any fatal errors directly from
+                                                       !! this routine.
   logical,            optional, intent(in)  :: only_on_PE !< If present and true, do not do the sum
-                                                    !! across processors, only reporting the local sum
-  real                                      :: sum  !< The sum of the values in array in arbitrary units [a]
+                                                       !! across processors, only reporting the local sum
+  real,               optional, intent(in)  :: unscale !< A factor that is used to undo scaling of array before it is
+                                                       !! summed, often to compensate for the scaling in [a A-1 ~> 1]
+  real                                      :: sum     !< The sum of the values in array in the same
+                                                       !! arbitrary units as array [a] or [A ~> a]
 
-  !   This subroutine uses a conversion to an integer representation
-  ! of real numbers to give order-invariant sums that will reproduce
-  ! across PE count.  This idea comes from R. Hallberg and A. Adcroft.
-
+  ! Local variables
   real    :: val ! The real number that is extracted in arbitrary units [a]
   real    :: max_mag_term ! A running maximum magnitude of the val's in arbitrary units [a]
+  real    :: descale    ! A local copy of unscale if it is present [a A-1 ~> 1] or 1
+  real    :: I_unscale  ! The Adcroft reciprocal of unscale [A a-1 ~> 1]
   integer(kind=int64), dimension(ni)  :: ints_sum
   integer(kind=int64), dimension(ni,size(array,3))  :: ints_sums
   integer(kind=int64) :: prec_error
   character(len=256) :: mesg
-  logical :: do_sum_across_PEs
+  logical :: do_sum_across_PEs, do_unscale
   integer :: i, j, k, is, ie, js, je, ke, isz, jsz, n
 
   if (num_PEs() > max_count_prec) call MOM_error(FATAL, &
@@ -384,6 +411,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
   jsz = je+1-js; isz = ie+1-is
 
   do_sum_across_PEs = .true. ; if (present(only_on_PE)) do_sum_across_PEs = .not.only_on_PE
+  do_unscale = .false. ; if (present(unscale)) do_unscale = (unscale /= 1.0)
 
   if (present(sums) .or. present(EFP_lay_sums)) then
     if (present(sums)) then ; if (size(sums) < ke) then
@@ -396,22 +424,28 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     overflow_error = .false. ; NaN_error = .false. ; max_mag_term = 0.0
     if (jsz*isz < max_count_prec) then
       do k=1,ke
-        do j=js,je ; do i=is,ie
-          call increment_ints_faster(ints_sums(:,k), array(i,j,k), max_mag_term)
-        enddo ; enddo
+        if (do_unscale) then
+          do j=js,je ; do i=is,ie
+            call increment_ints_faster(ints_sums(:,k), unscale*array(i,j,k), max_mag_term)
+          enddo ; enddo
+        else
+          do j=js,je ; do i=is,ie
+            call increment_ints_faster(ints_sums(:,k), array(i,j,k), max_mag_term)
+          enddo ; enddo
+        endif
         call carry_overflow(ints_sums(:,k), prec_error)
       enddo
     elseif (isz < max_count_prec) then
       do k=1,ke ; do j=js,je
         do i=is,ie
-          call increment_ints_faster(ints_sums(:,k), array(i,j,k), max_mag_term)
+          call increment_ints_faster(ints_sums(:,k), descale*array(i,j,k), max_mag_term)
         enddo
         call carry_overflow(ints_sums(:,k), prec_error)
       enddo ; enddo
     else
       do k=1,ke ; do j=js,je ; do i=is,ie
         call increment_ints(ints_sums(:,k), &
-                            real_to_ints(array(i,j,k), prec_error), prec_error)
+                            real_to_ints(descale*array(i,j,k), prec_error), prec_error)
       enddo ; enddo ; enddo
     endif
     if (present(err)) then
@@ -458,21 +492,27 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     overflow_error = .false. ; NaN_error = .false. ; max_mag_term = 0.0
     if (jsz*isz < max_count_prec) then
       do k=1,ke
-        do j=js,je ; do i=is,ie
-          call increment_ints_faster(ints_sum, array(i,j,k), max_mag_term)
-        enddo ; enddo
+        if (do_unscale) then
+          do j=js,je ; do i=is,ie
+            call increment_ints_faster(ints_sum, unscale*array(i,j,k), max_mag_term)
+          enddo ; enddo
+        else
+          do j=js,je ; do i=is,ie
+            call increment_ints_faster(ints_sum, array(i,j,k), max_mag_term)
+          enddo ; enddo
+        endif
         call carry_overflow(ints_sum, prec_error)
       enddo
     elseif (isz < max_count_prec) then
       do k=1,ke ; do j=js,je
         do i=is,ie
-          call increment_ints_faster(ints_sum, array(i,j,k), max_mag_term)
+          call increment_ints_faster(ints_sum, descale*array(i,j,k), max_mag_term)
         enddo
         call carry_overflow(ints_sum, prec_error)
       enddo ; enddo
     else
       do k=1,ke ; do j=js,je ; do i=is,ie
-        call increment_ints(ints_sum, real_to_ints(array(i,j,k), prec_error), &
+        call increment_ints(ints_sum, real_to_ints(descale*array(i,j,k), prec_error), &
                             prec_error)
       enddo ; enddo ; enddo
     endif
@@ -504,6 +544,15 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
     endif
   endif
 
+  if (do_unscale) then
+    ! Revise the sum to restore the scaling of input array before it is returned
+    I_unscale = 0.0 ; if (abs(unscale) > 0.0) I_unscale = 1.0 / unscale
+    sum = sum * I_unscale
+    if (present(sums)) then
+      do k=1,ke ; sums(k) = sums(k) * I_unscale ; enddo
+    endif
+  endif
+
 end function reproducing_sum_3d
 
 !> Convert a real number into the array of integers constitute its extended-fixed-point representation
@@ -516,9 +565,11 @@ function real_to_ints(r, prec_error, overflow) result(ints)
   logical,         optional, intent(inout) :: overflow !< Returns true if the conversion is being
                                               !! done on a value that is too large to be represented
   integer(kind=int64), dimension(ni)  :: ints
+
   !   This subroutine converts a real number to an equivalent representation
   ! using several long integers.
 
+  ! Local variables
   real :: rs  ! The remaining value to add, in arbitrary units [a]
   character(len=80) :: mesg
   integer(kind=int64) :: ival, prec_err

--- a/src/framework/MOM_unit_scaling.F90
+++ b/src/framework/MOM_unit_scaling.F90
@@ -47,6 +47,7 @@ type, public :: unit_scale_type
   real :: QRZ_T_to_W_m2   !< Convert heat fluxes from Q R Z T-1 to W m-2                    [W T Q-1 R-1 Z-1 m-2 ~> 1]
   ! Not used enough:  real :: kg_m2_to_RZ   !< Convert mass loads from kg m-2 to R Z                [R Z m2 kg-1 ~> 1]
   real :: RZ_to_kg_m2     !< Convert mass loads from R Z to kg m-2                               [kg R-1 Z-1 m-2 ~> 1]
+  real :: RZL2_to_kg      !< Convert masses from R Z L2 to kg                                    [kg R-1 Z-1 L-2 ~> 1]
   real :: kg_m2s_to_RZ_T  !< Convert mass fluxes from kg m-2 s-1 to R Z T-1                   [R Z m2 s T-1 kg-1 ~> 1]
   real :: RZ_T_to_kg_m2s  !< Convert mass fluxes from R Z T-1 to kg m-2 s-1                [T kg R-1 Z-1 m-2 s-1 ~> 1]
   real :: RZ3_T3_to_W_m2  !< Convert turbulent kinetic energy fluxes from R Z3 T-3 to W m-2    [W T3 R-1 Z-3 m-2 ~> 1]
@@ -224,6 +225,8 @@ subroutine set_unit_scaling_combos(US)
   ! Wind stresses:
   US%RLZ_T2_to_Pa = US%R_to_kg_m3 * US%L_T_to_m_s**2 * US%Z_to_L
   US%Pa_to_RLZ_T2 = US%kg_m3_to_R * US%m_s_to_L_T**2 * US%L_to_Z
+  ! Masses:
+  US%RZL2_to_kg = US%R_to_kg_m3 * US%Z_to_m * US%L_to_m**2
 
 end subroutine set_unit_scaling_combos
 

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -1314,17 +1314,14 @@ subroutine compute_global_grid_integrals(G, US)
 
   ! Local variables
   real, dimension(G%isc:G%iec, G%jsc:G%jec) :: tmpForSumming ! Masked and unscaled cell areas [m2]
-  real :: area_scale  ! A scaling factor for area into MKS units [m2 L-2 ~> 1]
-  integer :: i,j
-
-  area_scale = US%L_to_m**2
+  integer :: i, j
 
   tmpForSumming(:,:) = 0.
   G%areaT_global = 0.0 ; G%IareaT_global = 0.0
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
-    tmpForSumming(i,j) = area_scale*G%areaT(i,j) * G%mask2dT(i,j)
+    tmpForSumming(i,j) = G%areaT(i,j) * G%mask2dT(i,j)
   enddo ; enddo
-  G%areaT_global = reproducing_sum(tmpForSumming)
+  G%areaT_global = US%L_to_m**2 * reproducing_sum(tmpForSumming, unscale=US%L_to_m**2)
 
   if (G%areaT_global == 0.0) &
     call MOM_error(FATAL, "compute_global_grid_integrals: zero ocean area (check topography?)")

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -625,27 +625,24 @@ real function remaining_transport_sum(G, GV, US, uhtr, vhtr, h_new)
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: trans_rem_col !< The vertical sum of the absolute value of
-                     !! transports through the faces of a column, in MKS units [kg].
+                     !! transports through the faces of a column [R Z L2 ~> kg].
   real :: trans_cell !< The sum of the absolute value of the remaining transports through the faces
                      !! of a tracer cell [H L2 ~> m3 or kg]
-  real :: HL2_to_kg_scale !< Unit conversion factor to cell mass [kg H-1 L-2 ~> kg m-3 or 1]
   integer :: i, j, k, is, ie, js, je, nz
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-
-  HL2_to_kg_scale = GV%H_to_kg_m2 * US%L_to_m**2
 
   trans_rem_col(:,:) = 0.0
   do k=1,nz ; do j=js,je ; do i=is,ie
     trans_cell = (ABS(uhtr(I-1,j,k)) + ABS(uhtr(I,j,k))) + &
                  (ABS(vhtr(i,J-1,k)) + ABS(vhtr(i,J,k)))
     if (trans_cell > max(1.0e-16*h_new(i,j,k), GV%H_subroundoff) * G%areaT(i,j)) &
-      trans_rem_col(i,j) =  trans_rem_col(i,j) + HL2_to_kg_scale * trans_cell
+      trans_rem_col(i,j) =  trans_rem_col(i,j) + GV%H_to_RZ * trans_cell
   enddo ; enddo ; enddo
 
   ! The factor of 0.5 here is to avoid double-counting because two cells share a face.
-  remaining_transport_sum = 0.5 * GV%kg_m2_to_H*US%m_to_L**2 * &
-      reproducing_sum(trans_rem_col, is+(1-G%isd), ie+(1-G%isd), js+(1-G%jsd), je+(1-G%jsd))
+  remaining_transport_sum = 0.5 * GV%RZ_to_H * reproducing_sum(trans_rem_col, &
+                             is+(1-G%isd), ie+(1-G%isd), js+(1-G%jsd), je+(1-G%jsd), unscale=US%RZL2_to_kg)
 
 end function remaining_transport_sum
 
@@ -876,8 +873,8 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vhtr_sub ! Remaining meridional mass transports [H L2 ~> m3 or kg]
 
   real, dimension(SZI_(G),SZJB_(G)) :: rem_col_flux ! The summed absolute value of the remaining
-                         ! fluxes through the faces of a column or within a column, in mks units [kg]
-  real :: sum_flux       ! Globally summed absolute value of fluxes in mks units [kg], which is
+                         ! mass fluxes through the faces of a column or within a column [R Z L2 ~> kg]
+  real :: sum_flux       ! Globally summed absolute value of fluxes [R Z L2 ~> kg], which is
                          ! used to keep track of how close to convergence we are.
 
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
@@ -890,7 +887,6 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
   ! Work arrays for temperature and salinity
   integer :: iter
   real    :: dt_iter  ! The timestep of each iteration [T ~> s]
-  real    :: HL2_to_kg_scale ! Unit conversion factors to cell mass [kg H-1 L-2 ~> kg m-3 or 1]
   character(len=160) :: mesg  ! The text of an error message
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
@@ -993,22 +989,22 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
     call pass_vector(uhtr,vhtr,G%Domain)
 
     ! Calculate how close we are to converging by summing the remaining fluxes at each point
-    HL2_to_kg_scale = US%L_to_m**2*GV%H_to_kg_m2
     rem_col_flux(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do i=is,ie
-      rem_col_flux(i,j) = rem_col_flux(i,j) + HL2_to_kg_scale * &
+      rem_col_flux(i,j) = rem_col_flux(i,j) + GV%H_to_RZ * &
           ( (abs(eatr(i,j,k)) + abs(ebtr(i,j,k))) + &
            ((abs(uhtr(I-1,j,k)) + abs(uhtr(I,j,k))) + &
             (abs(vhtr(i,J-1,k)) + abs(vhtr(i,J,k))) ) )
     enddo ; enddo ; enddo
-    sum_flux = reproducing_sum(rem_col_flux, is+(1-G%isd), ie+(1-G%isd), js+(1-G%jsd), je+(1-G%jsd))
+    sum_flux = reproducing_sum(rem_col_flux, is+(1-G%isd), ie+(1-G%isd), js+(1-G%jsd), je+(1-G%jsd), &
+                               unscale=US%RZL2_to_kg)
 
     if (sum_flux==0) then
       write(mesg,*) 'offline_advection_layer: Converged after iteration', iter
       call MOM_mesg(mesg)
       exit
     else
-      write(mesg,*) "offline_advection_layer: Iteration ", iter, " remaining total fluxes: ", sum_flux
+      write(mesg,*) "offline_advection_layer: Iteration ", iter, " remaining total fluxes: ", sum_flux*US%RZL2_to_kg
       call MOM_mesg(mesg)
     endif
 


### PR DESCRIPTION
  This PR consists of a series of 4 commits that adds optional `unscale` arguments to the publicly visible `reproducing_sum()` interfaces in `MOM_coms`, and then uses them to refactor the routines in `MOM_sum_output` and 4 other modules to eliminate about 19 dimensional rescaling factors, and to work more broadly in rescaled variables for dimensional consistency testing.

  All answers are bitwise identical, but there are new optional arguments to 2 publicly visible interfaces and a new element in the transparent unit_scale_type.  This commits in this PR include:

- NOAA-GFDL/MOM6@193c83ec9 Use reproducing_sum with unscale in 5 places
- NOAA-GFDL/MOM6@842bbf4da Work in rescaled units in write_energy
- NOAA-GFDL/MOM6@4d255baf7 +Add RZL2_to_kg element to unit_scale_type
- NOAA-GFDL/MOM6@9e7e16523 +Add optional unscale argument to reproducing_sum