### PR TITLE
Add salt restore conversion option

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -146,7 +146,7 @@ type, public :: surface_forcing_CS ; private
   character(len=200) :: inputdir              !< Directory where NetCDF input files are
   character(len=200) :: salt_restore_file     !< Filename for salt restoring data
   character(len=30)  :: salt_restore_var_name !< Name of surface salinity in salt_restore_file
-  logical            :: salt_restore_is_practical !< Specifies that salt restore salinity practical and not absolute.
+  logical            :: salt_restore_is_practical !< Specifies that the target salinity is practical and not absolute.
   logical            :: mask_srestore         !< If true, apply a 2-dimensional mask to the surface
                                               !! salinity restoring fluxes. The masking file should be
                                               !! in inputdir/salt_restore_mask.nc and the field should
@@ -1496,7 +1496,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
                  default="salt")
     call get_param(param_file, mdl, "SALT_RESTORE_PRACTICAL_SALINITY", CS%salt_restore_is_practical, &
                  "Specifies if the restoring surface salinity variable is practical salinity.  If this "//&
-                 "flag is set to false it is assumed that the salinity is absolute salinity.", default=.true.)
+                 "flag is set to false it is assumed that the salinity is absolute salinity.", default=.false.)
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -17,7 +17,7 @@ use MOM_EOS_UNESCO, only : UNESCO_EOS
 use MOM_EOS_Roquet_rho, only : Roquet_rho_EOS
 use MOM_EOS_Roquet_SpV, only : Roquet_SpV_EOS
 use MOM_EOS_TEOS10, only : TEOS10_EOS
-use MOM_EOS_TEOS10, only : gsw_sp_from_sr, gsw_pt_from_ct
+use MOM_EOS_TEOS10, only : gsw_sp_from_sr, gsw_pt_from_ct, gsw_sr_from_sp
 use MOM_temperature_convert, only : poTemp_to_consTemp, consTemp_to_poTemp
 use MOM_TFreeze,    only : calculate_TFreeze_linear, calculate_TFreeze_Millero
 use MOM_TFreeze,    only : calculate_TFreeze_teos10, calculate_TFreeze_TEOS_poly
@@ -52,6 +52,7 @@ public convert_temp_salt_for_TEOS10
 public cons_temp_to_pot_temp
 public abs_saln_to_prac_saln
 public gsw_sp_from_sr
+public gsw_sr_from_sp
 public gsw_pt_from_ct
 public query_compressible
 public get_EOS_name

--- a/src/equation_of_state/MOM_EOS_TEOS10.F90
+++ b/src/equation_of_state/MOM_EOS_TEOS10.F90
@@ -3,7 +3,7 @@ module MOM_EOS_TEOS10
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use gsw_mod_toolbox, only : gsw_sp_from_sr, gsw_pt_from_ct
+use gsw_mod_toolbox, only : gsw_sp_from_sr, gsw_pt_from_ct, gsw_sr_from_sp
 use gsw_mod_toolbox, only : gsw_rho, gsw_specvol
 use gsw_mod_toolbox, only : gsw_rho_first_derivatives, gsw_specvol_first_derivatives
 use gsw_mod_toolbox, only : gsw_rho_second_derivatives
@@ -11,7 +11,7 @@ use MOM_EOS_base_type, only : EOS_base
 
 implicit none ; private
 
-public gsw_sp_from_sr, gsw_pt_from_ct
+public gsw_sp_from_sr, gsw_pt_from_ct, gsw_sr_from_sp
 public TEOS10_EOS
 
 real, parameter :: Pa2db  = 1.e-4  !< The conversion factor from Pa to dbar [dbar Pa-1]


### PR DESCRIPTION
This PR addresses  issue #852.

- The model restores its salinity directly toward the provided dataset.  If the dataset was in practical salinity and the model absolute, there was no conversion and hence the wrong restoring flux was used.
- This commit adds an option to convert the dataset salinity to absolute salinity if the model is absolute and the dataset is practical.
- This commit does not provide the opposite capability, since I'm unaware of that issue being encountered.