### PR TITLE
+(*)Kelvin wave rotation and indexing bug fix

### DIFF
--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -12,9 +12,8 @@ use MOM_error_handler,  only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
 use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE
-use MOM_open_boundary,  only : OBC_segment_type, register_OBC
-use MOM_open_boundary,  only : OBC_DIRECTION_N, OBC_DIRECTION_E
-use MOM_open_boundary,  only : OBC_DIRECTION_S, OBC_DIRECTION_W
+use MOM_open_boundary,  only : OBC_segment_type, register_OBC, rotate_OBC_segment_direction
+use MOM_open_boundary,  only : OBC_DIRECTION_N, OBC_DIRECTION_E, OBC_DIRECTION_S, OBC_DIRECTION_W
 use MOM_open_boundary,  only : OBC_registry_type
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
@@ -221,6 +220,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   real :: depth_tot(SZI_(G),SZJ_(G))  ! The total depth of the ocean [Z ~> m]
   real :: depth_tot_vel ! The total depth of the ocean at a velocity point [Z ~> m]
   real :: depth_tot_corner ! The total depth of the ocean at a vorticity point [Z ~> m]
+  real :: Cor_vel      ! The Coriolis parameter interpolated to a velocity point [T-1 ~> s-1]
   real    :: mag_SSH ! An overall magnitude of the external wave sea surface height at the coastline [Z ~> m]
   real    :: mag_int ! An overall magnitude of the internal wave at the coastline [L T-1 ~> m s-1]
   real    :: x1, y1  ! Various positions [L ~> m]
@@ -230,10 +230,13 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   real    :: val2    ! The local wave amplitude [Z ~> m]
   real    :: km_to_L_scale  ! A scaling factor from longitudes in km to L [L km-1 ~> 1e3]
   real    :: sina, cosa  ! The sine and cosine of the coast angle [nondim]
+  real    :: normal_sign ! A variable that corrects the sign of normal velocities for rotation [nondim]
+  real    :: trans_sign  ! A variable that corrects the sign of transverse velocities for rotation [nondim]
   type(OBC_segment_type), pointer :: segment => NULL()
+  integer :: unrot_dir ! The unrotated direction of the segmetn
   integer :: turns    ! Number of index quarter turns
   integer :: i, j, k, n, is, ie, js, je, isd, ied, jsd, jed, nz
-  integer :: IsdB, IedB, JsdB, JedB
+  integer :: IsdB, IedB, JsdB, JedB, isq, ieq, jsq, jeq, is_vel, ie_vel, js_vel, je_vel
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -248,6 +251,9 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   PI = 4.0*atan(1.0)
 
   turns = modulo(G%HI%turns, 4)
+
+  if (CS%indexing_bugs .and. (turns /= 0)) call MOM_error(FATAL, &
+    "Kelvin_set_OBC_data does not support grid rotation when KELVIN_SET_OBC_INDEXING_BUGS is true.")
 
   do j=jsd,jed ; do i=isd,ied
     depth_tot(i,j) = 0.0
@@ -277,8 +283,17 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
     if (.not. segment%on_pe) cycle
+
+   unrot_dir = segment%direction
+   if (turns /= 0) unrot_dir = rotate_OBC_segment_direction(segment%direction, -turns)
+
     ! Apply values to the inflow end only.
-    if ((segment%direction == OBC_DIRECTION_E) .or. (segment%direction == OBC_DIRECTION_N)) cycle
+    if ((unrot_dir == OBC_DIRECTION_E) .or. (unrot_dir == OBC_DIRECTION_N)) cycle
+
+    ! Set variables that correct for sign changes during rotation.
+    normal_sign = 1.0
+    if ( (segment%is_E_or_W .and. ((turns == 1) .or. (turns == 2))) .or. &
+         (segment%is_N_or_S .and. ((turns == 2) .or. (turns == 3))) ) normal_sign = -1.0
 
     ! If OBC_nudging_time is negative, the value of Velocity_nudging_timescale_in that was set
     ! when the segments are initialized is retained.
