### PR TITLE
+Refactor totalTandS to optionally work with scaled variables

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -5,7 +5,7 @@ module MOM
 
 ! Infrastructure modules
 use MOM_array_transform,      only : rotate_array, rotate_vector
-use MOM_debugging,            only : MOM_debugging_init, hchksum, uvchksum
+use MOM_debugging,            only : MOM_debugging_init, hchksum, uvchksum, totalTandS
 use MOM_debugging,            only : check_redundant, query_debugging_checks
 use MOM_checksum_packages,    only : MOM_thermo_chksum, MOM_state_chksum
 use MOM_checksum_packages,    only : MOM_accel_chksum, MOM_surface_chksum
@@ -1719,6 +1719,13 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
   call cpu_clock_end(id_clock_thermo)
 
   call disable_averaging(CS%diag)
+
+! This works in general:
+!  if (associated(tv%T)) &
+!    call totalTandS(G%HI, h, G%areaT, tv%T, tv%S, "End of step_MOM", US, GV%H_to_mks)
+! This works only if there is no rescaling being used:
+!  if (associated(tv%T)) &
+!    call totalTandS(G%HI, h, G%areaT, tv%T, tv%S, "End of step_MOM")
 
   if (showCallTree) call callTree_leave("step_MOM_thermo(), MOM.F90")
 


### PR DESCRIPTION
  Refactored `totalTandS()` and `totalStuff()` to optionally work with scaled variables, by adding an optional `unit_scale_type` argument and a optional argument specifying the unscaling of thickness to `totalTandS()` and an optional `unscale` argument to `totalStuff()`.  The comments describing the units of 19 variables were modified to reflect the various units that might be used.  All solutions are bitwise identical, and output is unchanged when dimensional rescaling is not being used, but the debugging output can now be unaltered by the use of dimensional rescaling.  There are new optional arguments to two publicly visible routines.

  This change has been tested via calls to `totalTandS()` added to `step_MOM_thermo()`, but because `totalTandS()` is only intended for debugging, these testing calls are commented out.  I am uncertain whether to ultimately retain these comments to illustrate the use of `totalTandS()` or whether to delete them before this PR is merged into dev/gfdl, but retaining them for now seems like they may help the PR review process.