### PR TITLE
Rescale 6 ice shelf variables

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -556,12 +556,14 @@ end subroutine initialize_ice_shelf_boundary_from_file
 subroutine initialize_ice_C_basal_friction(C_basal_friction, G, US, PF)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(inout) :: C_basal_friction !< Ice-stream basal friction [Pa (s m-1)^(n_basal_fric)]
+                         intent(inout) :: C_basal_friction !< Ice-stream basal friction
+                                             !! in units of [R L Z T-2 (s m-1)^n_basal_fric ~> Pa (s m-1)^n_basal_fric]
   type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
   type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 
 !  integer :: i, j
-  real :: C_friction
+  real :: C_friction  ! Constant ice-stream basal friction in units of
+                      ! [R L Z T-2 (s m-1)^n_basal_fric ~> Pa (s m-1)^n_basal_fric]
   character(len=40)  :: mdl = "initialize_ice_basal_friction" ! This subroutine's name.
   character(len=200) :: config
   character(len=200) :: varname
@@ -574,7 +576,7 @@ subroutine initialize_ice_C_basal_friction(C_basal_friction, G, US, PF)
 
   if (trim(config)=="CONSTANT") then
     call get_param(PF, mdl, "BASAL_FRICTION_COEFF", C_friction, &
-                 "Coefficient in sliding law.", units="Pa (s m-1)^(n_basal_fric)", default=5.e10)
+                 "Coefficient in sliding law.", units="Pa (s m-1)^(n_basal_fric)", default=5.e10, scale=US%Pa_to_RLZ_T2)
 
     C_basal_friction(:,:) = C_friction
   elseif (trim(config)=="FILE") then
@@ -595,7 +597,7 @@ subroutine initialize_ice_C_basal_friction(C_basal_friction, G, US, PF)
     if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
        " initialize_ice_basal_friction_from_file: Unable to open "//trim(filename))
 
-    call MOM_read_data(filename,trim(varname),C_basal_friction,G%Domain)
+    call MOM_read_data(filename, trim(varname), C_basal_friction, G%Domain, scale=US%Pa_to_RLZ_T2)
 
   endif
 end subroutine


### PR DESCRIPTION
  Changed the rescaling of 6 ice shelf variables to cancel out common conversion factors that appear in several expressions.

  The `C_basal_friction` argument to `initialize_ice_C_basal_friction()` is now in partially rescaled units, reflecting the portion that does not cancel out fractional-power units from a power law fit with an arbitrary power.  The `C_basal_friction` array in `ice_shelf_dyn_CS` and the `C_friction` variable in `initialize_ice_C_basal_friction()` were similarly rescaled.  There are new scale factors in a `get_param()` call and a `MOM_read_data()` call and a conversion factor in a `register_restart_field()` call that reflect these changes.

  The `KE_tot` and `mass_tot` variables in `write_ice_shelf_energy()`, are kept in scaled units until they are written.

  The internal variable `fN` in calc_shelf_taub()` is kept in scaled units, but there is now a scaling factor of `US%Z_to_L` in the expression for `fB`.  This latter could be folded into the `CF_Max` element of `ice_shelf_dyn_CS`, but I am unsure whether this would be physically sensible.

  All answers should be bitwise identical and no output should change, but this has not been extensively tested yet.