### PR TITLE
Refactor ice shelf rescaling and diagnostic calcs

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -321,7 +321,7 @@ subroutine initialize_ice_shelf_boundary_channel(u_face_mask_bdry, v_face_mask_b
 
   call get_param(PF, mdl, "INPUT_VEL_ICE_SHELF", input_vel, &
                  "inflow ice velocity at upstream boundary", &
-                 units="m s-1", default=0., scale=US%m_s_to_L_T*US%m_to_Z) !### This conversion factor is wrong?
+                 units="m s-1", default=0., scale=US%m_s_to_L_T)
   call get_param(PF, mdl, "INPUT_THICK_ICE_SHELF", input_thick, &
                  "flux thickness at upstream boundary", &
                  units="m", default=1000., scale=US%m_to_Z)
@@ -556,7 +556,7 @@ end subroutine initialize_ice_shelf_boundary_from_file
 subroutine initialize_ice_C_basal_friction(C_basal_friction, G, US, PF)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(inout) :: C_basal_friction !< Ice-stream basal friction
+                         intent(inout) :: C_basal_friction !< Ice-stream basal friction [Pa (s m-1)^(n_basal_fric)]
   type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
   type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 


### PR DESCRIPTION
  This PR consists of two commits that refactor the MOM6 ice_shelf code to work more extensively in rescaled variables, and to do the unscaling of all diagnostics by the conversions arguments to `register_diag_field()` or `register_scalar_field()` calls.
These change make use of the recently added unscale argument to `reproducing_sum()`. Several missing unit conversion factors for rates of mass change were also added, and the diagnostics have now been verified to pass dimensional consistency testing.  After these commits, all of the dimensional scaling factors for diagnostics in the ice_shelf code occur via conversion factors that are immediately adjacent to the declaration of the units of those diagnostics, facilitating comparison for consistency.

  The specific changes included refactoring of `volume_above_floatation()`, `write_ice_shelf_energy()` and `ice_shelf_solve_outer()` to work in rescaled arguments, and the conversion of `integrate_over_Ice_sheet_area()` into a function that returns the integral in rescaled units.

  The declared units of one diagnostic, "taub_beta", were revised from "MPa s m-1" to "MPa yr m-1" to be consistent with its conversion factor, which was also corrected (essentially by a factor of [Z L-1 ~> 1]).

  The input scale factor for the (perhaps unused) variable `INPUT_VEL_ICE_SHELF` was corrected from `US%m_s_to_L_T*US%m_to_Z` to just `US%m_s_to_L_T`.  This could change answers for some rescaled configurations with forced inflow into an ice sheet, such as that of Goldberg et al., (2010), but such configurations do not appear to be used much.

  As a part of these changes, comments documenting the units of about 26 real variables were added or corrected.

  With these changes, all solutions in our test cases are bitwise identical and are passing dimensional consistency testing.  The ice shelf diagnostics should now be invariant when dimensional rescaling is applied, and the units of the ice shelf diagnostics are now all consistent with the required rescaling factors.  The commits in this PR include:

- NOAA-GFDL/MOM6@d9344bd1a (*)Conversion arguments for ice shelf scalar diags
- NOAA-GFDL/MOM6@4d8d2a74f Revise the ice_shelf dimensional rescaling
