### PR TITLE
+(*)Clarify turbulent energetics and add EPBL_BBL_TIDAL_EFFIC

### DIFF
--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -295,7 +295,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     call safe_alloc_ptr(fluxes%salt_flux_in,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%salt_flux_added,isd,ied,jsd,jed)
 
-    call safe_alloc_ptr(fluxes%TKE_tidal,isd,ied,jsd,jed)
+    call safe_alloc_ptr(fluxes%BBL_tidal_dis,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%ustar_tidal,isd,ied,jsd,jed)
 
     if (CS%allow_flux_adjustments) then
@@ -304,7 +304,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     endif
 
     do j=js-2,je+2 ; do i=is-2,ie+2
-      fluxes%TKE_tidal(i,j)   = CS%TKE_tidal(i,j)
+      fluxes%BBL_tidal_dis(i,j)   = US%Z_to_L**2*CS%TKE_tidal(i,j)
       fluxes%ustar_tidal(i,j) = CS%ustar_tidal(i,j)
     enddo ; enddo
 

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -317,7 +317,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     call safe_alloc_ptr(fluxes%salt_flux_in,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%salt_flux_added,isd,ied,jsd,jed)
 
-    call safe_alloc_ptr(fluxes%TKE_tidal,isd,ied,jsd,jed)
+    call safe_alloc_ptr(fluxes%BBL_tidal_dis,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%ustar_tidal,isd,ied,jsd,jed)
 
     if (CS%allow_flux_adjustments) then
@@ -326,7 +326,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     endif
 
     do j=js-2,je+2 ; do i=is-2,ie+2
-      fluxes%TKE_tidal(i,j)   = CS%TKE_tidal(i,j)
+      fluxes%BBL_tidal_dis(i,j)   = US%Z_to_L**2*CS%TKE_tidal(i,j)
       fluxes%ustar_tidal(i,j) = CS%ustar_tidal(i,j)
     enddo ; enddo
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -237,8 +237,8 @@ type, public :: vertvisc_type
     kv_bbl_v, &    !< The bottom boundary layer viscosity at the v-points [H Z T-1 ~> m2 s-1 or Pa s]
     ustar_BBL, &   !< The turbulence velocity in the bottom boundary layer at
                    !! h points [H T-1 ~> m s-1 or kg m-2 s-1].
-    TKE_BBL, &     !< A term related to the bottom boundary layer source of turbulent kinetic
-                   !! energy, currently in [H Z2 T-3 ~> m3 s-3 or W m-2].
+    BBL_meanKE_loss, & !< The viscous loss of mean kinetic energy in the bottom boundary layer
+                   !! [H L2 T-3 ~> m3 s-3 or W m-2].
     taux_shelf, &  !< The zonal stresses on the ocean under shelves [R Z L T-2 ~> Pa].
     tauy_shelf     !< The meridional stresses on the ocean under shelves [R Z L T-2 ~> Pa].
   real, allocatable, dimension(:,:) :: tbl_thick_shelf_u

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -239,6 +239,9 @@ type, public :: vertvisc_type
                    !! h points [H T-1 ~> m s-1 or kg m-2 s-1].
     BBL_meanKE_loss, & !< The viscous loss of mean kinetic energy in the bottom boundary layer
                    !! [H L2 T-3 ~> m3 s-3 or W m-2].
