### PR TITLE
Correct variable units in comments in 4 modules

### DIFF
--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1183,7 +1183,7 @@ subroutine find_ustar_fluxes(fluxes, tv, U_star, G, GV, US, halo, H_T_units)
   ! Local variables
   real :: I_rho        ! The inverse of the reference density [R-1 ~> m3 kg-1]
                        ! or in some semi-Boussinesq cases the reference
-                       ! density [H2 R-1 ~> m3 kg-1 or kg m-3]
+                       ! density [H2 Z-2 R-1 ~> m3 kg-1 or kg m-3]
   logical :: Z_T_units ! If true, U_star is returned in units of [Z T-1 ~> m s-1], otherwise it is
                        ! returned in [H T-1 ~> m s-1 or kg m-2 s-1]
   integer :: i, j, k, is, ie, js, je, hs
@@ -1248,7 +1248,7 @@ subroutine find_ustar_mech_forcing(forces, tv, U_star, G, GV, US, halo, H_T_unit
 
   ! Local variables
   real :: I_rho        ! The inverse of the reference density [R-1 ~> m3 kg-1] or in some semi-Boussinesq cases
-                       ! the rescaled reference density [H2 R-1 ~> m3 kg-1 or kg m-3]
+                       ! the rescaled reference density [H2 Z-2 R-1 ~> m3 kg-1 or kg m-3]
   logical :: Z_T_units ! If true, U_star is returned in units of [Z T-1 ~> m s-1], otherwise it is
                        ! returned in [H T-1 ~> m s-1 or kg m-2 s-1]
   integer :: i, j, k, is, ie, js, je, hs

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -75,8 +75,8 @@ type, public :: ocean_grid_type
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
     mask2dT, &   !< 0 for land points and 1 for ocean points on the h-grid [nondim].
-    geoLatT, &   !< The geographic latitude at q points [degrees_N] or [km] or [m].
-    geoLonT, &   !< The geographic longitude at q points [degrees_E] or [km] or [m].
+    geoLatT, &   !< The geographic latitude at tracer (h) points [degrees_N] or [km] or [m]
+    geoLonT, &   !< The geographic longitude at tracer (h) points [degrees_E] or [km] or [m]
     dxT, &       !< dxT is delta x at h points [L ~> m].
     IdxT, &      !< 1/dxT [L-1 ~> m-1].
     dyT, &       !< dyT is delta y at h points [L ~> m].

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -72,7 +72,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   real :: min_depth                 ! The minimum depth of the ocean [Z ~> m]
   real :: dummy1                    ! The position relative to the sponge width [nondim]
   real :: min_thickness             ! A minimum layer thickness [H ~> m or kg m-2] (unused)
-  real :: lensponge                 ! The width of the sponge [km]
+  real :: lensponge                 ! The width of the sponge in axis units, [km] or [m]
   character(len=40) :: filename, state_file
   character(len=40) :: temp_var, salt_var, eta_var, inputdir, h_var
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -115,7 +115,6 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
   real :: S_range         ! The range of salinities in this test case [S ~> ppt]
   real :: S_light, S_dense ! The lightest and densest salinities in the sponges [S ~> ppt].
   real :: eta_IC_quanta   ! The granularity of quantization of initial interface heights [Z-1 ~> m-1].
-  real :: x               ! Along-channel position in the axis units [m] or [km] or [deg]
   logical :: dbrotate     ! If true, rotate the domain.
   logical :: use_ALE      ! True if ALE is being used, False if in layered mode
 
@@ -156,16 +155,10 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
                  default=.false., do_not_log=just_read)
     do j=js,je
       do i=is,ie
-        ! Compute normalized zonal coordinates (x,y=0 at center of domain)
-        if (dbrotate) then
-          ! This is really y in the rotated case
-          x = G%geoLatT(i,j)
-        else
-          x = G%geoLonT(i,j)
-        endif
+        ! Work relative to the center of the domain, where geoLonT and geoLatT are both 0.
         eta1D(1) = 0.0
         eta1D(nz+1) = -depth_tot(i,j)
-        if (x<0.0) then
+        if (((.not.dbrotate) .and. (G%geoLonT(i,j)<0.0)) .or. (dbrotate .and. (G%geoLatT(i,j)<0.0))) then
           do k=nz,2, -1
             eta1D(k) =  eta1D(k+1) + min_thickness
           enddo


### PR DESCRIPTION
  Corrected the descriptions of the units of two `I_rho` variables in `find_ustar_fluxes()` and `find_ustar_mech_forcing()` and of the `lensponge` internal variable in `RGC_initialize_sponges()`.  Also corrected the comments describing the locations of `grid%geolatT` and `grid%geolonT`.  Also refactored `dumbbell_initialize_thickness()` to use `geoLonT` or `geoLatT` directly rather than setting a temporary variable with ill-defined units that is only used once. Only changes in comments or very simple code logic changes are included in this commit, and all answers are bitwise identical.