### PR TITLE
Extend diag_mediator to allow the piecemeal posting of diagnostics

### DIFF
--- a/src/core/MOM_unit_tests.F90
+++ b/src/core/MOM_unit_tests.F90
@@ -5,6 +5,9 @@
 !> Invokes unit tests in all modules that have them
 module MOM_unit_tests
 
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_diag_buffers,               only : diag_buffer_unit_tests_2d, diag_buffer_unit_tests_3d
 use MOM_error_handler,              only : MOM_error, FATAL, is_root_pe
 use MOM_hor_bnd_diffusion,          only : near_boundary_unit_tests
 use MOM_intrinsic_functions,        only : intrinsic_functions_unit_tests
@@ -51,6 +54,10 @@ subroutine unit_tests(verbosity)
        "MOM_unit_tests: CFC_cap_unit_tests FAILED")
     if (mixedlayer_restrat_unit_tests(verbose)) call MOM_error(FATAL, &
        "MOM_unit_tests: mixedlayer_restrat_unit_tests FAILED")
+    if (diag_buffer_unit_tests_2d(verbose)) call MOM_error(FATAL, &
+       "MOM_unit_tests: diag_buffer_unit_tests_2d FAILED")
+    if (diag_buffer_unit_tests_3d(verbose)) call MOM_error(FATAL, &
+       "MOM_unit_tests: diag_buffer_unit_tests_3d FAILED")
   endif
 
 end subroutine unit_tests

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -10,6 +10,7 @@ implicit none ; private
 
 public :: diag_buffer_unit_tests_2d, diag_buffer_unit_tests_3d
 
+!> The base class for the diagnostic buffers in this module
 type, abstract :: diag_buffer_base ; private
   integer :: is !< The start slot of the array i-direction
   integer :: js !< The start slot of the array j-direction
@@ -21,12 +22,12 @@ type, abstract :: diag_buffer_base ; private
 
   contains
 
-  procedure(a_grow), deferred :: grow
-  procedure, public :: check_capacity_by_id
-  procedure, public :: set_horizontal_extents
-  procedure, public :: mark_available
-  procedure, public :: grow_ids
-  procedure, public :: find_buffer_slot
+  procedure(a_grow), deferred :: grow !< Increase the size of the buffer
+  procedure, public :: check_capacity_by_id !< Check the size size of the buffer and increase if necessary
+  procedure, public :: set_horizontal_extents !< Define the horizontal extents of the arrays
+  procedure, public :: mark_available !< Mark that a slot in the buffer can be reused
+  procedure, public :: grow_ids !< Increase the size of the vector storing diagnostic ids
+  procedure, public :: find_buffer_slot !< Find the slot corresponding to a specific diagnostic id
 end type diag_buffer_base
 
 !> Dynamically growing buffer for 2D arrays.
@@ -35,8 +36,8 @@ type, extends(diag_buffer_base), public :: diag_buffer_2d
 
   contains
 
-  procedure, public :: grow => grow_2d
-  procedure, public :: store => store_2d
+  procedure, public :: grow => grow_2d !< Increase the size of the buffer
+  procedure, public :: store => store_2d !< Store a field in the buffer, increasing as necessary
 end type diag_buffer_2d
 
 !> Dynamically growing buffer for 3D arrays.
@@ -47,9 +48,9 @@ type, extends(diag_buffer_base), public :: diag_buffer_3d ; private
 
   contains
 
-  procedure, public :: set_vertical_extent
-  procedure, public :: grow => grow_3d
-  procedure, public :: store => store_3d
+  procedure, public :: set_vertical_extent !< Set the vertical extents of the buffer
+  procedure, public :: grow => grow_3d !< Increase the size of the buffer
+  procedure, public :: store => store_3d !< Store a field in the buffer, increasing as necessary
 end type diag_buffer_3d
 
 contains
@@ -199,6 +200,7 @@ subroutine store_3d(this, data, id)
   this%buffer(slot,:,:,:) = data(:,:,:)
 end subroutine store_3d
 
+!> Unit tests for the 2d version of the diag buffer
 function diag_buffer_unit_tests_2d(verbose) result(fail)
   logical, intent(in) :: verbose !< If true, write results to stdout
   logical :: fail !< True if any of the unit tests fail
@@ -306,6 +308,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
 
 end function diag_buffer_unit_tests_2d
 
+!> Test the 3d version of the buffer
 function diag_buffer_unit_tests_3d(verbose) result(fail)
   logical, intent(in) :: verbose !< If true, write results to stdout
   logical :: fail !< True if any of the unit tests fail
@@ -416,6 +419,3 @@ end function diag_buffer_unit_tests_3d
 
 end module MOM_diag_buffers
 
-!> \namespace mom_cpu_clock
-!!
-!! APIs are defined and implemented in mom_cpu_clock_infra.

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -32,7 +32,7 @@ end type diag_buffer_base
 
 !> Dynamically growing buffer for 2D arrays.
 type, extends(diag_buffer_base), public :: diag_buffer_2d
-  real, public, allocatable, dimension(:,:,:) :: buffer !< The actual buffer to store data
+  real, public, allocatable, dimension(:,:,:) :: buffer !< The actual buffer to store data [arbitrary]
 
   contains
 
@@ -44,7 +44,7 @@ end type diag_buffer_2d
 type, extends(diag_buffer_base), public :: diag_buffer_3d ; private
   integer :: ks !< The start slot in the k-dimension
   integer :: ke !< The last slot in the k-dimension
-  real, public, allocatable, dimension(:,:,:,:) :: buffer !< The actual buffer to store data
+  real, public, allocatable, dimension(:,:,:,:) :: buffer !< The actual buffer to store data [arbitrary]
 
   contains
 
@@ -148,7 +148,8 @@ subroutine grow_2d(this)
   class(diag_buffer_2d), intent(inout) :: this !< This 2d buffer
 
   integer :: n
-  real, allocatable, dimension(:,:,:) :: temp
+  real, allocatable, dimension(:,:,:) :: temp ! Temporary array to hold the contents of the buffer
+                                              ! prior to allocating new memory [arbitrary]
 
   call this%grow_ids()
 
@@ -162,7 +163,7 @@ end subroutine grow_2d
 !> Store a 2D array into this buffer
 subroutine store_2d(this, data, id)
   class(diag_buffer_2d), intent(inout) :: this !< This 2d buffer
-  real, dimension(:,:),  intent(in)    :: data !< The data to be stored in the buffer
+  real, dimension(:,:),  intent(in)    :: data !< The data to be stored in the buffer [arbitrary]
   integer,               intent(in)    :: id !< The diagnostic id
 
   integer :: slot
@@ -176,7 +177,8 @@ subroutine grow_3d(this)
   class(diag_buffer_3d), intent(inout) :: this !< This 3d buffer
 
   integer :: n
-  real, allocatable, dimension(:,:,:,:) :: temp
+  real, allocatable, dimension(:,:,:,:) :: temp ! Temporary array to hold the contents of the buffer
+                                                ! prior to allocating new memory [arbitrary]
 
   call this%grow_ids()
 
@@ -190,7 +192,7 @@ end subroutine grow_3d
 !> Store a 3d array into this buffer
 subroutine store_3d(this, data, id)
   class(diag_buffer_3d),  intent(inout) :: this !< This 3d buffer
