### PR TITLE
+OBC grid rotation debugging code

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -181,7 +181,8 @@ type, public :: MOM_dyn_split_RK2_CS ; private
                      !! Euler (1) [nondim].  0 is often used.
   real    :: Cemp_NL   !< Empirical coefficient of non-local momentum mixing [nondim]
   logical :: debug     !< If true, write verbose checksums for debugging purposes.
-  logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
+  logical :: debug_OBC !< If true, do additional calls resetting values to help debug the correctness
+                       !! of the open boundary condition code.
   logical :: fpmix     !< If true, add non-local momentum flux increments and diffuse down the Eulerian gradient.
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
   logical :: visc_rem_dt_bug = .true. !< If true, recover a bug that uses dt_pred rather than dt for vertvisc_rem
@@ -1473,7 +1474,10 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
+  call get_param(param_file, mdl, "OBC_DEBUGGING_TESTS", CS%debug_OBC, &
+                 "If true, do additional calls resetting certain values to help verify the "//&
+                 "correctness of the open boundary condition code.", &
+                 default=.false., old_name="DEBUG_OBC", debuggingParam=.true., do_not_log=.true.)
   call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
   call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, &

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -171,7 +171,8 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
                      !! is forward-backward (0) or simulated backward
                      !! Euler (1) [nondim].  0 is often used.
   logical :: debug   !< If true, write verbose checksums for debugging purposes.
-  logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
+  logical :: debug_OBC !< If true, do additional calls resetting values to help verify the correctness
+                       !! of the open boundary condition code.
   logical :: fpmix = .false.                 !< If true, applies profiles of momentum flux magnitude and direction.
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
   logical :: visc_rem_dt_bug = .true. !< If true, recover a bug that uses dt_pred rather than dt for vertvisc_rem
@@ -1359,7 +1360,10 @@ subroutine initialize_dyn_split_RK2b(u, v, h, tv, uh, vh, eta, Time, G, GV, US, 
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
+  call get_param(param_file, mdl, "OBC_DEBUGGING_TESTS", CS%debug_OBC, &
+                 "If true, do additional calls resetting certain values to help verify the "//&
+                 "correctness of the open boundary condition code.", &
+                 default=.false., old_name="DEBUG_OBC", debuggingParam=.true., do_not_log=.true.)
   call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
                  default=.false.)
   call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -72,6 +72,7 @@ public update_OBC_ramp
 public remap_OBC_fields
 public rotate_OBC_config
 public rotate_OBC_init
+public rotate_OBC_segment_direction
 public initialize_segment_data
 public flood_fill
 public flood_fill2
@@ -6028,36 +6029,64 @@ subroutine rotate_OBC_segment_config(segment_in, G_in, segment, G, turns)
   endif
 
   ! Reconfigure the directional flags
-  ! TODO: This is hardcoded for 90 degrees, and needs to be generalized.
-  select case (segment_in%direction)
-    case (OBC_DIRECTION_N)
-      segment%direction = OBC_DIRECTION_W
-      segment%is_E_or_W_2 = segment_in%is_N_or_S
-      segment%is_E_or_W = segment_in%is_N_or_S .and. segment_in%on_pe
-      segment%is_N_or_S = .false.
-    case (OBC_DIRECTION_W)
-      segment%direction = OBC_DIRECTION_S
-      segment%is_N_or_S = segment_in%is_E_or_W
-      segment%is_E_or_W = .false.
-      segment%is_E_or_W_2 = .false.
-    case (OBC_DIRECTION_S)
-      segment%direction = OBC_DIRECTION_E
-      segment%is_E_or_W_2 = segment_in%is_N_or_S
-      segment%is_E_or_W = segment_in%is_N_or_S .and. segment_in%on_pe
-      segment%is_N_or_S = .false.
-    case (OBC_DIRECTION_E)
-      segment%direction = OBC_DIRECTION_N
-      segment%is_N_or_S = segment_in%is_E_or_W
-      segment%is_E_or_W = .false.
-      segment%is_E_or_W_2 = .false.
-    case (OBC_NONE)
-      segment%direction = OBC_NONE
-  end select
+  segment%direction = rotate_OBC_segment_direction(segment_in%direction, turns)
+
+  segment%is_E_or_W_2 = ((segment%direction == OBC_DIRECTION_E) .or. &
+                         (segment%direction == OBC_DIRECTION_W))
+  segment%is_E_or_W = segment_in%on_PE .and. segment%is_E_or_W_2
+  segment%is_N_or_S = segment_in%on_PE .and. &
+                        ((segment%direction == OBC_DIRECTION_N) .or. &
+                         (segment%direction == OBC_DIRECTION_S))
 
   ! These are conditionally set if Lscale_{in,out} are present
   segment%Tr_InvLscale_in = segment_in%Tr_InvLscale_in
   segment%Tr_InvLscale_out = segment_in%Tr_InvLscale_out
 end subroutine rotate_OBC_segment_config
