### PR TITLE
Replace checksum scale arguments with unscale

### DIFF
--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -659,7 +659,7 @@ subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=unscale)
+    call uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -691,7 +691,7 @@ subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=unscale)
+    call uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -723,8 +723,8 @@ subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, scale=unscale)
-    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, scale=unscale)
+    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, unscale=unscale)
+    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -758,8 +758,8 @@ subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric, un
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, symmetric=symmetric, scale=unscale)
-    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, symmetric=symmetric, scale=unscale)
+    call Bchksum(u_comp, mesg//"(u)", G%HI, halos, symmetric=symmetric, unscale=unscale)
+    call Bchksum(v_comp, mesg//"(v)", G%HI, halos, symmetric=symmetric, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -791,8 +791,8 @@ subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call hchksum(u_comp, mesg//"(u)", G%HI, halos, scale=unscale)
-    call hchksum(v_comp, mesg//"(v)", G%HI, halos, scale=unscale)
+    call hchksum(u_comp, mesg//"(u)", G%HI, halos, unscale=unscale)
+    call hchksum(v_comp, mesg//"(v)", G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -824,8 +824,8 @@ subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call hchksum(u_comp, mesg//"(u)", G%HI, halos, scale=unscale)
-    call hchksum(v_comp, mesg//"(v)", G%HI, halos, scale=unscale)
+    call hchksum(u_comp, mesg//"(u)", G%HI, halos, unscale=unscale)
+    call hchksum(v_comp, mesg//"(v)", G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -1502,7 +1502,7 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
     do m=1,CS%ntr
       call hchksum(CS%STF(:,:,m), &
           trim(MARBL_instances%tracer_metadata(m)%short_name)//" sfc_flux", G%HI, &
-          scale=US%Z_to_m*US%s_to_T)
+          unscale=US%Z_to_m*US%s_to_T)
     enddo
   endif
 
@@ -1545,7 +1545,7 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
       enddo ; enddo
       if (CS%debug) &
         call hchksum(riv_flux_loc(:,:), &
-            trim(MARBL_instances%tracer_metadata(m)%short_name)//' riv flux', G%HI, scale=GV%H_to_m)
+            trim(MARBL_instances%tracer_metadata(m)%short_name)//' riv flux', G%HI, unscale=GV%H_to_m)
       call applyTracerBoundaryFluxesInOut(G, GV, CS%tracer_data(m)%tr(:,:,:) , dt, fluxes, h_work, &
           evap_CFL_limit, minimum_forcing_depth, in_flux_optional=riv_flux_loc)
       call tracer_vertdiff(h_work, ea, eb, dt, CS%tracer_data(m)%tr(:,:,:), G, GV, &

--- a/src/tracer/MOM_hor_bnd_diffusion.F90
+++ b/src/tracer/MOM_hor_bnd_diffusion.F90
@@ -234,7 +234,7 @@ subroutine hor_bnd_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, visc, CS)
     tracer => Reg%tr(m)
 
     if (CS%debug) then
-      call hchksum(tracer%t, "before HBD "//tracer%name, G%HI, scale=tracer%conc_scale)
+      call hchksum(tracer%t, "before HBD "//tracer%name, G%HI, unscale=tracer%conc_scale)
     endif
 
     ! for diagnostics
@@ -290,7 +290,7 @@ subroutine hor_bnd_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, visc, CS)
     endif
 
     if (CS%debug) then
-      call hchksum(tracer%t, "after HBD "//tracer%name, G%HI, scale=tracer%conc_scale)
+      call hchksum(tracer%t, "after HBD "//tracer%name, G%HI, unscale=tracer%conc_scale)
       ! tracer (native grid) integrated tracer amounts before and after HBD
       tracer_int_prev = global_mass_integral(h, G, GV, tracer_old, scale=tracer%conc_scale)
       tracer_int_end = global_mass_integral(h, G, GV, tracer%t, scale=tracer%conc_scale)


### PR DESCRIPTION
  Replaced 14 `scale` arguments in recently added `checksum()` calls with the preferred `unscale` argument, following the pattern used elsewhere throughout the MOM6 code.  These two arguments are functionally equivalent, but `unscale` makes it easier to identify implausible combinations of scaling factors.  All answers are bitwise identical.