### PR TITLE
Add ePBL BBL mstar and bottom mixed layer diagnostics

### DIFF
--- a/src/diagnostics/MOM_diagnose_KdWork.F90
+++ b/src/diagnostics/MOM_diagnose_KdWork.F90
@@ -340,7 +340,7 @@ subroutine KdWork_Diagnostics(G,GV,US,diag,VBF,N2_Salt,N2_Temp,dz)
                 global_area_integral(VBF%Bflx_salt_dz(:,:,k), G, tmp_scale=GV%H_to_kg_m2*US%Z_to_m**2*US%s_to_T**3))
       enddo
     endif
-  elseif (VBF%id_Bdif_ePBL>0) then
+  elseif (VBF%id_Bdif_bkgnd>0) then
     call diagnoseKdWork(G, GV, N2_salt, VBF%Kd_bkgnd, VBF%Bflx_salt)
     call diagnoseKdWork(G, GV, N2_temp, VBF%Kd_bkgnd, VBF%Bflx_temp)
   endif
@@ -783,37 +783,40 @@ subroutine Allocate_VBF_CS(G, GV, VBF)
   if (VBF%do_bflx_temp_dz) &
      allocate(VBF%Bflx_temp_dz(isd:ied,jsd:jed,nz), source=0.0)
 