@@ -287,26 +302,48 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
     isd = segment%HI%isd ; ied = segment%HI%ied ; IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
     jsd = segment%HI%jsd ; jed = segment%HI%jed ; JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
 
-    if (segment%direction == OBC_DIRECTION_W) then
-      do j=jsd,jed ; do I=IsdB,IedB
-        x1 = G%grid_unit_to_L * G%geoLonCu(I,j)
-        y1 = G%grid_unit_to_L * G%geoLatCu(I,j)
+    if (unrot_dir == OBC_DIRECTION_W) then
+      if (segment%is_E_or_W) then
+        is_vel = IsdB ; ie_vel = IedB ; js_vel = jsd ; je_vel = jed
+      else
+        is_vel = isd ; ie_vel = ied ; js_vel = JsdB ; je_vel = JedB
+      endif
+      do j=js_vel,je_vel ; do I=is_vel,ie_vel
+        if (segment%is_E_or_W) then
+          x1 = G%grid_unit_to_L * G%geoLonCu(I,j)
+          y1 = G%grid_unit_to_L * G%geoLatCu(I,j)
+        else
+          x1 = G%grid_unit_to_L * G%geoLonCv(i,J)
+          y1 = G%grid_unit_to_L * G%geoLatCv(i,J)
+        endif
         x = (x1 - CS%coast_offset1) * cosa + y1 * sina
         y = -(x1 - CS%coast_offset1) * sina + y1 * cosa
         if (CS%mode == 0) then
           ! Use inside bathymetry
-          cff = sqrt(GV%g_Earth * depth_tot(i+1,j) )
-          val2 = mag_SSH * exp(- CS%F_0 * y / cff)
+          if (segment%direction == OBC_DIRECTION_W) then
+            depth_tot_vel = depth_tot(i+1,j)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1))
+          elseif (segment%direction == OBC_DIRECTION_S) then
+            depth_tot_vel = depth_tot(i,j+1)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J))
+          elseif (segment%direction == OBC_DIRECTION_E) then
+            depth_tot_vel = depth_tot(i,j)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1))
+          elseif (segment%direction == OBC_DIRECTION_N) then
+            depth_tot_vel = depth_tot(i,j)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J))
+          endif
+          cff = sqrt(GV%g_Earth * depth_tot_vel )
+          val2 = mag_SSH * exp(- Cor_vel * y / cff)
           segment%SSH(I,j) = val2 * cos_wt
-          segment%normal_vel_bt(I,j) = val2 * (sin_wt * cff * cosa / depth_tot(i+1,j) )
+          segment%normal_vel_bt(I,j) = (normal_sign*val2) * (sin_wt * cff * cosa / depth_tot_vel )
           if (segment%nudged) then
             do k=1,nz
-              segment%nudged_normal_vel(I,j,k) = val2 * (sin_wt * cff * cosa / depth_tot(i+1,j) )
+              segment%nudged_normal_vel(I,j,k) = (normal_sign*val2) * (sin_wt * cff * cosa / depth_tot_vel )
             enddo
           elseif (segment%specified) then
             do k=1,nz
-              segment%normal_vel(I,j,k) = val2 * (sin_wt * cff * cosa / depth_tot(i+1,j) )
-              segment%normal_trans(I,j,k) = segment%normal_vel(I,j,k) * h(i+1,j,k) * G%dyCu(I,j)
+              segment%normal_vel(I,j,k) = (normal_sign*val2) * (sin_wt * cff * cosa / depth_tot_vel )
             enddo
           endif
         else
@@ -323,55 +360,60 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           ! in MOM_wave_speed() based on the horizontally uniform initial state.
           if (segment%nudged) then
             do k=1,nz
