### PR TITLE
+(*)Debug and correct errors with OBCs and grid rotation

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -115,7 +115,7 @@ use MOM_open_boundary,         only : ocean_OBC_type, OBC_registry_type
 use MOM_open_boundary,         only : register_temp_salt_segments, update_segment_tracer_reservoirs
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
 use MOM_open_boundary,         only : open_boundary_setup_vert, update_OBC_segment_data
-use MOM_open_boundary,         only : rotate_OBC_config, rotate_OBC_init
+use MOM_open_boundary,         only : rotate_OBC_config, rotate_OBC_init, write_OBC_info, chksum_OBC_segments
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML, set_visc_CS
@@ -286,6 +286,7 @@ type, public :: MOM_control_struct ; private
   logical :: count_calls = .false.   !< If true, count the calls to step_MOM, rather than the
                                      !! number of dynamics steps in nstep_tot
   logical :: debug                   !< If true, write verbose checksums for debugging purposes.
+  logical :: debug_OBCs              !< If true, write verbose OBC values for debugging purposes.
   integer :: ntrunc                  !< number u,v truncations since last call to write_energy
 
   integer :: cont_stencil            !< The stencil for thickness from the continuity solver.
@@ -1283,6 +1284,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
       endif
     endif
   endif
+  if (CS%debug_OBCs .and. associated(CS%OBC)) call chksum_OBC_segments(CS%OBC, G, GV, US, 3)
 
   if (CS%do_dynamics .and. CS%split) then !--------------------------- start SPLIT
     ! This section uses a split time stepping scheme for the dynamic equations,
@@ -2500,6 +2502,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call get_param(param_file, "MOM", "DEBUG_TRUNCATIONS", debug_truncations, &
                  "If true, calculate all diagnostics that are useful for "//&
                  "debugging truncations.", default=.false., debuggingParam=.true.)