-  if (VBF%do_bflx_salt .or. VBF%do_bflx_salt_dz ) &
+  if (VBF%id_Bdif_salt_dz>0 .or. VBF%id_Bdif_dz>0 .or. VBF%id_Bdif_salt>0 .or. VBF%id_Bdif>0 .or. &
+      VBF%id_Bdif_idz>0 .or. VBF%id_Bdif_salt_idz>0 .or. VBF%id_Bdif_idV>0 .or. VBF%id_Bdif_salt_idV>0) &
     allocate(VBF%Kd_salt(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%do_bflx_temp .or. VBF%do_bflx_temp_dz ) &
+  if (VBF%id_Bdif_temp_dz>0 .or. VBF%id_Bdif_dz>0 .or. VBF%id_Bdif_temp>0 .or. VBF%id_Bdif>0 .or. &
+      VBF%id_Bdif_idz>0 .or. VBF%id_Bdif_temp_idz>0 .or. VBF%id_Bdif_idV>0 .or. VBF%id_Bdif_temp_idV>0) &
     allocate(VBF%Kd_temp(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_BBL>0 .or. VBF%id_Bdif_dz_BBL>0 .or. VBF%id_Bdif_idV_BBL>0) &
+
+  if (VBF%id_Bdif_BBL>0 .or. VBF%id_Bdif_dz_BBL>0 .or. VBF%id_Bdif_idz_BBL>0 .or. VBF%id_Bdif_idV_BBL>0) &
     allocate(VBF%Kd_BBL(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_ePBL>0 .or. VBF%id_Bdif_dz_ePBL>0 .or. VBF%id_Bdif_idV_ePBL>0) &
+  if (VBF%id_Bdif_ePBL>0 .or. VBF%id_Bdif_dz_ePBL>0 .or. VBF%id_Bdif_idz_ePBL>0 .or. VBF%id_Bdif_idV_ePBL>0) &
     allocate(VBF%Kd_ePBL(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_KS>0 .or. VBF%id_Bdif_dz_KS>0 .or. VBF%id_Bdif_idV_KS>0) &
+  if (VBF%id_Bdif_KS>0 .or. VBF%id_Bdif_dz_KS>0 .or. VBF%id_Bdif_idz_KS>0 .or. VBF%id_Bdif_idV_KS>0) &
     allocate(VBF%Kd_KS(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_bkgnd>0 .or. VBF%id_Bdif_dz_bkgnd>0 .or. VBF%id_Bdif_idV_bkgnd>0) &
+  if (VBF%id_Bdif_bkgnd>0 .or. VBF%id_Bdif_dz_bkgnd>0 .or. VBF%id_Bdif_idz_bkgnd>0 .or. VBF%id_Bdif_idV_bkgnd>0) &
     allocate(VBF%Kd_bkgnd(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_ddiff_temp>0 .or. VBF%id_Bdif_dz_ddiff_temp>0 .or. VBF%id_Bdif_idV_ddiff_temp>0) &
-    allocate(VBF%Kd_ddiff_T(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_ddiff_salt>0 .or. VBF%id_Bdif_dz_ddiff_salt>0 .or. VBF%id_Bdif_idV_ddiff_salt>0) &
-    allocate(VBF%Kd_ddiff_S(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_leak>0 .or. VBF%id_Bdif_dz_leak>0 .or. VBF%id_Bdif_idV_leak>0) &
+  if (VBF%id_Bdif_ddiff_temp>0 .or. VBF%id_Bdif_dz_ddiff_temp>0 .or. VBF%id_Bdif_idz_ddiff_temp>0 &
+      .or. VBF%id_Bdif_idV_ddiff_temp>0) allocate(VBF%Kd_ddiff_T(isd:ied,jsd:jed,nz+1), source=0.0)
+  if (VBF%id_Bdif_ddiff_salt>0 .or. VBF%id_Bdif_dz_ddiff_salt>0 .or. VBF%id_Bdif_idV_ddiff_salt>0 &
+      .or. VBF%id_Bdif_idV_ddiff_salt>0) allocate(VBF%Kd_ddiff_S(isd:ied,jsd:jed,nz+1), source=0.0)
+  if (VBF%id_Bdif_leak>0 .or. VBF%id_Bdif_dz_leak>0 .or. VBF%id_Bdif_idz_leak>0 .or. VBF%id_Bdif_idV_leak>0) &
     allocate(VBF%Kd_leak(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_quad>0 .or. VBF%id_Bdif_dz_quad>0 .or. VBF%id_Bdif_idV_quad>0) &
+  if (VBF%id_Bdif_quad>0 .or. VBF%id_Bdif_dz_quad>0 .or. VBF%id_Bdif_idz_quad>0 .or. VBF%id_Bdif_idV_quad>0) &
     allocate(VBF%Kd_quad(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_itidal>0 .or. VBF%id_Bdif_dz_itidal>0 .or. VBF%id_Bdif_idV_itidal>0) &
+  if (VBF%id_Bdif_itidal>0 .or. VBF%id_Bdif_dz_itidal>0 .or. VBF%id_Bdif_idz_itidal>0 .or. VBF%id_Bdif_idV_itidal>0) &
     allocate(VBF%Kd_itidal(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_Froude>0 .or. VBF%id_Bdif_dz_Froude>0 .or. VBF%id_Bdif_idV_Froude>0) &
+  if (VBF%id_Bdif_Froude>0 .or. VBF%id_Bdif_dz_Froude>0 .or. VBF%id_Bdif_idz_Froude>0 .or. VBF%id_Bdif_idV_Froude>0) &
     allocate(VBF%Kd_Froude(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_slope>0 .or. VBF%id_Bdif_dz_slope>0 .or. VBF%id_Bdif_idV_slope>0) &
+  if (VBF%id_Bdif_slope>0 .or. VBF%id_Bdif_dz_slope>0 .or. VBF%id_Bdif_idz_slope>0 .or. VBF%id_Bdif_idV_slope>0) &
     allocate(VBF%Kd_slope(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_lowmode>0 .or. VBF%id_Bdif_dz_lowmode>0 .or. VBF%id_Bdif_idV_lowmode>0) &
+  if (VBF%id_Bdif_lowmode>0 .or. VBF%id_Bdif_dz_lowmode>0 .or. VBF%id_Bdif_idz_lowmode>0 .or. VBF%id_Bdif_idV_lowmode>0) &
     allocate(VBF%Kd_lowmode(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_Niku>0 .or. VBF%id_Bdif_dz_Niku>0 .or. VBF%id_Bdif_idV_Niku>0) &
+  if (VBF%id_Bdif_Niku>0 .or. VBF%id_Bdif_dz_Niku>0 .or. VBF%id_Bdif_idz_Niku>0 .or. VBF%id_Bdif_idV_Niku>0) &
     allocate(VBF%Kd_Niku(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_itides>0 .or. VBF%id_Bdif_dz_itides>0 .or. VBF%id_Bdif_idV_itides>0) &
+  if (VBF%id_Bdif_itides>0 .or. VBF%id_Bdif_dz_itides>0 .or. VBF%id_Bdif_idz_itides>0 .or. VBF%id_Bdif_idV_itides>0) &
     allocate(VBF%Kd_itides(isd:ied,jsd:jed,nz+1), source=0.0)
 
 end subroutine Allocate_VBF_CS

--- a/src/diagnostics/MOM_diagnose_KdWork.F90
+++ b/src/diagnostics/MOM_diagnose_KdWork.F90
@@ -812,8 +812,8 @@ subroutine Allocate_VBF_CS(G, GV, VBF)
     allocate(VBF%Kd_Froude(isd:ied,jsd:jed,nz+1), source=0.0)
   if (VBF%id_Bdif_slope>0 .or. VBF%id_Bdif_dz_slope>0 .or. VBF%id_Bdif_idz_slope>0 .or. VBF%id_Bdif_idV_slope>0) &
     allocate(VBF%Kd_slope(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (VBF%id_Bdif_lowmode>0 .or. VBF%id_Bdif_dz_lowmode>0 .or. VBF%id_Bdif_idz_lowmode>0 .or. VBF%id_Bdif_idV_lowmode>0) &
-    allocate(VBF%Kd_lowmode(isd:ied,jsd:jed,nz+1), source=0.0)
+  if (VBF%id_Bdif_lowmode>0 .or. VBF%id_Bdif_dz_lowmode>0 .or. VBF%id_Bdif_idz_lowmode>0 .or. &
+      VBF%id_Bdif_idV_lowmode>0) allocate(VBF%Kd_lowmode(isd:ied,jsd:jed,nz+1), source=0.0)
   if (VBF%id_Bdif_Niku>0 .or. VBF%id_Bdif_dz_Niku>0 .or. VBF%id_Bdif_idz_Niku>0 .or. VBF%id_Bdif_idV_Niku>0) &
     allocate(VBF%Kd_Niku(isd:ied,jsd:jed,nz+1), source=0.0)
   if (VBF%id_Bdif_itides>0 .or. VBF%id_Bdif_dz_itides>0 .or. VBF%id_Bdif_idz_itides>0 .or. VBF%id_Bdif_idV_itides>0) &

--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -413,7 +413,7 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
           !These are mathematically equivalent, the latter is numerically well-behaved, but the
           ! former is kept as a comment as it may be more intuitive how it is derived.
           !PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * ( (Zr + pe_dir*H_ML_TST)**2 - Zr**2.)
-          PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * (H_ML_TST * (H_ML_TST - 2.0*pe_dir*Zr))
+          PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * (H_ML_TST * (H_ML_TST + 2.0*pe_dir*Zr))
 
           ! Check if we supplied enough energy to mix to this layer
           if (PE_Mixed_TST - PE <= PE_threshold(iM)) then

--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -246,7 +246,7 @@ end subroutine diagnoseMLDbyDensityDifference
 
 !> Diagnose a mixed layer depth (MLD) determined by the depth a given energy value would mix.
 !> This routine is appropriate in MOM_diabatic_aux due to its position within the time stepping.
-subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr, MLD_out)
+subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds, diagPtr, OM4_iteration, MLD_out)
   ! Author: Brandon Reichl
   ! Date: October 2, 2020
   ! //
@@ -278,6 +278,9 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr,
   type(thermo_var_ptrs),   intent(in) :: tv          !< Structure containing pointers to any
                                                      !! available thermodynamic fields.
   type(diag_ctrl),         pointer    :: diagPtr     !< Diagnostics structure
+  integer, dimension(2), intent(in)   :: k_bounds    !< vertical interface bounds to apply calculations
+  logical, optional, intent(in)       :: OM4_iteration !< Uses a legacy version of the MLD iteration
+                                                     !! it is kept to reproduce OM4 output
   real, dimension(SZI_(G),SZJ_(G)), &
               optional, intent(out)   :: MLD_out     !< Send MLD to other routines [Z ~> m]
 
@@ -315,11 +318,16 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr,
   real :: Gpx        ! The derivative of Gx with x  [R Z2 ~> kg m-1]
   real :: Hx         ! The vertical integral depth [Z ~> m]
   real :: iHx        ! The inverse of Hx [Z-1 ~> m-1]
-  real :: Hpx        ! The derivative of Hx with x, hard coded to 1.  Why? [nondim]
+  real :: Hpx        ! The derivative of Hx with x, since H(x) = constant + x, its derivative is 1. [nondim]
   real :: Ix         ! A double integral in depth of density [R Z2 ~> kg m-1]
   real :: Ipx        ! The derivative of Ix with x [R Z ~> kg m-2]
   real :: Fgx        ! The mixing energy difference from the target [R Z2 ~> kg m-1]
   real :: Fpx        ! The derivative of Fgx with x  [R Z ~> kg m-2]
+  real :: Zr         ! An upper (lower) bound for the PE integration in surface (bottom) mixed layer mode [Z ~> m]
+  integer :: k_Zr    ! Sets the index of Zr
+  real :: pe_dir     ! A factor that is used to generalize the iteration for upper and lower mixed layers
+  integer :: k_int   ! Controls the direction of the loop to be forward or backward
+  logical :: use_OM4_iteration ! A logical to use the OM4_iteration if the optional argument is present
 
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: IT, iM
@@ -327,15 +335,32 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr,
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
+  if (present(OM4_iteration)) then
+    use_OM4_iteration = OM4_iteration
+  endif
+
   pRef_MLD(:) = 0.0
   mld(:,:,:) = 0.0
   PE_Threshold_fraction = 1.e-4 !Fixed threshold of 0.01%, could be runtime.
+
+  ! The derivative of H(x) is always 1., so it is moved outside the loops.
+  Hpx = 1.
 
   do iM=1,3
     PE_threshold(iM) = Mixing_Energy(iM) / GV%g_Earth_Z_T2
   enddo
 
   EOSdom(:) = EOS_domain(G%HI)
+
+  if (k_bounds(1)<k_bounds(2)) then
+    k_int = 1    ! k_interval is forward in k-space
+    pe_dir = -1. ! A "down" factor so calculations forward and backward use the same algorithm
+    k_Zr = k_bounds(1) !top of cell indicated by k_bounds(1)
+  else
+    k_int=-1     ! k_interval is backward in k-space
+    pe_dir = 1.  ! An "up" factor so calculations forward and backward use the same algorithm
+    k_Zr = k_bounds(1)+1 !bottom of cell indicated by k_bounds(1)
+  endif
 
   do j=js,je
     ! Find the vertical distances across layers.
@@ -347,10 +372,18 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr,
 
     do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
 
+      !We reference everything to the SSH, so that Z_int(1) is defined where Z=0.
+      ! All presently implemented calculations are not sensitive to this choice.
+      ! If "use_OM4_iteration = .true." setting this non-zero would break the iteration
       Z_int(1) = 0.0
       do k=1,nz
         Z_int(K+1) = Z_int(K) - dZ(i,k)
       enddo
+
+      ! Set the reference for the upper (lower) bound of the mixing integral as the surface
+      ! or the bottom depending on the direction of the calculation (as determined by
+      ! the interface bounds k_bounds)
+      Zr = Z_int(k_Zr)
 
       do iM=1,3
 
@@ -362,9 +395,9 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr,
         H_ML_TST = 0.0
         PE_Mixed = 0.0
 
-        do k=1,nz
+        do k=k_bounds(1),k_bounds(2),k_int
 
-          ! This is the unmixed PE cumulative sum from top down
+          ! This is the unmixed PE cumulative sum in the direction k_int
           PE = PE + 0.5 * Rho_c(i,k) * (Z_int(K)**2 - Z_int(K+1)**2)
 
           ! This is the depth and integral of density
@@ -375,65 +408,117 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, diagPtr,
           Rho_ML = RhoDZ_ML_TST/H_ML_TST
 
           ! The PE assuming all layers including this were mixed
-          ! Note that 0. could be replaced with "Surface", which doesn't have to be 0
-          ! but 0 is a good reference value.
-          PE_Mixed_TST = 0.5 * Rho_ML * (0.**2 - (0. - H_ML_TST)**2)
+          ! Zr is the upper (lower) bound of the integral when operating in surface (bottom)
+          ! mixed layer calculation mode.
+          PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * ( (Zr + pe_dir*H_ML_TST)**2 - Zr**2.)
 
           ! Check if we supplied enough energy to mix to this layer
           if (PE_Mixed_TST - PE <= PE_threshold(iM)) then
             H_ML = H_ML_TST
             RhoDZ_ML = RhoDZ_ML_TST
-
-          else ! If not, we need to solve where the energy ran out
+          else ! If not, we need to solve where the energy ran out within the layer
             ! This will be done with a Newton's method iteration:
-
-            R1 = RhoDZ_ML / H_ML ! The density of the mixed layer (not including this layer)
-            D1 = H_ML ! The thickness of the mixed layer (not including this layer)
-            R2 = Rho_c(i,k) ! The density of this layer
-            D2 = dZ(i,k) ! The thickness of this layer
-
-            ! This block could be used to calculate the function coefficients if
-            ! we don't reference all values to a surface designated as z=0
-            ! S = Surface
-            ! Ca  = -(R2)
-            ! Cb  = -( (R1*D1) + R2*(2.*D1-2.*S) )
-            ! D   = D1**2. - 2.*D1*S
-            ! Cc  = -( R1*D1*(2.*D1-2.*S) + R2*D )
-            ! Cd  = -(R1*D1*D)
-            ! Ca2 = R2
-            ! Cb2 = R2*(2*D1-2*S)
-            ! C   = S**2 + D2**2 + D1**2 - 2*D1*S - 2.*D2*S +2.*D1*D2
-            ! Cc2 = R2*(D+S**2-C)
-            !
-            ! If the surface is S = 0, it simplifies to:
-            Ca  = -R2
-            Cb  = -(R1 * D1 + R2 * (2. * D1))
-            D   = D1**2
-            Cc  = -(R1 * D1 * (2. * D1) + (R2 * D))
-            Cd  = -R1 * (D1 * D)
-            Ca2 = R2
-            Cb2 = R2 * (2. * D1)
-            C   = D2**2 + D1**2 + 2. * (D1 * D2)
-            Cc2 = R2 * (D - C)
 
             ! First guess for an iteration using Newton's method
             X = dZ(i,k) * 0.5
 
+            ! We are trying to solve the function:
+            ! F(x) = G(x)/H(x)+I(x)
+            ! for where F(x) = PE+PE_threshold, or equivalently for where
+            ! F(x) = G(x)/H(x)+I(x) - (PE+PE_threshold) = 0
+            ! We also need the derivative of this function for the Newton's method iteration
+            ! F'(x) = (G'(x)H(x)-G(x)H'(x))/H(x)^2 + I'(x)
+            !
+            !For the Surface Boundary Layer:
+            ! The total function F(x) adds the PE of the top layer with some entrained distance X
+            ! to the PE of the bottom layer below the entrained distance:
+            !      (Rho1*D1+Rho2*x)
+            ! PE = ---------------- (Zr^2 - (Zr-D1-x)^2)  + Rho2 * ((Zr-D1-x)^2 - (Zr-D1-D2)^2)
+            !         (D1 + x)
+            !
+            ! where Rho1 is the mixed density, D1 is the mixed thickness, Rho2 is the unmixed density,
+            ! D2 is the unmixed thickness, Zr is the top surface height, and x is the fraction of the
+            ! unmixed region that becomes mixed.
+            !
+            !//
+            !G(x)  = (Rho1*D1+Rho2*x)*(Zr^2 - (Zr-(D1+x))^2)
+            !
+            !      =  -Rho2 * x^3 + (-Rho1*D1-2*Rho2*D1+2*Rho2*Zr)*x^2
+            !         \-Ca-/         \--------Cb----------------/
+            !
+            !         + (-2*Rho1*D1^2+2*Rho1*D1*Zr-Rho2*D1^2+Rho2*2*D1*Zr)*X + Rho1*(-D1^3+2*D1^2*Zr)
+            !            \----------------------Cc----------------------/      \-------Cd----------/
+            !
+            !//
+            !H(x) = D1 + x
+            !
+            !//
+            !I(x) = Rho2 * ((Zr-(D1+x))^2-(Zr-(D1+D2))^2)
+            !     = Rho2 * x^2 + Rho2*(2*D1-2*Zr) * X + Rho2*(D1^2-2*D1*Zr-D2^2+D1^2-2*D1*Zr-2*D2*Zr+2*D1*D2)
+            !       \Ca2/        \-----Cb2-----/        \-------------------Cc2----------------------------/
+            !
+            !
+            !For the Bottom Boundary Layer:
+            ! The total function is relative to Zr as the bottom interface height, so slightly different:
+            !      (Rho1*D1+Rho2*X)
+            ! PE = ---------------- ((Zr+D1+X)^2 - Zr^2)  + Rho2 * ((Zr+D1+D2)^2 - (Zr+D1+X)^2)
+            !         (D1 + X)
+            ! These differences propagate through and are accounted for via the factor pe_dir
+            !
+            ! Set these coefficients before the iteration
+            R1 = RhoDZ_ML / H_ML ! The density of the mixed layer (not including this layer)
+            D1 = H_ML ! The thickness of the mixed layer (not including this layer)
+            R2 = Rho_c(i,k) ! The density of this layer to be mixed
+            D2 = dZ(i,k) ! The thickness of this layer to be mixed
+
+            ! This sets Zr to "0", which only works for the downward surface mixed layer calculation.
+            !  it should give the same answer at roundoff as the more general expressions below.
+            if (k_int>0 .and. use_OM4_iteration) then
+              Ca  = -(R2)
+              Cb  = -(R1 * D1 + R2 * (2. * D1))
+              D   = D1**2
+              Cc  = -(R1 * D1 * (2. * D1) + (R2 * D))
+              Cd  = -R1 * (D1 * D)
+              Ca2 = R2
+              Cb2 = R2 * (2. * D1)
+              C   = D2**2 + D1**2 + 2. * (D1 * D2)
+              D   = D1**2
+              Cc2 = R2 * (D - C)
+           else
+              ! recall pe_dir = -1 for down, pe_dir = 1 for up.
+              !down Ca  = -R2
+              !up   Ca  =  R2
+              Ca  = pe_dir * R2 ! Density of layer to be mixed
+              !down Cb  = -(R1*D1) - 2.*R2*D1 + 2.*Zr*R2
+              !up   Cb  =  (R1*D1) + 2.*R2*D1 + 2.*Zr*R2
+              Cb = pe_dir * ( (R1 * D1) + (2. * R2) * ( D1 + Zr ) )
+              !down Cc  = -2.*R1*D1**2 - R2*D1**2 + 2.*R2*D1*Zr + 2.*Zr*R1*D1
+              !up   Cc  =  2.*R1*D1**2 + R2*D1**2 + 2.*R2*D1*Zr + 2.*Zr*R1*D1
+              Cc = ( pe_dir * D1**2 ) * ( R2 + 2.*R1 ) + ( 2. * ( Zr * D1 ) ) * ( R2 + R1 )
+              !down Cd = R1*(-D1**3+2.*D1**2*Zr)
+              !up   Cd = R1*( D1**3+2.*D1**2*Zr)
+              Cd = ( R1 * D1**2 ) * ( pe_dir * D1 + 2. * Zr )
+              !down Ca2 =  R2
+              !up   Ca2 = -R2
+              Ca2 = ( -1. * pe_dir ) * R2
+              !down Cb2 = R2*(2*D1-2*Zr)
+              !up   Cb2 = R2*(2*D1-2*Zr)
+              Cb2 = ( 2. * R2 ) * ( D1 - Zr )
+              !down Cc2 = R2*(2.*Zr*D2-2.*D1*D2-D2**2)
+              !up   Cc2 = R2*(2.*Zr*D2+2.*D1*D2+D2**2)
+              Cc2 = ( R2 * D2 ) * ( 2.* Zr + pe_dir * ( 2. * D1 + D2 ) )
+            endif
+
             IT=0
             do while(IT<10)!We can iterate up to 10 times
-              ! We are trying to solve the function:
-              ! F(x) = G(x)/H(x)+I(x)
-              ! for where F(x) = PE+PE_threshold, or equivalently for where
-              ! F(x) = G(x)/H(x)+I(x) - (PE+PE_threshold) = 0
-              ! We also need the derivative of this function for the Newton's method iteration
-              ! F'(x) = (G'(x)H(x)-G(x)H'(x))/H(x)^2 + I'(x)
+
               ! G and its derivative
               Gx = 0.5 * (Ca * (X*X*X) + Cb * X**2 + Cc * X + Cd)
               Gpx = 0.5 * (3. * (Ca * X**2) + 2. * (Cb * X) + Cc)
               ! H, its inverse, and its derivative
               Hx = D1 + X
               iHx = 1. / Hx
-              Hpx = 1.
+              !Hpx = 1. ! The derivative is always 1 so it was moved outside the loop
               ! I and its derivative
               Ix = 0.5 * (Ca2 * X**2 + Cb2 * X + Cc2)
               Ipx = 0.5 * (2. * Ca2 * X + Cb2)

--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -357,7 +357,7 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
     pe_dir = -1. ! A "down" factor so calculations forward and backward use the same algorithm
     k_Zr = k_bounds(1) !top of cell indicated by k_bounds(1)
   else
-    k_int=-1     ! k_interval is backward in k-space
+    k_int = -1     ! k_interval is backward in k-space
     pe_dir = 1.  ! An "up" factor so calculations forward and backward use the same algorithm
     k_Zr = k_bounds(1)+1 !bottom of cell indicated by k_bounds(1)
   endif
@@ -410,7 +410,10 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
           ! The PE assuming all layers including this were mixed
           ! Zr is the upper (lower) bound of the integral when operating in surface (bottom)
           ! mixed layer calculation mode.
-          PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * ( (Zr + pe_dir*H_ML_TST)**2 - Zr**2.)
+          !These are mathematically equivalent, the latter is numerically well-behaved, but the
+          ! former is kept as a comment as it may be more intuitive how it is derived.
+          !PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * ( (Zr + pe_dir*H_ML_TST)**2 - Zr**2.)
+          PE_Mixed_TST = (0.5 * (Rho_ML*pe_dir)) * (H_ML_TST * (H_ML_TST - 2.0*pe_dir*Zr))
 
           ! Check if we supplied enough energy to mix to this layer
           if (PE_Mixed_TST - PE <= PE_threshold(iM)) then

--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -520,8 +520,8 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
               !up   Ca2 = -R2
               Ca2 = ( -1. * pe_dir ) * R2
               !down Cb2 = R2*(2*D1-2*Zr)
-              !up   Cb2 = R2*(2*D1-2*Zr)
-              Cb2 = ( 2. * R2 ) * ( D1 - Zr )
+              !up   Cb2 = R2*(-2*D1-2*Zr)
+              Cb2 = ( 2. * R2 ) * ( (-1.*pe_dir)*D1 - Zr )
               !down Cc2 = R2*(2.*Zr*D2-2.*D1*D2-D2**2)
               !up   Cc2 = R2*(2.*Zr*D2+2.*D1*D2+D2**2)
               Cc2 = ( R2 * D2 ) * ( 2.* Zr + pe_dir * ( 2. * D1 + D2 ) )

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -697,13 +697,11 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
         if (CS%MLD_iteration_guess .and. (CS%BBL_depth(i,j) > 0.0)) BBLD_io = CS%BBL_depth(i,j)
         BBLD_in = BBLD_io
         u_star_BBL = max(visc%ustar_BBL(i,j), CS%ustar_min*GV%Z_to_H)  ! units are H T-1
-        u_star_BBL_z_t = u_star_bbl*GV%H_to_Z
-        ! ^ units are now H T-1 * Z H-1 = Z T-1, but nonBoussinesq has a factor of Rho/Rho0
-        if (.not.GV%Boussinesq) then
-          u_star_BBL_z_t = u_star_BBL_z_t*(GV%Rho0*tv%SpV_avg(i,j,1)) ! factor of Rho/Rho0 is divided out
+        if (GV%Boussinesq) then
+          u_star_BBL_z_t = u_star_BBL*GV%H_to_Z
+        else
+          u_star_BBL_z_t = u_star_BBL*GV%H_to_RZ*tv%SpV_avg(i,j,1)
         endif
-
-        !
 
         if (CS%ePBL_BBL_use_mstar) then
           BBL_TKE = dt * ((u_star_BBL*GV%H_to_RZ) * u_star_BBL_z_t**2)

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -105,8 +105,8 @@ type, public :: energetic_PBL_CS ; private
 
   !mstar related options
   integer :: mstar_scheme    !< An encoded integer to determine which formula is used to set mstar
-  logical :: MSTAR_FLATCAP=.true. !< Set false to use asymptotic mstar cap.
-  real    :: mstar_cap       !< Since MSTAR is restoring undissipated energy to mixing,
+  integer :: BBL_mstar_scheme !< An encoded integer to determine which formula is used to set mstar
+  real    :: mstar_cap       !< Since mstar is restoring undissipated energy to mixing,
                              !! there must be a cap on how large it can be [nondim].  This
                              !! is definitely a function of latitude (Ekman limit),
                              !! but will be taken as constant for now.
@@ -115,31 +115,32 @@ type, public :: energetic_PBL_CS ; private
   real    :: TKE_decay       !< The ratio of the natural Ekman depth to the TKE decay scale [nondim].
 
   !/ mstar_scheme == 0
-  real    :: fixed_mstar     !< Mstar is the ratio of the friction velocity cubed to the TKE available to
+  real    :: fixed_mstar     !< mstar is the ratio of the friction velocity cubed to the TKE available to
                              !! drive entrainment [nondim]. This quantity is the vertically
                              !! integrated shear production minus the vertically integrated
                              !! dissipation of TKE produced by shear.  This value is used if the option
                              !! for using a fixed mstar is used.
+  real    :: BBL_fixed_mstar !< Similar to fixed_mstar, but for the bottom boundary layer
 
   !/ mstar_scheme == 2
-  real :: C_EK = 0.17        !< MSTAR Coefficient in rotation limit for mstar_scheme=OM4 [nondim]
-  real :: MSTAR_COEF = 0.3   !< MSTAR coefficient in rotation/stabilizing balance for mstar_scheme=OM4 [nondim]
+  real :: C_Ek = 0.17        !< mstar Coefficient in rotation limit for EPBL_MSTAR_SCHEME=OM4 [nondim]
+  real :: mstar_coef = 0.3   !< mstar coefficient in rotation/stabilizing balance for EPBL_MSTAR_SCHEME=OM4 [nondim]
 
   !/ mstar_scheme == 3
-  real    :: RH18_mstar_cN1  !< MSTAR_N coefficient 1 (outer-most coefficient for fit) [nondim].
+  real    :: RH18_mstar_cN1  !< mstar_N coefficient 1 (outer-most coefficient for fit) [nondim].
                              !! Value of 0.275 in RH18.  Increasing this
                              !! coefficient increases mechanical mixing for all values of Hf/ust,
                              !! but is most effective at low values (weakly developed OSBLs).
-  real    :: RH18_mstar_cN2  !< MSTAR_N coefficient 2 (coefficient outside of exponential decay) [nondim].
-                             !! Value of 8.0 in RH18.  Increasing this coefficient increases MSTAR
+  real    :: RH18_mstar_cN2  !< mstar_N coefficient 2 (coefficient outside of exponential decay) [nondim].
+                             !! Value of 8.0 in RH18.  Increasing this coefficient increases mstar
                              !! for all values of HF/ust, with a consistent affect across
                              !! a wide range of Hf/ust.
-  real    :: RH18_mstar_cN3  !< MSTAR_N coefficient 3 (exponential decay coefficient) [nondim]. Value of
+  real    :: RH18_mstar_cN3  !< mstar_N coefficient 3 (exponential decay coefficient) [nondim]. Value of
                              !! -5.0 in RH18.  Increasing this increases how quickly the value
-                             !! of MSTAR decreases as Hf/ust increases.
-  real    :: RH18_mstar_cS1  !< MSTAR_S coefficient for RH18 in stabilizing limit [nondim].
+                             !! of mstar decreases as Hf/ust increases.
+  real    :: RH18_mstar_cS1  !< mstar_S coefficient for RH18 in stabilizing limit [nondim].
                              !! Value of 0.2 in RH18.
-  real    :: RH18_mstar_cS2  !< MSTAR_S exponent for RH18 in stabilizing limit [nondim].
+  real    :: RH18_mstar_cS2  !< mstar_S exponent for RH18 in stabilizing limit [nondim].
                              !! Value of 0.4 in RH18.
 
   !/ Coefficient for shear/convective turbulence interaction
@@ -147,18 +148,18 @@ type, public :: energetic_PBL_CS ; private
 
   !/ Langmuir turbulence related parameters
   logical :: Use_LT = .false. !< Flag for using LT in Energy calculation
-  integer :: LT_ENHANCE_FORM !< Integer for Enhancement functional form (various options)
-  real    :: LT_ENHANCE_COEF !< Coefficient in fit for Langmuir Enhancement [nondim]
-  real    :: LT_ENHANCE_EXP  !< Exponent in fit for Langmuir Enhancement [nondim]
-  real :: LaC_MLDoEK         !< Coefficient for Langmuir number modification based on the ratio of
+  integer :: LT_enhance_form !< Integer for Enhancement functional form (various options)
+  real    :: LT_enhance_coef !< Coefficient in fit for Langmuir Enhancement [nondim]
+  real    :: LT_enhance_exp  !< Exponent in fit for Langmuir Enhancement [nondim]
+  real :: LaC_MLD_Ek         !< Coefficient for Langmuir number modification based on the ratio of
                              !! the mixed layer depth over the Ekman depth [nondim].
-  real :: LaC_MLDoOB_stab    !< Coefficient for Langmuir number modification based on the ratio of
+  real :: LaC_MLD_Ob_stab    !< Coefficient for Langmuir number modification based on the ratio of
                              !! the mixed layer depth over the Obukhov depth with stabilizing forcing [nondim].
-  real :: LaC_EKoOB_stab     !< Coefficient for Langmuir number modification based on the ratio of
+  real :: LaC_Ek_Ob_stab     !< Coefficient for Langmuir number modification based on the ratio of
                              !! the Ekman depth over the Obukhov depth with stabilizing forcing [nondim].
-  real :: LaC_MLDoOB_un      !< Coefficient for Langmuir number modification based on the ratio of
+  real :: LaC_MLD_Ob_un      !< Coefficient for Langmuir number modification based on the ratio of
                              !! the mixed layer depth over the Obukhov depth with destabilizing forcing [nondim].
-  real :: LaC_EKoOB_un       !< Coefficient for Langmuir number modification based on the ratio of
+  real :: LaC_Ek_Ob_un       !< Coefficient for Langmuir number modification based on the ratio of
                              !! the Ekman depth over the Obukhov depth with destabilizing forcing [nondim].
   real :: Max_Enhance_M = 5. !< The maximum allowed LT enhancement to the mixing [nondim].
 
@@ -221,6 +222,9 @@ type, public :: energetic_PBL_CS ; private
   logical :: BBL_effic_bug   !< If true, overestimate the efficiency of the non-tidal ePBL bottom boundary
                              !! layer diffusivity by a factor of 1/sqrt(CDRAG), which is often a factor of
                              !! about 18.3.
+  logical :: ePBL_BBL_use_mstar !< If true, use an mstar*ustar^3 paramaterization to get the TKE available
+                             !! to drive mixing in the bottom boundary layer version of ePBL.  Otherwise,
+                             !! use the meanflow energy loss to bottom drag scaled by a constant efficiency.
 
   !/ Options for documenting differences from parameter choices
   integer :: options_diff    !< If positive, this is a coded integer indicating a pair of
@@ -258,27 +262,28 @@ type, public :: energetic_PBL_CS ; private
 
   !>@{ Diagnostic IDs
   integer :: id_ML_depth = -1, id_hML_depth = -1, id_TKE_wind = -1, id_TKE_mixing = -1
+  integer :: id_ustar_ePBL = -1, id_bflx_ePBL = -1
   integer :: id_TKE_MKE = -1, id_TKE_conv = -1, id_TKE_forcing = -1
   integer :: id_TKE_mech_decay = -1, id_TKE_conv_decay = -1
   integer :: id_Mixing_Length = -1, id_Velocity_Scale = -1
   integer :: id_Kd_BBL = -1, id_BBL_Mix_Length = -1, id_BBL_Vel_Scale = -1
   integer :: id_TKE_BBL = -1, id_TKE_BBL_mixing = -1, id_TKE_BBL_decay = -1
-  integer :: id_ustar_BBL = -1, id_BBL_decay_scale = -1, id_BBL_depth = -1
-  integer :: id_MSTAR_mix = -1, id_LA_mod = -1, id_LA = -1, id_MSTAR_LT = -1
+  integer :: id_ustar_BBL = -1, id_bflx_BBL = -1, id_BBL_decay_scale = -1, id_BBL_depth = -1
+  integer :: id_mstar_sfc = -1, id_mstar_BBL = -1, id_LA_mod = -1, id_LA = -1, id_mstar_LT = -1
   ! The next options are used when passively diagnosing sensitivities from parameter choices
   integer :: id_opt_diff_Kd_ePBL = -1, id_opt_maxdiff_Kd_ePBL = -1, id_opt_diff_hML_depth = -1
   !>@}
 end type energetic_PBL_CS
 
-!>@{ Enumeration values for mstar_Scheme
-integer, parameter :: Use_Fixed_MStar = 0  !< The value of mstar_scheme to use a constant mstar
-integer, parameter :: MStar_from_Ekman = 2 !< The value of mstar_scheme to base mstar on the ratio
+!>@{ Enumeration values for mstar_scheme
+integer, parameter :: Use_Fixed_mstar = 0  !< The value of mstar_scheme to use a constant mstar
+integer, parameter :: mstar_from_Ekman = 2 !< The value of mstar_scheme to base mstar on the ratio
                                            !! of the Ekman layer depth to the Obukhov depth
-integer, parameter :: MStar_from_RH18 = 3  !< The value of mstar_scheme to base mstar of of RH18
-integer, parameter :: No_Langmuir = 0      !< The value of LT_ENHANCE_FORM not use Langmuir turbulence.
-integer, parameter :: Langmuir_rescale = 2 !< The value of LT_ENHANCE_FORM to use a multiplicative
+integer, parameter :: mstar_from_RH18 = 3  !< The value of mstar_scheme to base mstar of of RH18
+integer, parameter :: No_Langmuir = 0      !< The value of LT_enhance_form not use Langmuir turbulence.
+integer, parameter :: Langmuir_rescale = 2 !< The value of LT_enhance_form to use a multiplicative
                                            !! rescaling of mstar to account for Langmuir turbulence.
-integer, parameter :: Langmuir_add = 3     !< The value of LT_ENHANCE_FORM to add a contribution to
+integer, parameter :: Langmuir_add = 3     !< The value of LT_enhance_form to add a contribution to
                                            !! mstar from Langmuir turbulence to other contributions.
 integer, parameter :: wT_from_cRoot_TKE = 0 !< Use a constant times the cube root of remaining TKE
                                            !! to calculate the turbulent velocity.
@@ -306,6 +311,7 @@ type, public :: ePBL_column_diags ; private
   real :: LA        !< The value of the Langmuir number [nondim]
   real :: LAmod     !< The modified Langmuir number by convection [nondim]
   real :: mstar     !< The value of mstar used in ePBL [nondim]
+  real :: mstar_BBL !< The value of mstar used in ePBL BBL [nondim]
   real :: mstar_LT  !< The portion of mstar due to Langmuir turbulence [nondim]
   integer :: OBL_its !< The number of iterations used to find a self-consistent surface boundary layer depth
   integer :: BBL_its !< The number of iterations used to find a self-consistent bottom boundary layer depth
@@ -318,7 +324,7 @@ contains
 !!  have already been applied.  All calculations are done implicitly, and there
 !!  is no stability limit on the time step.
 subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, US, CS, &
-                         stoch_CS, dSV_dT, dSV_dS, TKE_forced, buoy_flux, Waves )
+                         stoch_CS, dSV_dT, dSV_dS, TKE_forced, buoy_flux, BBL_buoy_flux, Waves )
   type(ocean_grid_type),   intent(inout) :: G      !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV     !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
@@ -356,6 +362,8 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
   type(energetic_PBL_CS),  intent(inout) :: CS     !< Energetic PBL control structure
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)    :: buoy_flux !< The surface buoyancy flux [Z2 T-3 ~> m2 s-3].
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)    :: BBL_buoy_flux !< The bottom buoyancy flux [Z2 T-3 ~> m2 s-3].
   type(wave_parameters_CS), pointer      :: Waves  !< Waves control structure for Langmuir turbulence
   type(stochastic_CS),     pointer       :: stoch_CS  !< The control structure returned by a previous
 
@@ -373,7 +381,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
 ! mixing.
 !
 !   The key parameters for the mixed layer are found in the control structure.
-!   To use the classic constant mstar mixed layers choose MSTAR_SCHEME=CONSTANT.
+!   To use the classic constant mstar mixed layers choose EPBL_MSTAR_SCHEME=CONSTANT.
 ! The key parameters then include mstar, nstar, TKE_decay, and conv_decay.
 ! For the Oberhuber (1993) mixed layer,the values of these are:
 !      mstar = 1.25,  nstar = 1, TKE_decay = 2.5, conv_decay = 0.5
@@ -427,6 +435,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
   real :: mech_TKE  ! The mechanically generated turbulent kinetic energy available for mixing over a
                     ! timestep before the application of the efficiency in mstar [R Z3 T-2 ~> J m-2]
   real :: u_star_BBL ! The bottom boundary layer friction velocity [H T-1 ~> m s-1 or kg m-2 s-1].
+  real :: u_star_BBL_z_t ! The bottom boundary layer friction velocity converted to Z T-1 [Z T-1 ~> m s-1].
   real :: BBL_TKE   ! The mechanically generated turbulent kinetic energy available for bottom
                     ! boundary layer mixing within a timestep [R Z3 T-2 ~> J m-2]
   real :: I_rho     ! The inverse of the Boussinesq reference density [R-1 ~> m3 kg-1]
@@ -463,11 +472,12 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
                        ! layer [R Z3 T-3 ~> W m-2].
     diag_ustar_BBL, &  ! The bottom boundary layer friction velocity [H T-1 ~> m s-1 or kg m-2 s-1]
     diag_BBL_decay_scale, & ! The bottom boundary layer TKE decay length scale [H ~> m]
-
-    diag_mStar_MIX, &  ! Mstar used in EPBL [nondim]
-    diag_mStar_LT, &   ! Mstar due to Langmuir turbulence [nondim]
+    diag_mstar_sfc, &  ! mstar used in EPBL [nondim]
+    diag_mstar_BBL, &  ! mstar used in EPBL BBL [nondim]
+    diag_mstar_LT, &   ! mstar due to Langmuir turbulence [nondim]
     diag_LA, &         ! Langmuir number [nondim]
-    diag_LA_MOD        ! Modified Langmuir number [nondim]
+    diag_LA_mod, &     ! Modified Langmuir number [nondim]
+    diag_ustar, diag_bflx
 
   ! The following variables are only used for diagnosing sensitivities to ePBL settings
   real, dimension(SZK_(GV)+1) :: &
@@ -514,7 +524,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
   I_rho = GV%H_to_Z * GV%RZ_to_H ! == 1.0 / GV%Rho0 ! This is not used when fully non-Boussinesq.
   I_dt = 0.0 ; if (dt > 0.0) I_dt = 1.0 / dt
   I_rho0dt = 1.0 / (GV%Rho0 * dt)  ! This is not used when fully non-Boussinesq.
-  BBL_mixing = ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0))
+  BBL_mixing = ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0) .or. CS%ePBL_BBL_use_mstar)
 
   ! Zero out diagnostics before accumulation.
   if (CS%TKE_diagnostics) then
@@ -631,6 +641,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
         mech_TKE = dt * GV%Rho0 * u_star**3
         ! The line above is equivalent to: mech_TKE = dt * u_star * fluxes%tau_mag(i,j)
       endif
+      diag_ustar(i,j) = u_star
 
       if (allocated(tv%SpV_avg) .and. .not.GV%Boussinesq) then
         SpV_dt(1) = tv%SpV_avg(i,j,1) * I_dt
@@ -684,20 +695,25 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
       if (BBL_mixing) then
         if (CS%MLD_iteration_guess .and. (CS%BBL_depth(i,j) > 0.0)) BBLD_io = CS%BBL_depth(i,j)
         BBLD_in = BBLD_io
-        if (CS%BBL_effic_bug) then
-          BBL_TKE = CS%ePBL_BBL_effic * GV%H_to_RZ * dt * visc%BBL_meanKE_loss_sqrtCd(i,j)
-        else
-          BBL_TKE = CS%ePBL_BBL_effic * GV%H_to_RZ * dt * visc%BBL_meanKE_loss(i,j)
-        endif
         u_star_BBL = max(visc%ustar_BBL(i,j), CS%ustar_min*GV%Z_to_H)
-
-        ! Add in tidal dissipation energy at the bottom, noting that fluxes%BBL_tidal_dis is
-        ! in [R Z L2 T-3 ~> W m-2], unlike visc%BBL_meanKE_loss.
-        if ((CS%ePBL_tidal_effic > 0.0) .and. associated(fluxes%BBL_tidal_dis)) &
-          BBL_TKE = BBL_TKE + CS%ePBL_tidal_effic * dt * fluxes%BBL_tidal_dis(i,j)
+        u_star_BBL_z_t = u_star_bbl*GV%H_to_Z
+        if (CS%ePBL_BBL_use_mstar) then
+          BBL_TKE = dt * ((u_star_BBL*GV%H_to_RZ) * u_star_BBL_z_t**2)
+        else
+          if (CS%BBL_effic_bug) then
+            BBL_TKE = CS%ePBL_BBL_effic * GV%H_to_RZ * dt * visc%BBL_meanKE_loss_sqrtCd(i,j)
+          else
+            BBL_TKE = CS%ePBL_BBL_effic * GV%H_to_RZ * dt * visc%BBL_meanKE_loss(i,j)
+          endif
+          ! Add in tidal dissipation energy at the bottom, noting that fluxes%BBL_tidal_dis is
+          ! in [R Z L2 T-3 ~> W m-2], unlike visc%BBL_meanKE_loss.
+          if ((CS%ePBL_tidal_effic > 0.0) .and. associated(fluxes%BBL_tidal_dis)) &
+            BBL_TKE = BBL_TKE + CS%ePBL_tidal_effic * dt * fluxes%BBL_tidal_dis(i,j)
+        endif
 
         call ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT_1d, dSV_dS_1d, SpV_dt, absf, dt, Kd, BBL_TKE, &
-                             u_star_BBL, Kd_BBL, BBLD_io, mixvel_BBL, mixlen_BBL, GV, US, CS, eCD)
+                             u_star_BBL, u_star_BBL_z_t, BBL_buoy_flux(i,j), Kd_BBL, BBLD_io, mixvel_BBL, mixlen_BBL, &
+                             GV, US, CS, eCD)
 
         do K=1,nz+1 ; Kd(K) = Kd(K) + Kd_BBL(K) ; enddo
         if (CS%id_Kd_BBL > 0) then ; do K=1,nz+1
@@ -742,10 +758,11 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
         if (CS%id_TKE_BBL>0) &
           diag_TKE_BBL(i,j) = diag_TKE_BBL(i,j) + BBL_TKE
       endif
-      if (CS%id_MSTAR_MIX > 0) diag_mStar_mix(i,j) = eCD%mstar
-      if (CS%id_MSTAR_LT > 0) diag_mStar_lt(i,j) = eCD%mstar_LT
+      if (CS%id_mstar_sfc > 0) diag_mstar_sfc(i,j) = eCD%mstar
+      if (CS%id_mstar_bbl > 0) diag_mstar_BBL(i,j) = eCD%mstar_BBL
+      if (CS%id_mstar_LT > 0) diag_mstar_lt(i,j) = eCD%mstar_LT
       if (CS%id_LA > 0) diag_LA(i,j) = eCD%LA
-      if (CS%id_LA_MOD > 0) diag_LA_mod(i,j) = eCD%LAmod
+      if (CS%id_LA_mod > 0) diag_LA_mod(i,j) = eCD%LAmod
       if (report_avg_its) then
         CS%sum_its(1) = CS%sum_its(1) + real_to_EFP(real(eCD%OBL_its))
         CS%sum_its(2) = CS%sum_its(2) + real_to_EFP(1.0)
@@ -774,10 +791,13 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
           if ((CS%ePBL_tidal_effic > 0.0) .and. associated(fluxes%BBL_tidal_dis)) &
             BBL_TKE = BBL_TKE + CS%ePBL_tidal_effic * dt * fluxes%BBL_tidal_dis(i,j)
           u_star_BBL = max(visc%ustar_BBL(i,j), CS%ustar_min*GV%Z_to_H)
+          u_star_BBL_z_t = u_star_bbl*GV%H_to_Z
           call ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT_1d, dSV_dS_1d, SpV_dt, absf, dt, Kd, BBL_TKE, &
-                               u_star_BBL, Kd_1, BLD_1, mixvel_BBL, mixlen_BBL, GV, US, CS_tmp1, eCD_tmp)
+                               u_star_BBL, u_star_BBL_z_t, BBL_buoy_flux(i,j), Kd_1, BLD_1, mixvel_BBL, mixlen_BBL, &
+                               GV, US, CS_tmp1, eCD_tmp)
           call ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT_1d, dSV_dS_1d, SpV_dt, absf, dt, Kd, BBL_TKE, &
-                               u_star_BBL, Kd_2, BLD_2, mixvel_BBL, mixlen_BBL, GV, US, CS_tmp2, eCD_tmp)
+                               u_star_BBL, u_star_BBL_z_t, BBL_buoy_flux(i,j), Kd_2, BLD_2, mixvel_BBL, mixlen_BBL, &
+                               GV, US, CS_tmp2, eCD_tmp)
         endif
 
         if (CS%id_opt_diff_Kd_ePBL > 0) then
@@ -813,6 +833,8 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
   endif
 
   if (CS%id_ML_depth > 0) call post_data(CS%id_ML_depth, CS%ML_depth, CS%diag)
+  if (CS%id_ustar_ePBL > 0) call post_data(CS%id_ustar_ePBL, diag_ustar, CS%diag)
+  if (CS%id_bflx_ePBL > 0) call post_data(CS%id_bflx_ePBL, buoy_flux, CS%diag)
   if (CS%id_hML_depth > 0) call post_data(CS%id_hML_depth, CS%ML_depth, CS%diag)
   if (CS%id_TKE_wind > 0) call post_data(CS%id_TKE_wind, diag_TKE_wind, CS%diag)
   if (CS%id_TKE_MKE > 0)  call post_data(CS%id_TKE_MKE, diag_TKE_MKE, CS%diag)
@@ -825,7 +847,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
     call post_data(CS%id_TKE_conv_decay, diag_TKE_conv_decay, CS%diag)
   if (CS%id_Mixing_Length > 0) call post_data(CS%id_Mixing_Length, diag_Mixing_Length, CS%diag)
   if (CS%id_Velocity_Scale >0) call post_data(CS%id_Velocity_Scale, diag_Velocity_Scale, CS%diag)
-  if (CS%id_MSTAR_MIX > 0)     call post_data(CS%id_MSTAR_MIX, diag_mStar_MIX, CS%diag)
+  if (CS%id_mstar_sfc > 0)     call post_data(CS%id_mstar_sfc, diag_mstar_sfc, CS%diag)
   if (BBL_mixing) then
     if (CS%id_Kd_BBL > 0) call post_data(CS%id_Kd_BBL, Kd_BBL_3d, CS%diag)
     if (CS%id_BBL_Mix_Length > 0) call post_data(CS%id_BBL_Mix_Length, BBL_Mix_Length, CS%diag)
@@ -836,10 +858,11 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
     if (CS%id_TKE_BBL_mixing > 0) call post_data(CS%id_TKE_BBL_mixing, diag_TKE_BBL_mixing, CS%diag)
     if (CS%id_TKE_BBL_decay > 0) call post_data(CS%id_TKE_BBL_decay, diag_TKE_BBL_decay, CS%diag)
     if (CS%id_BBL_depth > 0) call post_data(CS%id_BBL_depth, CS%BBL_depth, CS%diag)
+    if (CS%id_mstar_BBL > 0)     call post_data(CS%id_mstar_BBL, diag_mstar_BBL, CS%diag)
   endif
   if (CS%id_LA > 0)       call post_data(CS%id_LA, diag_LA, CS%diag)
-  if (CS%id_LA_MOD > 0)   call post_data(CS%id_LA_MOD, diag_LA_MOD, CS%diag)
-  if (CS%id_MSTAR_LT > 0) call post_data(CS%id_MSTAR_LT, diag_mStar_LT, CS%diag)
+  if (CS%id_LA_mod > 0)   call post_data(CS%id_LA_mod, diag_LA_mod, CS%diag)
+  if (CS%id_mstar_LT > 0) call post_data(CS%id_mstar_LT, diag_mstar_LT, CS%diag)
   if (stoch_CS%pert_epbl) then
     if (stoch_CS%id_epbl1_wts > 0) call post_data(stoch_CS%id_epbl1_wts, stoch_CS%epbl1_wts, CS%diag)
     if (stoch_CS%id_epbl2_wts > 0) call post_data(stoch_CS%id_epbl2_wts, stoch_CS%epbl2_wts, CS%diag)
@@ -1213,19 +1236,19 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
     MLD_output = dz(1)
     sfc_connected = .true.
 
-    !/ Here we get MStar, which is the ratio of convective TKE driven mixing to UStar**3
+    !/ Here we get mstar, which is the ratio of convective TKE driven mixing to UStar**3
     if (CS%Use_LT) then
       call get_Langmuir_Number(LA, G, GV, US, abs(MLD_guess), u_star_mean, i, j, dz, Waves, &
                                U_H=u, V_H=v)
-      call find_mstar(CS, US, B_flux, u_star, MLD_guess, absf, &
+      call find_mstar(CS, US, B_flux, u_star, MLD_guess, absf, .false., &
                       mstar_total, Langmuir_Number=La, Convect_Langmuir_Number=LAmod,&
                       mstar_LT=mstar_LT)
     else
-      call find_mstar(CS, US, B_flux, u_star, MLD_guess, absf, mstar_total)
+      call find_mstar(CS, US, B_flux, u_star, MLD_guess, absf, .false., mstar_total)
     endif
 
-    !/ Apply MStar to get mech_TKE
-    if ((CS%answer_date < 20190101) .and. (CS%mstar_scheme==Use_Fixed_MStar)) then
+    !/ Apply mstar to get mech_TKE
+    if ((CS%answer_date < 20190101) .and. (CS%mstar_scheme==Use_Fixed_mstar)) then
       mech_TKE = (dt*mstar_total*GV%Rho0) * u_star**3
     else
       mech_TKE = mstar_total * mech_TKE_in
@@ -1861,11 +1884,11 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
     if (OBL_it >= CS%Max_MLD_Its) exit
 
     ! The following lines are used for the iteration.  Note the iteration has been altered
-    ! to use the value predicted by the TKE threshold (ML_DEPTH).  This is because the MSTAR
+    ! to use the value predicted by the TKE threshold (ML_depth).  This is because the mstar
     ! is now dependent on the ML, and therefore the ML needs to be estimated more precisely
     ! than the grid spacing.
 
-    ! New method uses ML_DEPTH as computed in ePBL routine
+    ! New method uses ML_depth as computed in ePBL routine
     MLD_found = MLD_output
 
     ! Find out whether to do another iteration and the new bounds on it.
@@ -1924,7 +1947,8 @@ end subroutine ePBL_column
 !> This subroutine determines the diffusivities from a bottom boundary layer version of
 !! the integrated energetics mixed layer model for a single column of water.
 subroutine ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, absf, &
-                           dt, Kd, BBL_TKE_in, u_star_BBL, Kd_BBL, BBLD_io, mixvel_BBL, mixlen_BBL, GV, US, CS, eCD)
+                           dt, Kd, BBL_TKE_in, u_star_BBL, u_star_BBL_z_t, b_flux_BBL, Kd_BBL, BBLD_io, mixvel_BBL, &
+                           mixlen_BBL, GV, US, CS, eCD)
   type(verticalGrid_type),   intent(in)  :: GV     !< The ocean's vertical grid structure.
   real, dimension(SZK_(GV)), intent(in)  :: h      !< Layer thicknesses [H ~> m or kg m-2].
   real, dimension(SZK_(GV)), intent(in)  :: dz     !< The vertical distance across layers [Z ~> m].
@@ -1954,7 +1978,10 @@ subroutine ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, absf, &
                                                    !! kinetic energy available for bottom boundary
                                                    !! layer mixing within a time step [R Z3 T-2 ~> J m-2].
   real,                    intent(in)    :: u_star_BBL !< The bottom boundary layer friction velocity
-                                                   !! in thickuness flux units [H T-1 ~> m s-1 or kg m-2 s-1]
+                                                       !! in thickness flux units [H T-1 ~> m s-1 or kg m-2 s-1]
+  real,                    intent(in)    :: u_star_BBL_z_t !< The bottom boundary layer friction velocity
+                                                       !! converted to length flux units [Z T-1 ~> m s-1]
+  real,                    intent(in)    :: b_flux_BBL !< The bottom boundary layer buoyancy flux
   real, dimension(SZK_(GV)+1), &
                            intent(out)   :: Kd_BBL !< The bottom boundary layer contribution to diffusivities
                                                    !! at interfaces [H Z T-1 ~> m2 s-1 or kg m-1 s-1].
@@ -2129,6 +2156,7 @@ subroutine ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, absf, &
   real :: Surface_Scale ! Surface decay scale for vstar [nondim]
   logical :: debug      ! This is used as a hard-coded value for debugging.
   logical :: no_MKE_conversion  ! If true, there is conversion of MKE to TKE in this routine.
+  real :: mstar_BBL !< the value of mstar for the bottom boundary layer [nondim]
 
   !  The following arrays are used only for debugging purposes.
   real :: dPE_debug     ! An estimate of the potential energy change [R Z3 T-2 ~> J m-2]
@@ -2152,7 +2180,8 @@ subroutine ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, absf, &
   no_MKE_conversion = ((CS%direct_calc) ) ! .and. (CS%MKE_to_TKE_effic == 0.0))
 
   ! Add bottom boundary layer mixing if there is energy to support it.
-  if (((CS%ePBL_BBL_effic <= 0.0) .and. (CS%ePBL_tidal_effic <= 0.0)) .or. (BBL_TKE_in <= 0.0)) then
+  if (((CS%ePBL_BBL_effic <= 0.0) .and. (CS%ePBL_tidal_effic <= 0.0) .and. (.not.CS%ePBL_BBL_use_mstar)) &
+      .or. (BBL_TKE_in <= 0.0)) then
     ! There is no added bottom boundary layer mixing.
     BBLD_io = 0.0
     Kd_BBL(:) = 0.0
@@ -2269,8 +2298,14 @@ subroutine ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, absf, &
       BBLD_output = dz(nz)
       bot_connected = .true.
 
-      mech_BBL_TKE = BBL_TKE_in
-
+      if (CS%ePBL_BBL_use_mstar) then
+        call find_mstar(CS, US, B_flux_BBL, u_star_BBL_z_t, BBLD_guess, absf, .true., mstar_BBL)
+        eCD%mstar_BBL = mstar_BBL
+        mech_BBL_TKE = mstar_BBL * BBL_TKE_in
+      else
+        mech_BBL_TKE = BBL_TKE_in
+        eCD%mstar_BBL = 0.0
+      endif
       if (CS%TKE_diagnostics) then
         ! eCD%dTKE_BBL_MKE = 0.0
         eCD%dTKE_BBL_mixing = 0.0
@@ -2704,7 +2739,6 @@ subroutine ePBL_BBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, absf, &
     enddo ! Iteration loop for converged boundary layer thickness.
 
     eCD%BBL_its = min(BBL_it, CS%max_BBLD_its)
-
     BBLD_io = BBLD_output
   endif
 
@@ -3475,103 +3509,115 @@ subroutine find_PE_chg_orig(Kddt_h, h_k, b_den_1, dTe_term, dSe_term, &
 
 end subroutine find_PE_chg_orig
 
-!> This subroutine finds the Mstar value for ePBL
+!> This subroutine finds the mstar value for ePBL
 subroutine find_mstar(CS, US, Buoyancy_Flux, UStar, &
-                      BLD, Abs_Coriolis, MStar, Langmuir_Number,&
-                      MStar_LT, Convect_Langmuir_Number)
+                      BLD, Abs_Coriolis, Is_BBL, mstar, &
+                      Langmuir_Number,mstar_LT, Convect_Langmuir_Number)
   type(energetic_PBL_CS), intent(in) :: CS    !< Energetic PBL control structure
   type(unit_scale_type), intent(in)  :: US    !< A dimensional unit scaling type
   real,                  intent(in)  :: UStar !< ustar including gustiness [Z T-1 ~> m s-1]
   real,                  intent(in)  :: Abs_Coriolis !< absolute value of the Coriolis parameter [T-1 ~> s-1]
   real,                  intent(in)  :: Buoyancy_Flux !< Buoyancy flux [Z2 T-3 ~> m2 s-3]
   real,                  intent(in)  :: BLD   !< boundary layer depth [Z ~> m]
-  real,                  intent(out) :: Mstar !< Output mstar (Mixing/ustar**3) [nondim]
+  logical,               intent(in)  :: Is_BBL !< Logcal flag to indicate if bottom boundary layer mode
+  real,                  intent(out) :: mstar !< Output mstar (Mixing/ustar**3) [nondim]
   real,        optional, intent(in)  :: Langmuir_Number !< Langmuir number [nondim]
-  real,        optional, intent(out) :: MStar_LT !< Mstar increase due to Langmuir turbulence [nondim]
+  real,        optional, intent(out) :: mstar_LT !< mstar increase due to Langmuir turbulence [nondim]
   real,        optional, intent(out) :: Convect_Langmuir_number !< Langmuir number including buoyancy flux [nondim]
 
   !/ Variables used in computing mstar
   real :: MSN_term       ! Temporary terms [nondim]
   real :: MSCR_term1, MSCR_term2 ! Temporary terms [Z3 T-3 ~> m3 s-3]
-  real :: MStar_Conv_Red ! Adjustment made to mstar due to convection reducing mechanical mixing [nondim]
-  real :: MStar_S, MStar_N ! Mstar in (S)tabilizing/(N)ot-stabilizing buoyancy flux [nondim]
+  real :: mstar_Conv_Red ! Adjustment made to mstar due to convection reducing mechanical mixing [nondim]
+  real :: mstar_S, mstar_N ! mstar in (S)tabilizing/(N)ot-stabilizing buoyancy flux [nondim]
+  integer :: mstar_scheme ! Toggles between surface and bottom boundary layer mstar scheme from control structure
 
   !/  Integer options for how to find mstar
 
   !/
 
-  if (CS%mstar_scheme == Use_Fixed_MStar) then
-    MStar = CS%Fixed_MStar
+  if (Is_BBL) then
+    mstar_scheme = CS%BBL_mstar_scheme
+  else
+    mstar_scheme = CS%mstar_scheme
+  endif
+
+  if (mstar_scheme == Use_Fixed_mstar) then
+    if (Is_BBL) then
+      mstar = CS%BBL_Fixed_mstar
+    else
+      mstar = CS%Fixed_mstar
+    endif
   !/ 1. Get mstar
-  elseif (CS%mstar_scheme == MStar_from_Ekman) then
+  elseif (mstar_scheme == mstar_from_Ekman) then
 
     if (CS%answer_date < 20190101) then
       ! The limit for the balance of rotation and stabilizing is f(L_Ekman,L_Obukhov)
-      MStar_S = CS%MStar_coef*sqrt(max(0.0,Buoyancy_Flux) / UStar**2 / &
+      mstar_S = CS%mstar_coef*sqrt(max(0.0,Buoyancy_Flux) / UStar**2 / &
                     (Abs_Coriolis + 1.e-10*US%T_to_s) )
       ! The limit for rotation (Ekman length) limited mixing
-      MStar_N =  CS%C_Ek * log( max( 1., UStar / (Abs_Coriolis + 1.e-10*US%T_to_s) / BLD ) )
+      mstar_N =  CS%C_Ek * log( max( 1., UStar / (Abs_Coriolis + 1.e-10*US%T_to_s) / BLD ) )
     else
       ! The limit for the balance of rotation and stabilizing is f(L_Ekman,L_Obukhov)
-      MStar_S = CS%MSTAR_COEF*sqrt(max(0.0, Buoyancy_Flux) / (UStar**2 * max(Abs_Coriolis, 1.e-20*US%T_to_s)))
+      mstar_S = CS%mstar_coef*sqrt(max(0.0, Buoyancy_Flux) / (UStar**2 * max(Abs_Coriolis, 1.e-20*US%T_to_s)))
       ! The limit for rotation (Ekman length) limited mixing
-      MStar_N = 0.0
-      if (UStar > Abs_Coriolis * BLD) Mstar_N = CS%C_EK * log(UStar / (Abs_Coriolis * BLD))
+      mstar_N = 0.0
+      if (UStar > Abs_Coriolis * BLD) mstar_N = CS%C_Ek * log(UStar / (Abs_Coriolis * BLD))
     endif
 
     ! Here 1.25 is about .5/von Karman, which gives the Obukhov limit.
-    MStar = max(MStar_S, min(1.25, MStar_N))
-    if (CS%MStar_Cap > 0.0) MStar = min( CS%MStar_Cap,MStar )
-  elseif ( CS%mstar_scheme == MStar_from_RH18 ) then
+    mstar = max(mstar_S, min(1.25, mstar_N))
+    if (CS%mstar_Cap > 0.0) mstar = min( CS%mstar_Cap,mstar )
+  elseif ( mstar_scheme == mstar_from_RH18 ) then
     if (CS%answer_date < 20190101) then
-      MStar_N = CS%RH18_MStar_cn1 * ( 1.0 - 1.0 / ( 1. + CS%RH18_MStar_cn2 * &
+      mstar_N = CS%RH18_mstar_cn1 * ( 1.0 - 1.0 / ( 1. + CS%RH18_mstar_cn2 * &
                 exp( CS%RH18_mstar_CN3 * BLD * Abs_Coriolis / UStar) ) )
     else
-      MSN_term = CS%RH18_MStar_cn2 * exp( CS%RH18_mstar_CN3 * BLD * Abs_Coriolis / UStar)
-      MStar_N = (CS%RH18_MStar_cn1 *  MSN_term) / ( 1. + MSN_term)
+      MSN_term = CS%RH18_mstar_cn2 * exp( CS%RH18_mstar_CN3 * BLD * Abs_Coriolis / UStar)
+      mstar_N = (CS%RH18_mstar_cn1 *  MSN_term) / ( 1. + MSN_term)
     endif
-    MStar_S = CS%RH18_MStar_CS1 * ( max(0.0, Buoyancy_Flux)**2 * BLD / &
+    mstar_S = CS%RH18_mstar_CS1 * ( max(0.0, Buoyancy_Flux)**2 * BLD / &
              ( UStar**5 * max(Abs_Coriolis,1.e-20*US%T_to_s) ) )**CS%RH18_mstar_cs2
-    MStar = MStar_N + MStar_S
+    mstar = mstar_N + mstar_S
   endif
 
   !/ 2. Adjust mstar to account for convective turbulence
   if (CS%answer_date < 20190101) then
-    MStar_Conv_Red = 1. - CS%MStar_Convect_coef * (-min(0.0,Buoyancy_Flux) + 1.e-10*US%T_to_s**3*US%m_to_Z**2) / &
+    mstar_Conv_Red = 1. - CS%mstar_Convect_coef * (-min(0.0,Buoyancy_Flux) + 1.e-10*US%T_to_s**3*US%m_to_Z**2) / &
                          ( (-min(0.0,Buoyancy_Flux) + 1.e-10*US%T_to_s**3*US%m_to_Z**2) + &
-                         2.0 *MStar * UStar**3 / BLD )
+                         2.0 *mstar * UStar**3 / BLD )
   else
     MSCR_term1 = -BLD * min(0.0, Buoyancy_Flux)
-    MSCR_term2 = 2.0*MStar * UStar**3
+    MSCR_term2 = 2.0*mstar * UStar**3
     if ( abs(MSCR_term2) > 0.0) then
-      MStar_Conv_Red = ((1.-CS%mstar_convect_coef) * MSCR_term1 + MSCR_term2) / (MSCR_term1 + MSCR_term2)
+      mstar_Conv_Red = ((1.-CS%mstar_convect_coef) * MSCR_term1 + MSCR_term2) / (MSCR_term1 + MSCR_term2)
     else
-      MStar_Conv_Red = 1.-CS%mstar_convect_coef
+      mstar_Conv_Red = 1.-CS%mstar_convect_coef
     endif
   endif
 
   !/3. Combine various mstar terms to get final value
-  MStar = MStar * MStar_Conv_Red
+  mstar = mstar * mstar_Conv_Red
 
-  if (present(Langmuir_Number)) then
-    call mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langmuir_Number, MStar, &
-                        MStar_LT, Convect_Langmuir_Number)
+  if ((.not.Is_BBL) .and. (present(Langmuir_Number))) then
+    call mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langmuir_Number, mstar, &
+                        mstar_LT, Convect_Langmuir_Number)
   endif
 
-end subroutine Find_Mstar
+end subroutine Find_mstar
 
-!> This subroutine modifies the Mstar value if the Langmuir number is present
-subroutine Mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langmuir_Number, &
-                          Mstar, MStar_LT, Convect_Langmuir_Number)
+!> This subroutine modifies the mstar value if the Langmuir number is present
+subroutine mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langmuir_Number, &
+                          mstar, mstar_LT, Convect_Langmuir_Number)
   type(energetic_PBL_CS), intent(in) :: CS    !< Energetic PBL control structure
   type(unit_scale_type), intent(in)  :: US    !< A dimensional unit scaling type
   real,                  intent(in)  :: Abs_Coriolis !< Absolute value of the Coriolis parameter [T-1 ~> s-1]
   real,                  intent(in)  :: Buoyancy_Flux !< Buoyancy flux [Z2 T-3 ~> m2 s-3]
   real,                  intent(in)  :: UStar !< Surface friction velocity with? gustiness [Z T-1 ~> m s-1]
   real,                  intent(in)  :: BLD   !< boundary layer depth [Z ~> m]
