### PR TITLE
Forget to set descale in reproducing_sum_3d

### DIFF
--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -412,6 +412,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
 
   do_sum_across_PEs = .true. ; if (present(only_on_PE)) do_sum_across_PEs = .not.only_on_PE
   do_unscale = .false. ; if (present(unscale)) do_unscale = (unscale /= 1.0)
+  descale = 1.0 ; if (do_unscale) descale = unscale
 
   if (present(sums) .or. present(EFP_lay_sums)) then
     if (present(sums)) then ; if (size(sums) < ke) then


### PR DESCRIPTION
CEFI's tidal regression tests fail after #767. After debugging, we found that the issue was due to a missing `descale=1.0` setting in the `reproducing_sum_3d` function. This PR addresses the bug. It does not affect any existing baselines.