+  call get_param(param_file, "MOM", "DEBUG_OBCS", CS%debug_OBCs, &
+                 "If true, write out verbose debugging data about OBCs.", &
+                 default=.false., debuggingParam=.true.)
 
   call get_param(param_file, "MOM", "DT", CS%dt, &
                  "The (baroclinic) dynamics time step.  The time-step that "//&
@@ -2882,9 +2887,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     call copy_dyngrid_to_MOM_grid(dG, G, US)
 
     if (associated(OBC_in)) then
-      ! TODO: General OBC index rotations is not yet supported.
-      if (modulo(turns, 4) /= 1) &
-        call MOM_error(FATAL, "OBC index rotation of 180 and 270 degrees is not yet supported.")
       allocate(CS%OBC)
       call rotate_OBC_config(OBC_in, dG_in, CS%OBC, dG, turns)
     endif
@@ -3080,8 +3082,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   if (associated(CS%OBC)) then
     ! Set up remaining information about open boundary conditions that is needed for OBCs.
+    ! Package specific changes to OBCs occur here.
     call call_OBC_register(G, GV, US, param_file, CS%update_OBC_CSp, CS%OBC, CS%tracer_Reg)
-  !### Package specific changes to OBCs need to go here?
 
     ! This is the equivalent to 2 calls to register_segment_tracer (per segment), which
     ! could occur with the call to update_OBC_data or after the main initialization.
@@ -3094,27 +3096,34 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     ! reservoirs are used.
     call open_boundary_register_restarts(HI, GV, US, CS%OBC, CS%tracer_Reg, &
                           param_file, restart_CSp, use_temperature)
-    if (turns /= 0) then
-      if (CS%OBC%radiation_BCs_exist_globally) then
-        OBC_in%rx_normal => CS%OBC%rx_normal
-        OBC_in%ry_normal => CS%OBC%ry_normal
-      endif
-      if (CS%OBC%oblique_BCs_exist_globally) then
-        OBC_in%rx_oblique_u => CS%OBC%rx_oblique_u
-        OBC_in%ry_oblique_u => CS%OBC%ry_oblique_u
-        OBC_in%rx_oblique_v => CS%OBC%rx_oblique_v
-        OBC_in%ry_oblique_v => CS%OBC%ry_oblique_v
-        OBC_in%cff_normal_u => CS%OBC%cff_normal_u
-        OBC_in%cff_normal_v => CS%OBC%cff_normal_v
-      endif
-      if (any(CS%OBC%tracer_x_reservoirs_used)) then
-        OBC_in%tres_x => CS%OBC%tres_x
-      endif
-      if (any(CS%OBC%tracer_y_reservoirs_used)) then
-        OBC_in%tres_y => CS%OBC%tres_y
-      endif
+    ! Is block of code this necessary at all?
+    if (CS%rotate_index .and. associated(OBC_in)) then
+      ! if (mod(turns,2) == 0) then
+        if (CS%OBC%radiation_BCs_exist_globally) then
+          OBC_in%rx_normal => CS%OBC%rx_normal
+          OBC_in%ry_normal => CS%OBC%ry_normal
+        endif
+        if (CS%OBC%oblique_BCs_exist_globally) then
+          OBC_in%rx_oblique_u => CS%OBC%rx_oblique_u
+          OBC_in%ry_oblique_u => CS%OBC%ry_oblique_u
+          OBC_in%rx_oblique_v => CS%OBC%rx_oblique_v
+          OBC_in%ry_oblique_v => CS%OBC%ry_oblique_v
+          OBC_in%cff_normal_u => CS%OBC%cff_normal_u
+          OBC_in%cff_normal_v => CS%OBC%cff_normal_v
+        endif
+        if (any(CS%OBC%tracer_x_reservoirs_used)) then
+          OBC_in%tres_x => CS%OBC%tres_x
+        endif
+        if (any(CS%OBC%tracer_y_reservoirs_used)) then
+          OBC_in%tres_y => CS%OBC%tres_y
+        endif
+      ! else
+        ! Do we need to swap around the u- and v-components?
+      ! endif
     endif
   endif
+
+  if (CS%debug_OBCs .and. associated(CS%OBC)) call write_OBC_info(CS%OBC, G, GV, US)
 
   if (present(waves_CSp)) then
     call waves_register_restarts(waves_CSp, HI, GV, US, param_file, restart_CSp)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -181,7 +181,8 @@ type, public :: MOM_dyn_split_RK2_CS ; private
                      !! Euler (1) [nondim].  0 is often used.
   real    :: Cemp_NL   !< Empirical coefficient of non-local momentum mixing [nondim]
   logical :: debug     !< If true, write verbose checksums for debugging purposes.
-  logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
+  logical :: debug_OBC !< If true, do additional calls resetting values to help debug the correctness
+                       !! of the open boundary condition code.
   logical :: fpmix     !< If true, add non-local momentum flux increments and diffuse down the Eulerian gradient.
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
   logical :: visc_rem_dt_bug = .true. !< If true, recover a bug that uses dt_pred rather than dt for vertvisc_rem
@@ -1473,7 +1474,10 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
+  call get_param(param_file, mdl, "OBC_DEBUGGING_TESTS", CS%debug_OBC, &
+                 "If true, do additional calls resetting certain values to help verify the "//&
+                 "correctness of the open boundary condition code.", &
+                 default=.false., old_name="DEBUG_OBC", debuggingParam=.true., do_not_log=.true.)
   call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
   call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, &

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -171,7 +171,8 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
                      !! is forward-backward (0) or simulated backward
                      !! Euler (1) [nondim].  0 is often used.
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
-  logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
+  logical :: debug_OBC !< If true, do additional calls resetting values to help verify the correctness
+                       !! of the open boundary condition code.
   logical :: fpmix = .false.                 !< If true, applies profiles of momentum flux magnitude and direction.
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
   logical :: visc_rem_dt_bug = .true. !< If true, recover a bug that uses dt_pred rather than dt for vertvisc_rem
@@ -1359,7 +1360,10 @@ subroutine initialize_dyn_split_RK2b(u, v, h, tv, uh, vh, eta, Time, G, GV, US, 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
+  call get_param(param_file, mdl, "OBC_DEBUGGING_TESTS", CS%debug_OBC, &
+                 "If true, do additional calls resetting certain values to help verify the "//&
+                 "correctness of the open boundary condition code.", &
+                 default=.false., old_name="DEBUG_OBC", debuggingParam=.true., do_not_log=.true.)
   call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
   call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -447,13 +447,15 @@ subroutine open_boundary_config(G, US, param_file, OBC)
 
   ! Local variables
   integer :: l ! For looping over segments
-  logical :: debug, debug_OBC, mask_outside, reentrant_x, reentrant_y
+  logical :: debug, mask_outside, reentrant_x, reentrant_y
   character(len=15) :: segment_param_str ! The run-time parameter name for each segment
   character(len=1024) :: segment_str      ! The contents (rhs) for parameter "segment_param_str"
   character(len=200) :: config1          ! String for OBC_USER_CONFIG
   real               :: Lscale_in, Lscale_out ! parameters controlling tracer values at the boundaries [L ~> m]
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: check_remapping, force_bounds_in_subcell
+  logical :: debugging_tests ! If true, do additional calls resetting values to help debug the performance
+                             ! of the open boundary condition code.
   logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -550,21 +552,25 @@ subroutine open_boundary_config(G, US, param_file, OBC)
     endif
 
     call get_param(param_file, mdl, "DEBUG", debug, default=.false.)
-    ! This extra get_param call is to enable logging if either DEBUG or DEBUG_OBC are true.
-    call get_param(param_file, mdl, "DEBUG_OBC", debug_OBC, default=debug)
-    call get_param(param_file, mdl, "DEBUG_OBC", OBC%debug, &
+    call get_param(param_file, mdl, "DEBUG_OBCS", OBC%debug, &
                  "If true, do additional calls to help debug the performance "//&
                  "of the open boundary condition code.", &
-                 default=debug, do_not_log=.not.(debug_OBC.or.debug), debuggingParam=.true.)
+                 default=.false., debuggingParam=.true.)
+    if (OBC%debug .and. (num_PEs() > 1)) &
+      call MOM_error(FATAL, "DEBUG_OBCS = True is currently only supported for single PE runs.")
+    call get_param(param_file, mdl, "OBC_DEBUGGING_TESTS", debugging_tests, &
+                 "If true, do additional calls resetting certain values to help verify the correctness "//&
+                 "of the open boundary condition code.", &
+                 default=.false., old_name="DEBUG_OBC", debuggingParam=.true.)
 
     call get_param(param_file, mdl, "OBC_SILLY_THICK", OBC%silly_h, &
                  "A silly value of thicknesses used outside of open boundary "//&
                  "conditions for debugging.", units="m", default=0.0, scale=US%m_to_Z, &
-                 do_not_log=.not.OBC%debug, debuggingParam=.true.)
+                 do_not_log=.not.debugging_tests, debuggingParam=.true.)
     call get_param(param_file, mdl, "OBC_SILLY_VEL", OBC%silly_u, &
                  "A silly value of velocities used outside of open boundary "//&
                  "conditions for debugging.", units="m/s", default=0.0, scale=US%m_s_to_L_T, &
-                 do_not_log=.not.OBC%debug, debuggingParam=.true.)
+                 do_not_log=.not.debugging_tests, debuggingParam=.true.)
     call get_param(param_file, mdl, "EXTERIOR_OBC_BUG", OBC%exterior_OBC_bug, &
                  "If true, recover a bug in barotropic solver and other routines when "//&
                  "boundary contitions interior to the domain are used.", &
@@ -6252,6 +6258,11 @@ subroutine rotate_OBC_segment_data(segment_in, segment, turns)
 
   num_fields = segment_in%num_fields
   allocate(segment%field(num_fields))
+
+  isd = segment%HI%isd ; ied = segment%HI%ied
+  jsd = segment%HI%jsd ; jed = segment%HI%jed
+  IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
+  JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
 
   if ((turns == 0) .or. (turns == 2)) then
     segment%uamp_index = segment_in%uamp_index

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -6,7 +6,7 @@ module MOM_open_boundary
 use MOM_array_transform,      only : rotate_array, rotate_array_pair
 use MOM_coms,                 only : sum_across_PEs, Set_PElist, Get_PElist, PE_here, num_PEs
 use MOM_cpu_clock,            only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
-use MOM_debugging,            only : hchksum, uvchksum
+use MOM_debugging,            only : hchksum, uvchksum, chksum
 use MOM_diag_mediator,        only : diag_ctrl, time_type
 use MOM_domains,              only : pass_var, pass_vector
 use MOM_domains,              only : create_group_pass, do_group_pass, group_pass_type
@@ -18,7 +18,7 @@ use MOM_grid,                 only : ocean_grid_type, hor_index_type
 use MOM_interface_heights,    only : thickness_to_dz
 use MOM_interpolate,          only : init_external_field, time_interp_external, time_interp_external_init
 use MOM_interpolate,          only : external_field
-use MOM_io,                   only : slasher, field_size, file_exists, SINGLE_FILE
+use MOM_io,                   only : slasher, field_size, file_exists, stderr, SINGLE_FILE
 use MOM_io,                   only : vardesc, query_vardesc, var_desc
 use MOM_obsolete_params,      only : obsolete_logical, obsolete_int, obsolete_real, obsolete_char
 use MOM_regridding,           only : regridding_CS
@@ -73,7 +73,7 @@ public remap_OBC_fields
 public rotate_OBC_config
 public rotate_OBC_init
 public rotate_OBC_segment_direction
-public write_OBC_info
+public write_OBC_info, chksum_OBC_segments
 public initialize_segment_data
 public flood_fill
 public flood_fill2
@@ -3386,15 +3386,15 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
     sym = G%Domain%symmetric
     if (OBC%radiation_BCs_exist_globally) then
       call uvchksum("radiation_OBCs: OBC%r[xy]_normal", OBC%rx_normal, OBC%ry_normal, G%HI, &
-                  haloshift=0, symmetric=sym, unscale=1.0)
+                  haloshift=0, symmetric=sym, scalar_pair=.true., unscale=1.0)
     endif
     if (OBC%oblique_BCs_exist_globally) then
       call uvchksum("radiation_OBCs: OBC%r[xy]_oblique_[uv]", OBC%rx_oblique_u, OBC%ry_oblique_v, G%HI, &
-                  haloshift=0, symmetric=sym, unscale=1.0/US%L_T_to_m_s**2)
+                  haloshift=0, symmetric=sym, scalar_pair=.true., unscale=1.0/US%L_T_to_m_s**2)
       call uvchksum("radiation_OBCs: OBC%r[yx]_oblique_[uv]", OBC%ry_oblique_u, OBC%rx_oblique_v, G%HI, &
-                  haloshift=0, symmetric=sym, unscale=1.0/US%L_T_to_m_s**2)
+                  haloshift=0, symmetric=sym, scalar_pair=.true., unscale=1.0/US%L_T_to_m_s**2)
       call uvchksum("radiation_OBCs: OBC%cff_normal_[uv]", OBC%cff_normal_u, OBC%cff_normal_v, G%HI, &
-                  haloshift=0, symmetric=sym, unscale=1.0/US%L_T_to_m_s**2)
+                  haloshift=0, symmetric=sym, scalar_pair=.true., unscale=1.0/US%L_T_to_m_s**2)
     endif
     if (OBC%ntr == 0) return
     if (.not. associated (OBC%tres_x) .or. .not. associated (OBC%tres_y)) return