-  real, dimension(:,:,:), intent(in)    :: data !< The data to be stored in the buffer
+  real, dimension(:,:,:), intent(in)    :: data !< The data to be stored in the buffer [arbitrary]
   integer,                intent(in)    :: id !< The diagnostic id
 
   integer :: slot

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -1,0 +1,421 @@
+!> Provides buffers that can dynamically grow as needed. These are primarily intended for the
+!! diagnostics which need to store intermediate or partial states of state variables
+module MOM_diag_buffers
+
+use iso_fortran_env, only : stdout => output_unit, stderr => error_unit
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+implicit none ; private
+
+public :: diag_buffer_unit_tests_2d, diag_buffer_unit_tests_3d
+
+type, abstract :: diag_buffer_base ; private
+  integer :: is !< The start slot of the array i-direction
+  integer :: js !< The start slot of the array j-direction
+  integer :: ie !< The end slot of the array i-direction
+  integer :: je !< The end slot of the array j-direction
+
+  integer, allocatable, dimension(:) :: ids  !< List of diagnostic ids whose slot corresponds to the row in the buffer
+  integer :: length = 0 !< The number of slots in the buffer
+
+  contains
+
+  procedure(a_grow), deferred :: grow
+  procedure, public :: check_capacity_by_id
+  procedure, public :: set_horizontal_extents
+  procedure, public :: mark_available
+  procedure, public :: grow_ids
+  procedure, public :: find_buffer_slot
+end type diag_buffer_base
+
+!> Dynamically growing buffer for 2D arrays.
+type, extends(diag_buffer_base), public :: diag_buffer_2d
+  real, public, allocatable, dimension(:,:,:) :: buffer !< The actual buffer to store data
+
+  contains
+
+  procedure, public :: grow => grow_2d
+  procedure, public :: store => store_2d
+end type diag_buffer_2d
+
+!> Dynamically growing buffer for 3D arrays.
+type, extends(diag_buffer_base), public :: diag_buffer_3d ; private
+  integer :: ks !< The start slot in the k-dimension
+  integer :: ke !< The last slot in the k-dimension
+  real, public, allocatable, dimension(:,:,:,:) :: buffer !< The actual buffer to store data
+
+  contains
+
+  procedure, public :: set_vertical_extent
+  procedure, public :: grow => grow_3d
+  procedure, public :: store => store_3d
+end type diag_buffer_3d
+
+contains
+
+!> Signature for the grow methods on n-dimension diagnostic buffer types
+subroutine a_grow(this)
+  class(diag_buffer_base), intent(inout) :: this !< The diagnostic buffer
+end subroutine
+
+!> Mark a slot in the buffer as unused based on a diagnostic id. For example,
+!! the data in that slot has already been consumed and can thus be overwritten
+subroutine mark_available(this, id)
+  class(diag_buffer_base), intent(inout) :: this !< The diagnostic buffer
+  integer,                 intent(in)    :: id   !< The diagnostic id
+  integer :: slot
+
+  slot = this%find_buffer_slot(id)
+  this%ids(slot) = 0
+end subroutine mark_available
+
+!> Return the slot of the buffer corresponding to the diagnostic id
+pure function find_buffer_slot(this, id) result(slot)
+  class(diag_buffer_base), intent(in) :: this !< The diagnostic buffer
+  integer, intent(in) :: id !< The diagnostic id
+
+  integer, dimension(1) :: temp
+  integer :: slot !< The slot in the buffer corresponding to the diagnostic id
+
+  if(allocated(this%ids)) then
+    !NOTE: Alternatively could do slot = SUM(findloc(...))
+    temp = findloc(this%ids(:), id)
+    slot = temp(1)
+  else
+    slot = 0
+  endif
+
+end function find_buffer_slot
+
+!> Grow the ids array by one
+subroutine grow_ids(this)
+  class(diag_buffer_base), intent(inout) :: this !< This buffer
+
+  integer, allocatable, dimension(:) :: temp
+  integer :: n
+
+  n = this%length
+
+  allocate(temp(n+1))
+  if(n>0) temp(1:n) = this%ids(:)
+  call move_alloc(temp, this%ids)
+end subroutine grow_ids
+
+!> Check whether the id already has a slot reserved. If not, find a new empty slot and if
+!! need be, grow the buffer.
+impure function check_capacity_by_id(this, id) result(slot)
+  class(diag_buffer_base), intent(inout) :: this !< This 2d buffer
+  integer,                 intent(in)    :: id   !< The diagnostic id
+  integer :: slot
+
+  slot = this%find_buffer_slot(id)
+  if(slot==0) then
+    ! Check to see if there is an open slot
+    if(allocated(this%ids)) slot = this%find_buffer_slot(0)
+    ! If slot is still 0, then the buffer must grow
+    if (slot==0) then
+      call this%grow()
+      slot = this%length
+    endif
+    this%ids(slot) = id
+  endif
+end function check_capacity_by_id
+
+!> Set the horizontal extents of the buffer
+subroutine set_horizontal_extents(this, is, ie, js, je)
+  class(diag_buffer_base), intent(inout) :: this !< The diagnostic buffer
+  integer,               intent(in)    :: is !< The start slot of the array i-direction
+  integer,               intent(in)    :: ie !< The end slot of the array i-direction
+  integer,               intent(in)    :: js !< The start slot of the array j-direction
+  integer,               intent(in)    :: je !< The end slot of the array j-direction
+
+  this%is = is ; this%ie = ie ; this%js = js ; this%je = je
+end subroutine set_horizontal_extents
+
+!> Set the vertical extent of the buffer
+subroutine set_vertical_extent(this, ks, ke)
+  class(diag_buffer_3d), intent(inout) :: this !< The diagnostic buffer
+  integer,               intent(in)    :: ks !< The start slot of the array i-direction
+  integer,               intent(in)    :: ke !< The end slot of the array i-direction
+
+  this%ks = ks; this%ke = ke
+end subroutine set_vertical_extent
+
+!> Grow a buffer for 2D arrays
+subroutine grow_2d(this)
+  class(diag_buffer_2d), intent(inout) :: this !< This 2d buffer
+
+  integer :: n
+  real, allocatable, dimension(:,:,:) :: temp
+
+  call this%grow_ids()
+
+  n = this%length
+  allocate(temp(n+1, this%is:this%ie, this%js:this%je), source=0.)
+  if(n>0) temp(1:n,:,:) = this%buffer(:,:,:)
+  call move_alloc(temp, this%buffer)
+  this%length = this%length + 1
+end subroutine grow_2d
+
+!> Store a 2D array into this buffer
+subroutine store_2d(this, data, id)
+  class(diag_buffer_2d), intent(inout) :: this !< This 2d buffer
+  real, dimension(:,:),  intent(in)    :: data !< The data to be stored in the buffer
+  integer,               intent(in)    :: id !< The diagnostic id
+
+  integer :: slot
+
+  slot = this%check_capacity_by_id(id)
+  this%buffer(slot,:,:) = data(:,:)
+end subroutine store_2d
+
+!> Grow a buffer for 3d arrays
+subroutine grow_3d(this)
+  class(diag_buffer_3d), intent(inout) :: this !< This 3d buffer
+
+  integer :: n
+  real, allocatable, dimension(:,:,:,:) :: temp
+
+  call this%grow_ids()
+
+  n = this%length
+  allocate(temp(n+1, this%is:this%ie, this%js:this%je, this%ks:this%ke), source=0.)
+  if(n>0) temp(1:n,:,:,:) = this%buffer(:,:,:,:)
+  call move_alloc(temp, this%buffer)
+  this%length = this%length + 1
+end subroutine grow_3d
+
+!> Store a 3d array into this buffer
+subroutine store_3d(this, data, id)
+  class(diag_buffer_3d),  intent(inout) :: this !< This 3d buffer
+  real, dimension(:,:,:), intent(in)    :: data !< The data to be stored in the buffer
+  integer,                intent(in)    :: id !< The diagnostic id
+
+  integer :: slot
+
+  ! Find the first slot in the ids array that is 0, i.e. this is a portion of the buffer that can be reused
+  slot = this%check_capacity_by_id(id)
+  this%buffer(slot,:,:,:) = data(:,:,:)
+end subroutine store_3d
+
+function diag_buffer_unit_tests_2d(verbose) result(fail)
+  logical, intent(in) :: verbose !< If true, write results to stdout
+  logical :: fail !< True if any of the unit tests fail
+
+  fail = .false.
+  write(stdout,*) '==== MOM_diag_buffers: diag_buffers_unit_tests_2d ==='
+  fail = fail .or. new_buffer_2d()
+  fail = fail .or. grow_buffer_2d()
+  fail = fail .or. store_buffer_2d()
+  fail = fail .or. reuse_buffer_2d()
+
+  contains
+
+  !> Ensure properties of a newly initialized buffer
+  function new_buffer_2d() result(local_fail)
+    type(diag_buffer_2d) :: buffer_2d
+    logical :: local_fail !< True if any of the unit tests fail
+    local_fail = .false.
+    local_fail = local_fail .or. allocated(buffer_2d%buffer)
+    local_fail = local_fail .or. allocated(buffer_2d%ids)
+    local_fail = local_fail .or. buffer_2d%length /= 0
+    if(verbose) write(stdout,*) "new_buffer_2d: ", local_fail
+  end function new_buffer_2d
+
+  !> Test the growing of a buffer
+  function grow_buffer_2d() result(local_fail)
+    type(diag_buffer_2d) :: buffer_2d
+    logical :: local_fail !< True if any of the unit tests fail
+    integer, parameter :: is=1, ie=2, js=3, je=6
+    integer :: i
+
+    local_fail = .false.
+
+    buffer_2d = diag_buffer_2d(is=is, ie=ie, js=js, je=je)
+    ! Grow the buffer 3 times
+    do i=1,3
+      call buffer_2d%grow()
+      local_fail = local_fail .or. (buffer_2d%length /= i)
+      local_fail = local_fail .or. (size(buffer_2d%buffer, 1) /= i)
+      local_fail = local_fail .or. (lbound(buffer_2d%buffer, 2) /= is)
+      local_fail = local_fail .or. (ubound(buffer_2d%buffer, 2) /= ie)
+      local_fail = local_fail .or. (lbound(buffer_2d%buffer, 3) /= js)
+      local_fail = local_fail .or. (ubound(buffer_2d%buffer, 3) /= je)
+    enddo
+    if(verbose) write(stdout,*) "grow_buffer_2d: ", local_fail
+  end function grow_buffer_2d
+
+  !> Test storing a buffer based on a unique id
+  function store_buffer_2d() result(local_fail)
+    type(diag_buffer_2d) :: buffer_2d
+    logical :: local_fail !< True if any of the unit tests fail
+
+    integer, parameter :: is=1, ie=2, js=3, je=6, nlen=3
+    integer :: i
+    real, allocatable, dimension(:,:,:) :: test_2d
+
+    allocate(test_2d(nlen, is:ie, js:je))
+    call random_number(test_2d)
+    buffer_2d = diag_buffer_2d(is=is, ie=ie, js=js, je=je)
+
+    do i=1,nlen
+      call buffer_2d%store(test_2d(i,:,:), i*3)
+    enddo
+    local_fail = ANY(buffer_2d%buffer /= test_2d)
+
+    if(verbose) write(stdout,*) "store_buffer_2d: ", local_fail
+  end function store_buffer_2d
+
+  !> Test the reuse of a buffer. Fill it first like store_buffer_2d. Then,
+  !! loop through again, but use the slots of the buffer in the following
+  !! order: 2, 1, 3
+  function reuse_buffer_2d() result(local_fail)
+    type(diag_buffer_2d) :: buffer_2d
+    logical :: local_fail !< True if any of the unit tests fail
+
+    integer, parameter :: is=1, ie=2, js=3, je=6, nlen=3
+    integer :: i, new_i, id, new_id
+    real, dimension(nlen, is:ie, js:je) :: test_2d_first, test_2d_second
+    integer, dimension(nlen) :: reorder = [2,1,3]
+
+    local_fail = .false.
+    call random_number(test_2d_first)
+    call random_number(test_2d_second)
+
+    buffer_2d = diag_buffer_2d(is=is, ie=ie, js=js, je=je)
+
+    do i=1,nlen
+      call buffer_2d%store(test_2d_first(i,:,:), id=i*3)
+    enddo
+
+    do i=1,nlen
+      new_i = reorder(i)
+      ! id and new_id are multiplied by primes to make sure they are unique
+      id = reorder(i)*3
+      new_id = i*7
+      call buffer_2d%mark_available(id=reorder(i)*3)
+      call buffer_2d%store(test_2d_second(i,:,:), id=new_id)
+      local_fail = local_fail .or. buffer_2d%find_buffer_slot(new_id) /= new_i
+      test_2d_first(new_i,:,:) = test_2d_second(i,:,:)
+    enddo
+    local_fail = local_fail .or. any(buffer_2d%ids /= [14, 7, 21])
+    local_fail = local_fail .or. any(buffer_2d%buffer /= test_2d_first)
+    if(verbose) write(stdout,*) "reuse_buffer_2d: ", local_fail
+  end function reuse_buffer_2d
+
+end function diag_buffer_unit_tests_2d
+
+function diag_buffer_unit_tests_3d(verbose) result(fail)
+  logical, intent(in) :: verbose !< If true, write results to stdout
+  logical :: fail !< True if any of the unit tests fail
+
+  fail = .false.
+  write(stdout,*) '==== MOM_diag_buffers: diag_buffers_unit_tests_3d ==='
+  fail = fail .or. new_buffer_3d()
+  fail = fail .or. grow_buffer_3d()
+  fail = fail .or. store_buffer_3d()
+  fail = fail .or. reuse_buffer_3d()
+
+  contains
+
+  !> Ensure properties of a newly initialized buffer
+  function new_buffer_3d() result(local_fail)
+    type(diag_buffer_3d) :: buffer_3d
+    logical :: local_fail !< True if any of the unit tests fail
+    local_fail = .false.
+    local_fail = local_fail .or. allocated(buffer_3d%buffer)
+    local_fail = local_fail .or. allocated(buffer_3d%ids)
+    local_fail = local_fail .or. buffer_3d%length /= 0
+    if(verbose) write(stdout,*) "new_buffer_3d: ", local_fail
+  end function new_buffer_3d
+
+  !> Test the growing of a buffer
+  function grow_buffer_3d() result(local_fail)
+    type(diag_buffer_3d) :: buffer_3d
+    logical :: local_fail !< True if any of the unit tests fail
+    integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10
+    integer :: i
+
+    local_fail = .false.
+
+    buffer_3d = diag_buffer_3d(is=is, ie=ie, js=js, je=je, ks=ks, ke=ke)
+    ! Grow the buffer 3 times
+    do i=1,3
+      call buffer_3d%grow()
+      local_fail = local_fail .or. (buffer_3d%length /= i)
+      local_fail = local_fail .or. (size(buffer_3d%buffer, 1) /= i)
+      local_fail = local_fail .or. (lbound(buffer_3d%buffer, 2) /= is)
+      local_fail = local_fail .or. (ubound(buffer_3d%buffer, 2) /= ie)
+      local_fail = local_fail .or. (lbound(buffer_3d%buffer, 3) /= js)
+      local_fail = local_fail .or. (ubound(buffer_3d%buffer, 3) /= je)
+      local_fail = local_fail .or. (lbound(buffer_3d%buffer, 4) /= ks)
+      local_fail = local_fail .or. (ubound(buffer_3d%buffer, 4) /= ke)
+    enddo
+    if(verbose) write(stdout,*) "grow_buffer_3d: ", local_fail
+  end function grow_buffer_3d
+
+  !> Test storing a buffer based on a unique id
+  function store_buffer_3d() result(local_fail)
+    type(diag_buffer_3d) :: buffer_3d
+    logical :: local_fail !< True if any of the unit tests fail
+
+    integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10, nlen=3
+    integer :: i
+    real, dimension(nlen, is:ie, js:je, ks:ke) :: test_3d
+
+    call random_number(test_3d)
+    buffer_3d = diag_buffer_3d(is=is, ie=ie, js=js, je=je, ks=1, ke=10)
+
+    do i=1,nlen
+      call buffer_3d%store(test_3d(i,:,:,:), i*3)
+    enddo
+    local_fail = ANY(buffer_3d%buffer /= test_3d)
+
+    if(verbose) write(stdout,*) "store_buffer_3d: ", local_fail
+  end function store_buffer_3d
+
+  !> Test the reuse of a buffer. Fill it first like store_buffer_3d. Then,
+  !! loop through again, but use the slots of the buffer in the following
+  !! order: 2, 1, 3
+  function reuse_buffer_3d() result(local_fail)
+    type(diag_buffer_3d) :: buffer_3d
+    logical :: local_fail !< True if any of the unit tests fail
+
+    integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10, nlen=3
+    integer :: i, new_i, id, new_id
+    real, dimension(nlen, is:ie, js:je, ks:ke) :: test_3d_first, test_3d_second
+    integer, dimension(nlen) :: reorder = [2,1,3]
+
+    local_fail = .false.
+    call random_number(test_3d_first)
+    call random_number(test_3d_second)
+
+    buffer_3d = diag_buffer_3d(is=is, ie=ie, js=js, je=je, ks=ks, ke=ke)
+
+    do i=1,nlen
+      call buffer_3d%store(test_3d_first(i,:,:,:), id=i*3)
+    enddo
+
+    do i=1,nlen
+      new_i = reorder(i)
+      ! id and new_id are multiplied by primes to make sure they are unique
+      id = reorder(i)*3
+      new_id = i*7
+      call buffer_3d%mark_available(id=reorder(i)*3)
+      call buffer_3d%store(test_3d_second(i,:,:,:), id=new_id)
+      local_fail = local_fail .or. buffer_3d%find_buffer_slot(new_id) /= new_i
+      test_3d_first(new_i,:,:,:) = test_3d_second(i,:,:,:)
+    enddo
+    local_fail = local_fail .or. any(buffer_3d%ids /= [14, 7, 21])
+    local_fail = local_fail .or. any(buffer_3d%buffer /= test_3d_first)
+    if(verbose) write(stdout,*) "reuse_buffer_3d: ", local_fail
+  end function reuse_buffer_3d
+
+end function diag_buffer_unit_tests_3d
+
+end module MOM_diag_buffers
+
+!> \namespace mom_cpu_clock
+!!
+!! APIs are defined and implemented in mom_cpu_clock_infra.

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -80,6 +80,7 @@ subroutine set_fill_value(this, fill_value)
   class(diag_buffer_base), intent(inout) :: this !< The diagnostic buffer
   real,                    intent(in)    :: fill_value !< The fill value to use when growing the buffer [arbitrary]
 