+    BBL_meanKE_loss_sqrtCd, & !< The viscous loss of mean kinetic energy in the bottom boundary layer
+                   !! divided by the square root of the drag coefficient [H L2 T-3 ~> m3 s-3 or W m-2].
+                   !! This is being set only to retain old answers, and should be phased out.
     taux_shelf, &  !< The zonal stresses on the ocean under shelves [R Z L T-2 ~> Pa].
     tauy_shelf     !< The meridional stresses on the ocean under shelves [R Z L T-2 ~> Pa].
   real, allocatable, dimension(:,:) :: tbl_thick_shelf_u

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -1416,8 +1416,8 @@ subroutine add_drag_diffusivity(h, u, v, tv, fluxes, visc, j, TKE_to_Kd, maxTKE,
     endif
     TKE(i) = ((CS%BBL_effic * cdrag_sqrt) * exp(-I2decay(i)*h(i,j,nz)) ) * visc%BBL_meanKE_loss(i,j)
 
-    if (associated(fluxes%TKE_tidal)) &
-      TKE(i) = TKE(i) + US%Z_to_L**2*fluxes%TKE_tidal(i,j) * GV%RZ_to_H * &
+    if (associated(fluxes%BBL_tidal_dis)) &
+      TKE(i) = TKE(i) + fluxes%BBL_tidal_dis(i,j) * GV%RZ_to_H * &
            (CS%BBL_effic * exp(-I2decay(i)*h(i,j,nz)))
 
     ! Distribute the work over a BBL of depth 20^2 ustar^2 / g' following
@@ -1647,9 +1647,9 @@ subroutine add_LOTW_BBL_diffusivity(h, u, v, tv, fluxes, visc, j, N2_int, Rho_bo
     !### I am still unsure about sqrt(cdrag) in this expressions - AJA
     BBL_meanKE_dis = cdrag_sqrt * visc%BBL_meanKE_loss(i,j)
     ! Add in tidal dissipation energy at the bottom [H Z2 T-3 ~> m3 s-3 or W m-2].
-    ! Note that TKE_tidal is in [R Z3 T-3 ~> W m-2].
-    if (associated(fluxes%TKE_tidal)) &
-      BBL_meanKE_dis = BBL_meanKE_dis + US%Z_to_L**2*fluxes%TKE_tidal(i,j) * GV%RZ_to_H
+    ! Note that BBL_tidal_dis is in [R Z L2 T-3 ~> W m-2].
+    if (associated(fluxes%BBL_tidal_dis)) &
+      BBL_meanKE_dis = BBL_meanKE_dis + fluxes%BBL_tidal_dis(i,j) * GV%RZ_to_H
     TKE_column = CS%BBL_effic * BBL_meanKE_dis ! Only use a fraction of the mechanical dissipation for mixing.
 
     TKE_remaining = TKE_column

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -3140,6 +3140,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
     allocate(visc%kv_bbl_v(isd:ied,JsdB:JedB), source=0.0)
     allocate(visc%ustar_bbl(isd:ied,jsd:jed), source=0.0)
     allocate(visc%BBL_meanKE_loss(isd:ied,jsd:jed), source=0.0)
+    allocate(visc%BBL_meanKE_loss_sqrtCd(isd:ied,jsd:jed), source=0.0)
 
     CS%id_bbl_thick_u = register_diag_field('ocean_model', 'bbl_thick_u', &
        diag%axesCu1, Time, 'BBL thickness at u points', 'm', conversion=US%Z_to_m)
@@ -3215,6 +3216,7 @@ subroutine set_visc_end(visc, CS)
   if (associated(visc%Kv_shear_Bu)) deallocate(visc%Kv_shear_Bu)
   if (allocated(visc%ustar_bbl)) deallocate(visc%ustar_bbl)
   if (allocated(visc%BBL_meanKE_loss)) deallocate(visc%BBL_meanKE_loss)
+  if (allocated(visc%BBL_meanKE_loss_sqrtCd)) deallocate(visc%BBL_meanKE_loss_sqrtCd)
   if (allocated(visc%taux_shelf)) deallocate(visc%taux_shelf)
   if (allocated(visc%tauy_shelf)) deallocate(visc%tauy_shelf)
   if (allocated(visc%tbl_thick_shelf_u)) deallocate(visc%tbl_thick_shelf_u)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -3139,7 +3139,7 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
     allocate(visc%kv_bbl_u(IsdB:IedB,jsd:jed), source=0.0)
     allocate(visc%kv_bbl_v(isd:ied,JsdB:JedB), source=0.0)
     allocate(visc%ustar_bbl(isd:ied,jsd:jed), source=0.0)
-    allocate(visc%TKE_bbl(isd:ied,jsd:jed), source=0.0)
+    allocate(visc%BBL_meanKE_loss(isd:ied,jsd:jed), source=0.0)
 
     CS%id_bbl_thick_u = register_diag_field('ocean_model', 'bbl_thick_u', &
        diag%axesCu1, Time, 'BBL thickness at u points', 'm', conversion=US%Z_to_m)
@@ -3214,7 +3214,7 @@ subroutine set_visc_end(visc, CS)
   if (associated(visc%Kv_shear)) deallocate(visc%Kv_shear)
   if (associated(visc%Kv_shear_Bu)) deallocate(visc%Kv_shear_Bu)
   if (allocated(visc%ustar_bbl)) deallocate(visc%ustar_bbl)
-  if (allocated(visc%TKE_bbl)) deallocate(visc%TKE_bbl)
+  if (allocated(visc%BBL_meanKE_loss)) deallocate(visc%BBL_meanKE_loss)
   if (allocated(visc%taux_shelf)) deallocate(visc%taux_shelf)
   if (allocated(visc%tauy_shelf)) deallocate(visc%tauy_shelf)
   if (allocated(visc%tbl_thick_shelf_u)) deallocate(visc%tbl_thick_shelf_u)


### PR DESCRIPTION
  This PR consists of 4 commits that make the purpose and nature of two fields in the forcing type and the `vertvisc_type` clearer, and also adds the option to use the dissipated tidal energy supplied via the fluxes type to drive mixing in `ePBL_BBL_column()`.  It also corrects a bug in the energy being used in the recently added ePBL BBL mixing.

  `Visc%TKE_BBL` has been revised to `visc%BBL_meanKE_loss` to reflect that this array contains the mean kinetic energy that has been extracted by the bottom drag, and that the efficiency has not yet been applied.  The units were also changed from `[R Z3 T-3 ~> W m-2]` to `[R Z L2 T-3 ~> W m-2]`, with the extra conversion factors to translate from the units of mean kinetic energy to those of turbulent kinetic energy folded into `set_diffusivity_CS%BBL_effic` and `energetic_PBL_CS%ePBL_BBL_effic`.  Similarly, `fluxes%TKE_tidal` has been renamed to `fluxes%BBL_tidal_dis` and its units are changed to `[R Z L2 T-3 ~> W m-2]` to reflect that this is the mean kinetic energy that has been dissipated and that the fractional efficiency has not been applied yet.

  This PR also adds the option to use the energy source in `fluxes%BBL_tidal_dis` to drive mixing in `ePBL_BBL_column()` has been added, with the new runtime parameter `EPBL_BBL_TIDAL_EFFIC` to control how much mixing is applied.  By default this parameter is set to 0 and all answers are bitwise identical.

  Finally, this PR corrects a confusing situation regarding the absence of a factor of the square root of the drag coefficient in `visc%TKE_BBL`, which led to both a bug when it was used in the ePBL BBL mixing and the persistence of a comment about this confusion that had not been addressed in 10 years.  To correct this confusing situation, `visc%BBL_meanKE_loss` includes the missing factor of the square root of the drag coefficient, while  `visc%BBL_meanKE_loss_sqrtCd` has the same values as were previously in `visc%TKE_BBL`  to allow for the previous answers to be recovered when the new runtime parameter `EPBL_BBL_EFFIC_BUG` is set to true and `DRAG_DIFFUSIVITY_ANSWER_DATE` is set below 20250302.  Because the ePBL bottom boundary layer was only added to dev/gfdl a month ago and has not yet been merged into main, we can be confident that it has only received very limited use as yet, so the default for `EPBL_BBL_EFFIC_BUG` is false but this default will change answers when `EPBL_BBL_EFFIC > 0`.  The default for `DRAG_DIFFUSIVITY_ANSWER_DATE` is 20250101, which will preserve the previous answers, but the default should later be taken from `DEFAULT_ANSWER_DATE`.

  All answers and output are bitwise identical by default in any cases that are more than a month old, but answers can change by default in a few very recent experiments.  There are renamed and rescaled elements in two transparent types, and new entries in some MOM_parameter_doc files.  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@2a510f9c2 +(*)EPBL_BBL_EFFIC_BUG & DRAG_DIFFUSIVITY_ANSWER_DATE
 - NOAA-GFDL/MOM6@2d6adc437 +Add EPBL_BBL_TIDAL_EFFIC
 - NOAA-GFDL/MOM6@3176b17ed +Rename fluxes%TKE_tidal to fluxes%BBL_tidal_dis
 - NOAA-GFDL/MOM6@30edcf897 +Rename visc%TKE_BBL to visc%BBL_meanKE_loss