@@ -6486,31 +6486,46 @@ subroutine allocate_rotated_seg_data(src_array, HI_in, tgt_array, segment)
 end subroutine allocate_rotated_seg_data
 
 
-!> Write out information about the contents of the OBCs.
+!> Write out information about the contents of the OBC control structure
 subroutine write_OBC_info(OBC, G, GV, US)
-  type(ocean_OBC_type),    pointer    :: OBC   !< OBC on input map
+  type(ocean_OBC_type),    pointer    :: OBC   !< An open boundary condition control structure
   type(ocean_grid_type),   intent(in) :: G     !< Rotated grid metric
   type(verticalGrid_type), intent(in) :: GV    !< Vertical grid
   type(unit_scale_type),   intent(in) :: US    !< Unit scaling
 
   ! Local variables
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
-  integer :: c, n
+  integer :: turns    ! Number of index quarter turns
+  integer :: c, n, dir, unrot_dir
   character(len=1024) :: mesg
+
+  turns = modulo(G%HI%turns, 4)
 
   write(mesg, '("OBC has ", I3, " segments.")') OBC%number_of_segments
   call MOM_mesg(mesg, verb=1)
   !  call MOM_error(WARNING, mesg)
 
-  if (OBC%open_u_BCs_exist_globally) call MOM_mesg("open_u_BCs_exist_globally", verb=1)
-  if (OBC%open_v_BCs_exist_globally) call MOM_mesg("open_v_BCs_exist_globally", verb=1)
-  if (OBC%Flather_u_BCs_exist_globally) call MOM_mesg("Flather_u_BCs_exist_globally", verb=1)
-  if (OBC%Flather_v_BCs_exist_globally) call MOM_mesg("Flather_v_BCs_exist_globally", verb=1)
+  if (modulo(turns, 2) == 0) then
+    if (OBC%open_u_BCs_exist_globally) call MOM_mesg("open_u_BCs_exist_globally", verb=1)
+    if (OBC%open_v_BCs_exist_globally) call MOM_mesg("open_v_BCs_exist_globally", verb=1)
+    if (OBC%Flather_u_BCs_exist_globally) call MOM_mesg("Flather_u_BCs_exist_globally", verb=1)
+    if (OBC%Flather_v_BCs_exist_globally) call MOM_mesg("Flather_v_BCs_exist_globally", verb=1)
+    if (OBC%nudged_u_BCs_exist_globally) call MOM_mesg("nudged_u_BCs_exist_globally", verb=1)
+    if (OBC%nudged_v_BCs_exist_globally) call MOM_mesg("nudged_v_BCs_exist_globally", verb=1)
+    if (OBC%specified_u_BCs_exist_globally) call MOM_mesg("specified_u_BCs_exist_globally", verb=1)
+    if (OBC%specified_v_BCs_exist_globally) call MOM_mesg("specified_v_BCs_exist_globally", verb=1)
+  else  ! The u- and v-directions are swapped.
+    if (OBC%open_v_BCs_exist_globally) call MOM_mesg("open_u_BCs_exist_globally", verb=1)
+    if (OBC%open_u_BCs_exist_globally) call MOM_mesg("open_v_BCs_exist_globally", verb=1)
+    if (OBC%Flather_v_BCs_exist_globally) call MOM_mesg("Flather_u_BCs_exist_globally", verb=1)
+    if (OBC%Flather_u_BCs_exist_globally) call MOM_mesg("Flather_v_BCs_exist_globally", verb=1)
+    if (OBC%nudged_v_BCs_exist_globally) call MOM_mesg("nudged_u_BCs_exist_globally", verb=1)
+    if (OBC%nudged_u_BCs_exist_globally) call MOM_mesg("nudged_v_BCs_exist_globally", verb=1)
+    if (OBC%specified_v_BCs_exist_globally) call MOM_mesg("specified_u_BCs_exist_globally", verb=1)
+    if (OBC%specified_u_BCs_exist_globally) call MOM_mesg("specified_v_BCs_exist_globally", verb=1)
+  endif
+
   if (OBC%oblique_BCs_exist_globally) call MOM_mesg("oblique_BCs_exist_globally", verb=1)
