### PR TITLE
Intent out halos

### DIFF
--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -598,6 +598,7 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     local_open_BC = OBC%open_u_BCs_exist_globally
   endif ; endif
 
+  if (present(u_cor)) u_cor(:,:,:) = 0.0
   if (present(du_cor)) du_cor(:,:) = 0.0
 
   if (present(LB_in)) then
@@ -1491,6 +1492,7 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     local_open_BC = OBC%open_v_BCs_exist_globally
   endif ; endif
 
+  if (present(v_cor)) v_cor(:,:,:) = 0.0
   if (present(dv_cor)) dv_cor(:,:) = 0.0
 
   if (present(LB_in)) then

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -901,6 +901,8 @@ subroutine convert_MLD_to_ML_thickness(MLD_in, h, h_MLD, tv, G, GV, halo)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
+  h_MLD(:,:) = 0.0
+
   halos = 0 ; if (present(halo)) halos = halo
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1198,6 +1198,11 @@ subroutine MEKE_lengthScales(CS, MEKE, G, GV, US, SN_u, SN_v, EKE, depth_tot, &
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   h_neglect = GV%H_subroundoff
 
+  ! This code sets the halo regions for these intent(out) variables.
+  LmixScale(:,:) = 0.0
+  bottomFac2(:,:) = 0.0
+  barotrFac2(:,:) = 0.0
+
 !$OMP do
   do j=js,je ; do i=is,ie
     if (.not.CS%use_old_lscale) then

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -3384,6 +3384,7 @@ subroutine energetic_PBL_get_MLD(CS, MLD, G, US, m_to_MLD_units)
 
   scale = 1.0 ; if (present(m_to_MLD_units)) scale = US%Z_to_m * m_to_MLD_units
 
+  MLD(:,:) = 0.0  ! This ensures that the halos have appropriate values for land.
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
     MLD(i,j) = scale*CS%ML_depth(i,j)
   enddo ; enddo


### PR DESCRIPTION
+(*)Set initialized state halos & intent out halos

  This PR consists of 3 commits that set the halo regions of several intent(out) variables that are subsequently used in halo update or checksum calls or could otherwise be used to set other variables, such as those related to open boundary conditions.

  To achieve this, the new overloaded interfaces `reset_h_var_halo_vals()` and `reset_vector_halo_vals()` have been added to the MOM_debugging module to reset the halo regions of a 2-d or 3-d tracer-cell array or the components of a 2-d or 3-d C-grid vector to specified values.  When the new runtime parameter RESET_STATE_HALOS_POST_INIT is set to true, these are used to set the 5 state variable halos (`h`, `u`, `v`, `T` and `S`) to sensible values before a pass var is done on htem.  Enabling this option does change answers with the Baltic_OM4_05 test case and perhaps others, but it is not enabled by default.

  The halos of 7 other intent out variables that are used in halo updates or checksums but do not appear to changes answers (probably because their previously unset halo points are masked out by landmasks when they would not be reset by a halo update) are also explicitly set.  The impacted arrays are `u_cor` and `v_cor` in `continuity_PPM()`, `h_MLD` in `convert_MLD_to_ML_thickness()`, `MLD` in `energetic_PBL_get_MLD()` and `LmixScale`, `bottomFac2` and `barotrFac2` in `MEKE_lengthScales()`.  This commit does change the values in the debugging checksum output for some cases to more nearly reproduce under dimensional rescaling and rotation.

  By default, all answers in the MOM6-examples test suite are bitwise identical. However, it is possible that there are cases where the answers change, but if so the existing answers should probably be considered to be incorrect.  There are two new public interfaces, and a new entry in the MOM_parameter_doc files. The commits in this PR include:

- NOAA-GFDL/MOM6@27e8cbd24 +Reset state var halo values after initialization
- NOAA-GFDL/MOM6@5c361958b +Add reset_h_var_halo_vals and reset_vector_halo_vals
- NOAA-GFDL/MOM6@6d5fbc241 (*)Initialize halos for 7 intent out arrays