-              segment%nudged_normal_vel(I,j,k) = mag_int * &
+              segment%nudged_normal_vel(I,j,k) = (normal_sign*mag_int) * &
                    exp(-lambda * y) * cos(PI * CS%mode * (k - 0.5) / nz) * cos_wt
             enddo
           elseif (segment%specified) then
             do k=1,nz
-              segment%normal_vel(I,j,k) = mag_int * &
+              segment%normal_vel(I,j,k) = (normal_sign*mag_int) * &
                    exp(-lambda * y) * cos(PI * CS%mode * (k - 0.5) / nz) * cos_wt
-              segment%normal_trans(I,j,k) = segment%normal_vel(I,j,k) * h(i+1,j,k) * G%dyCu(I,j)
             enddo
           endif
         endif
       enddo ; enddo
-      if (allocated(segment%tangential_vel)) then
-        do J=JsdB+1,JedB-1 ; do I=IsdB,IedB
-          depth_tot_corner = 0.5*(depth_tot(i+1,j+1) + depth_tot(i+1,j))
-          x1 = G%grid_unit_to_L * G%geoLonBu(I,J)
-          y1 = G%grid_unit_to_L * G%geoLatBu(I,J)
-          x = (x1 - CS%coast_offset1) * cosa + y1 * sina
-          y = - (x1 - CS%coast_offset1) * sina + y1 * cosa
-          if (CS%indexing_bugs) then
-            cff = sqrt(GV%g_Earth * depth_tot(i+1,j) )
-          else
-            cff = sqrt(GV%g_Earth * depth_tot_corner )
-          endif
-          val2 = mag_SSH * exp(- G%CoriolisBu(I,J) * y / cff)
-          if (CS%mode == 0) then ; do k=1,nz
-            segment%tangential_vel(I,J,k) = (sin_wt * val2 * cff * sina) / depth_tot_corner
-          enddo ; endif
-        enddo ; enddo
+    endif
+
+    if (unrot_dir == OBC_DIRECTION_S) then
+      if (segment%is_E_or_W) then
+        is_vel = IsdB ; ie_vel = IedB ; js_vel = jsd ; je_vel = jed
+      else
+        is_vel = isd ; ie_vel = ied ; js_vel = JsdB ; je_vel = JedB
       endif
-    else ! Must be south
-      do J=JsdB,JedB ; do i=isd,ied
-        x1 = G%grid_unit_to_L * G%geoLonCv(i,J)
-        y1 = G%grid_unit_to_L * G%geoLatCv(i,J)
+      do J=js_vel,je_vel ; do i=is_vel,ie_vel
+        if (segment%is_E_or_W) then
+          x1 = G%grid_unit_to_L * G%geoLonCu(I,j)
+          y1 = G%grid_unit_to_L * G%geoLatCu(I,j)
+        else
+          x1 = G%grid_unit_to_L * G%geoLonCv(i,J)
+          y1 = G%grid_unit_to_L * G%geoLatCv(i,J)
+        endif
         x = (x1 - CS%coast_offset1) * cosa + y1 * sina
         y = - (x1 - CS%coast_offset1) * sina + y1 * cosa
         if (CS%mode == 0) then
-          cff = sqrt(GV%g_Earth * depth_tot(i,j+1) )
-          val2 = mag_SSH * exp(- 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J)) * y / cff)
+          if (segment%direction == OBC_DIRECTION_W) then
+            depth_tot_vel = depth_tot(i+1,j)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1))
+          elseif (segment%direction == OBC_DIRECTION_S) then
+            depth_tot_vel = depth_tot(i,j+1)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J))
+          elseif (segment%direction == OBC_DIRECTION_E) then
+            depth_tot_vel = depth_tot(i,j)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1))
+          elseif (segment%direction == OBC_DIRECTION_N) then
+            depth_tot_vel = depth_tot(i,j)
+            Cor_vel = 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J))
+          endif
+          cff = sqrt(GV%g_Earth * depth_tot_vel )
+          val2 = mag_SSH * exp(- Cor_vel * y / cff)
           segment%SSH(I,j) = val2 * cos_wt