-  if (OBC%nudged_u_BCs_exist_globally) call MOM_mesg("nudged_u_BCs_exist_globally", verb=1)
-  if (OBC%nudged_v_BCs_exist_globally) call MOM_mesg("nudged_v_BCs_exist_globally", verb=1)
-  if (OBC%specified_u_BCs_exist_globally) call MOM_mesg("specified_u_BCs_exist_globally", verb=1)
-  if (OBC%specified_v_BCs_exist_globally) call MOM_mesg("specified_v_BCs_exist_globally", verb=1)
   if (OBC%radiation_BCs_exist_globally) call MOM_mesg("radiation_BCs_exist_globally", verb=1)
   if (OBC%user_BCs_set_globally) call MOM_mesg("user_BCs_set_globally", verb=1)
   if (OBC%update_OBC) call MOM_mesg("update_OBC", verb=1)
@@ -6557,14 +6572,22 @@ subroutine write_OBC_info(OBC, G, GV, US)
 
   do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
-    write(mesg, '(" Segment ", I3, " has direction ", I3)') n, segment%direction
-    if (segment%direction == OBC_DIRECTION_N)  write(mesg, '(" Segment ", I3, " is Northern")') n
-    if (segment%direction == OBC_DIRECTION_S)  write(mesg, '(" Segment ", I3, " is Southern")') n
-    if (segment%direction == OBC_DIRECTION_E)  write(mesg, '(" Segment ", I3, " is Eastern")') n
-    if (segment%direction == OBC_DIRECTION_W)  write(mesg, '(" Segment ", I3, " is Western")') n
+    dir = segment%direction
+
+    unrot_dir = rotate_OBC_segment_direction(dir, -turns)
+    write(mesg, '(" Segment ", I3, " has direction ", I3)') n, unrot_dir
+    if (unrot_dir == OBC_DIRECTION_N)  write(mesg, '(" Segment ", I3, " is Northern")') n
+    if (unrot_dir == OBC_DIRECTION_S)  write(mesg, '(" Segment ", I3, " is Southern")') n
+    if (unrot_dir == OBC_DIRECTION_E)  write(mesg, '(" Segment ", I3, " is Eastern")') n
+    if (unrot_dir == OBC_DIRECTION_W)  write(mesg, '(" Segment ", I3, " is Western")') n
     call MOM_mesg(mesg, verb=1)
 
-    write(mesg, '("  range: ", 4I3)') segment%Is_obc, segment%Ie_obc, segment%Js_obc, segment%Je_obc
+    ! write(mesg, '("  range: ", 4I3)') segment%Is_obc, segment%Ie_obc, segment%Js_obc, segment%Je_obc
+    if (modulo(turns, 2) == 0) then
+      write(mesg, '("  size: ", 4I3)') 1+abs(segment%Ie_obc-segment%Is_obc), 1+abs(segment%Je_obc-segment%Js_obc)
+    else
+      write(mesg, '("  size: ", 4I3)') 1+abs(segment%Je_obc-segment%Js_obc), 1+abs(segment%Ie_obc-segment%Is_obc)
+    endif
     call MOM_mesg(mesg, verb=1)
 
     if (segment%on_pe)          call MOM_mesg("  Segment is on PE.", verb=1)
@@ -6585,57 +6608,34 @@ subroutine write_OBC_info(OBC, G, GV, US)
     if (segment%open)           call MOM_mesg("  open", verb=1)
     if (segment%gradient)       call MOM_mesg("  gradient", verb=1)
     if (segment%values_needed)  call MOM_mesg("  values_needed", verb=1)
