### PR TITLE
.testing: Fix optimized target paths

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -285,6 +285,12 @@ $(BUILD)/target/MOM6: $(BUILD)/target FORCE | $(TARGET_CODEBASE)
 $(BUILD)/target: | $(TARGET_CODEBASE)
 	ln -s $(abspath $(TARGET_CODEBASE))/.testing/build/symmetric $@
 
+$(BUILD)/opt_target/MOM6: $(BUILD)/opt_target FORCE | $(TARGET_CODEBASE)
+	$(MAKE) -C $(TARGET_CODEBASE)/.testing BUILD=build build/opt/MOM6
+
+$(BUILD)/opt_target: | $(TARGET_CODEBASE)
+	ln -s $(abspath $(TARGET_CODEBASE))/.testing/build/opt $@
+
 FORCE:
 
 

--- a/.testing/tools/compare_perf.py
+++ b/.testing/tools/compare_perf.py
@@ -33,7 +33,9 @@ def main():
 
     clock_cmp = {}
 
-    print('{:35s}{:8s}  {:8s}'.format('', 'Profile', 'Reference'))
+    name_len = 60
+    table_fmt = '{:' + str(name_len) + 's}{:8s}  {:8s}'
+    print(table_fmt.format('', 'Profile', 'Reference'))
     print()
 
     with open(args.expt) as profile_expt, open(args.ref) as profile_ref:
@@ -93,12 +95,12 @@ def main():
                 # Remove GCC optimization renaming
                 sname = sname.replace('.constprop.0', '')
 
-                if len(sname) > 32:
-                    sname = sname[:29] + '...'
+                if len(sname) > name_len - 3:
+                    sname = sname[:name_len - 6] + '...'
 
                 print('{}{}: {:7.3f}s, {:7.3f}s ({:.1f}%){}'.format(
                     ansi_color,
-                    ' ' * (32 - len(sname)) + sname,
+                    ' ' * (name_len - 3 - len(sname)) + sname,
                     t_expt,
                     t_ref,
                     100. * dclk,


### PR DESCRIPTION
This fixes the path for the optimized target builds (opt_target) used in
the profiling tests.  Previously they were pointing to the wrong
directories and were never built.

Due to oddities of rule order and overrides, the optimized targets were
using the latest code.  That is, **the perf tests were being run against
themselves**.

The perf and profile rules now correctly compare optimized output to the
optimized target output (typically dev/gfdl).

This PR also contains a minor improvement to the perf comparison script output.