-          segment%normal_vel_bt(I,j) = (sin_wt * cff * sina / depth_tot(i,j+1) ) * val2
+          segment%normal_vel_bt(I,j) = (sin_wt * cff * sina / depth_tot_vel ) * (normal_sign*val2)
           if (segment%nudged) then
             do k=1,nz
-              segment%nudged_normal_vel(I,j,k) = (sin_wt * cff * sina / depth_tot(i,j+1)) * val2
+              segment%nudged_normal_vel(I,j,k) = (sin_wt * cff * sina / depth_tot_vel) * (normal_sign*val2)
             enddo
           elseif (segment%specified) then
             do k=1,nz
-              segment%normal_vel(I,j,k) = (sin_wt * cff * sina / depth_tot(i,j+1) ) * val2
-              segment%normal_trans(i,J,k) = segment%normal_vel(i,J,k) * h(i,j+1,k) * G%dxCv(i,J)
+              segment%normal_vel(I,j,k) = (sin_wt * cff * sina / depth_tot_vel ) * (normal_sign*val2)
             enddo
           endif
         else
@@ -380,32 +422,57 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
           segment%normal_vel_bt(i,J) = 0.0
           if (segment%nudged) then
             do k=1,nz
-              segment%nudged_normal_vel(i,J,k) = mag_int * &
+              segment%nudged_normal_vel(i,J,k) = (normal_sign*mag_int) * &
                    exp(- lambda * y) * cos(PI * CS%mode * (k - 0.5) / nz) * cosa
               ! This is missing cos_wt
             enddo
           elseif (segment%specified) then
             do k=1,nz
-              segment%normal_vel(i,J,k) = mag_int * &
+              segment%normal_vel(i,J,k) = (normal_sign*mag_int) * &
                    exp(- lambda * y) * cos(PI * CS%mode * (k - 0.5) / nz) * cosa
               ! This is missing cos_wt
-              segment%normal_trans(i,J,k) = segment%normal_vel(i,J,k) * h(i,j+1,k) * G%dxCv(i,J)
             enddo
           endif
         endif
       enddo ; enddo
-      if (allocated(segment%tangential_vel)) then
-        do J=JsdB,JedB ; do I=IsdB+1,IedB-1
-          depth_tot_corner = 0.5*(depth_tot(i+1,j+1) + depth_tot(i,j+1))
+    endif
+
+    if (allocated(segment%tangential_vel)) then
+      trans_sign = 1.0
+      if (segment%is_E_or_W) then
+        Isq = IsdB ; Ieq = IedB ; Jsq = JsdB+1 ; Jeq = JedB-1
+        if ((turns == 2) .or. (turns == 3)) trans_sign = -1.0
+      else
+        Isq = IsdB+1 ; Ieq = IedB-1 ; Jsq = JsdB ; Jeq = JedB
+        if ((turns == 1) .or. (turns == 2)) trans_sign = -1.0
+      endif
+
+      if ((unrot_dir == OBC_DIRECTION_W) .or. (unrot_dir == OBC_DIRECTION_S)) then
+        do J=Jsq,Jeq ; do I=Isq,Ieq
+          if (segment%direction == OBC_DIRECTION_W) then
+            depth_tot_corner = 0.5*(depth_tot(i+1,j+1) + depth_tot(i+1,j))
+          elseif (segment%direction == OBC_DIRECTION_E) then
+            depth_tot_corner = 0.5*(depth_tot(i,j+1) + depth_tot(i,j))
+          elseif (segment%direction == OBC_DIRECTION_S) then
+            depth_tot_corner = 0.5*(depth_tot(i+1,j+1) + depth_tot(i,j+1))
+          elseif (segment%direction == OBC_DIRECTION_N) then
+            depth_tot_corner = 0.5*(depth_tot(i+1,j) + depth_tot(i,j))
+          endif
           x1 = G%grid_unit_to_L * G%geoLonBu(I,J)
           y1 = G%grid_unit_to_L * G%geoLatBu(I,J)
           x = (x1 - CS%coast_offset1) * cosa + y1 * sina
           y = - (x1 - CS%coast_offset1) * sina + y1 * cosa
           cff = sqrt(GV%g_Earth * depth_tot_corner )