-  real,                  intent(inout) :: Mstar !< Input/output mstar (Mixing/ustar**3) [nondim]
+  real,                  intent(inout) :: mstar !< Input/output mstar (Mixing/ustar**3) [nondim]
   real,                  intent(in)  :: Langmuir_Number !< Langmuir number [nondim]
-  real,                  intent(out) :: MStar_LT !< Mstar increase due to Langmuir turbulence [nondim]
+  real,                  intent(out) :: mstar_LT !< mstar increase due to Langmuir turbulence [nondim]
   real,                  intent(out) :: Convect_Langmuir_number !< Langmuir number including buoyancy flux [nondim]
 
   !/
@@ -3597,7 +3643,7 @@ subroutine Mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langm
   ! Set default values for no Langmuir effects.
   enhance_mstar = 1.0 ; mstar_LT_add = 0.0
 
-  if (CS%LT_Enhance_Form /= No_Langmuir) then
+  if (CS%LT_enhance_form /= No_Langmuir) then
     ! a. Get parameters for modified LA
     if (CS%answer_date < 20190101) then
       iL_Ekman   = Abs_Coriolis / Ustar
@@ -3631,24 +3677,24 @@ subroutine Mstar_Langmuir(CS, US, Abs_Coriolis, Buoyancy_Flux, UStar, BLD, Langm
     !    Assumes linear factors based on length scale ratios to adjust LA
     !    Note when these coefficients are set to 0 recovers simple LA.
     Convect_Langmuir_Number = Langmuir_Number * &
-                    ( (1.0 + max(-0.5, CS%LaC_MLDoEK * MLD_Ekman)) + &
-                   ((CS%LaC_EKoOB_stab * Ekman_Obukhov_stab + CS%LaC_EKoOB_un * Ekman_Obukhov_un) + &
-                    (CS%LaC_MLDoOB_stab * MLD_Obukhov_stab  + CS%LaC_MLDoOB_un * MLD_Obukhov_un)) )
+                    ( (1.0 + max(-0.5, CS%LaC_MLD_Ek * MLD_Ekman)) + &
+                   ((CS%LaC_Ek_Ob_stab * Ekman_Obukhov_stab + CS%LaC_Ek_Ob_un * Ekman_Obukhov_un) + &
+                    (CS%LaC_MLD_Ob_stab * MLD_Obukhov_stab  + CS%LaC_MLD_Ob_un * MLD_Obukhov_un)) )
 
-    if (CS%LT_Enhance_Form == Langmuir_rescale) then
+    if (CS%LT_enhance_form == Langmuir_rescale) then
       ! Enhancement is multiplied (added mst_lt set to 0)
       Enhance_mstar = min(CS%Max_Enhance_M, &
-                          (1. + CS%LT_ENHANCE_COEF * Convect_Langmuir_Number**CS%LT_ENHANCE_EXP) )
-    elseif (CS%LT_ENHANCE_Form == Langmuir_add) then
+                          (1. + CS%LT_enhance_coef * Convect_Langmuir_Number**CS%LT_enhance_exp) )
+    elseif (CS%LT_enhance_form == Langmuir_add) then
       ! or Enhancement is additive (multiplied enhance_m set to 1)
