### PR TITLE
GitHub: Update FMS CI version to 2025.02.01

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -77,7 +77,7 @@ AC_SRCDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../ac
 -include config.mk
 
 # Set the FMS library
-FMS_COMMIT ?= 2023.03
+FMS_COMMIT ?= 2025.02.01
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
 export FMS_COMMIT
 export FMS_URL


### PR DESCRIPTION
This changes the default version of FMS in `.testing`.

Although this won't affect regression testing (which defines its own version of FMS), it is still worth verifying that our automated .testing builds work correctly before merging.