### PR TITLE
FMS API: Convert real kind of constants

### DIFF
--- a/config_src/infra/FMS1/MOM_constants.F90
+++ b/config_src/infra/FMS1/MOM_constants.F90
@@ -3,12 +3,16 @@ module MOM_constants
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use constants_mod, only : HLV, HLF
+use constants_mod, only : FMS_HLV => HLV
+use constants_mod, only : FMS_HLF => HLF
 
 implicit none ; private
 
-!> The constant offset for converting temperatures in Kelvin to Celsius
 real, public, parameter :: CELSIUS_KELVIN_OFFSET = 273.15
-public :: HLV, HLF
+  !< The constant offset for converting temperatures in Kelvin to Celsius [K]
+real, public, parameter :: HLV = real(FMS_HLV, kind=kind(1.0))
+  !< Latent heat of vaporization [J kg-1]
+real, public, parameter :: HLF = real(FMS_HLF, kind=kind(1.0))
+  !< Latent heat of fusion [J kg-1]
 
 end module MOM_constants

--- a/config_src/infra/FMS2/MOM_constants.F90
+++ b/config_src/infra/FMS2/MOM_constants.F90
@@ -3,12 +3,16 @@ module MOM_constants
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use constants_mod, only : HLV, HLF
+use constants_mod, only : FMS_HLV => HLV
+use constants_mod, only : FMS_HLF => HLF
 
 implicit none ; private
 
-!> The constant offset for converting temperatures in Kelvin to Celsius
 real, public, parameter :: CELSIUS_KELVIN_OFFSET = 273.15
-public :: HLV, HLF
+  !< The constant offset for converting temperatures in Kelvin to Celsius [K]
+real, public, parameter :: HLV = real(FMS_HLV, kind=kind(1.0))
+  !< Latent heat of vaporization [J kg-1]
+real, public, parameter :: HLF = real(FMS_HLF, kind=kind(1.0))
+  !< Latent heat of fusion [J kg-1]
 
 end module MOM_constants


### PR DESCRIPTION
Two latent heat constants are imported directly from FMS, which is built independently of MOM6.  Previously, it was a safe assumption that both would be built with double precision, but this is no longer the case since FMS now supports both single and double precision.  This could cause conflicts with mixed-precision builds.

This patch converts the values from FMS-precision to MOM-precision.

Single->double should not affect reproducibility since every single-precision number can be exactly represented in double precision. Double->single could affect reproducibility, but this is not an issue since MOM6 does not run in single precision.