+  this%fill_value = fill_value
 end subroutine set_fill_value
 
 !> Mark a slot in the buffer as unused based on a diagnostic id. For example,
@@ -249,6 +250,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
   write(stdout,*) '==== MOM_diag_buffers: diag_buffers_unit_tests_2d ==='
   fail = fail .or. new_buffer_2d()
   fail = fail .or. grow_buffer_2d()
+  fail = fail .or. fill_value_2d()
   fail = fail .or. store_buffer_2d()
   fail = fail .or. reuse_buffer_2d()
 
@@ -288,6 +290,25 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
     enddo
     if (verbose) write(stdout,*) "grow_buffer_2d: ", local_fail
   end function grow_buffer_2d
+
+  !> Test that growing new buffer fills the array with a set fill value
+  function fill_value_2d() result(local_fail)
+    type(diag_buffer_2d) :: buffer
+    logical :: local_fail !< True if any of the unit tests fail
+    integer, parameter :: is=1, ie=2, js=3, je=6
+    real, parameter :: fill_value = -123.456
+    integer :: i
+
+
+    local_fail = .false.
+
+    call buffer%set_horizontal_extents(is=is, ie=ie, js=js, je=je)
+    call buffer%set_fill_value(fill_value)
+    ! Grow the buffer 3 times
+    call buffer%grow()
+    if (any(buffer%buffer(1)%field(:,:) /= fill_value)) local_fail = .true.
+    if (verbose) write(stdout,*) "fill_value_2d: ", local_fail
+  end function fill_value_2d
 
   !> Test storing a buffer based on a unique id
   function store_buffer_2d() result(local_fail)
