### PR TITLE
Added more dox and tidy-up for numerical_testing_type

### DIFF
--- a/config_src/drivers/unit_tests/test_numerical_testing_type.F90
+++ b/config_src/drivers/unit_tests/test_numerical_testing_type.F90
@@ -1,7 +1,7 @@
 program test_numerical_testing_type
 
-use numerical_testing_type, only : testing_type_unit_test
+use numerical_testing_type, only : numerical_testing_type_unit_tests
 
-if (testing_type_unit_test(.true.)) stop 1
+if (numerical_testing_type_unit_tests(.true.)) stop 1
 
 end program test_numerical_testing_type


### PR DESCRIPTION
This is mostly aesthetic update. It cleans up the apparent fails in the coverage log that were really just tests of the testing. All the apparent, but expected fails, are now redirected to stdout so we don't clutter the coverage step with unnecessary output.

- Minor re-factor of numerical_testing_type_unit_tests()
- Added a doxygen blurb for the module including usage for the helper class
- Updated test_numerical_testing_type with rename of unit_test function