### PR TITLE
+Fix OBC reproducibility across restarts

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -779,7 +779,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
     if (CS%VarMix%use_variable_mixing) then
       call enable_averages(cycle_time, Time_start + real_to_time(US%T_to_s*cycle_time), CS%diag)
-      call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, dt)
+      call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, CS%OBC, dt)
       call calc_depth_function(G, CS%VarMix)
       call disable_averaging(CS%diag)
     endif
@@ -2069,7 +2069,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         if (.not. skip_diffusion) then
           if (CS%VarMix%use_variable_mixing) then
             call pass_var(CS%h, G%Domain)
-            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, dt_offline)
+            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, CS%OBC, dt_offline)
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif
@@ -2096,7 +2096,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
         if (.not. skip_diffusion) then
           if (CS%VarMix%use_variable_mixing) then
             call pass_var(CS%h, G%Domain)
-            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, dt_offline)
+            call calc_resoln_function(CS%h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, CS%OBC, dt_offline)
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -28,8 +28,8 @@ contains
 
 !> Calculate isopycnal slopes, and optionally return other stratification dependent functions such as N^2
 !! and dz*S^2*g-prime used, or calculable from factors used, during the calculation.
-subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stanley, &
-                                  slope_x, slope_y, N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, halo, OBC)
+subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stanley, slope_x, slope_y, &
+                                  N2_u, N2_v, dzu, dzv, dzSxN, dzSyN, halo, OBC, OBC_N2)
   type(ocean_grid_type),                       intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type),                     intent(in)    :: GV   !< The ocean's vertical grid structure
   type(unit_scale_type),                       intent(in)    :: US   !< A dimensional unit scaling type
@@ -61,6 +61,9 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                                                                      !! Eady growth rate at v-points. [Z T-1 ~> m s-1]
   integer,                           optional, intent(in)    :: halo !< Halo width over which to compute
   type(ocean_OBC_type),              optional, pointer       :: OBC  !< Open boundaries control structure.
+  logical,                           optional, intent(in)    :: OBC_N2 !< If present and true, use interior data
+                                                                     !! to calculate stratification at open boundary
+                                                                     !! condition faces.
 
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G), SZK_(GV)) :: &
@@ -127,6 +130,8 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   logical :: present_N2_u, present_N2_v
   logical :: local_open_u_BC, local_open_v_BC ! True if u- or v-face OBCs exist anywhere in the global domain.
+  logical :: OBC_friendly  ! If true, open boundary conditions are in use and only interior data should
+                        ! be used to calculate N2 at OBC faces.
   integer, dimension(2) :: EOSdom_u  ! The shifted I-computational domain to use for equation of
                                      ! state calculations at u-points.
   integer, dimension(2) :: EOSdom_v  ! The shifted i-computational domain to use for equation of
@@ -155,9 +160,11 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
 
   local_open_u_BC = .false.
   local_open_v_BC = .false.
+  OBC_friendly = .false.
   if (present(OBC)) then ; if (associated(OBC)) then
     local_open_u_BC = OBC%open_u_BCs_exist_globally
     local_open_v_BC = OBC%open_v_BCs_exist_globally
+    if (present(OBC_N2)) OBC_friendly = OBC_N2
   endif ; endif
 
   use_EOS = associated(tv%eqn_of_state)
@@ -241,12 +248,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   enddo
 
   do I=is-1,ie
-    GxSpV_u(I) = G_Rho0  !This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
+    GxSpV_u(I) = G_Rho0  ! This will be changed if both use_EOS and allocated(tv%SpV_avg) are true
   enddo
   !$OMP parallel do default(none) shared(nz,is,ie,js,je,IsdB,use_EOS,G,GV,US,pres,T,S,tv,h,e, &
   !$OMP                                  h_neglect,dz_neglect,h_neglect2, &
   !$OMP                                  present_N2_u,G_Rho0,N2_u,slope_x,dzSxN,EOSdom_u,EOSdom_h1, &
-  !$OMP                                  local_open_u_BC,dzu,OBC,use_stanley) &
+  !$OMP                                  local_open_u_BC,dzu,OBC,use_stanley,OBC_friendly) &
   !$OMP                          private(drdiA,drdiB,drdkL,drdkR,pres_u,T_u,S_u,      &
   !$OMP                                  drho_dT_u,drho_dS_u,hg2A,hg2B,hg2L,hg2R,haA, &
   !$OMP                                  drho_dT_dT_h,scrap,pres_h,T_h,S_h, &
@@ -266,6 +273,22 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         T_u(I) = 0.25*((T(i,j,k) + T(i+1,j,k)) + (T(i,j,k-1) + T(i+1,j,k-1)))
         S_u(I) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
+      if (OBC_friendly) then
+        do I=is-1,ie
+          l_seg = OBC%segnum_u(I,j)
+          if (l_seg /= OBC_NONE) then
+            if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+              pres_u(I) = pres(i,j,K)
+              T_u(I) = 0.5*(T(i,j,k) + T(i,j,k-1))
+              S_u(I) = 0.5*(S(i,j,k) + S(i,j,k-1))
+            elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) then
+              pres_u(I) = pres(i+1,j,K)
+              T_u(I) = 0.5*(T(i+1,j,k) + T(i+1,j,k-1))
+              S_u(I) = 0.5*(S(i+1,j,k) + S(i+1,j,k-1))
+            endif
+          endif
+        enddo
+      endif
       call calculate_density_derivs(T_u, S_u, pres_u, drho_dT_u, drho_dS_u, &
                                     tv%eqn_of_state, EOSdom_u)
       if (present_N2_u .or. (present(dzSxN))) then