+
+
+!> Return the direction of an OBC segment on after rotation to the new grid.  Note that
+!! rotate_OBC_seg_direction(rotate_OBC_seg_direction(direction, turns), -turns) = direction.
+function rotate_OBC_segment_direction(direction, turns) result(rotated_dir)
+  integer, intent(in) :: direction  !< The orientation of an OBC segment on the original grid
+  integer, intent(in) :: turns      !< Number of quarter turns
+  integer :: rotated_dir  !< An integer encoding the new rotated segment direction
+
+  integer :: qturns ! The number of quarter turns in the range of 0 to 3
+
+  qturns = modulo(turns, 4)
+
+  if ((qturns == 0) .or. (direction == OBC_NONE)) then
+    rotated_dir = direction
+  else  ! Determine the segment direction on a rotated grid
+    select case (direction)
+      case (OBC_DIRECTION_N)
+        if (qturns == 0) rotated_dir = OBC_DIRECTION_N
+        if (qturns == 1) rotated_dir = OBC_DIRECTION_W
+        if (qturns == 2) rotated_dir = OBC_DIRECTION_S
+        if (qturns == 3) rotated_dir = OBC_DIRECTION_E
+      case (OBC_DIRECTION_W)
+        if (qturns == 0) rotated_dir = OBC_DIRECTION_W
+        if (qturns == 1) rotated_dir = OBC_DIRECTION_S
+        if (qturns == 2) rotated_dir = OBC_DIRECTION_E
+        if (qturns == 3) rotated_dir = OBC_DIRECTION_N
+      case (OBC_DIRECTION_S)
+        if (qturns == 0) rotated_dir = OBC_DIRECTION_S
+        if (qturns == 1) rotated_dir = OBC_DIRECTION_E
+        if (qturns == 2) rotated_dir = OBC_DIRECTION_N
+        if (qturns == 3) rotated_dir = OBC_DIRECTION_W
+      case (OBC_DIRECTION_E)
+        if (qturns == 0) rotated_dir = OBC_DIRECTION_E
+        if (qturns == 1) rotated_dir = OBC_DIRECTION_N
+        if (qturns == 2) rotated_dir = OBC_DIRECTION_W
+        if (qturns == 3) rotated_dir = OBC_DIRECTION_S
+      case (OBC_NONE)
+        rotated_dir = OBC_NONE
+      case default ! This should never happen.
+        rotated_dir = direction
+    end select
+  endif
+
+end function rotate_OBC_segment_direction
 
 
 !> Initialize the segments and field-related data of a rotated OBC.

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -177,7 +177,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
                         ! allows the use of Fatal unused parameters.
   type(EOS_type), pointer :: eos => NULL()
   logical :: debug      ! If true, write debugging output.
-  logical :: debug_obc  ! If true, do debugging calls related to OBCs.
+  logical :: debug_obc  ! If true, do additional calls resetting values to help debug the correctness
+                        ! of the open boundary condition code.
   logical :: debug_layers = .false.
   logical :: use_ice_shelf
   character(len=80) :: mesg
@@ -194,7 +195,10 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
   call callTree_enter("MOM_initialize_state(), MOM_state_initialization.F90")
   call log_version(PF, mdl, version, "")
   call get_param(PF, mdl, "DEBUG", debug, default=.false.)
-  call get_param(PF, mdl, "DEBUG_OBC", debug_obc, default=.false.)
+  call get_param(PF, mdl, "OBC_DEBUGGING_TESTS", debug_obc, &
+                 "If true, do additional calls resetting values to help verify the correctness "//&
+                 "of the open boundary condition code.", default=.false.,  &
+                 do_not_log=.true., old_name="DEBUG_OBC", debuggingParam=.true.)
 
   new_sim = is_new_run(restart_CS)
   just_read = .not.new_sim


### PR DESCRIPTION
  This PR consists of three commits that add diagnostic capabilities the to help diagnose the models' (in)ability to rotate (single-processor) configurations that use open boundary conditions and obtain bitwise identical solutions.  

  The changes include the introduction of the new publicly visible routines `write_OBC_info()` and `chksum_OBC_segments()` that write extensive debugging information about the OBC fields, and which were used to identify the various bugs that will be corrected in a subsequent pull request.  Calls to these routines are enabled via the new runtime parameters `DEBUG_OBCS` and`NK_OBC_DEBUG`. The new function `rotate_OBC_segment_direction()` is now available to convert the directions of OBC segments when there is grid rotation.

  A fatal error message that previously prevented cases with OBCs from running with arbitrary rotation has been removed.

  The previous runtime parameter `DEBUG_OBC` has been renamed to `OBC_DEBUGGING_TESTS` (while retaining `DEBUG_OBC` as the old name for backward compatibility) to avoid confusion with other debugging calls that do not actually change the model state.

  Apart from the minor refactoring of transferring some code into the small publicly visible routine `rotate_OBC_segment_direction()`, only debugging code was add or modified.  All solutions are bitwise identical, although some cases that were previously blocked by a fatal error message will now work. However, there are several new or renamed runtime parameters and three new publicly visible interfaces.  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@06c63f52f +Add DEBUG_OBCS and OBC_DEBUGGING_TESTS
 - NOAA-GFDL/MOM6@6d0dc7c85 +Add chksum_OBC_segments and write_OBC_info
 - NOAA-GFDL/MOM6@4ccfb173b +Add rotate_OBC_segment_direction