-      mstar_LT_add = CS%LT_ENHANCE_COEF * Convect_Langmuir_Number**CS%LT_ENHANCE_EXP
+      mstar_LT_add = CS%LT_enhance_coef * Convect_Langmuir_Number**CS%LT_enhance_exp
     endif
   endif
 
   mstar_LT = (enhance_mstar - 1.0)*mstar + mstar_LT_add  ! Diagnose the full increase in mstar.
   mstar = mstar*enhance_mstar + mstar_LT_add
 
-end subroutine Mstar_Langmuir
+end subroutine mstar_Langmuir
 
 
 !> Copies the ePBL active mixed layer depth into MLD, in units of [Z ~> m] unless other units are specified.
@@ -3688,6 +3734,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_energetic_PBL"  ! This module's name.
   character(len=20)  :: tmpstr  ! A string that is parsed for parameter settings
+  character(len=20)  :: mstar_scheme ! A string that is parsed for mstar parameter settings
   character(len=20)  :: vel_scale_str ! A string that is parsed for velocity scale parameter settings
   character(len=120) :: diff_text ! A clause describing parameter setting that differ.
   real :: omega_frac_dflt  ! The default for omega_frac [nondim]
@@ -3773,8 +3820,9 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  default=.false., do_not_log=(CS%MKE_to_TKE_effic>0.0))
 
 
-!/2. Options related to setting MSTAR
-  call get_param(param_file, mdl, "EPBL_MSTAR_SCHEME", tmpstr, &
+!/2. Options related to setting mstar
+
+  call get_param(param_file, mdl, "EPBL_MSTAR_SCHEME", mstar_scheme, &
                  "EPBL_MSTAR_SCHEME selects the method for setting mstar.  Valid values are: \n"//&
                  "\t CONSTANT   - Use a fixed mstar given by MSTAR \n"//&
                  "\t OM4        - Use L_Ekman/L_Obukhov in the stabilizing limit, as in OM4 \n"//&
@@ -3782,87 +3830,115 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  default=CONSTANT_STRING, do_not_log=.true.)
   call get_param(param_file, mdl, "MSTAR_MODE", mstar_mode, default=-1)
   if (mstar_mode == 0) then
-    tmpstr = CONSTANT_STRING
+    mstar_scheme = CONSTANT_STRING
     call MOM_error(WARNING, "Use EPBL_MSTAR_SCHEME = CONSTANT instead of the archaic MSTAR_MODE = 0.")
   elseif (mstar_mode == 1) then
     call MOM_error(FATAL, "You are using a legacy mstar mode in ePBL that has been phased out. "//&
                           "If you need to use this setting please report this error.  Also use "//&
                           "EPBL_MSTAR_SCHEME to specify the scheme for mstar.")
   elseif (mstar_mode == 2) then
-    tmpstr = OM4_STRING
+    mstar_scheme = OM4_STRING
     call MOM_error(WARNING, "Use EPBL_MSTAR_SCHEME = OM4 instead of the archaic MSTAR_MODE = 2.")
   elseif (mstar_mode == 3) then
-    tmpstr = RH18_STRING
+    mstar_scheme = RH18_STRING
     call MOM_error(WARNING, "Use EPBL_MSTAR_SCHEME = REICHL_H18 instead of the archaic MSTAR_MODE = 3.")
   elseif (mstar_mode > 3) then
     call MOM_error(FATAL, "An unrecognized value of the obsolete parameter MSTAR_MODE was specified.")
   endif
-  call log_param(param_file, mdl, "EPBL_MSTAR_SCHEME", tmpstr, &
+  call log_param(param_file, mdl, "EPBL_MSTAR_SCHEME", mstar_scheme, &
                  "EPBL_MSTAR_SCHEME selects the method for setting mstar.  Valid values are: \n"//&
                  "\t CONSTANT   - Use a fixed mstar given by MSTAR \n"//&
                  "\t OM4        - Use L_Ekman/L_Obukhov in the stabilizing limit, as in OM4 \n"//&
                  "\t REICHL_H18 - Use the scheme documented in Reichl & Hallberg, 2018.", &
                  default=CONSTANT_STRING)
-  tmpstr = uppercase(tmpstr)
-  select case (tmpstr)
+  mstar_scheme = uppercase(mstar_scheme)
+  select case (mstar_scheme)
     case (CONSTANT_STRING)
-      CS%mstar_Scheme = Use_Fixed_MStar
+      CS%mstar_scheme = Use_Fixed_mstar
     case (OM4_STRING)
-      CS%mstar_Scheme = MStar_from_Ekman
+      CS%mstar_scheme = mstar_from_Ekman
     case (RH18_STRING)
-      CS%mstar_Scheme = MStar_from_RH18
+      CS%mstar_scheme = mstar_from_RH18
     case default
-      call MOM_mesg('energetic_PBL_init: EPBL_MSTAR_SCHEME ="'//trim(tmpstr)//'"', 0)
+      call MOM_mesg('energetic_PBL_init: EPBL_MSTAR_SCHEME ="'//trim(mstar_scheme)//'"', 0)
       call MOM_error(FATAL, "energetic_PBL_init: Unrecognized setting "// &
-            "EPBL_MSTAR_SCHEME = "//trim(tmpstr)//" found in input file.")
+            "EPBL_MSTAR_SCHEME = "//trim(mstar_scheme)//" found in input file.")
   end select
-
   call get_param(param_file, mdl, "MSTAR", CS%fixed_mstar, &
                  "The ratio of the friction velocity cubed to the TKE input to the "//&
-                 "mixed layer.  This option is used if EPBL_MSTAR_SCHEME = CONSTANT.", &
-                 units="nondim", default=1.2, do_not_log=(CS%mstar_scheme/=Use_Fixed_MStar))
+                 "surface boundary layer.  This option is used if EPBL_MSTAR_SCHEME = CONSTANT.", &
+                 units="nondim", default=1.2, do_not_log=(CS%mstar_scheme/=Use_Fixed_mstar))
+
   call get_param(param_file, mdl, "MSTAR_CAP", CS%mstar_cap, &
                  "If this value is positive, it sets the maximum value of mstar "//&
-                 "allowed in ePBL.  (This is not used if EPBL_MSTAR_SCHEME = CONSTANT).", &
-                 units="nondim", default=-1.0, do_not_log=(CS%mstar_scheme==Use_Fixed_MStar))
-  ! mstar_scheme==MStar_from_Ekman options
-  call get_param(param_file, mdl, "MSTAR2_COEF1", CS%MSTAR_COEF, &
+                 "allowed in ePBL.  (This is not used if EPBL_mstar_scheme = CONSTANT).", &
+                 units="nondim", default=-1.0, do_not_log=(CS%mstar_scheme==Use_Fixed_mstar))
+  ! mstar_scheme==mstar_from_Ekman options
+  call get_param(param_file, mdl, "MSTAR2_COEF1", CS%mstar_coef, &
                  "Coefficient in computing mstar when rotation and stabilizing "//&
-                 "effects are both important (used if EPBL_MSTAR_SCHEME = OM4).", &
-                 units="nondim", default=0.3, do_not_log=(CS%mstar_scheme/=MStar_from_Ekman))
-  call get_param(param_file, mdl, "MSTAR2_COEF2", CS%C_EK, &
+                 "effects are both important (used if EPBL_mstar_scheme = OM4).", &
+                 units="nondim", default=0.3, do_not_log=(CS%mstar_scheme/=mstar_from_Ekman))
+  call get_param(param_file, mdl, "MSTAR2_COEF2", CS%C_Ek, &
                  "Coefficient in computing mstar when only rotation limits "// &
                  "the total mixing (used if EPBL_MSTAR_SCHEME = OM4)", &
-                 units="nondim", default=0.085, do_not_log=(CS%mstar_scheme/=MStar_from_Ekman))
-  ! mstar_scheme==MStar_from_RH18 options
+                 units="nondim", default=0.085, do_not_log=(CS%mstar_scheme/=mstar_from_Ekman))
+  ! mstar_scheme==mstar_from_RH18 options
   call get_param(param_file, mdl, "RH18_MSTAR_CN1", CS%RH18_mstar_cn1,&
                  "MSTAR_N coefficient 1 (outer-most coefficient for fit). "//&
                  "The value of 0.275 is given in RH18.  Increasing this "//&
-                 "coefficient increases MSTAR for all values of Hf/ust, but more "//&
+                 "coefficient increases mstar for all values of Hf/ust, but more "//&
                  "effectively at low values (weakly developed OSBLs).", &
-                 units="nondim", default=0.275, do_not_log=(CS%mstar_scheme/=MStar_from_RH18))
+                 units="nondim", default=0.275, do_not_log=(CS%mstar_scheme/=mstar_from_RH18))
   call get_param(param_file, mdl, "RH18_MSTAR_CN2", CS%RH18_mstar_cn2,&
                  "MSTAR_N coefficient 2 (coefficient outside of exponential decay). "//&
                  "The value of 8.0 is given in RH18.  Increasing this coefficient "//&
-                 "increases MSTAR for all values of HF/ust, with a much more even "//&
+                 "increases mstar for all values of HF/ust, with a much more even "//&
                  "effect across a wide range of Hf/ust than CN1.", &
-                 units="nondim", default=8.0, do_not_log=(CS%mstar_scheme/=MStar_from_RH18))
+                 units="nondim", default=8.0, do_not_log=(CS%mstar_scheme/=mstar_from_RH18))
   call get_param(param_file, mdl, "RH18_MSTAR_CN3", CS%RH18_mstar_CN3,&
                  "MSTAR_N coefficient 3 (exponential decay coefficient). "//&
                  "The value of -5.0 is given in RH18.  Increasing this increases how "//&
-                 "quickly the value of MSTAR decreases as Hf/ust increases.", &
-                  units="nondim", default=-5.0, do_not_log=(CS%mstar_scheme/=MStar_from_RH18))
+                 "quickly the value of mstar decreases as Hf/ust increases.", &
+                  units="nondim", default=-5.0, do_not_log=(CS%mstar_scheme/=mstar_from_RH18))
   call get_param(param_file, mdl, "RH18_MSTAR_CS1", CS%RH18_mstar_cs1,&
                  "MSTAR_S coefficient for RH18 in stabilizing limit. "//&
                  "The value of 0.2 is given in RH18 and increasing it increases "//&
-                 "MSTAR in the presence of a stabilizing surface buoyancy flux.", &
-                 units="nondim", default=0.2, do_not_log=(CS%mstar_scheme/=MStar_from_RH18))
+                 "mstar in the presence of a stabilizing surface buoyancy flux.", &
+                 units="nondim", default=0.2, do_not_log=(CS%mstar_scheme/=mstar_from_RH18))
   call get_param(param_file, mdl, "RH18_MSTAR_CS2", CS%RH18_mstar_cs2,&
                  "MSTAR_S exponent for RH18 in stabilizing limit. "//&
-                 "The value of 0.4 is given in RH18 and increasing it increases MSTAR "//&
+                 "The value of 0.4 is given in RH18 and increasing it increases mstar "//&
                  "exponentially in the presence of a stabilizing surface buoyancy flux.", &
-                 Units="nondim", default=0.4, do_not_log=(CS%mstar_scheme/=MStar_from_RH18))
-
+                 Units="nondim", default=0.4, do_not_log=(CS%mstar_scheme/=mstar_from_RH18))
+!/ BBL mstar related options
+  call get_param(param_file, mdl, "EPBL_BBL_USE_MSTAR", CS%ePBL_BBL_use_mstar, &
+                 "A logical to use mstar in the calculation of TKE in the ePBL BBL scheme", &
+                 units="nondim", default=.false.)
+  if (CS%ePBL_BBL_use_mstar) then
+    call get_param(param_file, mdl, "EPBL_BBL_MSTAR_SCHEME", tmpstr, &
+                   "EPBL_BBL_MSTAR_SCHEME selects the method for setting mstar in the BBL.  Valid values are: \n"//&
+                   "\t CONSTANT   - Use a fixed mstar given by MSTAR_BBL \n"//&
+                   "\t OM4        - Use L_Ekman/L_Obukhov in the stabilizing limit, as in OM4 \n"//&
+                   "\t REICHL_H18 - Use the scheme documented in Reichl & Hallberg, 2018.", &
+                   default=mstar_scheme)
+    tmpstr = uppercase(tmpstr)
+    select case (tmpstr)
+      case (CONSTANT_STRING)
+        CS%BBL_mstar_scheme = Use_Fixed_mstar
+      case (OM4_STRING)
+        CS%BBL_mstar_scheme = mstar_from_Ekman
+      case (RH18_STRING)
+        CS%BBL_mstar_scheme = mstar_from_RH18
+      case default
+        call MOM_mesg('energetic_PBL_init: EPBL_BBL_MSTAR_SCHEME ="'//trim(tmpstr)//'"', 0)
+        call MOM_error(FATAL, "energetic_PBL_init: Unrecognized setting "// &
+              "EPBL_BBL_MSTAR_SCHEME = "//trim(tmpstr)//" found in input file.")
+    end select
+    call get_param(param_file, mdl, "MSTAR_BBL", CS%BBL_fixed_mstar, &
+                   "The ratio of the friction velocity cubed to the TKE input to the "//&
+                   "bottom boundary layer.  This option is used if EPBL_BBL_MSTAR_SCHEME = CONSTANT.", &
+                   units="nondim", default=1.2, do_not_log=(CS%BBL_mstar_scheme/=Use_Fixed_mstar))
+  endif
 
 !/ Convective turbulence related options
   call get_param(param_file, mdl, "NSTAR", CS%nstar, &
@@ -4076,20 +4152,20 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "\t ADDITIVE - Add a Langmuir turbulence contribution to mstar to other contributions", &
                  default=NONE_STRING, do_not_log=.true.)
     call get_param(param_file, mdl, "LT_ENHANCE", LT_enhance, default=-1)
-    if (LT_ENHANCE == 0) then
+    if (LT_enhance == 0) then
       tmpstr = NONE_STRING
       call MOM_error(WARNING, "Use EPBL_LANGMUIR_SCHEME = NONE instead of the archaic LT_ENHANCE = 0.")
-    elseif (LT_ENHANCE == 1) then
+    elseif (LT_enhance == 1) then
       call MOM_error(FATAL, "You are using a legacy LT_ENHANCE mode in ePBL that has been phased out. "//&
                             "If you need to use this setting please report this error.  Also use "//&
                             "EPBL_LANGMUIR_SCHEME to specify the scheme for mstar.")
-    elseif (LT_ENHANCE == 2) then
+    elseif (LT_enhance == 2) then
       tmpstr = RESCALED_STRING
       call MOM_error(WARNING, "Use EPBL_LANGMUIR_SCHEME = RESCALE instead of the archaic LT_ENHANCE = 2.")
-    elseif (LT_ENHANCE == 3) then
+    elseif (LT_enhance == 3) then
       tmpstr = ADDITIVE_STRING
       call MOM_error(WARNING, "Use EPBL_LANGMUIR_SCHEME = ADDITIVE instead of the archaic LT_ENHANCE = 3.")
-    elseif (LT_ENHANCE > 3) then
+    elseif (LT_enhance > 3) then
       call MOM_error(FATAL, "An unrecognized value of the obsolete parameter LT_ENHANCE was specified.")
     endif
     call log_param(param_file, mdl, "EPBL_LANGMUIR_SCHEME", tmpstr, &
@@ -4113,29 +4189,29 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
               "EPBL_LANGMUIR_SCHEME = "//trim(tmpstr)//" found in input file.")
     end select
 
-    call get_param(param_file, mdl, "LT_ENHANCE_COEF", CS%LT_ENHANCE_COEF, &
+    call get_param(param_file, mdl, "LT_ENHANCE_COEF", CS%LT_enhance_coef, &
                  "Coefficient for Langmuir enhancement of mstar", &
                  units="nondim", default=0.447, do_not_log=(CS%LT_enhance_form==No_Langmuir))
-    call get_param(param_file, mdl, "LT_ENHANCE_EXP", CS%LT_ENHANCE_EXP, &
+    call get_param(param_file, mdl, "LT_ENHANCE_EXP", CS%LT_enhance_exp, &
                  "Exponent for Langmuir enhancement of mstar", &
                  units="nondim", default=-1.33,  do_not_log=(CS%LT_enhance_form==No_Langmuir))
-    call get_param(param_file, mdl, "LT_MOD_LAC1", CS%LaC_MLDoEK, &
+    call get_param(param_file, mdl, "LT_MOD_LAC1", CS%LaC_MLD_Ek, &
                  "Coefficient for modification of Langmuir number due to "//&
                  "MLD approaching Ekman depth.", &
                  units="nondim", default=-0.87,  do_not_log=(CS%LT_enhance_form==No_Langmuir))
-    call get_param(param_file, mdl, "LT_MOD_LAC2", CS%LaC_MLDoOB_stab, &
+    call get_param(param_file, mdl, "LT_MOD_LAC2", CS%LaC_MLD_Ob_stab, &
                  "Coefficient for modification of Langmuir number due to "//&
                  "MLD approaching stable Obukhov depth.", &
                  units="nondim", default=0.0,  do_not_log=(CS%LT_enhance_form==No_Langmuir))
-    call get_param(param_file, mdl, "LT_MOD_LAC3", CS%LaC_MLDoOB_un, &
+    call get_param(param_file, mdl, "LT_MOD_LAC3", CS%LaC_MLD_Ob_un, &
                  "Coefficient for modification of Langmuir number due to "//&
                  "MLD approaching unstable Obukhov depth.", &
                  units="nondim", default=0.0,  do_not_log=(CS%LT_enhance_form==No_Langmuir))
-    call get_param(param_file, mdl, "LT_MOD_LAC4", CS%Lac_EKoOB_stab, &
+    call get_param(param_file, mdl, "LT_MOD_LAC4", CS%Lac_Ek_Ob_stab, &
                  "Coefficient for modification of Langmuir number due to "//&
                  "ratio of Ekman to stable Obukhov depth.", &
                  units="nondim", default=0.95,  do_not_log=(CS%LT_enhance_form==No_Langmuir))
-    call get_param(param_file, mdl, "LT_MOD_LAC5", CS%Lac_EKoOB_un, &
+    call get_param(param_file, mdl, "LT_MOD_LAC5", CS%Lac_Ek_Ob_un, &
                  "Coefficient for modification of Langmuir number due to "//&
                  "ratio of Ekman to unstable Obukhov depth.", &
                  units="nondim", default=0.95,  do_not_log=(CS%LT_enhance_form==No_Langmuir))
@@ -4258,6 +4334,10 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
   ! This is an alias for the same variable as ePBL_h_ML
   CS%id_hML_depth = register_diag_field('ocean_model', 'h_ML', diag%axesT1, &
       Time, 'Surface mixed layer depth based on active turbulence', units='m', conversion=US%Z_to_m)
+  CS%id_ustar_ePBL = register_diag_field('ocean_model', 'ePBL_ustar', diag%axesT1, &
+      Time, 'Surface friction in ePBL', units='m s-1', conversion=US%Z_to_m*US%s_to_T)
+  CS%id_bflx_ePBL = register_diag_field('ocean_model', 'ePBL_bflx', diag%axesT1, &
+      Time, 'Surface buoyancy flux in ePBL', units='m2 s-3', conversion=US%Z_to_m**2*US%s_to_T**3)
   CS%id_TKE_wind = register_diag_field('ocean_model', 'ePBL_TKE_wind', diag%axesT1, &
       Time, 'Wind-stirring source of mixed layer TKE', units='W m-2', conversion=US%RZ3_T3_to_W_m2)
   CS%id_TKE_MKE = register_diag_field('ocean_model', 'ePBL_TKE_MKE', diag%axesT1, &
@@ -4277,9 +4357,9 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
       Time, 'Mixing Length that is used', units='m', conversion=US%Z_to_m)
   CS%id_Velocity_Scale = register_diag_field('ocean_model', 'Velocity_Scale', diag%axesTi, &
       Time, 'Velocity Scale that is used.', units='m s-1', conversion=US%Z_to_m*US%s_to_T)
-  CS%id_MSTAR_mix = register_diag_field('ocean_model', 'MSTAR', diag%axesT1, &
+  CS%id_mstar_sfc = register_diag_field('ocean_model', 'MSTAR', diag%axesT1, &
       Time, 'Total mstar that is used.', 'nondim')
-  if ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0)) then
+  if ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0) .or. CS%ePBL_BBL_use_mstar) then
     CS%id_Kd_BBL = register_diag_field('ocean_model', 'Kd_ePBL_BBL', diag%axesTi, &
         Time, 'ePBL bottom boundary layer diffusivity', units='m2 s-1', conversion=GV%HZ_T_to_m2_s)
     CS%id_BBL_Mix_Length = register_diag_field('ocean_model', 'BBL_Mixing_Length', diag%axesTi, &
@@ -4300,13 +4380,15 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
     CS%id_TKE_BBL_decay = register_diag_field('ocean_model', 'ePBL_BBL_TKE_decay', diag%axesT1, &
         Time, 'Energy decay sink of mixed layer TKE in the bottom boundary layer', &
         units='W m-2', conversion=US%RZ3_T3_to_W_m2)
+    CS%id_mstar_BBL = register_diag_field('ocean_model', 'MSTAR_BBL', diag%axesT1, &
+        Time, 'Total BBL mstar that is used.', 'nondim')
   endif
   if (CS%use_LT) then
     CS%id_LA = register_diag_field('ocean_model', 'LA', diag%axesT1, &
         Time, 'Langmuir number.', 'nondim')
     CS%id_LA_mod = register_diag_field('ocean_model', 'LA_MOD', diag%axesT1, &
         Time, 'Modified Langmuir number.', 'nondim')
-    CS%id_MSTAR_LT = register_diag_field('ocean_model', 'MSTAR_LT', diag%axesT1, &
+    CS%id_mstar_LT = register_diag_field('ocean_model', 'MSTAR_LT', diag%axesT1, &
         Time, 'Increase in mstar due to Langmuir Turbulence.', 'nondim')
   endif
 
@@ -4330,7 +4412,7 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
   CS%TKE_diagnostics = (max(CS%id_TKE_wind, CS%id_TKE_MKE, CS%id_TKE_conv, &
                             CS%id_TKE_mixing, CS%id_TKE_mech_decay, CS%id_TKE_forcing, &
                             CS%id_TKE_conv_decay) > 0)
-  if ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0)) then
+  if ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0) .or. CS%ePBL_BBL_use_mstar) then
     CS%TKE_diagnostics = CS%TKE_diagnostics .or. &
         (max(CS%id_TKE_BBL, CS%id_TKE_BBL_mixing, CS%id_TKE_BBL_decay) > 0)
   endif
@@ -4356,7 +4438,7 @@ subroutine energetic_PBL_end(CS)
     write (mesg,*) "Average ePBL iterations = ", avg_its
     call MOM_mesg(mesg)
 
-    if ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0)) then
+    if ((CS%ePBL_BBL_effic > 0.0) .or. (CS%ePBL_tidal_effic > 0.0) .or. CS%ePBL_BBL_use_mstar) then
       call EFP_sum_across_PEs(CS%sum_its_BBL, 2)
       avg_its = EFP_to_real(CS%sum_its_BBL(1)) / EFP_to_real(CS%sum_its_BBL(2))
       write (mesg,*) "Average ePBL BBL iterations = ", avg_its

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -700,7 +700,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, visc, dt, Kd_int, G, GV, 
         u_star_BBL_z_t = u_star_bbl*GV%H_to_Z
         ! ^ units are now H T-1 * Z H-1 = Z T-1, but nonBoussinesq has a factor of Rho/Rho0
         if (.not.GV%Boussinesq) then
-          u_star_BBL = u_star_BBL*(GV%Rho0*tv%SpV_avg(i,j,1)) ! factor of Rho/Rho0 is divided out
+          u_star_BBL_z_t = u_star_BBL_z_t*(GV%Rho0*tv%SpV_avg(i,j,1)) ! factor of Rho/Rho0 is divided out
         endif
 
         !

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -619,7 +619,7 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS, useALEalgorith
   if (id > 0) call post_data(id, CS%geo_heat, diag, .true.)
 
   CS%id_geothermal_buoyancy_flux = register_diag_field('ocean_model', &
-        'geo_bflx',diag%axesT1,Time,'Geothermal buoyancy flux into ocean', &
+        'geo_bflx', diag%axesT1, Time, 'Geothermal buoyancy flux into ocean', &
         'm2 s-3', conversion=US%Z_to_m**2*US%s_to_T**3)
 
   ! Diagnostic for tendencies due to internal heat (in 3d)

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -13,7 +13,8 @@ use MOM_grid,          only : ocean_grid_type
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs
 use MOM_verticalGrid,  only : verticalGrid_type, get_thickness_units
-use MOM_EOS,           only : calculate_density, calculate_density_derivs
+use MOM_EOS,           only : calculate_density, calculate_density_derivs, EOS_domain
+use MOM_EOS,           only : calculate_specific_vol_derivs
 
 implicit none ; private
 
@@ -39,7 +40,7 @@ type, public :: geothermal_CS ; private
   integer :: id_internal_heat_heat_tendency = -1  !< ID for diagnostic of heat tendency
   integer :: id_internal_heat_temp_tendency = -1  !< ID for diagnostic of temperature tendency
   integer :: id_internal_heat_h_tendency = -1     !< ID for diagnostic of thickness tendency
-
+  integer :: id_geothermal_buoyancy_flux = -1     !< ID for diagnostic of bottom buoyancy flux
 end type geothermal_CS
 
 contains
@@ -360,7 +361,7 @@ end subroutine geothermal_entraining
 !> Applies geothermal heating to the bottommost layers that occur within GEOTHERMAL_THICKNESS of
 !! the bottom, by simply heating the water in place.  Any heat that can not be applied to the ocean
 !! is returned (WHERE)?
-subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
+subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, BFlx_geothermal, halo)
   type(ocean_grid_type),                     intent(inout) :: G  !< The ocean's grid structure.
   type(verticalGrid_type),                   intent(in)    :: GV !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h  !< Layer thicknesses [H ~> m or kg m-2]
@@ -369,12 +370,19 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
   real,                                      intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
   type(geothermal_CS),                       intent(in)    :: CS !< Geothermal heating control struct
+  real, dimension(SZI_(G), SZJ_(G)),         intent(out)   :: BFlx_geothermal !< Geothermal Buoyancy Flux [m2 s-3]
   integer,                         optional, intent(in)    :: halo !< Halo width over which to work
+
 
   ! Local variables
   real, dimension(SZI_(G)) :: &
     heat_rem,  & ! remaining heat [H C ~> m degC or kg degC m-2]
-    h_geo_rem    ! remaining thickness to apply geothermal heating [H ~> m or kg m-2]
+    h_geo_rem, & ! remaining thickness to apply geothermal heating [H ~> m or kg m-2]
+    bottom_pressure, & ! Hydrostatic pressure in bottom layer [R L2 T-2 ~> Pa]
+    dRhodT, &    ! Partial derivative of density with temperature [R C-1 ~> kg m-3 degC-1]
+    dRhodS, &    ! Partial derivative of density with salinity [R S-1 ~> kg m-3 ppt-1]
+    dSpVdT, &    ! Partial derivative of specific volume with temperature [R-1 C-1 ~> m3 kg-1 degC-1]
+    dSpVdS       ! Partial derivative of specific volume with salinity [R-1 S-1 ~> m3 kg-1 ppt-1]
 
   real :: Angstrom, H_neglect  ! small thicknesses [H ~> m or kg m-2]
   real :: heat_here     ! heating applied to the present layer [C H ~> degC m or degC kg m-2]
@@ -386,8 +394,13 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
     dTdt_diag           ! Diagnostic of temperature tendency [C T-1 ~> degC s-1] which might be
                         ! converted into a layer-integrated heat tendency [Q R Z T-1 ~> W m-2]
   real :: Idt           ! inverse of the timestep [T-1 ~> s-1]
+  real :: H_to_Pres     ! A conversion factor from thicknesses to pressure [R L2 T-2 H-1 ~> Pa m-1 or Pa m2 kg-1]
+  real :: I_Cp          ! 1.0 / C_p [C Q-1 ~> kg degC J-1]
+  real :: I_Rho0Squared ! 1.0 / rho_0^2 (Boussinesq only) [ R-2 ~> kg2 m-6]
   logical :: do_any     ! True if there is more to be done on the current j-row.
   logical :: calc_diags ! True if diagnostic tendencies are needed.
+  logical :: nonBous    ! If true, do not make the Boussinesq approximation.
+  integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, nz, isj, iej
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -399,10 +412,15 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
          "Module must be initialized before it is used.")
   if (.not.CS%apply_geothermal) return
 
+  nonBous =  .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
   Irho_cp   = 1.0 / (GV%H_to_RZ * tv%C_p)
   Angstrom  = GV%Angstrom_H
   H_neglect = GV%H_subroundoff
   Idt       = 1.0 / dt
+  H_to_pres = GV%H_to_RZ * GV%g_Earth
+  I_Cp = 1. /tv%C_p
+  if (.not.nonBous) I_Rho0squared = 1. / (GV%Rho0**2)
+  EOSdom(:) = EOS_domain(G%HI)
 
   if (.not.associated(tv%T)) call MOM_error(FATAL, "MOM geothermal_in_place: "//&
       "Geothermal heating can only be applied if T & S are state variables.")
@@ -413,11 +431,37 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
 
   ! Conditionals for tracking diagnostic depdendencies
   calc_diags = (CS%id_internal_heat_heat_tendency > 0) .or. (CS%id_internal_heat_temp_tendency > 0)
+  BFlx_geothermal(:,:) = 0.0
 
   if (calc_diags) dTdt_diag(:,:,:) = 0.0
 
   !$OMP parallel do default(shared) private(heat_rem,do_any,h_geo_rem,isj,iej,heat_here,dTemp)
   do j=js,je
+    bottom_pressure(:) = 0.0
+    do k=1,nz ; do i=is,ie
+      bottom_pressure(i) = bottom_pressure(i) + H_to_pres * h(i,j,k)
+    enddo; enddo
+    if (nonBous) then
+      dSpVdT(:) = 0.0
+      dSpVdS(:) = 0.0
+      call calculate_specific_vol_derivs(tv%T(:,j,nz), tv%S(:,j,nz), bottom_pressure, dSpVdT, dSpVdS, &
+                                         tv%eqn_of_state, EOSdom)
+      do i=is,ie
+        BFlx_geothermal(i,j) = ( (GV%g_Earth_Z_T2 * dSpVdT(i)) * (CS%geo_heat(i,j)*I_Cp) ) * G%mask2dT(i,j)
+      enddo
+    else
+      dRhodT(:) = 0.0
+      dRhodS(:) = 0.0
+      call calculate_density_derivs(tv%T(:,j,nz), tv%S(:,j,nz), bottom_pressure, dRhodT, dRhodS, &
+                                    tv%eqn_of_state, EOSdom)
+      do i=is,ie
+        BFlx_geothermal(i,j) = - ( (GV%g_Earth_Z_T2*I_Rho0squared) * ((I_Cp*dRhodT(i))*CS%geo_heat(i,j)) ) &
+                                 * G%mask2dT(i,j)
+      enddo
+    endif
+
+
+
     ! Only work on columns that are being heated, and heat the near-bottom water.
 
     ! If there is not enough mass in the ocean, pass some of the heat up
@@ -480,7 +524,9 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, halo)
     enddo ; enddo ; enddo
     call post_data(CS%id_internal_heat_heat_tendency, dTdt_diag, CS%diag, alt_h=h)
   endif