-    if (segment%u_values_needed) call MOM_mesg("  u_values_needed", verb=1)
-    if (segment%uamp_values_needed) call MOM_mesg("  uamp_values_needed", verb=1)
-    if (segment%uphase_values_needed) call MOM_mesg("  uphase_values_needed", verb=1)
-    if (segment%v_values_needed) call MOM_mesg("  v_values_needed", verb=1)
-    if (segment%vamp_values_needed) call MOM_mesg("  vamp_values_needed", verb=1)
-    if (segment%vphase_values_needed) call MOM_mesg("  vphase_values_needed", verb=1)
+    if (modulo(turns, 2) == 0) then
+      if (segment%is_N_or_S)      call MOM_mesg("  is_N_or_S", verb=1)
+      if (segment%is_E_or_W)      call MOM_mesg("  is_E_or_W", verb=1)
+      if (segment%u_values_needed) call MOM_mesg("  u_values_needed", verb=1)
+      if (segment%uamp_values_needed) call MOM_mesg("  uamp_values_needed", verb=1)
+      if (segment%uphase_values_needed) call MOM_mesg("  uphase_values_needed", verb=1)
+      if (segment%v_values_needed) call MOM_mesg("  v_values_needed", verb=1)
+      if (segment%vamp_values_needed) call MOM_mesg("  vamp_values_needed", verb=1)
+      if (segment%vphase_values_needed) call MOM_mesg("  vphase_values_needed", verb=1)
+    else  ! The x- and y-directions are swapped.
+      if (segment%is_E_or_W)      call MOM_mesg("  is_N_or_S", verb=1)
+      if (segment%is_N_or_S)      call MOM_mesg("  is_E_or_W", verb=1)
+      if (segment%v_values_needed) call MOM_mesg("  u_values_needed", verb=1)
+      if (segment%vamp_values_needed) call MOM_mesg("  uamp_values_needed", verb=1)
+      if (segment%vphase_values_needed) call MOM_mesg("  uphase_values_needed", verb=1)
+      if (segment%u_values_needed) call MOM_mesg("  v_values_needed", verb=1)
+      if (segment%uamp_values_needed) call MOM_mesg("  vamp_values_needed", verb=1)
+      if (segment%uphase_values_needed) call MOM_mesg("  vphase_values_needed", verb=1)
+    endif
     if (segment%t_values_needed) call MOM_mesg("  t_values_needed", verb=1)
     if (segment%s_values_needed) call MOM_mesg("  s_values_needed", verb=1)
     if (segment%z_values_needed) call MOM_mesg("  z_values_needed", verb=1)
     if (segment%zamp_values_needed) call MOM_mesg("  zamp_values_needed", verb=1)
     if (segment%zphase_values_needed) call MOM_mesg("  zphase_values_needed", verb=1)
     if (segment%g_values_needed) call MOM_mesg("  g_values_needed", verb=1)
-    if (segment%is_N_or_S)      call MOM_mesg("  is_N_or_S", verb=1)
-    if (segment%is_E_or_W)      call MOM_mesg("  is_E_or_W", verb=1)
-    if (segment%is_E_or_W_2)    call MOM_mesg("  is_E_or_W_2", verb=1)
+!    if (segment%is_E_or_W_2)    call MOM_mesg("  is_E_or_W_2", verb=1)
     if (segment%temp_segment_data_exists) call MOM_mesg("  temp_segment_data_exists", verb=1)
     if (segment%salt_segment_data_exists) call MOM_mesg("  salt_segment_data_exists", verb=1)
-
-    if (allocated(segment%Cg)) call write_2d_array_vals("Cg", segment%Cg, unscale=US%L_T_to_m_s)
-    if (allocated(segment%Htot)) call write_2d_array_vals("Htot", segment%Htot, unscale=GV%H_to_mks)
-    if (allocated(segment%dZtot)) call write_2d_array_vals("dZtot", segment%dZtot, unscale=US%Z_to_m)
-    if (allocated(segment%SSH)) call write_2d_array_vals("SSH", segment%SSH, unscale=US%Z_to_m)
-    if (allocated(segment%h)) call write_3d_array_vals("h", segment%h, unscale=GV%H_to_mks)
-    if (allocated(segment%normal_vel)) call write_3d_array_vals("normal_vel", segment%normal_vel, unscale=US%L_T_to_m_s)
-    if (allocated(segment%normal_vel_bt)) &
-      call write_2d_array_vals("normal_vel_bt", segment%normal_vel_bt, unscale=US%L_T_to_m_s)
-    if (allocated(segment%tangential_vel)) &
-      call write_3d_array_vals("tangential_vel", segment%tangential_vel, unscale=US%L_T_to_m_s)
-    if (allocated(segment%tangential_grad)) &
-      call write_3d_array_vals("tangential_grad", segment%tangential_grad, unscale=US%s_to_T)
-    if (allocated(segment%normal_trans)) call write_3d_array_vals("normal_trans", segment%normal_trans)
-    if (allocated(segment%grad_normal)) &
-      call write_3d_array_vals("grad_normal", segment%grad_normal, unscale=US%L_T_to_m_s)
-    if (allocated(segment%grad_tan)) call write_3d_array_vals("grad_tan", segment%grad_tan, unscale=US%L_T_to_m_s)
-    if (allocated(segment%grad_gradient)) &
-      call write_3d_array_vals("grad_gradient", segment%grad_gradient, unscale=US%s_to_T)
-
-    if (allocated(segment%rx_norm_rad)) call write_3d_array_vals("rx_norm_rad", segment%rx_norm_rad, unscale=1.0)
-    if (allocated(segment%ry_norm_rad)) call write_3d_array_vals("ry_norm_rad", segment%ry_norm_rad, unscale=1.0)
-    if (allocated(segment%rx_norm_obl)) &
-      call write_3d_array_vals("rx_norm_obl", segment%grad_gradient, unscale=US%L_T_to_m_s**2)
-    if (allocated(segment%ry_norm_obl)) &
-      call write_3d_array_vals("ry_norm_obl", segment%ry_norm_obl, unscale=US%L_T_to_m_s**2)
-    if (allocated(segment%cff_normal)) &
-      call write_3d_array_vals("cff_normal", segment%cff_normal, unscale=US%L_T_to_m_s**2)
-    if (allocated(segment%nudged_normal_vel)) &
-      call write_3d_array_vals("nudged_normal_vel", segment%nudged_normal_vel, unscale=US%L_T_to_m_s)
-    if (allocated(segment%nudged_tangential_vel)) &
-      call write_3d_array_vals("nudged_tangential_vel", segment%nudged_tangential_vel, unscale=US%L_T_to_m_s)
-    if (allocated(segment%nudged_tangential_grad)) &
-      call write_3d_array_vals("nudged_tangential_grad", segment%nudged_tangential_grad, unscale=US%s_to_T)
 
     write(mesg, '("  Tr_InvLscale_out ", ES16.6)') segment%Tr_InvLscale_out*US%m_to_L
     call MOM_mesg(mesg, verb=1)