@@ -363,6 +384,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
   write(stdout,*) '==== MOM_diag_buffers: diag_buffers_unit_tests_3d ==='
   fail = fail .or. new_buffer_3d()
   fail = fail .or. grow_buffer_3d()
+  fail = fail .or. fill_value_3d()
   fail = fail .or. store_buffer_3d()
   fail = fail .or. reuse_buffer_3d()
 
@@ -404,6 +426,25 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
     enddo
     if (verbose) write(stdout,*) "grow_buffer_3d: ", local_fail
   end function grow_buffer_3d
+
+  !> Test that growing new buffer fills the array with a set fill value
+  function fill_value_3d() result(local_fail)
+    type(diag_buffer_3d) :: buffer
+    logical :: local_fail !< True if any of the unit tests fail
+    integer, parameter :: is=1, ie=2, js=3, je=6
+    real, parameter :: fill_value = -123.456
+    integer :: i
+
+
+    local_fail = .false.
+
+    call buffer%set_horizontal_extents(is=is, ie=ie, js=js, je=je)
+    call buffer%set_fill_value(fill_value)
+    ! Grow the buffer 3 times
+    call buffer%grow()
+    if (any(buffer%buffer(1)%field(:,:,:) /= fill_value)) local_fail = .true.
+    if (verbose) write(stdout,*) "fill_value_3d: ", local_fail
+  end function fill_value_3d
 
   !> Test storing a buffer based on a unique id
   function store_buffer_3d() result(local_fail)

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -323,7 +323,10 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
 
     allocate(test_2d(nlen, is:ie, js:je))
     call random_number(test_2d)
-    buffer = diag_buffer_2d(is=is, ie=ie, js=js, je=je)
+    buffer%is = is
+    buffer%ie = ie
+    buffer%js = js
+    buffer%je = je
 
     do i=1,nlen
       call buffer%store(test_2d(i,:,:), i*3)
@@ -457,7 +460,12 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
 
     local_fail = .false.
     call random_number(test_3d)
-    buffer = diag_buffer_3d(is=is, ie=ie, js=js, je=je, ks=1, ke=10)
+    buffer%is = is
+    buffer%ie = ie
+    buffer%js = js
+    buffer%je = je
+    buffer%ks = ks
+    buffer%ke = ke
 
     do i=1,nlen
       call buffer%store(test_3d(i,:,:,:), i*3)
@@ -484,7 +492,12 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
     call random_number(test_3d_first)
     call random_number(test_3d_second)
 
-    buffer = diag_buffer_3d(is=is, ie=ie, js=js, je=je, ks=ks, ke=ke)
+    buffer%is = is
+    buffer%ie = ie
+    buffer%js = js
+    buffer%je = je
+    buffer%ks = ks
+    buffer%ke = ke
 
     do i=1,nlen
       call buffer%store(test_3d_first(i,:,:,:), id=i*3)

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -79,7 +79,7 @@ pure function find_buffer_slot(this, id) result(slot)
   integer, dimension(1) :: temp
   integer :: slot !< The slot in the buffer corresponding to the diagnostic id
 
-  if(allocated(this%ids)) then
+  if (allocated(this%ids)) then
     !NOTE: Alternatively could do slot = SUM(findloc(...))
     temp = findloc(this%ids(:), id)
     slot = temp(1)
@@ -99,7 +99,7 @@ subroutine grow_ids(this)
   n = this%length
 
   allocate(temp(n+1))
-  if(n>0) temp(1:n) = this%ids(:)
+  if (n>0) temp(1:n) = this%ids(:)
   call move_alloc(temp, this%ids)
 end subroutine grow_ids
 
@@ -111,9 +111,9 @@ impure function check_capacity_by_id(this, id) result(slot)
   integer :: slot
 
   slot = this%find_buffer_slot(id)
-  if(slot==0) then
+  if (slot==0) then
     ! Check to see if there is an open slot
-    if(allocated(this%ids)) slot = this%find_buffer_slot(0)
+    if (allocated(this%ids)) slot = this%find_buffer_slot(0)
     ! If slot is still 0, then the buffer must grow
     if (slot==0) then
       call this%grow()
@@ -154,7 +154,7 @@ subroutine grow_2d(this)
 
   n = this%length
   allocate(temp(n+1, this%is:this%ie, this%js:this%je), source=0.)
-  if(n>0) temp(1:n,:,:) = this%buffer(:,:,:)
+  if (n>0) temp(1:n,:,:) = this%buffer(:,:,:)
   call move_alloc(temp, this%buffer)
   this%length = this%length + 1
 end subroutine grow_2d
@@ -182,7 +182,7 @@ subroutine grow_3d(this)
 
   n = this%length
   allocate(temp(n+1, this%is:this%ie, this%js:this%je, this%ks:this%ke), source=0.)
-  if(n>0) temp(1:n,:,:,:) = this%buffer(:,:,:,:)
+  if (n>0) temp(1:n,:,:,:) = this%buffer(:,:,:,:)
   call move_alloc(temp, this%buffer)
   this%length = this%length + 1
 end subroutine grow_3d
@@ -222,7 +222,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
     local_fail = local_fail .or. allocated(buffer_2d%buffer)
     local_fail = local_fail .or. allocated(buffer_2d%ids)
     local_fail = local_fail .or. buffer_2d%length /= 0
-    if(verbose) write(stdout,*) "new_buffer_2d: ", local_fail
+    if (verbose) write(stdout,*) "new_buffer_2d: ", local_fail
   end function new_buffer_2d
 
   !> Test the growing of a buffer
@@ -245,7 +245,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
       local_fail = local_fail .or. (lbound(buffer_2d%buffer, 3) /= js)
       local_fail = local_fail .or. (ubound(buffer_2d%buffer, 3) /= je)
     enddo
