### PR TITLE
+Refactor homogenize_field and revise its interface

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2928,8 +2928,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
     if (homogenize) then
       ! Horizontally homogenize data to produce perfectly "flat" initial conditions
       do k=1,nz
-        call homogenize_field(tv%T(:,:,k), G%mask2dT, G, scale=US%degC_to_C, answer_date=hor_regrid_answer_date)
-        call homogenize_field(tv%S(:,:,k), G%mask2dT, G, scale=US%ppt_to_S, answer_date=hor_regrid_answer_date)
+        call homogenize_field(tv%T(:,:,k), G, tmp_scale=US%C_to_degC, answer_date=hor_regrid_answer_date)
+        call homogenize_field(tv%S(:,:,k), G, tmp_scale=US%S_to_ppt, answer_date=hor_regrid_answer_date)
       enddo
     endif
 


### PR DESCRIPTION
  Refactored the `homogenize_field()` routine in MOM_horizontal_regridding to make use of the `unscale` argument to `reproducing_sum()`, and revised its interface to make it more nearly consistent with the interface to `homogenize_field_t()` in `MOM_forcing_type`.

  The interface changes include revising the order of the arguments, making the weight argument options, replacing the scale argument with an optional `tmp_scale` argument that is the inverse of the previous `scale`, and making the default for the use of reproducing sums to be true when the `answer_date` argument is absent. The two `homogenize_field` routines now give equivalent behavior when none of the optional arguments to `homogenize_field()` are absent.  The `homogenize_field()` calls in `MOM_temp_salt_initialize_from_Z()` and the `horiz_interp_and_extrap_tracer()` routines have been modified in accordance with the interface changes.

  All answers are bitwise identical, but the interface to a publicly visible routine has been substantially changed to the point where any calls using the previous interface will not compile.