### PR TITLE
Chksum diag timestamp

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -503,14 +503,10 @@ $(foreach c,$(CONFIGS),$(eval $(call CONFIG_DIM_RULE,$(c))))
 # Regression testing only checks for changes in existing diagnostics
 .PRECIOUS: $(WORK)/%/target/chksum_diag
 %.regression.diag: $(foreach b,symmetric target,$(WORK)/%/$(b)/chksum_diag)
-	@! diff $^ | grep "^[<>]" | grep "^>" > /dev/null \
-	  || ! (\
-	    mkdir -p $(WORK)/results/$*; \
-	    (diff $^ | tee $(WORK)/results/$*/chksum_diag.regression.diff | head -n 20) ; \
+	@tools/diff_diag.sh $^ || ! (\
 	    echo -e "$(FAIL): Diagnostics $*.regression.diag have changed." \
 	  )
-	@cmp $^ || ( \
-	  diff $^ | head -n 20; \
+	@tools/cmp_diag.sh $^ || ( \
 	  echo -e "$(WARN): New diagnostics in $<" \
 	)
 	@echo -e "$(PASS): Diagnostics $*.regression.diag agree."

--- a/.testing/tools/cmp_diag.sh
+++ b/.testing/tools/cmp_diag.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for chk in $1 $2; do
+    awk '{print $(NF-2) " " $(NF-1) " " $(NF),$0}' ${chk} | sort > ${chk}.sorted
+done
+
+cmp $1.sorted $2.sorted
+
+if [ $? -eq 1 ]; then
+    diff $1.sorted $2.sorted | head -n 100
+    exit 1
+fi

--- a/.testing/tools/diff_diag.sh
+++ b/.testing/tools/diff_diag.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for chk in $1 $2; do
+    awk '{print $(NF-2) " " $(NF-1) " " $(NF),$0}' ${chk} | sort > ${chk}.sorted
+done
+
+diff $1.sorted $2.sorted | grep "^[<>]" | grep "^>" > /dev/null
+
+if [ $? -eq 0 ]; then
+    diff $1.sorted $2.sorted | head -n 100
+    exit 1
+fi


### PR DESCRIPTION
This PR has two commits:

* A timestamp is appended to the checksum output of chksum_diag, to facilitate sorting.
* CI testing sorts this output in order to eliminate false-negative diagnostic regressions.

Since it changes the `chksum_diag` files, there will be a regression.  But it should not propagate to future runs.  It may, however, propagate to other forks, such as MOM-ocean.