### PR TITLE
Updates to use EPBL_BBL_EFFIC

### DIFF
--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -699,6 +699,8 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
         if (CS%debug .or. (CS%id_BBL_Vel_Scale>0)) then ; do k=1,nz
           BBL_Vel_Scale(i,j,k) = mixvel_BBL(k)
         enddo ; endif
+        if (CS%id_TKE_BBL>0) &
+          diag_TKE_BBL(i,j) = diag_TKE_BBL(i,j) + BBL_TKE
       endif
       if (CS%id_MSTAR_MIX > 0) diag_mStar_mix(i,j) = eCD%mstar
       if (CS%id_MSTAR_LT > 0) diag_mStar_lt(i,j) = eCD%mstar_LT

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -76,7 +76,9 @@ type, public :: set_diffusivity_CS ; private
   real    :: Von_Karm        !< The von Karman constant as used in the BBL diffusivity calculation
                              !! [nondim].  See (http://en.wikipedia.org/wiki/Von_Karman_constant)
   real    :: BBL_effic       !< efficiency with which the energy extracted
-                             !! by bottom drag drives BBL diffusion [nondim]
+                             !! by bottom drag drives BBL diffusion in the original BBL scheme [nondim]
+  real    :: ePBL_BBL_effic  !< efficiency with which the energy extracted
+                             !! by bottom drag drives BBL diffusion in the ePBL BBL scheme [nondim]
   real    :: cdrag           !< quadratic drag coefficient [nondim]
   real    :: dz_BBL_avg_min  !< A minimal distance over which to average to determine the average
                              !! bottom boundary layer density [Z ~> m]
@@ -1943,7 +1945,7 @@ subroutine set_BBL_TKE(u, v, h, tv, fluxes, visc, G, GV, US, CS, OBC)
   if (.not.CS%initialized) call MOM_error(FATAL,"set_BBL_TKE: "//&
          "Module must be initialized before it is used.")
 
-  if (.not.CS%bottomdraglaw .or. (CS%BBL_effic<=0.0)) then
+  if (.not.CS%bottomdraglaw .or. (CS%BBL_effic<=0.0 .and. CS%ePBL_BBL_effic<=0.0)) then
     if (allocated(visc%ustar_BBL)) then
       do j=js,je ; do i=is,ie ; visc%ustar_BBL(i,j) = 0.0 ; enddo ; enddo
     endif
@@ -2359,6 +2361,8 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                  "The efficiency with which the energy extracted by "//&
                  "bottom drag drives BBL diffusion.  This is only "//&
                  "used if BOTTOMDRAGLAW is true.", units="nondim", default=0.20)
+    call get_param(param_file, mdl, "EPBL_BBL_EFFIC", CS%ePBL_BBL_effic, &
+                 units="nondim", default=0.0,do_not_log=.true.)
     call get_param(param_file, mdl, "BBL_MIXING_MAX_DECAY", decay_length, &
                  "The maximum decay scale for the BBL diffusion, or 0 to allow the mixing "//&
                  "to penetrate as far as stratification and rotation permit.  The default "//&


### PR DESCRIPTION
- The present code only tests BBL_EFFIC when deciding whether to set the bottom TKE and ustar, but this means they are all zero when EPBL_BBL_EFFIC is non-zero and BBL_EFFIC is zero.
- Adds logic to also check EPBL_BBL_EFFIC, thereby allowing non-zero ustar and TKE for EPBL_BBL_EFFIC>0.0
- Fixed BBL_TKE diagnostic in EPBL that was not populated.
- Will change answers when EPBL_BBL_EFFIC>0.0, but won't change answers in any of our existing configurations.