-          val2 = mag_SSH * exp(- G%CoriolisBu(I,J) * y / cff)
+          val2 = (trans_sign*mag_SSH) * exp(- G%CoriolisBu(I,J) * y / cff)
           if (CS%indexing_bugs) then
-            cff = sqrt(GV%g_Earth * depth_tot(i,j+1) )
-            val2 = mag_SSH * exp(- 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J)) * y / cff)
+            if (unrot_dir == OBC_DIRECTION_W) then
+              cff = sqrt(GV%g_Earth * depth_tot(i+1,j) )
+              val2 = (trans_sign*mag_SSH) * exp(- G%CoriolisBu(I,J) * y / cff)
+            endif
+            if (unrot_dir == OBC_DIRECTION_S) then
+              cff = sqrt(GV%g_Earth * depth_tot(i,j+1) )
+              val2 = (trans_sign*mag_SSH) * exp(- 0.5 * (G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J)) * y / cff)
+            endif
           endif
           if (CS%mode == 0) then ; do k=1,nz
             segment%tangential_vel(I,J,k) = (sin_wt * val2 * cff * sina) / depth_tot_corner
@@ -413,6 +480,28 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
         enddo ; enddo
       endif
     endif
+
+    if (segment%specified .and. (.not.segment%nudged) .and. &
+        ((unrot_dir == OBC_DIRECTION_S) .or. (unrot_dir == OBC_DIRECTION_W))) then
+      if (segment%direction == OBC_DIRECTION_W) then
+        do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB
+          segment%normal_trans(I,j,k) = segment%normal_vel(I,j,k) * h(i+1,j,k) * G%dyCu(I,j)
+        enddo ; enddo ; enddo
+      elseif (segment%direction == OBC_DIRECTION_E) then
+        do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB
+          segment%normal_trans(I,j,k) = segment%normal_vel(I,j,k) * h(i,j,k) * G%dyCu(I,j)
+        enddo ; enddo ; enddo
+      elseif (segment%direction == OBC_DIRECTION_S) then
+        do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied
+          segment%normal_trans(i,J,k) = segment%normal_vel(i,J,k) * h(i,j+1,k) * G%dxCv(i,J)
+        enddo ; enddo ; enddo
+      elseif (segment%direction == OBC_DIRECTION_N) then
+        do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied
+          segment%normal_trans(i,J,k) = segment%normal_vel(i,J,k) * h(i,j,k) * G%dxCv(i,J)
+        enddo ; enddo ; enddo
+      endif
+    endif
+
   enddo
 
 end subroutine Kelvin_set_OBC_data


### PR DESCRIPTION
  This pull request consists of two commits that first add the option to correct several spatial indexing errors and then adds code to `Kelvin_set_OBC_data()` so that the Kelvin wave test cases give identical answers after grid rotation (when the bugs avoided).  The new runtime parameter `KELVIN_SET_OBC_INDEXING_BUGS` is true by default, but when set to false it avoids the Kelvin wave indexing bugs.  By default all answers are bitwise identical, but there is a new runtime parameter that will appear in some MOM_parameter_doc files.  The specific commits in this PR are:

 - NOAA-GFDL/MOM6@595aaba5d (*)Kelvin_set_OBC_data works with grid rotation
 - NOAA-GFDL/MOM6@b64e7f274 +Fix Kelvin_set_OBC_data spatial indexing errors
 
 This PR builds upon the yet-to-be-merged PR #916, which includes the single commit:
 - NOAA-GFDL/MOM6@520f050ce *Fix PE-layout reproducibility with interior OBCs