### PR TITLE
+Obsoleted INTERNAL_TIDE_CORNER_ADVECT

### DIFF
--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -114,6 +114,7 @@ subroutine find_obsolete_params(param_file)
 
   call obsolete_logical(param_file, "SMOOTH_RI", hint="Instead use N_SMOOTH_RI.")
 
+  call obsolete_logical(param_file, "INTERNAL_TIDE_CORNER_ADVECT", .false.)
   call obsolete_logical(param_file, "TIDE_USE_SAL_SCALAR", hint="Use SAL_SCALAR_APPROX instead.")
   call obsolete_logical(param_file, "TIDAL_SAL_SHT", hint="Use SAL_HARMONICS instead.")
   call obsolete_int(param_file, "TIDAL_SAL_SHT_DEGREE", hint="Use SAL_HARMONICS_DEGREE instead.")


### PR DESCRIPTION
  This commit cleans up several aspects of the MOM_internal_tides code, including the elimination of one runtime option, the correction of some units in comments and a start toward enabling the propagation directions to alternate.

1. Eliminated the internal routine `propagate_corner_spread()`.  This routine was never completely implemented, and it has never been used in any realistic configurations.  In particular, it appears that it will only work on a Cartesian grid in which the position variables (`G%geoLonBu` and `G%geoLatBu`) have the same units as `G%dx`. The comment describing `propagate_corner_spread()` indicates that "it is too numerically diffusive to be of much use as of yet" and that "it is not yet compatible with reflection schemes", so we have no plans to complete its implementation.  Although it is being deleted, it can always be recovered from older branches of MOM6.

2. The runtime parameter `INTERNAL_TIDE_CORNER_ADVECT`, which triggered the use of `propagate_corner_spread()` was obsoleted.

3. Started adding the option to alternate the direction of the internal tide propagation.  The code that actually enacts the change is still commented out to avoid changing answers, but it could readily be enabled later with changes to a single line, and all the required code is present.

4. The units of 9 area-integrated energy budget debugging diagnostics were corrected, as is rescaling factor when their sum is written to `stdout`.

  With these changes, all answers are expected to be bitwise identical in any cases that are in active use, but an under-used runtime option has been eliminated from some MOM_parameter_doc files.