### PR TITLE
*Fix PE-count dependency with some kinds of OBCs

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3250,10 +3250,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
     if (associated(OBC_in)) then
       call rotate_OBC_init(OBC_in, G, GV, US, param_file, CS%tv, restart_CSp, CS%OBC)
-      if (CS%OBC%some_need_no_IO_for_data) then
-        call calc_derived_thermo(CS%tv, CS%h, G, GV, US)
-        call update_OBC_segment_data(G, GV, US, CS%OBC, CS%tv, CS%h, Time)
-      endif
+      call calc_derived_thermo(CS%tv, CS%h, G, GV, US)
+      call update_OBC_segment_data(G, GV, US, CS%OBC, CS%tv, CS%h, Time)
     endif
 
     deallocate(u_in)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -624,11 +624,10 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   if (associated(OBC)) then
     call initialize_segment_data(G, GV, US, OBC, PF)
 !     call open_boundary_config(G, US, PF, OBC)
-    ! Call this once to fill boundary arrays from fixed values
-    if (OBC%some_need_no_IO_for_data) then
-      call calc_derived_thermo(tv, h, G, GV, US)
-      call update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
-    endif
+
+    call calc_derived_thermo(tv, h, G, GV, US)
+    ! Call this during initialization to fill boundary arrays from fixed values
+    call update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
 
     call get_param(PF, mdl, "OBC_USER_CONFIG", config, &
                  "A string that sets how the user code is invoked to set open boundary data: \n"//&


### PR DESCRIPTION
  Fixed a bug that was causing some open boundary condition fields (e.g., those related to the tides) not to be read in from files before they are used unless there are some PEs that do NOT include any input date based OBC points.  This bug causes certain configurations with not to reproduce across PE count.  Most high-PE count jobs (those with at least 3 PEs in each direction) previously were correct, but single PE jobs or jobs with a prime number or 2 times a prime number of PEs were never correct for these cases.  Specifically, this commit removes the `some_need_no_IO_for_data` element from the `ocean_OBC_type`, and it always calls `update_OBC_segment_data()` during initialization when any OBCs are being used.  It also replaces three calls to `allocate_rotated_array()` with calls to the new internal subroutine `allocate_rotated_seg_data()` to avoid a bug where the size of rotated data segments is right but the index range is wrong.  This commit will change low-PE count answers for some cases with certain types of open boundary conditions.