### PR TITLE
A few minor changes in vertical viscosity 

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -228,8 +228,6 @@ end type cont_diag_ptrs
 
 !> Vertical viscosities, drag coefficients, and related fields.
 type, public :: vertvisc_type
-  real :: Prandtl_turb       !< The Prandtl number for the turbulent diffusion
-                             !! that is captured in Kd_shear [nondim].
   real, allocatable, dimension(:,:) :: &
     bbl_thick_u, & !< The bottom boundary layer thickness at the u-points [Z ~> m].
     bbl_thick_v, & !< The bottom boundary layer thickness at the v-points [Z ~> m].

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -1969,7 +1969,7 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
                  default=13, do_not_log=just_read)
   call get_param(param_file, mdl, "PRANDTL_TURB", CS%Prandtl_turb, &
                  "The turbulent Prandtl number applied to shear instability.", &
-                 units="nondim", default=1.0, do_not_log=.true.)
+                 units="nondim", default=1.0, do_not_log=just_read)
   call get_param(param_file, mdl, "VEL_UNDERFLOW", CS%vel_underflow, &
                  "A negligibly small velocity magnitude below which velocity components are set "//&
                  "to 0.  A reasonable value might be 1e-30 m/s, which is less than an "//&

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2956,9 +2956,6 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
     CS%RiNo_mix = kappa_shear_is_used(param_file)
   endif
 
-  call get_param(param_file, mdl, "PRANDTL_TURB", visc%Prandtl_turb, &
-                 "The turbulent Prandtl number applied to shear "//&
-                 "instability.", units="nondim", default=1.0)
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false.)
 
   call get_param(param_file, mdl, "DYNAMIC_VISCOUS_ML", CS%dynamic_viscous_ML, &

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -2105,11 +2105,7 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
       dhc = hvel(i,nz)*0.5
       ! These expressions assume that Kv_tot(i,nz+1) = CS%Kv, consistent with
       ! the suppression of turbulent mixing by the presence of a solid boundary.
-      if (dhc < bbl_thick(i)) then
-        a_cpl(i,nz+1) = kv_bbl(i) / ((dhc+h_neglect) + I_amax*kv_bbl(i))
-      else
-        a_cpl(i,nz+1) = kv_bbl(i) / ((bbl_thick(i)+h_neglect) + I_amax*kv_bbl(i))
-      endif
+      a_cpl(i,nz+1) = kv_bbl(i) / ((min(dhc, bbl_thick(i)) + h_neglect) + I_amax*kv_bbl(i))
     endif ; enddo
     do K=nz,2,-1 ; do i=is,ie ; if (do_i(i)) then
       !    botfn determines when a point is within the influence of the bottom


### PR DESCRIPTION
This PR refactors a few random lines in vertical viscosity. 

* Remove an unused parameter `Prandtl_turb` in `vertvisc_type`, which also allows the said parameter documented in the correct section in MOM_parameter_doc
* In subroutine `set_viscous_BBL`, move and merge two instances of `u2_bg` calculation to avoid redundancy and if-branch within do-loops.
* In subroutine `set_viscous_BBL`, add a comment on explaining the reason to reset Ray_[uv]
* In subroutine `find_coupling_coef`, replace an if-branch with min()

This PR does not change answers. 

05b1e065abf874b044b9865058ffb0f4bd1e4284: Remove Prandtl_turb from vertvisc_type
d63ea3bca1df34276004608143f51b2fd70a374f: Minor changes to vertical viscosity