-    if(verbose) write(stdout,*) "grow_buffer_2d: ", local_fail
+    if (verbose) write(stdout,*) "grow_buffer_2d: ", local_fail
   end function grow_buffer_2d
 
   !> Test storing a buffer based on a unique id
@@ -266,7 +266,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
     enddo
     local_fail = ANY(buffer_2d%buffer /= test_2d)
 
-    if(verbose) write(stdout,*) "store_buffer_2d: ", local_fail
+    if (verbose) write(stdout,*) "store_buffer_2d: ", local_fail
   end function store_buffer_2d
 
   !> Test the reuse of a buffer. Fill it first like store_buffer_2d. Then,
@@ -303,7 +303,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
     enddo
     local_fail = local_fail .or. any(buffer_2d%ids /= [14, 7, 21])
     local_fail = local_fail .or. any(buffer_2d%buffer /= test_2d_first)
-    if(verbose) write(stdout,*) "reuse_buffer_2d: ", local_fail
+    if (verbose) write(stdout,*) "reuse_buffer_2d: ", local_fail
   end function reuse_buffer_2d
 
 end function diag_buffer_unit_tests_2d
@@ -330,7 +330,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
     local_fail = local_fail .or. allocated(buffer_3d%buffer)
     local_fail = local_fail .or. allocated(buffer_3d%ids)
     local_fail = local_fail .or. buffer_3d%length /= 0
-    if(verbose) write(stdout,*) "new_buffer_3d: ", local_fail
+    if (verbose) write(stdout,*) "new_buffer_3d: ", local_fail
   end function new_buffer_3d
 
   !> Test the growing of a buffer
@@ -355,7 +355,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
       local_fail = local_fail .or. (lbound(buffer_3d%buffer, 4) /= ks)
       local_fail = local_fail .or. (ubound(buffer_3d%buffer, 4) /= ke)
     enddo
-    if(verbose) write(stdout,*) "grow_buffer_3d: ", local_fail
+    if (verbose) write(stdout,*) "grow_buffer_3d: ", local_fail
   end function grow_buffer_3d
 
   !> Test storing a buffer based on a unique id
@@ -375,7 +375,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
     enddo
     local_fail = ANY(buffer_3d%buffer /= test_3d)
 
-    if(verbose) write(stdout,*) "store_buffer_3d: ", local_fail
+    if (verbose) write(stdout,*) "store_buffer_3d: ", local_fail
   end function store_buffer_3d
 
   !> Test the reuse of a buffer. Fill it first like store_buffer_3d. Then,
@@ -412,7 +412,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
     enddo
     local_fail = local_fail .or. any(buffer_3d%ids /= [14, 7, 21])
     local_fail = local_fail .or. any(buffer_3d%buffer /= test_3d_first)
-    if(verbose) write(stdout,*) "reuse_buffer_3d: ", local_fail
+    if (verbose) write(stdout,*) "reuse_buffer_3d: ", local_fail
   end function reuse_buffer_3d
 
 end function diag_buffer_unit_tests_3d

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -53,6 +53,7 @@ type, extends(diag_buffer_base), public :: diag_buffer_2d; private
 
   procedure, public :: grow => grow_2d !< Increase the size of the buffer
   procedure, public :: store => store_2d !< Store a field in the buffer, increasing as necessary
+  procedure, public :: set_extents_from_array => set_extents_from_array_2d !< Set extents from array bounds
 end type diag_buffer_2d
 
 !> Dynamically growing buffer for 3D arrays.
@@ -66,6 +67,7 @@ type, extends(diag_buffer_base), public :: diag_buffer_3d ; private
   procedure, public :: set_vertical_extent !< Set the vertical extents of the buffer
   procedure, public :: grow => grow_3d !< Increase the size of the buffer
   procedure, public :: store => store_3d !< Store a field in the buffer, increasing as necessary
+  procedure, public :: set_extents_from_array => set_extents_from_array_3d !< Set extents from array bounds
 end type diag_buffer_3d
 
 contains
@@ -165,6 +167,29 @@ subroutine set_vertical_extent(this, ks, ke)
 
   this%ks = ks; this%ke = ke
 end subroutine set_vertical_extent
+
+!> Set the extents of a 2D buffer from the bounds of a 2D array
+subroutine set_extents_from_array_2d(this, array, fill_value_in)
+  class(diag_buffer_2d), intent(inout) :: this !< The diagnostic buffer
+  real, dimension(:,:), intent(in)     :: array !< The array whose bounds define the buffer extents
+  real, optional,       intent(in)     :: fill_value_in !< Optional fill value
+
+  call this%set_horizontal_extents(lbound(array,1), ubound(array,1), &
+                                   lbound(array,2), ubound(array,2))
+  if (present(fill_value_in)) call this%set_fill_value(fill_value_in)
+end subroutine set_extents_from_array_2d
+
+!> Set the extents of a 3D buffer from the bounds of a 3D array
+subroutine set_extents_from_array_3d(this, array, fill_value_in)
+  class(diag_buffer_3d), intent(inout) :: this !< The diagnostic buffer
+  real, dimension(:,:,:), intent(in)   :: array !< The array whose bounds define the buffer extents
+  real, optional,         intent(in)   :: fill_value_in !< Optional fill value
+
+  call this%set_horizontal_extents(lbound(array,1), ubound(array,1), &
+                                   lbound(array,2), ubound(array,2))
+  call this%set_vertical_extent(lbound(array,3), ubound(array,3))
+  if (present(fill_value_in)) call this%set_fill_value(fill_value_in)
+end subroutine set_extents_from_array_3d
 
 !> Grow a 2d diagnostic buffer
 subroutine grow_2d(this)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -140,8 +140,8 @@ type, public :: axes_grp
   type(diag_dsamp), dimension(2:MAX_DSAMP_LEV) :: dsamp !< Downsample container
 
   ! For diagnostics posted piecemeal
-  type(diag_buffer_2d) :: buffer_2d
-  type(diag_buffer_3d) :: buffer_3d
+  type(diag_buffer_2d) :: buffer_2d !< A dynamically reallocated buffer for 2d piecemeal diagnostics
+  type(diag_buffer_3d) :: buffer_3d !< A dynamically reallocated buffer for 3d piecemeal diagnostics
 end type axes_grp
 
 !> Contains an array to store a diagnostic target grid

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -11,6 +11,7 @@ use MOM_checksums,        only : hchksum, uchksum, vchksum, Bchksum
 use MOM_coms,             only : PE_here
 use MOM_cpu_clock,        only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,        only : CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_diag_buffers,     only : diag_buffer_2d, diag_buffer_3d
 use MOM_diag_manager_infra, only : MOM_diag_manager_init, MOM_diag_manager_end
 use MOM_diag_manager_infra, only : diag_axis_init=>MOM_diag_axis_init, get_MOM_diag_axis_name
 use MOM_diag_manager_infra, only : send_data_infra, MOM_diag_field_add_attribute, EAST, NORTH
@@ -45,6 +46,7 @@ implicit none ; private
 #define MAX_DSAMP_LEV 2
 
 public set_axes_info, post_data, register_diag_field, time_type
+public post_data_3d_by_column, post_data_3d_final
 public post_product_u, post_product_sum_u, post_product_v, post_product_sum_v
 public set_masks_for_axes
 ! post_data_1d_k is a deprecated interface that can be replaced by a call to post_data, but
@@ -136,6 +138,10 @@ type, public :: axes_grp
   real, pointer, dimension(:,:)   :: mask2d => null() !< Mask for 2d (x-y) axes [nondim]
   real, pointer, dimension(:,:,:) :: mask3d => null() !< Mask for 3d axes [nondim]
   type(diag_dsamp), dimension(2:MAX_DSAMP_LEV) :: dsamp !< Downsample container
+
+  ! For diagnostics posted piecemeal
+  type(diag_buffer_2d) :: buffer_2d
+  type(diag_buffer_3d) :: buffer_3d
 end type axes_grp
 
 !> Contains an array to store a diagnostic target grid
@@ -1104,6 +1110,8 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
     if (axes%is_u_point) axes%mask2d => diag_cs%mask2dCu
     if (axes%is_v_point) axes%mask2d => diag_cs%mask2dCv
     if (axes%is_q_point) axes%mask2d => diag_cs%mask2dBu
+    call axes%buffer_2d%set_horizontal_extents(lbound(axes%mask2d,1), ubound(axes%mask2d,1), &
+                                               lbound(axes%mask2d,2), ubound(axes%mask2d,2))
   endif
   ! A static 3d mask for non-native coordinates can only be setup when a grid is available
   axes%mask3d => null()
