### PR TITLE
halo_size in MOM.F90 and option conflicts in MOM_wave_interface.F90

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -779,14 +779,14 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! Update wave information, which is presently kept static over each call to step_mom
       call enable_averages(time_interval, Time_start + real_to_time(US%T_to_s*time_interval), CS%diag)
       call find_ustar(forces, CS%tv, U_star, G, GV, US, halo=1)
-      call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)
+      call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=2)
       call Update_Stokes_Drift(G, GV, US, Waves, dz, U_star, time_interval, do_dyn)
       call disable_averaging(CS%diag)
     endif
   else ! not do_dyn.
     if (CS%UseWaves) then ! Diagnostics are not enabled in this call.
       call find_ustar(fluxes, CS%tv, U_star, G, GV, US, halo=1)
-      call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)
+      call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=2)
       call Update_Stokes_Drift(G, GV, US, Waves, dz, U_star, time_interval, do_dyn)
     endif
   endif

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -403,7 +403,10 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
   call get_param(param_file, mdl, "PASSIVE_STOKES_DDT", CS%Passive_Stokes_DDT, &
        "Flag to make Stokes d/dt diagnostic only", &
        default=.false.)
-
+  if (CS%robust_Stokes_PGF .and. CS%Stokes_PGF) then
+    !To avoid conflicts, these two options cannot be set to True simultaneously.
+    call MOM_error(FATAL, "ROBUST_STOKES_PGF and STOKES_PGF are both True, please set one to False to continue.")
+  endif 
   ! Get Wave Method and write to integer WaveMethod
   call get_param(param_file,mdl,"WAVE_METHOD",TMPSTRING1,             &
        "Choice of wave method, valid options include: \n"//           &


### PR DESCRIPTION
This commitment resolves two issues:

1. Halo Size in thickness_to_dz Function:
In the MOM.F90 file, the halo size (additional boundary cells surrounding a computational subdomain) for the thickness has been revised. For a 3D grid interface, the halo size should be set to 2 layers.

2. Conflict in Stokes_PGF Options:
The conflict between the Stokes_PGF options has been addressed in the MOM_wave_interface.F90 file, ensuring compatibility and preventing errors related to these settings.