@@ -6644,65 +6644,202 @@ subroutine write_OBC_info(OBC, G, GV, US)
 
   enddo
 
+  call chksum_OBC_segments(OBC, G, GV, US, 0)
+
+end subroutine write_OBC_info
+
+!> Write checksums and perhaps the values of all the allocated arrays on an OBC segments.
+subroutine chksum_OBC_segments(OBC, G, GV, US, nk)
+  type(ocean_OBC_type),    pointer    :: OBC   !< OBC on input map
+  type(ocean_grid_type),   intent(in) :: G     !< Rotated grid metric
+  type(verticalGrid_type), intent(in) :: GV    !< Vertical grid
+  type(unit_scale_type),   intent(in) :: US    !< Unit scaling
+  integer,                 intent(in) :: nk    !< The number of layers to print
+
+  ! Local variables
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
+  real :: norm ! A sign change used when rotating a normal component [nondim]
+  real :: tang ! A sign change used when rotating a normal component [nondim]
+  character(len=8) :: sn, segno
+  character(len=1024) :: mesg
+  integer :: c, n, dir
+
+  do n=1,OBC%number_of_segments
+    segment => OBC%segment(n)
+    dir = segment%direction
+
+    write(segno, '(I3)') n
+    sn = '('//trim(adjustl(segno))//')'
+
+    ! Turn each segment and write it as though it is an eastern face.
+    norm = 0.0 ; tang = 0.0
+    if (dir == OBC_DIRECTION_E) then
+      norm = 1.0 ; tang = 1.0
+    elseif (dir == OBC_DIRECTION_N) then
+      norm = 1.0 ; tang = -1.0
+    elseif (dir == OBC_DIRECTION_W) then
+      norm = -1.0 ; tang = -1.0
+    elseif (dir == OBC_DIRECTION_S) then
+      norm = -1.0 ; tang = 1.0
+    endif
+
+    if (allocated(segment%Cg)) call write_2d_array_vals("Cg"//trim(sn), segment%Cg, dir, nk, unscale=US%L_T_to_m_s)
+    if (allocated(segment%Htot)) call write_2d_array_vals("Htot"//trim(sn), segment%Htot, dir, nk, unscale=GV%H_to_mks)
+    if (allocated(segment%dZtot)) call write_2d_array_vals("dZtot"//trim(sn), segment%dZtot, dir, nk, unscale=US%Z_to_m)
+    if (allocated(segment%SSH)) call write_2d_array_vals("SSH"//trim(sn), segment%SSH, dir, nk, unscale=US%Z_to_m)
+    if (allocated(segment%h)) call write_3d_array_vals("h"//trim(sn), segment%h, dir, nk, unscale=GV%H_to_mks)
+    if (allocated(segment%normal_vel)) &
+      call write_3d_array_vals("normal_vel"//trim(sn), segment%normal_vel, dir, nk, unscale=norm*US%L_T_to_m_s)
+    if (allocated(segment%normal_vel_bt)) &
+      call write_2d_array_vals("normal_vel_bt"//trim(sn), segment%normal_vel_bt, dir, nk, unscale=norm*US%L_T_to_m_s)
+    if (allocated(segment%tangential_vel)) &
+      call write_3d_array_vals("tangential_vel"//trim(sn), segment%tangential_vel, dir, nk, unscale=tang*US%L_T_to_m_s)
+    if (allocated(segment%tangential_grad)) &
+      call write_3d_array_vals("tangential_grad"//trim(sn), segment%tangential_grad, dir, nk, &
+                    unscale=tang*norm*US%s_to_T)
+    if (allocated(segment%normal_trans)) &
+      call write_3d_array_vals("normal_trans"//trim(sn), segment%normal_trans, dir, nk, &
+                    unscale=norm*GV%H_to_mks*US%L_T_to_m_s*US%L_to_m)
+    if (allocated(segment%grad_normal)) &
+      call write_3d_array_vals("grad_normal"//trim(sn), segment%grad_normal, dir, nk, unscale=norm*tang*US%L_T_to_m_s)
+    if (allocated(segment%grad_tan)) &
+      call write_3d_array_vals("grad_tan"//trim(sn), segment%grad_tan, dir, nk, unscale=1.0*US%L_T_to_m_s)
+    if (allocated(segment%grad_gradient)) &
+      call write_3d_array_vals("grad_gradient"//trim(sn), segment%grad_gradient, dir, nk, unscale=norm*US%s_to_T)
+
+    if (allocated(segment%rx_norm_rad)) &
+      call write_3d_array_vals("rxy_norm_rad"//trim(sn), segment%rx_norm_rad, dir, nk, unscale=1.0)
+    if (allocated(segment%ry_norm_rad)) &
+      call write_3d_array_vals("rxy_norm_rad"//trim(sn), segment%ry_norm_rad, dir, nk, unscale=1.0)
+    if (segment%is_E_or_W) then
+      if (allocated(segment%rx_norm_obl)) &
+        call write_3d_array_vals("rx_norm_obl"//trim(sn), segment%rx_norm_obl, dir, nk, unscale=US%L_T_to_m_s**2)
+      if (allocated(segment%ry_norm_obl)) &
+        call write_3d_array_vals("ry_norm_obl"//trim(sn), segment%ry_norm_obl, dir, nk, unscale=US%L_T_to_m_s**2)
+    else ! The x- and y- directions are swapped.
+      if (allocated(segment%ry_norm_obl)) &
+        call write_3d_array_vals("rx_norm_obl"//trim(sn), segment%ry_norm_obl, dir, nk, unscale=US%L_T_to_m_s**2)
+      if (allocated(segment%rx_norm_obl)) &
+        call write_3d_array_vals("ry_norm_obl"//trim(sn), segment%rx_norm_obl, dir, nk, unscale=US%L_T_to_m_s**2)
+    endif
+
+    if (allocated(segment%cff_normal)) &
+      call write_3d_array_vals("cff_normal"//trim(sn), segment%cff_normal, dir, nk, unscale=US%L_T_to_m_s**2)
+    if (allocated(segment%nudged_normal_vel)) &
+      call write_3d_array_vals("nudged_normal_vel"//trim(sn), segment%nudged_normal_vel, dir, nk, &
+                    unscale=norm*US%L_T_to_m_s)
+    if (allocated(segment%nudged_tangential_vel)) &
+      call write_3d_array_vals("nudged_tangential_vel"//trim(sn), segment%nudged_tangential_vel, dir, nk, &
+                    unscale=tang*US%L_T_to_m_s)
+    if (allocated(segment%nudged_tangential_grad)) &
+      call write_3d_array_vals("nudged_tangential_grad"//trim(sn), segment%nudged_tangential_grad, dir, nk, &
+                    unscale=tang*norm*US%s_to_T)
+  enddo
+
   contains
 
-  !> Write out the values in a named 2-d array
-  subroutine write_2d_array_vals(name, Array, unscale)
-    character(len=*),     intent(in) :: name  !< The name of the variable
-    real, dimension(:,:), intent(in) :: Array  !< The 2-d array to write [A ~> a]
-    real,       optional, intent(in) :: unscale  !< A factor that undoes the scaling of the array [a A-1 ~> 1]
+  !> Write out the values in a named 2-d segment data array
+  subroutine write_2d_array_vals(name, Array, seg_dir, nkp, unscale)
+    character(len=*),     intent(in) :: name    !< The name of the variable
+    real, dimension(:,:), intent(in) :: Array   !< The 2-d array to write [A ~> a]
+    integer,              intent(in) :: seg_dir !< The direction of the segment
+    integer,              intent(in) :: nkp     !< Print all the values if this is greater than 0
+    real,       optional, intent(in) :: unscale !< A factor that undoes the scaling of the array [a A-1 ~> 1]
     ! Local variables
     real :: scale  !  A factor that undoes the scaling of the array [a A-1 ~> 1]
     character(len=1024) :: mesg
     character(len=24) :: val
-    integer :: i, j, n
+    integer :: i, j, n, iounit
 
     scale = 1.0 ; if (present(unscale)) scale = unscale
+    iounit = stderr
 
-    call MOM_mesg("  "//trim(name)//": ", verb=1)
-    mesg = "" ; n = 0
-    do j=1,size(Array,2) ; do i=1,size(Array,1)
-      write(val, '(ES16.6)') scale*Array(i,j)
-      mesg = trim(mesg)//" "//trim(val)
-      n = n + 1
-      if (n >= 12) then
-        call MOM_mesg("   "//trim(mesg), verb=1)
-        mesg = ""
-        n = 0
+    if (nkp > 0) then
+      write(iounit, '(2X,A,":")') trim(name)
+      mesg = "" ; n = 0
+      if ((seg_dir == OBC_DIRECTION_N) .or. (seg_dir == OBC_DIRECTION_W)) then
+        do j=size(Array,2),1,-1 ; do i=size(Array,1),1,-1
+          write(val, '(ES16.6)') scale*Array(i,j)
+          mesg = trim(mesg)//" "//trim(val) ;  n = n + 1
+          if (n >= 12) then
+            write(iounit, '(2X,A)') trim(mesg)
+            mesg = "" ; n = 0
+          endif
+        enddo ; enddo
+      else
+        do j=1,size(Array,2) ; do i=1,size(Array,1)
+          write(val, '(ES16.6)') scale*Array(i,j)
+          mesg = trim(mesg)//" "//trim(val) ;  n = n + 1
+          if (n >= 12) then
+            write(iounit, '(2X,A)') trim(mesg)
+            mesg = "" ; n = 0
+          endif
+        enddo ; enddo
       endif
-    enddo ; enddo
-    if (n > 0) call MOM_mesg("   "//trim(mesg), verb=1)
+      if (n > 0) write(iounit, '(2X,A)') trim(mesg)
+    endif
+
+    if (scale == 1.0) then
+      call chksum(Array, name)
+    else
+      call chksum(scale*Array(:,:), name)
+    endif
   end subroutine write_2d_array_vals
 
-  !> Write out the values in a 3-d array
-  subroutine write_3d_array_vals(name, Array, unscale)
-    character(len=*),       intent(in) :: name   !< The name of the variable
-    real, dimension(:,:,:), intent(in) :: Array  !< The 3-d array to write
+  !> Write out the values in a 3-d segment data array
+  subroutine write_3d_array_vals(name, Array, seg_dir, nkp, unscale)
+    character(len=*),       intent(in) :: name    !< The name of the variable
+    real, dimension(:,:,:), intent(in) :: Array   !< The 3-d array to write
+    integer,                intent(in) :: seg_dir !< The direction of the segment
+    integer,                intent(in) :: nkp     !< The number of layers to print
     real,         optional, intent(in) :: unscale !< A factor that undoes the scaling of the array [a A-1 ~> 1]
     ! Local variables
     real :: scale  !  A factor that undoes the scaling of the array [a A-1 ~> 1]
+    logical :: reverse
     character(len=1024) :: mesg
     character(len=24) :: val
-    integer :: i, j, k, n
+    integer :: i, j, k, n, nk, iounit
 
     scale = 1.0 ; if (present(unscale)) scale = unscale
+    iounit = stderr
 
-    call MOM_mesg("  "//trim(name)//": ", verb=1)
-    mesg = "" ; n = 0
-    do k=1,size(Array,3) ; do j=1,size(Array,2) ; do i=1,size(Array,1)
-      write(val, '(ES16.6)') scale*Array(i,j,k)
-      mesg = trim(mesg)//" "//trim(val)
-      n = n + 1
-      if (n >= 12) then
-        call MOM_mesg("   "//trim(mesg), verb=1)
-        mesg = ""
-        n = 0
-      endif
-    enddo ; enddo ; enddo
-    if (n > 0) call MOM_mesg("   "//trim(mesg), verb=1)
+    if (nkp > 0) then
+      nk = min(nkp, size(Array,3))
+      write(iounit, '(2X,A,":")') trim(name)
+      do k=1,nk
+        mesg = "" ; n = 0
+        if ((seg_dir == OBC_DIRECTION_N) .or. (seg_dir == OBC_DIRECTION_W)) then
+          do j=size(Array,2),1,-1 ; do i=size(Array,1),1,-1
+            write(val, '(ES16.6)') scale*Array(i,j,k)
+            mesg = trim(mesg)//" "//trim(val) ; n = n + 1
+            if (n >= 12) then
+              write(iounit, '(2X,A)') trim(mesg)
+              mesg = "" ; n = 0
+            endif
+          enddo ; enddo
+        else
+          do j=1,size(Array,2) ; do i=1,size(Array,1)
+            write(val, '(ES16.6)') scale*Array(i,j,k)
+            mesg = trim(mesg)//" "//trim(val) ; n = n + 1
+            if (n >= 12) then
+              write(iounit, '(2X,A)') trim(mesg)
+              mesg = "" ; n = 0
+            endif
+          enddo ; enddo
+        endif
+        if (n > 0) write(iounit, '(2X,A)') trim(mesg)
+      enddo
+    endif
+
+    if (scale == 1.0) then
+      call chksum(Array, name)
+    else
+      call chksum(scale*Array(:,:,:), name)
+    endif
+
   end subroutine write_3d_array_vals
 
-end subroutine write_OBC_info
+end subroutine chksum_OBC_segments
 
 !> \namespace mom_open_boundary
 !! This module implements some aspects of internal open boundary

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -177,7 +177,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
                         ! allows the use of Fatal unused parameters.
   type(EOS_type), pointer :: eos => NULL()
   logical :: debug      ! If true, write debugging output.
-  logical :: debug_obc  ! If true, do debugging calls related to OBCs.
+  logical :: debug_obc  ! If true, do additional calls resetting values to help debug the correctness
+                        ! of the open boundary condition code.
   logical :: debug_layers = .false.
   logical :: use_ice_shelf
   character(len=80) :: mesg
@@ -194,7 +195,10 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   call callTree_enter("MOM_initialize_state(), MOM_state_initialization.F90")
   call log_version(PF, mdl, version, "")
   call get_param(PF, mdl, "DEBUG", debug, default=.false.)
-  call get_param(PF, mdl, "DEBUG_OBC", debug_obc, default=.false.)
+  call get_param(PF, mdl, "OBC_DEBUGGING_TESTS", debug_obc, &
+                 "If true, do additional calls resetting values to help verify the correctness "//&
+                 "of the open boundary condition code.", default=.false.,  &
+                 do_not_log=.true., old_name="DEBUG_OBC", debuggingParam=.true.)
 
   new_sim = is_new_run(restart_CS)
   just_read = .not.new_sim


### PR DESCRIPTION
  This PR consists of five commits that implement the ability to rotate (single-processor) configurations that use open boundary conditions and obtain bitwise identical solutions.  It adds significant new debugging capabilities and it adds a new runtime option (`OBC_HOR_INDEXING_BUG`) to correct a group of 5 horizontal indexing bugs that will change answers with OBCs, even when the solution is not rotated.  Several other bugs that led to segmentation faults when the grid index rotation is enabled with OBCs were also corrected by setting the requisite pointers and copying missing data between rotated and unrotated OBC types.

  The specific answer changing bugs that are corrected by setting `OBC_HOR_INDEXING_BUG` to `false` are 4 instances where the wrong fields are being set by reading in a file in "brushcutter" mode, and the use of the wrong total thickness when remapping tangential velocity fields or their gradients.

  The changes include the introduction of the new publicly visible routines `write_OBC_info()` and `chksum_OBC_segments()` that write extensive debugging information about the OBC fields, and which were used to identify the various bugs that are being corrected with this pull request.  Calls to these routines are enabled via the new runtime parameters `DEBUG_OBCS` and `NK_OBC_DEBUG`. The new function `rotate_OBC_segment_direction()` is now available to convert the directions of OBC segments when there is grid rotation.

  A fatal error message that previously prevented cases with OBCs from running with arbitrary rotation has been removed.

  The previous runtime parameter `DEBUG_OBC` has been renamed to `OBC_DEBUGGING_TESTS` (while retaining `DEBUG_OBC` as the old name for backward compatability) to avoid confusion with other debugging calls that do not actually change the model state.

  By default, all non-rotated solutions are bitwise identical, but there are several new or renamed runtime parameters and three new publicly visible interfaces.  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@d610d8ed5 +(*)Add OBC_HOR_INDEXING_BUG and correct rotation
 - NOAA-GFDL/MOM6@f5af15233 +Add DEBUG_OBCS and OBC_DEBUGGING_TESTS
 - NOAA-GFDL/MOM6@ea6d2ece2 +Add chksum_OBC_segments
 - NOAA-GFDL/MOM6@8fa057428 +Add rotate_OBC_segment_direction
 - NOAA-GFDL/MOM6@6511e5769 +(*)Arbitrary grid rotation with MOM_open_boundary