@@ -338,8 +361,21 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! The expression for drdz above is mathematically equivalent to:
       !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
       !          ((hg2L/haL) + (hg2R/haR))
-      ! This is the gradient of density along geopotentials.
+      ! which is an estimate of the gradient of density across geopotentials.
       if (present_N2_u) then
+        if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
+          l_seg = OBC%segnum_u(I,j)
+          if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+            drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+          elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) then
+            drdz = drdkR / dzaR
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
+          endif
+        endif ; endif
+
         N2_u(I,j,K) = GxSpV_u(I) * drdz * G%mask2dCu(I,j) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
       endif
 
@@ -375,6 +411,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         endif
         slope = slope * max(G%mask2dT(i,j), G%mask2dT(i+1,j))
       endif
+
       slope_x(I,j,K) = slope
       if (present(dzSxN)) &
         dzSxN(I,j,K) = sqrt( GxSpV_u(I) * max(0., (wtL * ( dzaL * drdkL )) &
@@ -391,7 +428,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$OMP parallel do default(none) shared(nz,is,ie,js,je,IsdB,use_EOS,G,GV,US,pres,T,S,tv, &
   !$OMP                                  h,h_neglect,e,dz_neglect, &
   !$OMP                                  h_neglect2,present_N2_v,G_Rho0,N2_v,slope_y,dzSyN,EOSdom_v, &
-  !$OMP                                  dzv,local_open_v_BC,OBC,use_stanley) &
+  !$OMP                                  dzv,local_open_v_BC,OBC,use_stanley,OBC_friendly) &
   !$OMP                          private(drdjA,drdjB,drdkL,drdkR,pres_v,T_v,S_v,      &
   !$OMP                                  drho_dT_v,drho_dS_v,hg2A,hg2B,hg2L,hg2R,haA, &
   !$OMP                                  drho_dT_dT_h,scrap,pres_h,T_h,S_h, &
@@ -411,6 +448,22 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         T_v(i) = 0.25*((T(i,j,k) + T(i,j+1,k)) + (T(i,j,k-1) + T(i,j+1,k-1)))
         S_v(i) = 0.25*((S(i,j,k) + S(i,j+1,k)) + (S(i,j,k-1) + S(i,j+1,k-1)))
       enddo
+      if (OBC_friendly) then
+        do i=is,ie
+          l_seg = OBC%segnum_v(i,J)
+          if (l_seg /= OBC_NONE) then
+            if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+              pres_v(i) = pres(i,j,K)
+              T_v(i) = 0.5*(T(i,j,k) + T(i,j,k-1))
+              S_v(i) = 0.5*(S(i,j,k) + S(i,j,k-1))
+            elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) then
+              pres_v(i) = pres(i,j+1,K)
+              T_v(i) = 0.5*(T(i,j+1,k) + T(i,j+1,k-1))
+              S_v(i) = 0.5*(S(i,j+1,k) + S(i,j+1,k-1))
+            endif
+          endif
+        enddo
+      endif
       call calculate_density_derivs(T_v, S_v, pres_v, drho_dT_v, drho_dS_v, &
                                     tv%eqn_of_state, EOSdom_v)
 
@@ -490,8 +543,23 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       ! The expression for drdz above is mathematically equivalent to:
       !   drdz = ((hg2L/haL) * drdkL/dzaL + (hg2R/haR) * drdkR/dzaR) / &
       !          ((hg2L/haL) + (hg2R/haR))
-      ! This is the gradient of density along geopotentials.
-      if (present_N2_v) N2_v(i,J,K) = GxSpV_v(i) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
+      ! which is an estimate of the gradient of density across geopotentials.
+      if (present_N2_v) then
+        if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
+          l_seg = OBC%segnum_v(i,J)
+          if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+            drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
+          elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) then
+            drdz = drdkL / dzaL
+            if (use_EOS .and. allocated(tv%SpV_avg)) &
+              GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
+          endif
+        endif ; endif
+
+        N2_v(i,J,K) = GxSpV_v(i) * drdz * G%mask2dCv(i,J) ! Square of buoyancy freq. [L2 Z-2 T-2 ~> s-2]
+      endif
 
       if (use_EOS) then
         drdy = ((wtA * drdjA + wtB * drdjB) / (wtA + wtB) - &

--- a/src/parameterizations/vertical/MOM_kappa_shear.F90
+++ b/src/parameterizations/vertical/MOM_kappa_shear.F90
@@ -57,12 +57,12 @@ type, public :: Kappa_shear_CS ; private
   real    :: lz_rescale      !<   A coefficient to rescale the distance to the nearest
                              !! solid boundary. This adjustment is to account for
                              !! regions where 3 dimensional turbulence prevents the
-                             !! growth of shear instabilies [nondim].
+                             !! growth of shear instabilities [nondim].
   real    :: TKE_bg          !<   The background level of TKE [Z2 T-2 ~> m2 s-2].
   real    :: kappa_0         !<   The background diapycnal diffusivity [H Z T-1 ~> m2 s-1 or Pa s]
   real    :: kappa_seed      !<   A moderately large seed value of diapycnal diffusivity that
                              !! is used as a starting turbulent diffusivity in the iterations
-                             !! to findind an energetically constrained solution for the
+                             !! to finding an energetically constrained solution for the
                              !! shear-driven diffusivity [H Z T-1 ~> m2 s-1 or Pa s]
   real    :: kappa_trunc     !< Diffusivities smaller than this are rounded to 0 [H Z T-1 ~> m2 s-1 or Pa s]
   real    :: kappa_tol_err   !<   The fractional error in kappa that is tolerated [nondim].
@@ -77,7 +77,7 @@ type, public :: Kappa_shear_CS ; private
                              !! to estimate the time-averaged diffusivity.
   logical :: dKdQ_iteration_bug !< If true. use an older, dimensionally inconsistent estimate of
                              !! the derivative of diffusivity with energy in the Newton's method
-                             !! iteration.  The bug causes undercorrections when dz > 1m.
+                             !! iteration.  The bug causes under-corrections when dz > 1m.
   logical :: KS_at_vertex    !< If true, do the calculations of the shear-driven mixing
                              !! at the cell vertices (i.e., the vorticity points).
   logical :: eliminate_massless !< If true, massless layers are merged with neighboring
@@ -103,6 +103,10 @@ type, public :: Kappa_shear_CS ; private
                              !! are some massless layers.
   logical :: VS_viscosity_bug !< If true, use a bug in the calculation of the viscosity that sets
                              !! it to zero for all vertices that are on a coastline.
+  logical :: vertex_shear_OBC_bug !< If false, use extra masking when interpolating thicknesses to velocity
+                             !! points for setting up the shear velocities at vertices to avoid using
+                             !! external thicknesses at open boundaries.  When OBCs are not in use,
+                             !! this parameter does not change answers, but true is more efficient.
   logical :: VS_GeometricMean !< If true use geometric averaging for Kd from vertices to tracer points
   logical :: VS_ThicknessMean !< If true use thickness weighting when averaging Kd from vertices to
                              !! tracer points
@@ -214,8 +218,8 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
   k0dt = dt*CS%kappa_0
   dz_massless = 0.1*sqrt((US%Z_to_m*GV%m_to_H)*k0dt)
 
-  if (CS%id_N2_init>0) diag_N2_init(:,:,:) = 0.0
-  if (CS%id_S2_init>0) diag_S2_init(:,:,:) = 0.0
+  if ((CS%id_N2_init>0) .or. CS%debug) diag_N2_init(:,:,:) = 0.0
+  if ((CS%id_S2_init>0) .or. CS%debug) diag_S2_init(:,:,:) = 0.0
   if (CS%id_N2_mean>0) diag_N2_mean(:,:,:) = 0.0
   if (CS%id_S2_mean>0) diag_S2_mean(:,:,:) = 0.0
 
@@ -340,10 +344,10 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
         if (CS%id_S2_mean>0) then ; do K=1,nz+1
           diag_S2_mean(i,j,K) = S2_mean(K)
         enddo ; endif
-        if (CS%id_N2_init>0) then ; do K=1,nz+1
+        if ((CS%id_N2_init>0) .or. CS%debug) then ; do K=1,nz+1
           diag_N2_init(i,j,K) = N2_init(K)
         enddo ; endif
-        if (CS%id_S2_init>0) then ; do K=1,nz+1
+        if ((CS%id_S2_init>0) .or. CS%debug) then ; do K=1,nz+1
           diag_S2_init(i,j,K) = S2_init(K)
         enddo ; endif
       else
@@ -360,16 +364,16 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
           if (kf(K) == 0.0) then
             if (CS%id_N2_mean>0) diag_N2_mean(i,j,K) = N2_mean(kc(K))
             if (CS%id_S2_mean>0) diag_S2_mean(i,j,K) = S2_mean(kc(K))
-            if (CS%id_N2_init>0) diag_N2_init(i,j,K) = N2_init(kc(K))
-            if (CS%id_S2_init>0) diag_S2_init(i,j,K) = S2_init(kc(K))
+            if ((CS%id_N2_init>0) .or. CS%debug) diag_N2_init(i,j,K) = N2_init(kc(K))
+            if ((CS%id_S2_init>0) .or. CS%debug) diag_S2_init(i,j,K) = S2_init(kc(K))
           else
             if (CS%id_N2_mean>0) &
               diag_N2_mean(i,j,K) = (1.0-kf(K)) * N2_mean(kc(K)) + kf(K) * N2_mean(kc(K)+1)
             if (CS%id_S2_mean>0) &
               diag_S2_mean(i,j,K) = (1.0-kf(K)) * S2_mean(kc(K)) + kf(K) * S2_mean(kc(K)+1)
-            if (CS%id_N2_init>0) &
+            if ((CS%id_N2_init>0) .or. CS%debug) &
               diag_N2_init(i,j,K) = (1.0-kf(K)) * N2_init(kc(K)) + kf(K) * N2_init(kc(K)+1)
-            if (CS%id_S2_init>0) &
+            if ((CS%id_S2_init>0) .or. CS%debug) &
               diag_S2_init(i,j,K) = (1.0-kf(K)) * S2_init(kc(K)) + kf(K) * S2_init(kc(K)+1)
           endif
         enddo
@@ -391,6 +395,8 @@ subroutine Calculate_kappa_shear(u_in, v_in, h, tv, p_surf, kappa_io, tke_io, &
   enddo ! end of j-loop
 
   if (CS%debug) then
+    call hchksum(diag_N2_init, "kappa_shear N2_init", G%HI, unscale=US%s_to_T**2)
+    call hchksum(diag_S2_init, "kappa_shear S2_init", G%HI, unscale=US%s_to_T**2)
     call hchksum(kappa_io, "kappa", G%HI, unscale=GV%HZ_T_to_m2_s)
     call hchksum(tke_io, "tke", G%HI, unscale=US%Z_to_m**2*US%s_to_T**2)
   endif
@@ -453,8 +459,12 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
     dz_3d           ! Vertical distance between interface heights [Z ~> m].
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)+1) :: &
     kappa_vertex    ! Diffusivity at interfaces and vertices [H Z T-1 ~> m2 s-1 or Pa s]