@@ -1120,7 +1128,11 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
       if (axes%is_v_point) axes%mask3d => diag_cs%mask3dCvi
       if (axes%is_q_point) axes%mask3d => diag_cs%mask3dBi
     endif
+    call axes%buffer_3d%set_horizontal_extents(is=lbound(axes%mask3d,1), ie=ubound(axes%mask3d,1), &
+                                               js=lbound(axes%mask3d,2), je=ubound(axes%mask3d,2))
+    call axes%buffer_3d%set_vertical_extent(ks=lbound(axes%mask3d,3), ke=ubound(axes%mask3d,3))
   endif
+
 
 end subroutine define_axes_group
 
@@ -1910,6 +1922,58 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
     deallocate( locfield )
 
 end subroutine post_data_3d_low
+
+!> Put data into the buffer for a diagnostic one column at a time
+subroutine post_data_3d_by_column(diag_field_id, field, diag_cs, i, j)
+  integer,            intent(in) :: diag_field_id !< The id for an output variable returned by a
+                                                  !! previous call to register_diag_field.
+  real, dimension(:), intent(in) :: field         !< 3-d array being offered for output or averaging
+                                                  !! in internally scaled arbitrary units [A ~> a]
+  type(diag_ctrl), target, intent(in) :: diag_CS  !< Structure used to regulate diagnostic output
+  integer,            intent(in) :: i             !< The i-index to post the data in the buffer
+  integer,            intent(in) :: j             !< The j-index to post the data in the buffer
+
+  type(diag_type), pointer :: diag => null()
+  integer :: buffer_slot
+
+  diag => diag_cs%diags(diag_field_id)
+  buffer_slot = diag%axes%buffer_3d%check_capacity_by_id(diag_field_id)
+  diag%axes%buffer_3d%buffer(buffer_slot,i,j,:) = field
+end subroutine post_data_3d_by_column
+
+!> Put data into the buffer for a diagnostic one point at a time
+subroutine post_data_3d_by_point(diag_field_id, field, diag_cs, i, j, k)
+  integer,           intent(in) :: diag_field_id !< The id for an output variable returned by a
+                                                 !! previous call to register_diag_field.
+  real,              intent(in) :: field         !< 3-d array being offered for output or averaging
+                                                 !! in internally scaled arbitrary units [A ~> a]
+  type(diag_ctrl), target, intent(in) :: diag_CS !< Structure used to regulate diagnostic output
+  integer,           intent(in) :: i             !< The i-index to post the data in the buffer
+  integer,           intent(in) :: j             !< The j-index to post the data in the buffer
+  integer,           intent(in) :: k             !< The k-index to post the data in the buffer
+
+  type(diag_type), pointer :: diag => null()
+  integer :: buffer_slot
+
+  diag => diag_cs%diags(diag_field_id)
+  buffer_slot = diag%axes%buffer_3d%find_buffer_slot(diag_field_id)
+  diag%axes%buffer_3d%buffer(buffer_slot, i, j, k) = field
+end subroutine post_data_3d_by_point
+
+!> Post the final buffer using the standard post_data interface
+subroutine post_data_3d_final(diag_field_id, diag_cs)
+  integer,           intent(in) :: diag_field_id !< The id for an output variable returned by a
+                                                 !! previous call to register_diag_field.
+  type(diag_ctrl), target, intent(in) :: diag_CS !< Structure used to regulate diagnostic output
+
+  type(diag_type), pointer :: diag => null()
+  integer :: buffer_slot
+
+  diag => diag_cs%diags(diag_field_id)
+  buffer_slot = diag%axes%buffer_3d%find_buffer_slot(diag_field_id)
+  call post_data(diag_field_id, diag%axes%buffer_3d%buffer(buffer_slot,:,:,:), diag_CS)
+  call diag%axes%buffer_3d%mark_available(diag_field_id)
+end subroutine post_data_3d_final
 
 !> Calculate and write out diagnostics that are the product of two 3-d arrays at u-points
 subroutine post_product_u(id, u_a, u_b, G, nz, diag, mask, alt_h)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -60,6 +60,7 @@ public diag_mediator_close_registration, get_diag_time_end
 public diag_axis_init, ocean_register_diag, register_static_field
 public register_scalar_field
 public define_axes_group, diag_masks_set
+public set_piecemeal_extents
 public diag_register_area_ids
 public register_cell_measure, diag_associate_volume_cell_measure
 public diag_get_volume_cell_measure_dm_id
@@ -493,6 +494,9 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
        x_cell_method='point', y_cell_method='mean', is_u_point=.true.)
   call define_axes_group(diag_cs, (/ id_xh, id_yq /), diag_cs%axesCv1, &
        x_cell_method='mean', y_cell_method='point', is_v_point=.true.)
+
+  ! Define array extents for all piecemeal buffers
+  call set_piecemeal_extents(diag_cs)
 
   ! Axis group for special null axis from diag manager.
   id_null = diag_axis_init('scalar_axis', (/0./), 'none', 'N', 'none', null_axis=.true.)
@@ -3713,11 +3717,6 @@ subroutine diag_masks_set(G, nz, diag_cs)
   diag_cs%mask2dCu => G%mask2dCu
   diag_cs%mask2dCv => G%mask2dCv
 
-  call diag_cs%axesT1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dT, diag_cs%missing_value)
-  call diag_cs%axesB1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dBu, diag_cs%missing_value)
-  call diag_cs%axesCu1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dCu, diag_cs%missing_value)
-  call diag_cs%axesCv1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dCv, diag_cs%missing_value)
-
   ! 3d native masks are needed by diag_manager but the native variables
   ! can only be masked 2d - for ocean points, all layers exists.
   allocate(diag_cs%mask3dTL(G%isd:G%ied,G%jsd:G%jed,1:nz))
@@ -3741,7 +3740,23 @@ subroutine diag_masks_set(G, nz, diag_cs)
     diag_cs%mask3dCvi(:,:,k) = diag_cs%mask2dCv(:,:)
   enddo
 
-  ! Initialize piecemeal_3d buffer extents and fill values for native axes now that masks are allocated
+  !Allocate and initialize the downsampled masks
+  call downsample_diag_masks_set(G, nz, diag_cs)
+
+end subroutine diag_masks_set
+
+!> Set the extents and fill values for the piecemeal buffers for all axes
+subroutine set_piecemeal_extents(diag_cs)
+  type(diag_ctrl), intent(inout) :: diag_cs !< A pointer to a type with many variables
+                                                       !! used for diagnostics
+
+  ! Piecemeal buffers for 2d axes
+  call diag_cs%axesT1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dT, diag_cs%missing_value)
+  call diag_cs%axesB1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dBu, diag_cs%missing_value)
+  call diag_cs%axesCu1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dCu, diag_cs%missing_value)
+  call diag_cs%axesCv1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dCv, diag_cs%missing_value)
+
+  ! Piecemeal buffers for 3d axes
   call diag_cs%axesTL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dTL, diag_cs%missing_value)
   call diag_cs%axesBL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dBL, diag_cs%missing_value)
   call diag_cs%axesCuL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCuL, diag_cs%missing_value)
@@ -3751,10 +3766,7 @@ subroutine diag_masks_set(G, nz, diag_cs)
   call diag_cs%axesCui%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCui, diag_cs%missing_value)
   call diag_cs%axesCvi%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCvi, diag_cs%missing_value)
 
-  !Allocate and initialize the downsampled masks
-  call downsample_diag_masks_set(G, nz, diag_cs)
-
-end subroutine diag_masks_set
+end subroutine set_piecemeal_extents
 
 subroutine diag_mediator_close_registration(diag_CS)
   type(diag_ctrl), intent(inout) :: diag_CS !< Structure used to regulate diagnostic output

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1112,6 +1112,7 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
     if (axes%is_q_point) axes%mask2d => diag_cs%mask2dBu
     call axes%buffer_2d%set_horizontal_extents(lbound(axes%mask2d,1), ubound(axes%mask2d,1), &
                                                lbound(axes%mask2d,2), ubound(axes%mask2d,2))
+    call axes%buffer_2d%set_fill_value(diag_cs%missing_value)
   endif
   ! A static 3d mask for non-native coordinates can only be setup when a grid is available
   axes%mask3d => null()
