### PR TITLE
+Add the optional argument old_name to get_param()

### DIFF
--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -168,29 +168,15 @@ subroutine obsolete_logical(param_file, varname, warning_val, hint)
   character(len=*), optional, intent(in) :: hint   !< A hint to the user about what to do.
   ! Local variables
   logical :: test_logic, fatal_err
+  logical :: var_is_set  ! True if this value was read by read_param.
   character(len=128) :: hint_msg
 
-  test_logic = .false. ; call read_param(param_file, varname, test_logic)
+  test_logic = .false. ; call read_param(param_file, varname, test_logic, set=var_is_set)
   fatal_err = .true.
-  if (present(warning_val)) fatal_err = (warning_val .neqv. .true.)
+  if (var_is_set .and. present(warning_val)) fatal_err = (warning_val .neqv. test_logic)
   hint_msg = " " ; if (present(hint)) hint_msg = hint
 
-  if (test_logic) then
-    if (fatal_err) then
-      call MOM_ERROR(FATAL, "MOM_obsolete_params: "//trim(varname)//   &
-           " is an obsolete run-time flag, and should not be used. "// &
-           trim(hint_msg))
-    else
-      call MOM_ERROR(WARNING, "MOM_obsolete_params: "//trim(varname)// &
-           " is an obsolete run-time flag. "//trim(hint_msg))
-    endif
-  endif
-
-  test_logic = .true. ; call read_param(param_file, varname, test_logic)
-  fatal_err = .true.
-  if (present(warning_val)) fatal_err = (warning_val .neqv. .false.)
-
-  if (.not.test_logic) then
+  if (var_is_set) then
     if (fatal_err) then
       call MOM_ERROR(FATAL, "MOM_obsolete_params: "//trim(varname)//   &
            " is an obsolete run-time flag, and should not be used. "// &
@@ -211,12 +197,13 @@ subroutine obsolete_char(param_file, varname, warning_val, hint)
   character(len=*), optional, intent(in) :: hint  !< A hint to the user about what to do.
   ! Local variables
   character(len=200) :: test_string, hint_msg
+  logical :: var_is_set  ! True if this value was read by read_param.
   logical :: only_warn
 
-  test_string = ''; call read_param(param_file, varname, test_string)
+  test_string = ''; call read_param(param_file, varname, test_string, set=var_is_set)
   hint_msg = " " ; if (present(hint)) hint_msg = hint
 
-  if (len_trim(test_string) > 0) then
+  if (var_is_set) then
     only_warn = .false.
     if (present(warning_val)) then ! Check if test_string and warning_val are the same.
       if (len_trim(warning_val) == len_trim(test_string)) then
@@ -246,15 +233,16 @@ subroutine obsolete_real(param_file, varname, warning_val, hint, only_warn)
 
   ! Local variables
   real :: test_val, warn_val
+  logical :: var_is_set  ! True if this value was read by read_param.
   logical :: issue_warning
   character(len=128) :: hint_msg
 
-  test_val = -9e35; call read_param(param_file, varname, test_val)
+  test_val = -9e35; call read_param(param_file, varname, test_val, set=var_is_set)
   warn_val = -9e35; if (present(warning_val)) warn_val = warning_val
   hint_msg = " " ; if (present(hint)) hint_msg = hint
   issue_warning = .false. ; if (present(only_warn)) issue_warning = only_warn
 
-  if (test_val /= -9e35) then
+  if (var_is_set) then
     if ((test_val == warn_val) .or. issue_warning) then
       call MOM_ERROR(WARNING, "MOM_obsolete_params: "//trim(varname)// &
          " is an obsolete run-time flag. "//trim(hint_msg))
@@ -273,14 +261,15 @@ subroutine obsolete_int(param_file, varname, warning_val, hint)
   integer,     optional, intent(in) :: warning_val !< An allowed value that causes a warning instead of an error.
   character(len=*), optional, intent(in) :: hint   !< A hint to the user about what to do.
   ! Local variables
+  logical :: var_is_set  ! True if this value was read by read_param.
   integer :: test_val, warn_val
   character(len=128) :: hint_msg
 
-  test_val = -123456788; call read_param(param_file, varname, test_val)
+  test_val = -123456788; call read_param(param_file, varname, test_val, set=var_is_set)
   warn_val = -123456788; if (present(warning_val)) warn_val = warning_val
   hint_msg = " " ; if (present(hint)) hint_msg = hint
 
-  if (test_val /= -123456788) then
+  if (var_is_set) then
     if (test_val == warn_val) then
       call MOM_ERROR(WARNING, "MOM_obsolete_params: "//trim(varname)// &
          " is an obsolete run-time flag. "//trim(hint_msg))


### PR DESCRIPTION
  Added the new optional argument `old_name` to the 8 `get_param()` routines. This new capability allows for an archaic parameter name to be specified and for appropriate warnings encouraging the user to migrate to using the new name while still setting the parameter as intended, or error messages in the case of inconsistent setting via the archaic name and the correct name.  The logging inside of the `MOM_parameter_doc` files only uses the correct parameter name.

  Also added the new optional argument set to the 8 `read_param()` routines, to indicate whether a parameter has been found and successfully set.  The new set argument is now being used in `read_param()` calls in `obsolete_int()`, `obsolete_real()`, `obsolete_char()` and `obsolete_logical()`.  `Obsolete_logical()` in particular was substantially simplified by the use of this new argument, and is now only about half as long as it was.  The `read_param()` set argument is also used in all of the `get_param()` routines when they are given an `old_name` argument.

  The new `old_name` argument to `get_param()` is not yet being used in the version of the MOM6 code that is being checked in, but it has been tested extensively by adding or modifying `get_param()` calls in a variant of the initialization code, and it will be used in an updated version of github.com/NOAA-GFDL/MOM6/pull/725 to gracefully handle the deprecation of 4 parameter names.

  All answers are bitwise identical, but there are new optional arguments to two widely used interfaces.