-  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)+1) :: &
-    h_vert          ! Thicknesses interpolated to vertices [H Z T-1 ~> m2 s-1 or Pa s]
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)) :: &
+    h_vert          ! Thicknesses interpolated to vertices [H ~> m or kg m-2]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: &
+    h_at_u          ! A mask-weighted thickness interpolated to u-points [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &
+    h_at_v          ! A mask-weighted thickness interpolated to v-points [H ~> m or kg m-2]
   real, dimension(SZIB_(G),SZK_(GV)) :: &
     h_2d, &             ! A 2-D version of h interpolated to vertices [H ~> m or kg m-2].
     dz_2d, &            ! Vertical distance between interface heights [Z ~> m].
@@ -500,16 +510,18 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   real, dimension(SZK_(GV)+1) :: kf ! The fractional weight of interface kc+1 for
                         ! interpolating back to the original index space [nondim].
   real :: h_SW, h_SE, h_NW, h_NE ! Thicknesses at adjacent vertices [H ~> m or kg m-2]
-  real :: mks_to_HZ_T   ! A factor used to restore dimensional scaling after the geomentric mean
+  real :: mks_to_HZ_T   ! A factor used to restore dimensional scaling after the geometric mean
                         ! diffusivity is taken using thickness weighted powers [H Z s m-2 T-1 ~> 1]
                         ! or [H Z m s kg-1 T-1 ~> 1]
+  real :: H_tiny        ! A sub-roundoff thickness to use in the denominator when calculating
+                        ! thickness-weighted averages [H ~> m or kg m-2]
   integer :: IsB, IeB, JsB, JeB, i, j, k, nz, nzc
 
   ! Diagnostics that should be deleted?
   isB = G%isc-1 ; ieB = G%iecB ; jsB = G%jsc-1 ; jeB = G%jecB ; nz = GV%ke
 
-  if (CS%id_N2_init>0) diag_N2_init(:,:,:) = 0.0
-  if (CS%id_S2_init>0) diag_S2_init(:,:,:) = 0.0
+  if ((CS%id_N2_init>0) .or. CS%debug) diag_N2_init(:,:,:) = 0.0
+  if ((CS%id_S2_init>0) .or. CS%debug) diag_S2_init(:,:,:) = 0.0
   if (CS%id_N2_mean>0) diag_N2_mean(:,:,:) = 0.0
   if (CS%id_S2_mean>0) diag_S2_mean(:,:,:) = 0.0
   kappa_vertex(:,:,:) = 0.0
@@ -519,9 +531,38 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   k0dt =  dt*CS%kappa_0
   dz_massless = 0.1*sqrt((US%Z_to_m*GV%m_to_H)*k0dt)
   I_Prandtl = 0.0 ; if (CS%Prandtl_turb > 0.0) I_Prandtl = 1.0 / CS%Prandtl_turb
+  H_tiny = 0.5 * GV%H_subroundoff
 
   ! Convert layer thicknesses into geometric thickness in height units.
   call thickness_to_dz(h, tv, dz_3d, G, GV, US, halo_size=1)
+
+  if (CS%vertex_shear_OBC_bug) then
+    !$OMP parallel do default(shared)
+    do k=1,nz
+      do j=JsB,JeB+1 ; do I=IsB,IeB
+        h_at_u(I,j,k) = G%mask2dCu(I,j) * (h(i,j,k) + h(i+1,j,k)) * 0.5
+      enddo ; enddo
+      do J=JsB,JeB ; do i=IsB,IeB+1
+        h_at_v(i,J,k) = G%mask2dCv(i,J) * (h(i,j,k) + h(i,j+1,k)) * 0.5
+      enddo ; enddo
+    enddo
+  else
+    ! Because G%mask2dCu(I,j) is zero if either G%mask2dT(i,j) or G%mask2dT(i+1,j) except at OBC
+    ! faces, the following form give equivalent answers to those above unless OBCs are in use,
+    ! although the former is clearly less complicated and costly.
+    !$OMP parallel do default(shared)
+    do k=1,nz
+      do j=JsB,JeB+1 ; do I=IsB,IeB
+        h_at_u(I,j,k) = G%mask2dCu(I,j) * (G%mask2dT(i,j) * h(i,j,k) + G%mask2dT(i+1,j) * h(i+1,j,k)) / &
+                                          (G%mask2dT(i,j) + G%mask2dT(i+1,j) + 1.0e-36)
+      enddo ; enddo
+      do J=JsB,JeB ; do i=IsB,IeB+1
+        h_at_v(i,J,k) = G%mask2dCv(i,J) * (G%mask2dT(i,j) * h(i,j,k) + G%mask2dT(i,j+1) * h(i,j+1,k)) / &
+                                          (G%mask2dT(i,j) + G%mask2dT(i,j+1) + 1.0e-36)
+      enddo ; enddo
+    enddo
+  endif
+
 
   !$OMP parallel do default(private) shared(jsB,jeB,isB,ieB,nz,h,u_in,v_in,use_temperature,tv,G,GV,US,CS,kappa_io, &
   !$OMP                                     dz_massless,k0dt,p_surf,dt,tke_io,kv_io,kappa_vertex,h_vert,I_Prandtl, &
@@ -530,14 +571,11 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
 
     ! Interpolate the various quantities to the corners, using masks.
     do k=1,nz ; do I=IsB,IeB
-      u_2d(I,k) = (G%mask2dCu(I,j)   * (u_in(I,j,k)   * (h(i,j,k)   + h(i+1,j,k))) + &
-                   G%mask2dCu(I,j+1) * (u_in(I,j+1,k) * (h(i,j+1,k) + h(i+1,j+1,k))) ) / &
-                  ((G%mask2dCu(I,j)   * (h(i,j,k)   + h(i+1,j,k)) + &
-                    G%mask2dCu(I,j+1) * (h(i,j+1,k) + h(i+1,j+1,k))) + GV%H_subroundoff)
-      v_2d(I,k) = (G%mask2dCv(i,J)   * (v_in(i,J,k)   * (h(i,j,k)   + h(i,j+1,k))) + &
-                   G%mask2dCv(i+1,J) * (v_in(i+1,J,k) * (h(i+1,j,k) + h(i+1,j+1,k))) ) / &
-                  ((G%mask2dCv(i,J)   * (h(i,j,k)   + h(i,j+1,k)) + &
-                    G%mask2dCv(i+1,J) * (h(i+1,j,k) + h(i+1,j+1,k))) + GV%H_subroundoff)
+      u_2d(I,k) = ( (u_in(I,j,k) * h_at_u(I,j,k)) + (u_in(I,j+1,k) * h_at_u(I,j+1,k)) ) / &
+                  ( (h_at_u(I,j,k) + h_at_u(I,j+1,k)) + H_tiny )
+      v_2d(I,k) = ( (v_in(i,J,k) * h_at_v(i,J,k)) + (v_in(i+1,J,k) * h_at_v(i+1,J,k)) ) / &
+                  ( (h_at_v(i,J,k) + h_at_v(i+1,J,k)) + H_tiny )
+
       I_hwt = 1.0 / (((G%mask2dT(i,j) * h(i,j,k) + G%mask2dT(i+1,j+1) * h(i+1,j+1,k)) + &
                       (G%mask2dT(i+1,j) * h(i+1,j,k) + G%mask2dT(i,j+1) * h(i,j+1,k))) + &
                      GV%H_subroundoff)
@@ -668,22 +706,22 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
         do K=1,nz+1
           kappa_2d(I,K) = kappa_avg(K)
           if (CS%all_layer_TKE_bug) then
-            tke_2d(i,K) = tke(K)
+            tke_2d(I,K) = tke(K)
           else
-            tke_2d(i,K) = tke_avg(K)
+            tke_2d(I,K) = tke_avg(K)
           endif
         enddo
         if (CS%id_N2_mean>0) then ; do K=1,nz+1
-          diag_N2_mean(i,j,K) = N2_mean(K)
+          diag_N2_mean(I,J,K) = N2_mean(K)
         enddo ; endif
         if (CS%id_S2_mean>0) then ; do K=1,nz+1
-          diag_S2_mean(i,j,K) = S2_mean(K)
+          diag_S2_mean(I,J,K) = S2_mean(K)
         enddo ; endif
-        if (CS%id_N2_init>0) then ; do K=1,nz+1
-          diag_N2_init(i,j,K) = N2_init(K)
+        if ((CS%id_N2_init>0) .or. CS%debug) then ; do K=1,nz+1
+          diag_N2_init(I,J,K) = N2_init(K)
         enddo ; endif
-        if (CS%id_S2_init>0) then ; do K=1,nz+1
-          diag_S2_init(i,j,K) = S2_init(K)
+        if ((CS%id_S2_init>0) .or. CS%debug) then ; do K=1,nz+1
+          diag_S2_init(I,J,K) = S2_init(K)
         enddo ; endif
       else
         do K=1,nz+1
@@ -699,16 +737,16 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
           if (kf(K) == 0.0) then
             if (CS%id_N2_mean>0) diag_N2_mean(I,J,K) = N2_mean(kc(K))
             if (CS%id_S2_mean>0) diag_S2_mean(I,J,K) = S2_mean(kc(K))
-            if (CS%id_N2_init>0) diag_N2_init(I,J,K) = N2_init(kc(K))
-            if (CS%id_S2_init>0) diag_S2_init(I,J,K) = S2_init(kc(K))
+            if ((CS%id_N2_init>0) .or. CS%debug) diag_N2_init(I,J,K) = N2_init(kc(K))
+            if ((CS%id_S2_init>0) .or. CS%debug) diag_S2_init(I,J,K) = S2_init(kc(K))
           else
             if (CS%id_N2_mean>0) &
               diag_N2_mean(I,J,K) = (1.0-kf(K)) * N2_mean(kc(K)) + kf(K) * N2_mean(kc(K)+1)
             if (CS%id_S2_mean>0) &
               diag_S2_mean(I,J,K) = (1.0-kf(K)) * S2_mean(kc(K)) + kf(K) * S2_mean(kc(K)+1)
-            if (CS%id_N2_init>0) &
+            if ((CS%id_N2_init>0) .or. CS%debug) &
               diag_N2_init(I,J,K) = (1.0-kf(K)) * N2_init(kc(K)) + kf(K) * N2_init(kc(K)+1)
-            if (CS%id_S2_init>0) &
+            if ((CS%id_S2_init>0) .or. CS%debug) &
               diag_S2_init(I,J,K) = (1.0-kf(K)) * S2_init(kc(K)) + kf(K) * S2_init(kc(K)+1)
           endif
         enddo
@@ -749,39 +787,44 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
     kappa_io(i,j,1) = 0.0
     kappa_io(i,j,nz+1) = 0.0
   enddo ; enddo
-  if (CS%VS_ThicknessMean) then
-    ! This conversion factor is required to allow for aribtrary fracional powers of the diffusivities.
-    if (CS%VS_GeometricMean) mks_to_HZ_T = 1.0 /  GV%HZ_T_to_MKS
+  if (CS%VS_ThicknessMean .and. CS%VS_GeometricMean) then
+    ! This conversion factor is required to allow for arbitrary fractional powers of the diffusivities.
+    mks_to_HZ_T = 1.0 /  GV%HZ_T_to_MKS
     !$OMP parallel do default(private) shared(nz,G,GV,CS,kappa_io,kappa_vertex,h_vert)
     do K=2,nz ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
       h_SW = 0.5 * (h_vert(I-1,J-1,k) + h_vert(I-1,J-1,k-1))
       h_NE = 0.5 * (h_vert(I,J,k) + h_vert(I,J,k-1))
       h_NW = 0.5 * (h_vert(I-1,J,k) + h_vert(I-1,J,k-1))
       h_SE = 0.5 * (h_vert(I,J-1,k) + h_vert(I,J-1,k-1))
-      if (CS%VS_GeometricMean) then
-        if ((h_SW + h_NE) + (h_NW + h_SE) > 0.0) then
-          !  The geometric mean is zero if any component is zero, hence the need to use a floor
-          !  on the value of kappa_trunc in regions on boundaries of shear zones.
-          I_htot = 1.0 / ((h_SW + h_NE) + (h_NW + h_SE))
-          kappa_io(i,j,K) = G%mask2dT(i,j) * mks_to_HZ_T * &
-                              ( ((GV%HZ_T_to_MKS * max(kappa_vertex(I-1,J-1,K),CS%VS_GeoMean_Kdmin))**(h_SW*I_htot) * &
-                                   (GV%HZ_T_to_MKS * max(kappa_vertex(I,J,K),CS%VS_GeoMean_Kdmin))**(h_NE*I_htot)) * &
-                                  ((GV%HZ_T_to_MKS * max(kappa_vertex(I-1,J,K),CS%VS_GeoMean_Kdmin))**(h_NW*I_htot) * &
-                                   (GV%HZ_T_to_MKS * max(kappa_vertex(I,J-1,K),CS%VS_GeoMean_Kdmin))**(h_SE*I_htot)) )
-        else
-          ! If all points have zero thickness, the thikncess-weighted geometric mean is undefined, so use
-          ! the non-thickness weighted geometric mean instead.
-          kappa_io(i,j,K) = G%mask2dT(i,j) * sqrt(sqrt( &
-                (max(kappa_vertex(I-1,J-1,K),CS%VS_GeoMean_Kdmin) * max(kappa_vertex(I,J,K),CS%VS_GeoMean_Kdmin)) * &
-                (max(kappa_vertex(I-1,J,K),CS%VS_GeoMean_Kdmin) * max(kappa_vertex(I,J-1,K),CS%VS_GeoMean_Kdmin)) ))
-        endif
+      if ((h_SW + h_NE) + (h_NW + h_SE) > 0.0) then
+        !  The geometric mean is zero if any component is zero, hence the need to use a floor
+        !  on the value of kappa_trunc in regions on boundaries of shear zones.
+        I_htot = 1.0 / ((h_SW + h_NE) + (h_NW + h_SE))
+        kappa_io(i,j,K) = G%mask2dT(i,j) * mks_to_HZ_T * &
+                            ( ((GV%HZ_T_to_MKS * max(kappa_vertex(I-1,J-1,K), CS%VS_GeoMean_Kdmin))**(h_SW*I_htot) * &
+                               (GV%HZ_T_to_MKS * max(kappa_vertex(I,J,K), CS%VS_GeoMean_Kdmin))**(h_NE*I_htot)) * &
+                              ((GV%HZ_T_to_MKS * max(kappa_vertex(I-1,J,K), CS%VS_GeoMean_Kdmin))**(h_NW*I_htot) * &
+                               (GV%HZ_T_to_MKS * max(kappa_vertex(I,J-1,K), CS%VS_GeoMean_Kdmin))**(h_SE*I_htot)) )
       else
-        ! The following expression is a thickness weighted arithmetic mean at tracer points:
-        I_htot = 1.0 / (((h_SW + h_NE) + (h_NW + h_SE)) + GV%H_subroundoff)
-        kappa_io(i,j,K) = G%mask2dT(i,j) * &
-              (((kappa_vertex(I-1,J-1,K)*h_SW) + (kappa_vertex(I,J,K)*h_NE)) + &
-               ((kappa_vertex(I-1,J,K)*h_NW) + (kappa_vertex(I,J-1,K)*h_SE))) * I_htot
+        ! If all points have zero thickness, the thickness-weighted geometric mean is undefined, so use
+        ! the non-thickness weighted geometric mean instead.
+        kappa_io(i,j,K) = G%mask2dT(i,j) * sqrt(sqrt( &
+              (max(kappa_vertex(I-1,J-1,K),CS%VS_GeoMean_Kdmin) * max(kappa_vertex(I,J,K),CS%VS_GeoMean_Kdmin)) * &
+              (max(kappa_vertex(I-1,J,K),CS%VS_GeoMean_Kdmin) * max(kappa_vertex(I,J-1,K),CS%VS_GeoMean_Kdmin)) ))
       endif
+    enddo ; enddo ; enddo
+  elseif (CS%VS_ThicknessMean) then   ! Use thickness-weighted arithmetic mean diffusivities.
+    !$OMP parallel do default(private) shared(nz,G,GV,CS,kappa_io,kappa_vertex,h_vert)
+    do K=2,nz ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
+      h_SW = 0.5 * (h_vert(I-1,J-1,k) + h_vert(I-1,J-1,k-1))
+      h_NE = 0.5 * (h_vert(I,J,k) + h_vert(I,J,k-1))
+      h_NW = 0.5 * (h_vert(I-1,J,k) + h_vert(I-1,J,k-1))
+      h_SE = 0.5 * (h_vert(I,J-1,k) + h_vert(I,J-1,k-1))
+      ! The following expression is a thickness weighted arithmetic mean at tracer points:
+      I_htot = 1.0 / (((h_SW + h_NE) + (h_NW + h_SE)) + GV%H_subroundoff)
+      kappa_io(i,j,K) = G%mask2dT(i,j) * &
+            (((kappa_vertex(I-1,J-1,K)*h_SW) + (kappa_vertex(I,J,K)*h_NE)) + &
+             ((kappa_vertex(I-1,J,K)*h_NW) + (kappa_vertex(I,J-1,K)*h_SE))) * I_htot
     enddo ; enddo ; enddo
   elseif (CS%VS_GeometricMean) then   ! The geometic mean diffusivities are not thickness weighted.
     !$OMP parallel do default(private) shared(nz,G,CS,kappa_io,kappa_vertex)
@@ -800,6 +843,8 @@ subroutine Calc_kappa_shear_vertex(u_in, v_in, h, T_in, S_in, tv, p_surf, kappa_
   endif
 
   if (CS%debug) then
+    call Bchksum(diag_N2_init, "shear_vertex N2_init", G%HI, unscale=US%s_to_T**2)
+    call Bchksum(diag_S2_init, "shear_vertex S2_init", G%HI, unscale=US%s_to_T**2)
     call hchksum(kappa_io, "kappa", G%HI, unscale=GV%HZ_T_to_m2_s)
     call Bchksum(tke_io, "tke", G%HI, unscale=US%Z_to_m**2*US%s_to_T**2)
   endif
@@ -1341,7 +1386,7 @@ subroutine calculate_projected_state(kappa, u0, v0, T0, S0, dt, nz, dz, I_dz_int
   real, dimension(nz),   intent(in)    :: S0  !< The initial salinity [S ~> ppt].
   real,                  intent(in)    :: dt  !< The time step [T ~> s].
   real, dimension(nz),   intent(in)    :: dz  !< The layer thicknesses [H ~> m or kg m-2]
-  real, dimension(nz+1), intent(in)    :: I_dz_int !< The inverse of the distance between succesive
+  real, dimension(nz+1), intent(in)    :: I_dz_int !< The inverse of the distance between successive
                                               !! layer centers [Z-1 ~> m-1].
   real, dimension(nz+1), intent(in)    :: dbuoy_dT !< The partial derivative of buoyancy with
                                               !! temperature [Z T-2 C-1 ~> m s-2 degC-1].
@@ -2040,6 +2085,7 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
                     ! for setting the default of KD_SMOOTH [Z2 T-1 ~> m2 s-1]
   real :: kappa_0_default ! The default value for KD_KAPPA_SHEAR_0 [Z2 T-1 ~> m2 s-1]
   logical :: merge_mixedlayer
+  integer :: number_of_OBC_segments
   logical :: debug_shear
   logical :: just_read ! If true, this module is not used, so only read the parameters.
   ! This include declares and sets the variable "version".
@@ -2079,6 +2125,16 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
                  "If true, use a bug in vertex shear that zeros out viscosities at "//&
                  "vertices on coastlines.", &
                  default=.true., do_not_log=just_read.or.(.not.CS%KS_at_vertex))
+  call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", number_of_OBC_segments, &
+                 default=0, do_not_log=.true.)
+  call get_param(param_file, mdl, "VERTEX_SHEAR_OBC_BUG", CS%vertex_shear_OBC_bug, &
+                 "If false, use extra masking when interpolating thicknesses to velocity "//&
+                 "points for setting up the shear velocities at vertices to avoid using "//&
+                 "external thicknesses at open boundaries.  When OBCs are not in use, "//&
+                 "this parameter does not change answers, but true is more efficient.", &
+                 default=.true., &
+                 do_not_log=just_read.or.(.not.CS%KS_at_vertex).or.(number_of_OBC_segments<=0))
+                 !### Use OBC settings to set the default for VERTEX_SHEAR_OBC_BUG?
   call get_param(param_file, mdl, "VERTEX_SHEAR_GEOMETRIC_MEAN", CS%VS_GeometricMean, &
                  "If true, use a geometric mean for moving diffusivity from "//&
                  "vertices to tracer points.  False uses algebraic mean.", &
@@ -2092,7 +2148,7 @@ function kappa_shear_init(Time, G, GV, US, param_file, diag, CS)
                    CS%VS_GeoMean_Kdmin, "If using the geometric mean in vertex shear, "//&
                    "use this minimum value for Kd. This is an ad-hoc parameter, the "//&
                    "diffusivities on the edge of shear regions are sensitive to the choice.",&
-                   units="m2 s-1",default=0.0, scale=GV%m2_s_to_HZ_T, do_not_log=just_read)
+                   units="m2 s-1", default=0.0, scale=GV%m2_s_to_HZ_T, do_not_log=just_read)
   endif
   call get_param(param_file, mdl, "RINO_CRIT", CS%RiNo_crit, &
                  "The critical Richardson number for shear mixing.", &


### PR DESCRIPTION
  This pull request consists of a series of 6 commits that adds new runtime parameters (`VERTEX_SHEAR_OBC_BUG`,
`MIXING_COEFS_OBC_BUG` and `OBC_RESERVOIR_INIT_BUG`) that when set properly (to `False`) will allow some cases (and in particular the loop_current test case) with open boundary conditions to reproduce across restarts and to pass rotational consistency tests.  There is also some targeted refactoring along with the code changes to 6 files and some new arguments to public interfaces to enable these changes.  By default, all answers are bitwise identical.

  The detailed description of the various commits are as follows:

-  Refactoring for OBC restart fix

  This commit makes a set of changes to refactor code related to open boundary conditions to correct issues with restarts.

  Renamed `open_boundary_init()` to `open_boundary_halo_update()` to reflect what it actually does and eliminated the 4 unused arguments to this routine.

  Moved calls to `fill_temp_salt_segments()`, `setup_OBC_tracer_reservoirs()` and `open_boundary_halo_update()` outside of `rotate_OBC_init()`, and eliminated 5 unused parameters to `rotate_OBC_init()`.

  Moved halo updates for temperature and salinity and the call to `setup_OBC_tracer_reservoirs()` out of `fill_temp_salt_segments()` and made the `tv` argument to `fill_temp_salt_segments()` intent in.

  Moved the call to `open_boundary_halo_update()` after `MOM_state_initialization()` for both rotated and unrotated branches.

  Moved the calls to `fill_temp_salt_segments()` and `setup_OBC_tracer_reservoirs()` and the debugging calls for OBCs into the same code block as the rest of the OBC code in `MOM_initialize_state()`.

  All answers are bitwise identical, but there are changes to public interfaces and what does and does not occur in several routines.


 - +Add the runtime parameter VERTEX_SHEAR_OBC_BUG

  Added the new runtime option `VERTEX_SHEAR_OBC_BUG` that can be set to false to use masks to set the thicknesses interpolated to velocity points when open boundary conditions might be used.  This commit includes the addition of checksums of the input stratification and shear squared when `DEBUG` is true.  It also refactors the code setting the output diffusivity in `Calc_kappa_shear_vertex()` to move some logical branches outside of the do loops for efficiency.  A number of spelling errors were corrected, and some vertex-point indices were converted to uppercase to follow the MOM6 soft convention in MOM_kappa_shear.F90.  By default, all answers are bitwise identical, but there is a new runtime parameter.


 - +Add calc_isoneutral_slopes optional argument OBC_N2

  Added the new optional argument `OBC_N2` to `calc_isoneutral_slopes()` that can be used to specify that only interior points are used to calculate the buoyancy frequencies at velocity points when open boundary conditions are in use.  When the new `OBC_N2` argument is absent or false, the solutions are identical to what they had been previously, but this gives a dependence on the arbitrary outer thicknesses when open boundary conditions are used.  By default, all answers are bitwise identical, but there is a new optional argument to a publicly visible interface.

 - +Add the runtime parameter MIXING_COEFS_OBC_BUG

  Added the new runtime option `MIXING_COEFS_OBC_BUG` that can be set to false to specify that only interior data should be used for thickness weighting in the lateral mixing coefficient calculations when open boundary conditions are in use, and that only interior temperatures, salinities, pressures and thicknesses should be used when calculating the buoyancy frequency at open boundary velocity faces.  These changes are implemented by introducing two new 3-d arrays that set the thicknesses at velocity points and there are a few new logical tests inside of some loops, which may slow down the code slightly in routines that had never previously been notable for the amount of time spent there.  They also make use of the recently added `OBC_N2` argument to `calc_isoneutral_slopes()`.  The default setting for `MIXING_COEFS_OBC_BUG` retains the previous (incorrect) answers, and all answers are bitwise identical in cases without open boundary conditions regardless of how it is set.  There is a new entry in some MOM_parameter_doc
files for some cases with active open boundary conditions.


 - +Add OBC_RESERVOIR_INIT_BUG to fix OBC restarts

  This commit revises `setup_OBC_tracer_reservoirs()` and other OBC routines to allow some cases using open boundary conditions and tracer reservoirs to reproduce across restarts and adds the new runtime parameter `OBC_RESERVOIR_INIT_BUG` that can be set to true to recover the previous answers in cases that are not initialized from a restart file.   There is a new optional `MOM_restart_CS` argument to `setup_OBC_tracer_reservoirs()` that can be used to query whether the reservoirs have been read from a restart file before resetting them to values that may have been set during initialization.  If the reservoirs have not been set from a restart file, there is now a preference to set them from the tracer reservoir (`tres`) element in the OBC tracer registry on the segments (if it has been initialized) rather than the interior tracer values that have been recorded on the segment.

  `Fill_temp_salt_segments()` and `fill_obgc_segments()` have been modified to only set the `tres` segment data if it has not been initialized already, as indicated by the `is_initialized` field.

  This commit adds the new public routine `set_initialized_OBC_tracer_reservoirs()` that can be used to record in the restart control structure that the `OBC%tres_x` and `OBC%tres_y` fields have been initialized and should not be reset to new values during initialization.

  The calls to `setup_OBC_tracer_reservoirs()` and `open_boundary_halo update()` have been moved after the call to `tracer_flow_control_init()` so that the full arrays of tracer reservoirs do not need to be initialized in `fill_obgc_segments()`. `Fill_obgc_segments()` was refactored to separate out the steps that should occur
there from those that should not and are wrapped in a bug flag.

  A debugging checksum call to `chksum_OBC_segments()` was added to the top of `radiation_open_bdry_conds()` to assist in any future debugging of the OBC code.

  Doxygen comments were added describing several routines that were previously missing such a description.

  By default, all answers are bitwise identical, but there is a new publicly visible routine, a new optional argument to a public interface and a new runtime parameter that can be used to correct the previous behavior that broke the
reproducibility across restarts of some cases using open boundary conditions with tracer reservoirs.

- (*)Correct rotation with OBC tracer reservoirs

  Copy segment tracer registry data from the input segment to the target segment in `rotate_OBC_segment_data()`, including the tracer reservoirs on segments.  With this change, configurations using tracers with open boundary conditions are now
passing the rotational consistency tests.  This will change answers with some rotated cases with active OBCs, but all answers in non-rotated cases or cases without tracers in OBCs are bitwise identical.