### PR TITLE
Fix the incorrect index for v-point in the doc

### DIFF
--- a/src/framework/_Horizontal_indexing.dox
+++ b/src/framework/_Horizontal_indexing.dox
@@ -25,12 +25,12 @@ For example, when a loop is over h-points collocated variables
 - the do-loop statements will be for lower-case `i,j` variables
 - references to h-point variables will be `h(i,j)`, `D(i+1,j)`, etc.
 - references to u-point variables will be `u(I,j)` (meaning \f$u_{i+\frac{1}{2},j}\f$), `u(I-1,j)` (meaning \f$u_{i-\frac{1}{2},j}\f$), etc.
-- references to v-point variables will be `v(i,J)` (meaning \f$v_{i,j+\frac{1}{2}}\f$), `u(I-1,j)` (meaning \f$u_{i,j-\frac{1}{2}}\f$), etc.
+- references to v-point variables will be `v(i,J)` (meaning \f$v_{i,j+\frac{1}{2}}\f$), `v(i,J-1)` (meaning \f$v_{i,j-\frac{1}{2}}\f$), etc.
 - references to q-point variables will be `q(I,J)` (meaning \f$q_{i+\frac{1}{2},j+\frac{1}{2}}\f$), etc.
 
 In contrast, when a loop is over u-points collocated variables
 - the do-loop statements will be for upper-case `I` and lower-case `j` variables
-- the expression \f$ u_{i+\frac{1}{2},j} ( h_{i,j} + h_{i+1,j} ) \f$ is `u(I,j) * ( h(i,j) + h(i+1,j)`.
+- the expression \f$ u_{i+\frac{1}{2},j} ( h_{i,j} + h_{i+1,j} ) \f$ is `u(I,j) * ( h(i,j) + h(i+1,j) )`.
 
 
 \section section_Memory Declaration of variables


### PR DESCRIPTION
This tiny PR fix some typos in the MOM6 documentation when illustrating the index for v-point.

The current doc with the typo is at (https://mom6.readthedocs.io/en/main/api/generated/pages/Horizontal_Indexing.html)

Under Section "Soft convention for loop variables", the reference for v-point is incorrect. See the screenshot here:
![Screenshot 2025-04-07 at 12 08 18 PM](https://github.com/user-attachments/assets/3c5a004d-e46a-4d5d-a0ba-be91883d251a)


The later one should be v(i,J-1) and \f$v_{i,j-\frac{1}{2}}\f$

As suggested by @marshallward , Submit PR here instead of the repo `mom-ocean`