### PR TITLE
+(*)Fix bugs with dyed_channel_update_flow

### DIFF
--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -166,7 +166,7 @@ subroutine update_OBC_data(OBC, G, GV, US, tv, h, CS, Time)
   if (CS%use_shelfwave) &
       call shelfwave_set_OBC_data(OBC, CS%shelfwave_OBC_CSp, G, GV, US, h, Time)
   if (CS%use_dyed_channel) &
-      call dyed_channel_update_flow(OBC, CS%dyed_channel_OBC_CSp, G, GV, US, Time)
+      call dyed_channel_update_flow(OBC, CS%dyed_channel_OBC_CSp, G, GV, US, h, Time)
   if (OBC%any_needs_IO_for_data .or. OBC%add_tide_constituents)  &
       call update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
   if (CS%debug_OBCs) call chksum_OBC_segments(OBC, G, GV, US, CS%nk_OBC_debug)


### PR DESCRIPTION
  When there are specified open boundary conditions, `dyed_channel_update_flow()` was setting the normal transport with the wrong units of [L2 T-1 ~> m2 s-1] instead of [H L2 T-1 ~> m3 s-1 or kg s-1], effectively omitting the layer thickness in the transports.  This has been corrected by adding the new runtime parameter `CHANNEL_FLOW_OBC_TRANSPORT_BUG` that either uses a fixed thickness if true (of 1 m or 1 kg m-2) or the actual interior thickness.  In either case, the model is now passing the dimensional consistency testing.  This change requires a new layer thickness argument to  `dyed_channel_update_flow()`.  In addition, code was added to `dyed_channel_update_flow()` so that it also satisfies rotational consistency.  By default, answers are bitwise identical when no dimensional rescaling or grid rotation is applied, but there is a new runtime parameter and a new argument to `dyed_channel_update_flow()`.