-
+  if (CS%id_geothermal_buoyancy_flux > 0) then
+    call post_data(CS%id_geothermal_buoyancy_flux, BFlx_geothermal, CS%diag)
+  endif
 !  do j=js,je ; do i=is,ie
 !    resid(i,j) = tv%internal_heat(i,j) - resid(i,j) - GV%H_to_RZ * &
 !           (G%mask2dT(i,j) * (CS%geo_heat(i,j) * (dt*Irho_cp)))
@@ -571,6 +617,10 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS, useALEalgorith
         cmor_long_name='Upward geothermal heat flux at sea floor', &
         x_cell_method='mean', y_cell_method='mean', area_cell_method='mean')
   if (id > 0) call post_data(id, CS%geo_heat, diag, .true.)
+
+  CS%id_geothermal_buoyancy_flux = register_diag_field('ocean_model', &
+        'geo_bflx',diag%axesT1,Time,'Geothermal buoyancy flux into ocean', &
+        'm2 s-3', conversion=US%Z_to_m**2*US%s_to_T**3)
 
   ! Diagnostic for tendencies due to internal heat (in 3d)
   CS%id_internal_heat_heat_tendency = register_diag_field('ocean_model', &

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2429,9 +2429,9 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                  "diffusion.  This is only used if BOTTOMDRAGLAW is true.", &
                  units="nondim", default=0.20, scale=US%L_to_Z**2)
     call get_param(param_file, mdl, "EPBL_BBL_EFFIC", CS%ePBL_BBL_effic, &
-                   units="nondim", default=0.0,do_not_log=.true.)
+                 units="nondim", default=0.0, do_not_log=.true.)
     call get_param(param_file, mdl, "EPBL_BBL_USE_MSTAR", CS%ePBL_BBL_mstar, &
-                   default=.false.,do_not_log=.true.)
+                 default=.false., do_not_log=.true.)
     call get_param(param_file, mdl, "BBL_MIXING_MAX_DECAY", decay_length, &
                  "The maximum decay scale for the BBL diffusion, or 0 to allow the mixing "//&
                  "to penetrate as far as stratification and rotation permit.  The default "//&

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -82,6 +82,8 @@ type, public :: set_diffusivity_CS ; private
                              !! and those those used for TKE [Z2 L-2 ~> nondim].
   real    :: ePBL_BBL_effic  !< efficiency with which the energy extracted
                              !! by bottom drag drives BBL diffusion in the ePBL BBL scheme [nondim]
+  logical :: ePBL_BBL_mstar  !< logical if the bottom boundary layer uses an mstar x ustar^3 formulation
+                             !! needed here to know whether or not to populate the bottom ustar
   real    :: cdrag           !< quadratic drag coefficient [nondim]
   real    :: dz_BBL_avg_min  !< A minimal distance over which to average to determine the average
                              !! bottom boundary layer density [Z ~> m]
@@ -2002,7 +2004,8 @@ subroutine set_BBL_TKE(u, v, h, tv, fluxes, visc, G, GV, US, CS, OBC)
   if (.not.CS%initialized) call MOM_error(FATAL,"set_BBL_TKE: "//&
          "Module must be initialized before it is used.")
 
-  if (.not.CS%bottomdraglaw .or. (CS%BBL_effic<=0.0 .and. CS%ePBL_BBL_effic<=0.0)) then
+  if (.not.CS%bottomdraglaw .or. (CS%BBL_effic<=0.0 .and. CS%ePBL_BBL_effic<=0.0 .and. &
+      (.not.CS%ePBL_BBL_mstar))) then
     if (allocated(visc%ustar_BBL)) then
       do j=js,je ; do i=is,ie ; visc%ustar_BBL(i,j) = 0.0 ; enddo ; enddo
     endif
@@ -2426,7 +2429,9 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                  "diffusion.  This is only used if BOTTOMDRAGLAW is true.", &
                  units="nondim", default=0.20, scale=US%L_to_Z**2)
     call get_param(param_file, mdl, "EPBL_BBL_EFFIC", CS%ePBL_BBL_effic, &
-                 units="nondim", default=0.0,do_not_log=.true.)
+                   units="nondim", default=0.0,do_not_log=.true.)
+    call get_param(param_file, mdl, "EPBL_BBL_USE_MSTAR", CS%ePBL_BBL_mstar, &
+                   default=.false.,do_not_log=.true.)
     call get_param(param_file, mdl, "BBL_MIXING_MAX_DECAY", decay_length, &
                  "The maximum decay scale for the BBL diffusion, or 0 to allow the mixing "//&
                  "to penetrate as far as stratification and rotation permit.  The default "//&


### PR DESCRIPTION
**Fix issues in MOM_diagnose_KdWork logic**
- Fix missing allocation logic for diffusivities needed by idz variables.
- Fix a logic mistake cross-up of ePBL diagnostic id that should have been bkgnd diagnostic id

**Adds code to compute ePBL BBL mstar**
- Adds output of buoyancy flux from geothermal routine, needed for computing bottom mstar.
- Adds capability into ePBL to use mstar coefficient in BBL, including options to specify the same or different as the surface scheme

**Adds code to generalize energy based mixed layer depth for bottom up mixed layer diagnostic**
- Generalizes code to work moving up or down the column
- Adds flag to preserve OM4 solution, should be the same at round-off (may be able to recover the same bitwise answers, but it needs some testing)