### PR TITLE
Rescale volo and clean up the unit descriptions of 17 variables

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -398,7 +398,7 @@ end type ocean_OBC_type
 !> Control structure for open boundaries that read from files.
 !! Probably lots to update here.
 type, public :: file_OBC_CS ; private
-  real :: tide_flow = 3.0e6         !< Placeholder for now..., perhaps in [m3 s-1]?
+  logical :: OBC_file_used = .false.     !< Placeholder for now to avoid an empty type.
 end type file_OBC_CS
 
 !> Type to carry something (what??) for the OBC registry.

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -204,7 +204,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
                                             ! including [nondim] and [H ~> m or kg m-2].
   real :: uh_tmp(SZIB_(G),SZJ_(G),SZK_(GV)) ! A temporary zonal transport [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: vh_tmp(SZI_(G),SZJB_(G),SZK_(GV)) ! A temporary meridional transport [H L2 T-1 ~> m3 s-1 or kg s-1]
-  real :: mass_cell(SZI_(G),SZJ_(G))       ! The vertically integrated mass in a grid cell [kg]
+  real :: mass_cell(SZI_(G),SZJ_(G))       ! The vertically integrated mass in a grid cell [R Z L2 ~> kg]
   real :: rho_in_situ(SZI_(G))             ! In situ density [R ~> kg m-3]
   real :: cg1(SZI_(G),SZJ_(G))             ! First baroclinic gravity wave speed [L T-1 ~> m s-1]
   real :: Rd1(SZI_(G),SZJ_(G))             ! First baroclinic deformation radius [L ~> m]
@@ -226,7 +226,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   real, dimension(SZK_(GV)) :: salt_layer_ave ! The average salinity in a layer [S ~> ppt]
   real :: thetaoga  ! The volume mean potential temperature [C ~> degC]
   real :: soga      ! The volume mean ocean salinity [S ~> ppt]
-  real :: masso     ! The total mass of the ocean [kg]
+  real :: masso     ! The total mass of the ocean [R Z L2 ~> kg]
   real :: tosga     ! The area mean sea surface temperature [C ~> degC]
   real :: sosga     ! The area mean sea surface salinity [S ~> ppt]
 
@@ -1341,7 +1341,7 @@ subroutine post_surface_thermo_diags(IDs, G, GV, US, diag, dt_int, sfc_state, tv
     zos  ! dynamic sea lev (zero area mean) from inverse-barometer adjusted ssh [Z ~> m]
   real :: I_time_int    ! The inverse of the time interval [T-1 ~> s-1].
   real :: zos_area_mean ! Global area mean sea surface height [Z ~> m]
-  real :: volo          ! Total volume of the ocean [m3]
+  real :: volo          ! Total volume of the ocean [Z L2 ~> m3]
   real :: ssh_ga        ! Global ocean area weighted mean sea seaface height [Z ~> m]
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, is, ie, js, je
@@ -1375,7 +1375,7 @@ subroutine post_surface_thermo_diags(IDs, G, GV, US, diag, dt_int, sfc_state, tv
     do j=js,je ; do i=is,ie
       work_2d(i,j) = G%mask2dT(i,j) * (ssh(i,j) + G%bathyT(i,j))
     enddo ; enddo
-    volo = global_area_integral(work_2d, G, unscale=US%Z_to_m)
+    volo = global_area_integral(work_2d, G, tmp_scale=US%Z_to_m)
     call post_data(IDs%id_volo, volo, diag)
   endif
 
@@ -1914,7 +1914,7 @@ subroutine register_surface_diags(Time, G, US, IDs, diag, tv)
 
   ! Vertically integrated, budget, and surface state diagnostics
   IDs%id_volo = register_scalar_field('ocean_model', 'volo', Time, diag, &
-      long_name='Total volume of liquid ocean', units='m3', &
+      long_name='Total volume of liquid ocean', units='m3', conversion=US%Z_to_m*US%L_to_m**2, &
       standard_name='sea_water_volume')
   IDs%id_zos = register_diag_field('ocean_model', 'zos', diag%axesT1, Time, &
       standard_name = 'sea_surface_height_above_geoid', &

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -439,14 +439,14 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   real :: T_min   ! The global minimum unmasked value of the temperature [degC]
   real :: T_max   ! The global maximum unmasked value of the temperature [degC]
   real :: T_min_x ! The x-positions of the global temperature minima
-                  ! in the units of G%geoLonT, often [degreeT_E] or [km]
+                  ! in the units of G%geoLonT, often [degrees_E] or [km]
   real :: T_min_y ! The y-positions of the global temperature minima
-                  ! in the units of G%geoLatT, often [degreeT_N] or [km]
+                  ! in the units of G%geoLatT, often [degrees_N] or [km]
   real :: T_min_z ! The z-positions of the global temperature minima [layer]
   real :: T_max_x ! The x-positions of the global temperature maxima
-                  ! in the units of G%geoLonT, often [degreeT_E] or [km]
+                  ! in the units of G%geoLonT, often [degrees_E] or [km]
   real :: T_max_y ! The y-positions of the global temperature maxima
-                  ! in the units of G%geoLatT, often [degreeT_N] or [km]
+                  ! in the units of G%geoLatT, often [degrees_N] or [km]
   real :: T_max_z ! The z-positions of the global temperature maxima [layer]
 
 

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -1303,9 +1303,9 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
               ! renormalization of the integral of the profile
               w2avg = 0.0
               do k=1,kc
-                w2avg = w2avg + 0.5*(mode_struct(K)**2+mode_struct(K+1)**2)*Hc(k) ! [H L4 T-4]
+                w2avg = w2avg + 0.5*(mode_struct(K)**2+mode_struct(K+1)**2)*Hc(k) ! [H L4 T-4 ~> m5 s-4 or kg m2 s-4]
               enddo
-              renorm = sqrt(htot(i)*a_int/w2avg) ! [T2 L-2]
+              renorm = sqrt(htot(i)*a_int/w2avg) ! [T2 L-2 ~> s2 m-2]
               do K=1,kc+1 ; mode_struct(K) = renorm * mode_struct(K) ; enddo
               ! after renorm, mode_struct is again [nondim]
               if (abs(dlam) < tol_solve*lam_1) exit

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -662,11 +662,11 @@ end subroutine initialize_ice_AGlen
 subroutine initialize_ice_SMB(SMB, G, US, PF)
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(inout) :: SMB !< Ice surface mass balance parameter, often in [kg m-2 s-1]
+                         intent(inout) :: SMB !< Ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
   type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
   type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 
-  real :: SMB_val  ! Constant ice surface mass balance parameter, often in [kg m-2 s-1]
+  real :: SMB_val  ! Constant ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
   character(len=40)  :: mdl = "initialize_ice_SMB" ! This subroutine's name.
   character(len=200) :: config
   character(len=200) :: varname

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -175,7 +175,8 @@ subroutine set_grid_metrics_from_mosaic(G, param_file, US)
   real, dimension(2*G%isd-2:2*G%ied+1,2*G%jsd-2:2*G%jed+1) :: tmpT ! Areas [L2 ~> m2]
   real, dimension(2*G%isd-3:2*G%ied+1,2*G%jsd-2:2*G%jed+1) :: tmpU ! East face supergrid spacing [L ~> m]
   real, dimension(2*G%isd-2:2*G%ied+1,2*G%jsd-3:2*G%jed+1) :: tmpV ! North face supergrid spacing [L ~> m]
-  real, dimension(2*G%isd-3:2*G%ied+1,2*G%jsd-3:2*G%jed+1) :: tmpZ ! Corner latitudes or longitudes [degN] or [degE]
+  real, dimension(2*G%isd-3:2*G%ied+1,2*G%jsd-3:2*G%jed+1) :: tmpZ ! Corner latitudes [degrees_N] or
+                                                                   ! longitudes [degrees_E]
   real, dimension(:,:), allocatable :: tmpGlbl ! A global array of axis labels [degrees_N] or [km] or [m]
   character(len=200) :: filename, grid_file, inputdir
   character(len=64)  :: mdl = "MOM_grid_init set_grid_metrics_from_mosaic"

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -1310,15 +1310,15 @@ subroutine compute_global_grid_integrals(G, US)
   type(unit_scale_type),  intent(in)    :: US !< A dimensional unit scaling type
 
   ! Local variables
-  real, dimension(G%isc:G%iec, G%jsc:G%jec) :: tmpForSumming ! Masked and unscaled cell areas [m2]
+  real, dimension(G%isc:G%iec, G%jsc:G%jec) :: masked_area ! Masked cell areas [L2 ~> m2]
   integer :: i, j
 
-  tmpForSumming(:,:) = 0.
+  masked_area(:,:) = 0.
   G%areaT_global = 0.0 ; G%IareaT_global = 0.0
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
-    tmpForSumming(i,j) = G%areaT(i,j) * G%mask2dT(i,j)
+    masked_area(i,j) = G%areaT(i,j) * G%mask2dT(i,j)
   enddo ; enddo
-  G%areaT_global = reproducing_sum(tmpForSumming, unscale=US%L_to_m**2)
+  G%areaT_global = reproducing_sum(masked_area, unscale=US%L_to_m**2)
 
   if (G%areaT_global == 0.0) &
     call MOM_error(FATAL, "compute_global_grid_integrals: zero ocean area (check topography?)")

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -60,7 +60,7 @@ type, public :: bkgnd_mixing_cs ; private
                                     !! twice the Earth's rotation period, used with the
                                     !! Henyey scaling from the mixing [nondim]
   real    :: Henyey_max_lat         !< A latitude poleward of which the Henyey profile
-                                    !! is returned to the minimum diffusivity [degN]
+                                    !! is returned to the minimum diffusivity [degrees_N]
   real    :: prandtl_bkgnd          !< Turbulent Prandtl number used to convert
                                     !! vertical background diffusivity into viscosity [nondim]
   real    :: Kd_tanh_lat_scale      !< A nondimensional scaling for the range of


### PR DESCRIPTION

  This PR consists of four commits that correct the descriptions of the units or purpose of some variables.  Specifically this PR:
 - uses rescaled units for the calculation of the `volo` diagnostic
 - renames a local variable to `masked_area` for greater clarity
 - replaces the unused real placeholder element in `file_OBC_CS` with a logical placeholder
 - corrects the syntax or substance of the descriptions of the units of 14 variables.

  All solutions and output are bitwise identical, and no interfaces are changed. The specific commits in this PR include:

 - NOAA-GFDL/MOM6@1b142bad1 Switched the placeholder element of file_OBC_CS
 - NOAA-GFDL/MOM6@320a62fd6 Fix the syntax or substance in 10 comment units
 - NOAA-GFDL/MOM6@69ba88dc2 Rename masked_area in compute_global_grid_integral
 - NOAA-GFDL/MOM6@f83539457 Calculate volo in scaled units
 