### PR TITLE
Updates MOM_kappa_shear averaging and diagnostics.

### DIFF
--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -521,11 +521,6 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   if (CS%id_N2_mean>0) diag_N2_mean(:,:,:) = 0.0
   if (CS%id_S2_mean>0) diag_S2_mean(:,:,:) = 0.0
   kappa_vertex(:,:,:) = 0.0
-  hweight_ul(:,:,:) = 0.0
-  hweight_ur(:,:,:) = 0.0
-  hweight_ll(:,:,:) = 0.0
-  hweight_lr(:,:,:) = 0.0
-  h_int_mask(:,:,:) = 0.0
 
   use_temperature = associated(tv%T)
 
@@ -537,6 +532,11 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   call thickness_to_dz(h, tv, dz_3d, G, GV, US, halo_size=1)
 
   if (CS%VS_ThicknessMean) then
+    hweight_ul(:,:,:) = 0.0
+    hweight_ur(:,:,:) = 0.0
+    hweight_ll(:,:,:) = 0.0
+    hweight_lr(:,:,:) = 0.0
+    h_int_mask(:,:,:) = 0.0
     !Loop over halo and pre compute a masked thickness around each interface
     ! (excluding the top and bottom boundary)
     do j=G%jsc-1,G%jec+1; do K=2,nz; do i=G%isc-1,G%iec+1

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -521,6 +521,11 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   if (CS%id_N2_mean>0) diag_N2_mean(:,:,:) = 0.0
   if (CS%id_S2_mean>0) diag_S2_mean(:,:,:) = 0.0
   kappa_vertex(:,:,:) = 0.0
+  hweight_ul(:,:,:) = 0.0
+  hweight_ur(:,:,:) = 0.0
+  hweight_ll(:,:,:) = 0.0
+  hweight_lr(:,:,:) = 0.0
+  h_int_mask(:,:,:) = 0.0
 
   use_temperature = associated(tv%T)
 

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -2272,11 +2272,13 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
          's-2', conversion=US%s_to_T**2)
   else
     CS%id_TKE = register_diag_field('ocean_model','TKE_shear', diag%axesTi, Time, &
-         'Shear-driven Turbulent Kinetic Energy at horizontal tracer points', 'm2 s-2', conversion=US%Z_to_m**2*US%s_to_T**2)
+         'Shear-driven Turbulent Kinetic Energy at horizontal tracer points', 'm2 s-2', &
+         conversion=US%Z_to_m**2*US%s_to_T**2)
     CS%id_S2_init = register_diag_field('ocean_model','S2_shear_in', diag%axesTi, Time, &
          'Interface shear squared at horizontal tracer points, as input to kappa-shear', 's-2', conversion=US%s_to_T**2)
     CS%id_N2_init = register_diag_field('ocean_model','N2_shear_in', diag%axesTi, Time, &
-         'Interface straitification at horizontal tracer points, as input to kappa-shear', 's-2', conversion=US%s_to_T**2)
+         'Interface straitification at horizontal tracer points, as input to kappa-shear', 's-2', &
+         conversion=US%s_to_T**2)
     CS%id_S2_mean = register_diag_field('ocean_model','S2_shear_mean', diag%axesTi, Time, &
          'Interface shear squared at horizontal tracer points, averaged over timestep in kappa-shear', &
          's-2', conversion=US%s_to_T**2)


### PR DESCRIPTION
- Update to horizontal averaging procedure in MOM_kappa_shear for VERTEX_SHEAR = True.
- Adds geometric and thickness weighted averages for moving diffusivity from vertices to tracer points.
- Adds new diagnostics of N2, S2, Kd, and TKE both with and without VERTEX_SHEAR, useful for debugging.
- Bitwise reproduces OM5 config w/ VERTEX_SHEAR = True.