### PR TITLE
+Remove dyn_horgrid_type%Rad_Earth and ocean_grid_type%Rad_Earth

### DIFF
--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -198,7 +198,6 @@ type, public :: ocean_grid_type
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line [degrees_E] or [km] or [m]
   real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain [degrees_N] or [km] or [m]
   real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain [degrees_E] or [km] or [m]
-  real :: Rad_Earth     !< The radius of the planet [m]
   real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
   real :: max_depth     !< The maximum depth of the ocean in depth units [Z ~> m]
 end type ocean_grid_type

--- a/src/core/MOM_transcribe_grid.F90
+++ b/src/core/MOM_transcribe_grid.F90
@@ -139,7 +139,7 @@ subroutine copy_dyngrid_to_MOM_grid(dG, oG, US)
   oG%areaT_global = dG%areaT_global ; oG%IareaT_global = dG%IareaT_global
   oG%south_lat = dG%south_lat ; oG%west_lon  = dG%west_lon
   oG%len_lat = dG%len_lat ; oG%len_lon = dG%len_lon
-  oG%Rad_Earth = dG%Rad_Earth ; oG%Rad_Earth_L = dG%Rad_Earth_L
+  oG%Rad_Earth_L = dG%Rad_Earth_L
   oG%max_depth = dG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.
@@ -301,7 +301,7 @@ subroutine copy_MOM_grid_to_dyngrid(oG, dG, US)
   dG%areaT_global = oG%areaT_global ; dG%IareaT_global = oG%IareaT_global
   dG%south_lat = oG%south_lat ; dG%west_lon  = oG%west_lon
   dG%len_lat = oG%len_lat ; dG%len_lon = oG%len_lon
-  dG%Rad_Earth = oG%Rad_Earth ; dG%Rad_Earth_L = oG%Rad_Earth_L
+  dG%Rad_Earth_L = oG%Rad_Earth_L
   dG%max_depth = oG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -189,7 +189,6 @@ type, public :: dyn_horgrid_type
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line [degrees_E] or [km] or [m]
   real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain [degrees_N] or [km] or [m]
   real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain [degrees_E] or [km] or [m]
-  real :: Rad_Earth     !< The radius of the planet [m]
   real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
   real :: max_depth     !< The maximum depth of the ocean [Z ~> m]
 end type dyn_horgrid_type
@@ -407,7 +406,6 @@ subroutine rotate_dyn_horgrid(G_in, G, US, turns)
   G%grid_unit_to_L = G_in%grid_unit_to_L
   G%areaT_global = G_in%areaT_global
   G%IareaT_global = G_in%IareaT_global
-  G%Rad_Earth = G_in%Rad_Earth
   G%Rad_Earth_L = G_in%Rad_Earth_L
   G%max_depth = G_in%max_depth
 

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -102,7 +102,6 @@ subroutine set_grid_metrics(G, param_file, US)
     call get_param(param_file, "MOM_grid_init", "RAD_EARTH", G%Rad_Earth_L, &
                    "The radius of the Earth.", units="m", default=6.378e6, scale=US%m_to_L)
   endif
-  G%Rad_Earth = US%L_to_m*G%Rad_Earth_L
 
   ! Calculate derived metrics (i.e. reciprocals and products)
   call callTree_enter("set_derived_metrics(), MOM_grid_initialize.F90")


### PR DESCRIPTION
  Remove the unused element `Rad_Earth` from `ocean_grid_type` and `dyn_horgrid_type`. The dimensionally rescaled equivalent element `G%Rad_Earth_L` is extensively used, and it will continue to exist.  `G%Rad_Earth_L` was introduced in November 27, 2021 as a dimensionally rescaled version of `G%Rad_Earth`, while the unscaled version was retained because at the time, the `Rad_Earth` element of the `dyn_horgrid_type` is also used in SIS2.  However, SIS2 has not used `G%Rad_Earth` since December 23, 2021, so after 3 years we can now safely remove this unused element.

  Any cases on other branches that might be impacted by this change will not compile.  All answers are bitwise identical, but there is one less element in two transparent types.