@@ -1131,6 +1132,7 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
     call axes%buffer_3d%set_horizontal_extents(is=lbound(axes%mask3d,1), ie=ubound(axes%mask3d,1), &
                                                js=lbound(axes%mask3d,2), je=ubound(axes%mask3d,2))
     call axes%buffer_3d%set_vertical_extent(ks=lbound(axes%mask3d,3), ke=ubound(axes%mask3d,3))
+    call axes%buffer_3d%set_fill_value(diag_cs%missing_value)
   endif
 
 
@@ -1957,7 +1959,7 @@ subroutine post_data_3d_by_point(diag_field_id, field, diag_cs, i, j, k)
 
   diag => diag_cs%diags(diag_field_id)
   buffer_slot = diag%axes%buffer_3d%find_buffer_slot(diag_field_id)
-  diag%axes%buffer_3d%buffer(buffer_slot, i, j, k) = field
+  diag%axes%buffer_3d%buffer(buffer_slot,i,j,k) = field
 end subroutine post_data_3d_by_point
 
 !> Post the final buffer using the standard post_data interface

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1958,7 +1958,7 @@ subroutine post_data_3d_by_point(diag_field_id, field, diag_cs, i, j, k)
   integer :: buffer_slot
 
   diag => diag_cs%diags(diag_field_id)
-  buffer_slot = diag%axes%piecemeal_3d%find_buffer_slot(diag_field_id)
+  buffer_slot = diag%axes%piecemeal_3d%check_capacity_by_id(diag_field_id)
   diag%axes%piecemeal_3d%buffer(buffer_slot)%field(i,j,k) = field
 end subroutine post_data_3d_by_point
 
@@ -1973,8 +1973,11 @@ subroutine post_data_3d_final(diag_field_id, diag_cs)
 
   diag => diag_cs%diags(diag_field_id)
   buffer_slot = diag%axes%piecemeal_3d%find_buffer_slot(diag_field_id)
-  call post_data(diag_field_id, diag%axes%piecemeal_3d%buffer(buffer_slot)%field(:,:,:), diag_CS)
-  call diag%axes%piecemeal_3d%mark_available(diag_field_id)
+  ! Only perform an action if the buffer slot was actually used
+  if (buffer_slot>0) then
+    call post_data(diag_field_id, diag%axes%piecemeal_3d%buffer(buffer_slot)%field(:,:,:), diag_CS)
+    call diag%axes%piecemeal_3d%mark_available(diag_field_id)
+  endif
 end subroutine post_data_3d_final
 
 !> Calculate and write out diagnostics that are the product of two 3-d arrays at u-points

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -140,8 +140,8 @@ type, public :: axes_grp
   type(diag_dsamp), dimension(2:MAX_DSAMP_LEV) :: dsamp !< Downsample container
 
   ! For diagnostics posted piecemeal
-  type(diag_buffer_2d) :: buffer_2d !< A dynamically reallocated buffer for 2d piecemeal diagnostics
-  type(diag_buffer_3d) :: buffer_3d !< A dynamically reallocated buffer for 3d piecemeal diagnostics
+  type(diag_buffer_2d) :: piecemeal_2d !< A dynamically reallocated buffer for 2d piecemeal diagnostics
+  type(diag_buffer_3d) :: piecemeal_3d !< A dynamically reallocated buffer for 3d piecemeal diagnostics
 end type axes_grp
 
 !> Contains an array to store a diagnostic target grid
@@ -1110,9 +1110,9 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
     if (axes%is_u_point) axes%mask2d => diag_cs%mask2dCu
     if (axes%is_v_point) axes%mask2d => diag_cs%mask2dCv
     if (axes%is_q_point) axes%mask2d => diag_cs%mask2dBu
-    call axes%buffer_2d%set_horizontal_extents(lbound(axes%mask2d,1), ubound(axes%mask2d,1), &
+    call axes%piecemeal_2d%set_horizontal_extents(lbound(axes%mask2d,1), ubound(axes%mask2d,1), &
                                                lbound(axes%mask2d,2), ubound(axes%mask2d,2))
-    call axes%buffer_2d%set_fill_value(diag_cs%missing_value)
+    call axes%piecemeal_2d%set_fill_value(diag_cs%missing_value)
   endif
   ! A static 3d mask for non-native coordinates can only be setup when a grid is available
   axes%mask3d => null()
@@ -1129,10 +1129,10 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
       if (axes%is_v_point) axes%mask3d => diag_cs%mask3dCvi
       if (axes%is_q_point) axes%mask3d => diag_cs%mask3dBi
     endif
-    call axes%buffer_3d%set_horizontal_extents(is=lbound(axes%mask3d,1), ie=ubound(axes%mask3d,1), &
+    call axes%piecemeal_3d%set_horizontal_extents(is=lbound(axes%mask3d,1), ie=ubound(axes%mask3d,1), &
                                                js=lbound(axes%mask3d,2), je=ubound(axes%mask3d,2))
-    call axes%buffer_3d%set_vertical_extent(ks=lbound(axes%mask3d,3), ke=ubound(axes%mask3d,3))
-    call axes%buffer_3d%set_fill_value(diag_cs%missing_value)
+    call axes%piecemeal_3d%set_vertical_extent(ks=lbound(axes%mask3d,3), ke=ubound(axes%mask3d,3))
+    call axes%piecemeal_3d%set_fill_value(diag_cs%missing_value)
   endif
 
 
@@ -1939,8 +1939,8 @@ subroutine post_data_3d_by_column(diag_field_id, field, diag_cs, i, j)
   integer :: buffer_slot
 
   diag => diag_cs%diags(diag_field_id)
-  buffer_slot = diag%axes%buffer_3d%check_capacity_by_id(diag_field_id)
-  diag%axes%buffer_3d%buffer(buffer_slot,i,j,:) = field
+  buffer_slot = diag%axes%piecemeal_3d%check_capacity_by_id(diag_field_id)
+  diag%axes%piecemeal_3d%buffer(buffer_slot)%field(i,j,:) = field(:)
 end subroutine post_data_3d_by_column
 
 !> Put data into the buffer for a diagnostic one point at a time
@@ -1958,8 +1958,8 @@ subroutine post_data_3d_by_point(diag_field_id, field, diag_cs, i, j, k)
   integer :: buffer_slot
 
   diag => diag_cs%diags(diag_field_id)
-  buffer_slot = diag%axes%buffer_3d%find_buffer_slot(diag_field_id)
-  diag%axes%buffer_3d%buffer(buffer_slot,i,j,k) = field
+  buffer_slot = diag%axes%piecemeal_3d%find_buffer_slot(diag_field_id)
+  diag%axes%piecemeal_3d%buffer(buffer_slot)%field(i,j,k) = field
 end subroutine post_data_3d_by_point
 
 !> Post the final buffer using the standard post_data interface
@@ -1972,9 +1972,9 @@ subroutine post_data_3d_final(diag_field_id, diag_cs)
   integer :: buffer_slot
 
   diag => diag_cs%diags(diag_field_id)
-  buffer_slot = diag%axes%buffer_3d%find_buffer_slot(diag_field_id)
-  call post_data(diag_field_id, diag%axes%buffer_3d%buffer(buffer_slot,:,:,:), diag_CS)
-  call diag%axes%buffer_3d%mark_available(diag_field_id)
+  buffer_slot = diag%axes%piecemeal_3d%find_buffer_slot(diag_field_id)
+  call post_data(diag_field_id, diag%axes%piecemeal_3d%buffer(buffer_slot)%field(:,:,:), diag_CS)
+  call diag%axes%piecemeal_3d%mark_available(diag_field_id)
 end subroutine post_data_3d_final
 
 !> Calculate and write out diagnostics that are the product of two 3-d arrays at u-points

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1110,9 +1110,6 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
     if (axes%is_u_point) axes%mask2d => diag_cs%mask2dCu
     if (axes%is_v_point) axes%mask2d => diag_cs%mask2dCv
     if (axes%is_q_point) axes%mask2d => diag_cs%mask2dBu
-    call axes%piecemeal_2d%set_horizontal_extents(lbound(axes%mask2d,1), ubound(axes%mask2d,1), &
-                                               lbound(axes%mask2d,2), ubound(axes%mask2d,2))
-    call axes%piecemeal_2d%set_fill_value(diag_cs%missing_value)
   endif
   ! A static 3d mask for non-native coordinates can only be setup when a grid is available
   axes%mask3d => null()
@@ -1129,10 +1126,6 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
       if (axes%is_v_point) axes%mask3d => diag_cs%mask3dCvi
       if (axes%is_q_point) axes%mask3d => diag_cs%mask3dBi
     endif
-    call axes%piecemeal_3d%set_horizontal_extents(is=lbound(axes%mask3d,1), ie=ubound(axes%mask3d,1), &
-                                               js=lbound(axes%mask3d,2), je=ubound(axes%mask3d,2))
-    call axes%piecemeal_3d%set_vertical_extent(ks=lbound(axes%mask3d,3), ke=ubound(axes%mask3d,3))
-    call axes%piecemeal_3d%set_fill_value(diag_cs%missing_value)
   endif
 
 
@@ -3720,6 +3713,11 @@ subroutine diag_masks_set(G, nz, diag_cs)
   diag_cs%mask2dCu => G%mask2dCu
   diag_cs%mask2dCv => G%mask2dCv
 
+  call diag_cs%axesT1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dT, diag_cs%missing_value)
+  call diag_cs%axesB1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dBu, diag_cs%missing_value)
+  call diag_cs%axesCu1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dCu, diag_cs%missing_value)
+  call diag_cs%axesCv1%piecemeal_2d%set_extents_from_array(diag_cs%mask2dCv, diag_cs%missing_value)
+
   ! 3d native masks are needed by diag_manager but the native variables
   ! can only be masked 2d - for ocean points, all layers exists.
   allocate(diag_cs%mask3dTL(G%isd:G%ied,G%jsd:G%jed,1:nz))
