### PR TITLE
+Add and use optional conversion argument to register_field in MOM_io_file

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2771,20 +2771,20 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     if (CS%tv%T_is_conT) then
       vd_T = var_desc(name="contemp", units="Celsius", longname="Conservative Temperature", &
                       cmor_field_name="bigthetao", cmor_longname="Sea Water Conservative Temperature", &
-                      conversion=US%Q_to_J_kg*CS%tv%C_p)
+                      conversion=US%C_to_degC)
     else
       vd_T = var_desc(name="temp", units="degC", longname="Potential Temperature", &
                       cmor_field_name="thetao", cmor_longname="Sea Water Potential Temperature", &
-                      conversion=US%Q_to_J_kg*CS%tv%C_p)
+                      conversion=US%C_to_degC)
     endif
     if (CS%tv%S_is_absS) then
       vd_S = var_desc(name="abssalt", units="g kg-1", longname="Absolute Salinity", &
                       cmor_field_name="absso", cmor_longname="Sea Water Absolute Salinity", &
-                      conversion=0.001*US%S_to_ppt)
+                      conversion=US%S_to_ppt)
     else
       vd_S = var_desc(name="salt", units="psu", longname="Salinity", &
                       cmor_field_name="so", cmor_longname="Sea Water Salinity", &
-                      conversion=0.001*US%S_to_ppt)
+                      conversion=US%S_to_ppt)
     endif
 
     if (advect_TS) then

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -972,7 +972,7 @@ subroutine register_cell_measure(G, diag, Time)
   ! Local variables
   integer :: id
   id = register_diag_field('ocean_model', 'volcello', diag%axesTL, &
-                           Time, 'Ocean grid-cell volume', 'm3', &
+                           Time, 'Ocean grid-cell volume', units='m3', conversion=1.0, &
                            standard_name='ocean_volume', v_extensive=.true., &
                            x_cell_method='sum', y_cell_method='sum')
   call diag_associate_volume_cell_measure(diag, id)
@@ -3153,10 +3153,13 @@ function ocean_register_diag(var_desc, G, diag_CS, day)
   character(len=48) :: units            ! A variable's units.
   character(len=240) :: longname        ! A variable's longname.
   character(len=8) :: hor_grid, z_grid  ! Variable grid info.
+  real :: conversion ! A multiplicative factor for unit conversions for output,
+                     ! as might be needed to convert from intensive to extensive
+                     ! or for dimensional consistency testing [various] or [a A-1 ~> 1]
   type(axes_grp), pointer :: axes => NULL()
 
   call query_vardesc(var_desc, units=units, longname=longname, hor_grid=hor_grid, &
-                     z_grid=z_grid, caller="ocean_register_diag")
+                     z_grid=z_grid, conversion=conversion, caller="ocean_register_diag")
 
   ! Use the hor_grid and z_grid components of vardesc to determine the
   ! desired axes to register the diagnostic field for.
@@ -3211,8 +3214,8 @@ function ocean_register_diag(var_desc, G, diag_CS, day)
         "ocean_register_diag: unknown z_grid component "//trim(z_grid))
   end select
 
-  ocean_register_diag = register_diag_field("ocean_model", trim(var_name), &
-          axes, day, trim(longname), trim(units), missing_value=-1.0e+34)
+  ocean_register_diag = register_diag_field("ocean_model", trim(var_name), axes, day, &
+          trim(longname), units=trim(units), conversion=conversion, missing_value=-1.0e+34)
 
 end function ocean_register_diag
 

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -555,10 +555,10 @@ subroutine create_MOM_file(IO_handle, filename, vars, novars, fields, &
     pack = 1
     if (present(checksums)) then
       fields(k) = IO_handle%register_field(axes(1:numaxes), vars(k)%name, vars(k)%units, &
-                          vars(k)%longname, pack=pack, checksum=checksums(k,:))
+                          vars(k)%longname, pack=pack, checksum=checksums(k,:), conversion=vars(k)%conversion)
     else
       fields(k) = IO_handle%register_field(axes(1:numaxes), vars(k)%name, vars(k)%units, &
-                          vars(k)%longname, pack=pack)
+                          vars(k)%longname, pack=pack, conversion=vars(k)%conversion)
     endif
   enddo
 
@@ -1880,6 +1880,8 @@ subroutine modify_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid, &
   if (present(cmor_longname))   call safe_string_copy(cmor_longname, vd%cmor_longname, &
                                      "vd%cmor_longname of "//trim(vd%name), cllr)
 
+  if (present(conversion)) vd%conversion = conversion
+
   if (present(dim_names)) then
     do n=1,min(5,size(dim_names)) ; if (len_trim(dim_names(n)) > 0) then
       call safe_string_copy(dim_names(n), vd%dim_names(n), "vd%dim_names of "//trim(vd%name), cllr)
@@ -2084,6 +2086,9 @@ subroutine query_vardesc(vd, name, units, longname, hor_grid, z_grid, t_grid, &
                                      "vd%cmor_units of "//trim(vd%name), cllr)
   if (present(cmor_longname))   call safe_string_copy(vd%cmor_longname, cmor_longname, &
                                      "vd%cmor_longname of "//trim(vd%name), cllr)
+
+  if (present(conversion)) conversion = vd%conversion
+
   if (present(position)) then
     position = vd%position
     if (position == -1) position = position_from_horgrid(vd%hor_grid)


### PR DESCRIPTION
  This PR consists of three commits, the first of which adds the ability to rescale output variables that are written by the `MOM_io_file` routines analogously to what is already available for variables that are written via `MOM_write_field()` or via `MOM_diag_mediator()`.  The second commit uses this new capability in `write_energy()` and revises the internal calculations in `write_energy()` to work almost entirely with rescaled variables.  The third commit corrects 4 conversion arguments to `var_desc()` calls now that they might actually be used.

  The specific changes include the addition of a new optional conversion argument to `register_field()`, code to rescale variables in 10 `write_field()` routines, changes to `modify_vardesc()` and `query_vardesc()` to properly store and retrieve conversion factors, and the use of these new capabilities in `ocean_register_diag()` and `write_energy()`.

  All answers and output are bitwise identical, but there are new optional arguments to publicly visible types.  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@e2be48235 Fix 4 conversion arguments to var_desc calls
 - NOAA-GFDL/MOM6@cb2f49094 Specify conversion factors in write_energy
 - NOAA-GFDL/MOM6@c3da6766e +Add optional conversion argument to register_field