@@ -3742,6 +3740,16 @@ subroutine diag_masks_set(G, nz, diag_cs)
     diag_cs%mask3dCui(:,:,k) = diag_cs%mask2dCu(:,:)
     diag_cs%mask3dCvi(:,:,k) = diag_cs%mask2dCv(:,:)
   enddo
+
+  ! Initialize piecemeal_3d buffer extents and fill values for native axes now that masks are allocated
+  call diag_cs%axesTL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dTL, diag_cs%missing_value)
+  call diag_cs%axesBL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dBL, diag_cs%missing_value)
+  call diag_cs%axesCuL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCuL, diag_cs%missing_value)
+  call diag_cs%axesCvL%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCvL, diag_cs%missing_value)
+  call diag_cs%axesTi%piecemeal_3d%set_extents_from_array(diag_cs%mask3dTi, diag_cs%missing_value)
+  call diag_cs%axesBi%piecemeal_3d%set_extents_from_array(diag_cs%mask3dBi, diag_cs%missing_value)
+  call diag_cs%axesCui%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCui, diag_cs%missing_value)
+  call diag_cs%axesCvi%piecemeal_3d%set_extents_from_array(diag_cs%mask3dCvi, diag_cs%missing_value)
 
   !Allocate and initialize the downsampled masks
   call downsample_diag_masks_set(G, nz, diag_cs)

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -9,6 +9,7 @@ use MOM_cpu_clock,      only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLO
 use MOM_coms,           only : EFP_type, real_to_EFP, EFP_to_real, operator(+), assignment(=), EFP_sum_across_PEs
 use MOM_debugging,      only : hchksum
 use MOM_diag_mediator,  only : post_data, register_diag_field, safe_alloc_alloc
+use MOM_diag_mediator,  only : post_data_3d_by_column, post_data_3d_final
 use MOM_diag_mediator,  only : time_type, diag_ctrl
 use MOM_domains,        only : create_group_pass, do_group_pass, group_pass_type
 use MOM_error_handler,  only : MOM_error, FATAL, WARNING, MOM_mesg
@@ -263,6 +264,7 @@ type, public :: energetic_PBL_CS ; private
   type(EFP_type), dimension(2) :: sum_its_BBL !< The total number of iterations and columns worked on
 
   !>@{ Diagnostic IDs
+  integer :: id_Kd_ePBL_col_by_col = -1
   integer :: id_ML_depth = -1, id_hML_depth = -1, id_TKE_wind = -1, id_TKE_mixing = -1
   integer :: id_ustar_ePBL = -1, id_bflx_ePBL = -1
   integer :: id_TKE_MKE = -1, id_TKE_conv = -1, id_TKE_forcing = -1
@@ -692,6 +694,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
                          u_star, u_star_mean, mech_TKE, dt, MLD_io, Kd, mixvel, mixlen, GV, &
                          US, CS, eCD, Waves, G, i, j)
       endif
+      call post_data_3d_by_column(CS%id_Kd_ePBL_col_by_col, Kd, CS%diag, i, j)
 
       ! Add the diffusivity due to bottom boundary layer mixing, if there is energy to drive this mixing.
       if (BBL_mixing) then
@@ -827,6 +830,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
     do K=1,nz+1 ; do i=is,ie ; Kd_int(i,j,K) = Kd_2d(i,K) ; enddo ; enddo
 
   enddo ! j-loop
+  call post_data_3d_final(CS%id_Kd_ePBL_col_by_col, CS%diag)
 
   if (CS%debug .and. BBL_mixing) then
     call hchksum(visc%BBL_meanKE_loss, "ePBL visc%BBL_meanKE_loss", G%HI, &
@@ -4332,6 +4336,8 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
 
 
 !/ Checking output flags
+  CS%id_Kd_ePBL_col_by_col = register_diag_field('ocean_model', 'Kd_ePBL_col_by_col', diag%axesTi, Time, &
+      'ePBL diapycnal diffusivity at interfaces posted column by column', 'm2 s-1', conversion=GV%HZ_T_to_m2_s)
   CS%id_ML_depth = register_diag_field('ocean_model', 'ePBL_h_ML', diag%axesT1, &
       Time, 'Surface boundary layer depth', units='m', conversion=US%Z_to_m, &
       cmor_long_name='Ocean Mixed Layer Thickness Defined by Mixing Scheme')

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -694,7 +694,8 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
                          u_star, u_star_mean, mech_TKE, dt, MLD_io, Kd, mixvel, mixlen, GV, &
                          US, CS, eCD, Waves, G, i, j)
       endif
-      call post_data_3d_by_column(CS%id_Kd_ePBL_col_by_col, Kd, CS%diag, i, j)
+      if (CS%id_Kd_ePBL_col_by_col > 0) &
+        call post_data_3d_by_column(CS%id_Kd_ePBL_col_by_col, Kd, CS%diag, i, j)
 
       ! Add the diffusivity due to bottom boundary layer mixing, if there is energy to drive this mixing.
       if (BBL_mixing) then
@@ -830,7 +831,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
     do K=1,nz+1 ; do i=is,ie ; Kd_int(i,j,K) = Kd_2d(i,K) ; enddo ; enddo
 
   enddo ! j-loop
-  call post_data_3d_final(CS%id_Kd_ePBL_col_by_col, CS%diag)
+  if (CS%id_Kd_ePBL_col_by_col > 0) call post_data_3d_final(CS%id_Kd_ePBL_col_by_col, CS%diag)
 
   if (CS%debug .and. BBL_mixing) then
     call hchksum(visc%BBL_meanKE_loss, "ePBL visc%BBL_meanKE_loss", G%HI, &


### PR DESCRIPTION
Some quantities in MOM6 are calculated in subroutines which expect slices of the model's 2d or 3d arrays. Diagnosing these quantities can be challenging because the usual post_data calls expect whole arrays. To solve this problem, the changes here introduce a dynamic buffer that can grow as needed over the course of an simulation.

This buffer keeps track of the diagnostic IDs and the index in the buffer. When a slot in the buffer is no longer needed, for example if the whole array has been computed and posted, the slot is marked as "available" for overwriting. The buffer is only allowed to grow if all the currently allocated slots are in use.

Any computational cost associated with growing this buffer will only happen in the first few steps of the model as post_data for requested diagnostics is called for the first time in that run.

This new piecemeal posting of a diagnostic was implemented for `Kd_ePBL`. The new diagnostic `Kd_ePBL_col_by_col` is the same as the the original field in the `Baltic_OM4_05` case.

@adcroft @marshallward: Two points in particular that I'd like your feedback on:

- The underlying buffer is public, but I cannot think of a way to make it private and still allow a `post_data` call to be done without an extra copy. I have included a `store` subroutine that could be used if we made it private, but otherwise those should be deleted.
- Each time we post the data in a piecemeal fashion, the slot index is computed. We could put in some logic so that we store it once per loop at the beginning of the section where the diagnostic is being computed/posted. I am not sure that it would be worth the effort/complexity for what I am assuming would be a marginal performance gain.