### PR TITLE
+Make more use of OBC%segnum_u and OBC%segnum_v

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -1047,18 +1047,18 @@ subroutine ALE_remap_set_h_vel_OBC(G, GV, h_new, h_u, h_v, OBC)
     ! Take open boundary conditions into account.
     !$OMP parallel do default(shared)
     do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (OBC%segnum_u(I,j) /= 0) then
-      if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
+      if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
         do k=1,nz ; h_u(I,j,k) = h_new(i,j,k) ; enddo
-      else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+      else !  if (OBC%segnum_u(I,j) < 0) OBC_DIRECTION_W
         do k=1,nz ; h_u(I,j,k) = h_new(i+1,j,k) ; enddo
       endif
     endif ; enddo ; enddo
 
     !$OMP parallel do default(shared)
     do J=G%JscB,G%JecB ; do i=G%isc,G%iec ; if (OBC%segnum_v(i,J) /= 0) then
-      if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
+      if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
         do k=1,nz ; h_v(i,J,k) = h_new(i,j,k) ; enddo
-      else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+      else !  if (OBC%segnum_v(i,J)) < 0)  !  OBC_DIRECTION_S
         do k=1,nz ; h_v(i,J,k) = h_new(i,j+1,k) ; enddo
       endif
     endif ; enddo ; enddo

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -273,19 +273,24 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_u(I) = 0.25*((S(i,j,k) + S(i+1,j,k)) + (S(i,j,k-1) + S(i+1,j,k-1)))
       enddo
       if (OBC_friendly) then
-        do I=is-1,ie
-          if (OBC%segnum_u(I,j) /= 0) then
+        if (OBC%u_E_OBCs_on_PE .and. (j>=OBC%js_u_E_obc) .and. (j<=OBC%je_u_E_obc)) then
+          do I = max(is-1, OBC%Is_u_E_obc), min(ie, OBC%Ie_u_E_obc)
             if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
               pres_u(I) = pres(i,j,K)
               T_u(I) = 0.5*(T(i,j,k) + T(i,j,k-1))
               S_u(I) = 0.5*(S(i,j,k) + S(i,j,k-1))
-            elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
+            endif
+          enddo
+        endif
+        if (OBC%u_W_OBCs_on_PE .and. (j>=OBC%js_u_W_obc) .and. (j<=OBC%je_u_W_obc)) then
+          do I = max(is-1, OBC%Is_u_W_obc), min(ie, OBC%Ie_u_W_obc)
+            if (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
               pres_u(I) = pres(i+1,j,K)
               T_u(I) = 0.5*(T(i+1,j,k) + T(i+1,j,k-1))
               S_u(I) = 0.5*(S(i+1,j,k) + S(i+1,j,k-1))
             endif
-          endif
-        enddo
+          enddo
+        endif
       endif
       call calculate_density_derivs(T_u, S_u, pres_u, drho_dT_u, drho_dS_u, &
                                     tv%eqn_of_state, EOSdom_u)
@@ -445,19 +450,24 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
         S_v(i) = 0.25*((S(i,j,k) + S(i,j+1,k)) + (S(i,j,k-1) + S(i,j+1,k-1)))
       enddo
       if (OBC_friendly) then
-        do i=is,ie
-          if (OBC%segnum_v(i,J) /= 0) then
+        if (OBC%v_N_OBCs_on_PE .and. (J>=OBC%Js_v_N_obc) .and. (J<=OBC%Je_v_N_obc)) then
+          do i = max(is, OBC%is_v_N_obc), min(ie, OBC%ie_v_N_obc)
             if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
               pres_v(i) = pres(i,j,K)
               T_v(i) = 0.5*(T(i,j,k) + T(i,j,k-1))
               S_v(i) = 0.5*(S(i,j,k) + S(i,j,k-1))
-            elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
+            endif
+          enddo
+        endif
+        if (OBC%v_S_OBCs_on_PE .and. (J>=OBC%Js_v_S_obc) .and. (J<=OBC%Je_v_S_obc)) then
+          do i = max(is, OBC%is_v_S_obc), min(ie, OBC%ie_v_S_obc)
+            if (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
               pres_v(i) = pres(i,j+1,K)
               T_v(i) = 0.5*(T(i,j+1,k) + T(i,j+1,k-1))
               S_v(i) = 0.5*(S(i,j+1,k) + S(i,j+1,k-1))
             endif
-          endif
-        enddo
+          enddo
+        endif
       endif
       call calculate_density_derivs(T_v, S_v, pres_v, drho_dT_v, drho_dS_v, &
                                     tv%eqn_of_state, EOSdom_v)

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -140,7 +140,6 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                                      ! state calculations at h points with 1 extra halo point
   integer :: is, ie, js, je, nz, IsdB
   integer :: i, j, k
-  integer :: l_seg
 
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
@@ -258,7 +257,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$OMP                                  drho_dT_u,drho_dS_u,hg2A,hg2B,hg2L,hg2R,haA, &
   !$OMP                                  drho_dT_dT_h,scrap,pres_h,T_h,S_h, &
   !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-  !$OMP                                  drdx,mag_grad2,slope,l_seg) &
+  !$OMP                                  drdx,mag_grad2,slope) &
   !$OMP                          firstprivate(GxSpV_u)
   do j=js,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
@@ -275,13 +274,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       enddo
       if (OBC_friendly) then
         do I=is-1,ie
-          l_seg = OBC%segnum_u(I,j)
-          if (l_seg /= OBC_NONE) then
-            if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+          if (OBC%segnum_u(I,j) /= 0) then
+            if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
               pres_u(I) = pres(i,j,K)
               T_u(I) = 0.5*(T(i,j,k) + T(i,j,k-1))
               S_u(I) = 0.5*(S(i,j,k) + S(i,j,k-1))
-            elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) then
+            elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
               pres_u(I) = pres(i+1,j,K)
               T_u(I) = 0.5*(T(i+1,j,k) + T(i+1,j,k-1))
               S_u(I) = 0.5*(S(i+1,j,k) + S(i+1,j,k-1))
@@ -363,13 +361,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       !          ((hg2L/haL) + (hg2R/haR))
       ! which is an estimate of the gradient of density across geopotentials.
       if (present_N2_u) then
-        if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
-          l_seg = OBC%segnum_u(I,j)
-          if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+        if (OBC_friendly) then ; if (OBC%segnum_u(I,j) /= 0) then
+          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
             drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
             if (use_EOS .and. allocated(tv%SpV_avg)) &
               GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
-          elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) then
+          elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
             drdz = drdkR / dzaR
             if (use_EOS .and. allocated(tv%SpV_avg)) &
               GxSpV_u(I) = GV%g_Earth * 0.5 * (tv%SpV_avg(i+1,j,k) + tv%SpV_avg(i+1,j,k-1))
@@ -396,13 +393,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
 
       if (local_open_u_BC) then
-        l_seg = OBC%segnum_u(I,j)
-        if (l_seg /= OBC_NONE) then
-          if (OBC%segment(l_seg)%open) then
+        if (OBC%segnum_u(I,j) /= 0) then
+          if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
             slope = 0.
             ! This and/or the masking code below is to make slopes match inside
             ! land mask. Might not be necessary except for DEBUG output.
-!           if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
+!           if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
 !             slope_x(I+1,j,K) = 0.
 !           else
 !             slope_x(I-1,j,K) = 0.
@@ -434,7 +430,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
   !$OMP                                  drho_dT_dT_h,scrap,pres_h,T_h,S_h, &
   !$OMP                                  drho_dT_dT_hr,pres_hr,T_hr,S_hr,             &
   !$OMP                                  haB,haL,haR,dzaL,dzaR,wtA,wtB,wtL,wtR,drdz,  &
-  !$OMP                                  drdy,mag_grad2,slope,l_seg) &
+  !$OMP                                  drdy,mag_grad2,slope) &
   !$OMP                          firstprivate(GxSpV_v)
   do J=js-1,je ; do K=nz,2,-1
     if (.not.(use_EOS)) then
@@ -450,13 +446,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       enddo
       if (OBC_friendly) then
         do i=is,ie
-          l_seg = OBC%segnum_v(i,J)
-          if (l_seg /= OBC_NONE) then
-            if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+          if (OBC%segnum_v(i,J) /= 0) then
+            if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
               pres_v(i) = pres(i,j,K)
               T_v(i) = 0.5*(T(i,j,k) + T(i,j,k-1))
               S_v(i) = 0.5*(S(i,j,k) + S(i,j,k-1))
-            elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) then
+            elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
               pres_v(i) = pres(i,j+1,K)
               T_v(i) = 0.5*(T(i,j+1,k) + T(i,j+1,k-1))
               S_v(i) = 0.5*(S(i,j+1,k) + S(i,j+1,k-1))
@@ -545,13 +540,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       !          ((hg2L/haL) + (hg2R/haR))
       ! which is an estimate of the gradient of density across geopotentials.
       if (present_N2_v) then
-        if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
-          l_seg = OBC%segnum_v(i,J)
-          if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+        if (OBC_friendly) then ; if (OBC%segnum_v(i,J) /= 0) then
+          if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
             drdz = drdkL / dzaL  ! Note that drdz is not used for slopes at OBC faces.
             if (use_EOS .and. allocated(tv%SpV_avg)) &
               GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j,k) + tv%SpV_avg(i,j,k-1))
-          elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) then
+          elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
             drdz = drdkL / dzaL
             if (use_EOS .and. allocated(tv%SpV_avg)) &
               GxSpV_v(i) = GV%g_Earth * 0.5 * (tv%SpV_avg(i,j+1,k) + tv%SpV_avg(i,j+1,k-1))
@@ -578,13 +572,12 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
       endif
 
       if (local_open_v_BC) then
-        l_seg = OBC%segnum_v(i,J)
-        if (l_seg /= OBC_NONE) then
-          if (OBC%segment(l_seg)%open) then
+        if (OBC%segnum_v(i,J) /= 0) then
+          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
             slope = 0.
             ! This and/or the masking code below is to make slopes match inside
             ! land mask. Might not be necessary except for DEBUG output.
-!           if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
+!           if (OBC%segnum_v(i,J)) > 0) then ! OBC_DIRECTION_N
 !             slope_y(i,J+1,K) = 0.
 !           else
 !             slope_y(i,J-1,K) = 0.

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -712,7 +712,7 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
                                  ! interface or the inward equivalent with OBCs [H4 ~> m4 or kg2 m-4]
   real :: h4_v(SZI_(G),SZJB_(G),SZK_(GV)+1)  ! The product of the 4 thicknesses surrounding a v-point
                                  ! interface or the inward equivalent with OBCs [H4 ~> m4 or kg2 m-4]
-  integer :: i, j, k, is, ie, js, je, nz, l_seg
+  integer :: i, j, k, is, ie, js, je, nz
 
   if (.not. CS%initialized) call MOM_error(FATAL, "calc_Visbeck_coeffs_old: "// &
          "Module must be initialized before it is used.")
@@ -735,17 +735,15 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
 
   if (associated(OBC).and. CS%OBC_friendly) then
    ! Store the direction of any OBC faces.
-   !$OMP parallel do default(shared) private(l_seg)
-    do j=js-1,je+1 ; do I=is-1,ie ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
-      l_seg = OBC%segnum_u(I,j)
-      if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) OBC_dir_u(I,j) = 1
-      if (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) OBC_dir_u(I,j) = -1
+   !$OMP parallel do default(shared)
+    do j=js-1,je+1 ; do I=is-1,ie ; if (OBC%segnum_u(I,j) /= 0) then
+      if (OBC%segnum_u(I,j) > 0) OBC_dir_u(I,j) = 1   !  OBC_DIRECTION_E
+      if (OBC%segnum_u(I,j) < 0) OBC_dir_u(I,j) = -1  !  OBC_DIRECTION_W
     endif ; enddo ; enddo
    !$OMP parallel do default(shared)
-    do J=js-1,je ; do i=is-1,ie+1 ; if (OBC%segnum_v(i,J) /= OBC_NONE) then
-      l_seg = OBC%segnum_v(i,J)
-      if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) OBC_dir_v(i,J) = 1
-      if (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) OBC_dir_v(i,J) = -1
+    do J=js-1,je ; do i=is-1,ie+1 ; if (OBC%segnum_v(i,J) /= 0) then
+      if (OBC%segnum_v(i,J) > 0) OBC_dir_v(i,J) = 1   ! OBC_DIRECTION_N
+      if (OBC%segnum_v(i,J) < 0) OBC_dir_v(i,J) = -1  !  OBC_DIRECTION_S
     endif ; enddo ; enddo
 
     ! Use the masked product of the 4 (or 2) thicknesses around a velocity-point interface for weights.

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2042,15 +2042,13 @@ subroutine set_BBL_TKE(u, v, h, tv, fluxes, visc, G, GV, US, CS, OBC)
         ! Determine if grid point is an OBC
         has_obc = .false.
         if (local_open_v_BC) then
-          l_seg = OBC%segnum_v(i,J)
-          if (l_seg /= OBC_NONE) then
-            has_obc = OBC%segment(l_seg)%open
-          endif
+          l_seg = abs(OBC%segnum_v(i,J))
+          if (l_seg /= 0) has_obc = OBC%segment(l_seg)%open
         endif
 
         ! Compute h based on OBC state
         if (has_obc) then
-          if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+          if (OBC%segnum_v(i,J) > 0) then ! OBC_DIRECTION_N
             hvel = dz(i,j,k)
           else
             hvel = dz(i,j+1,k)
@@ -2094,15 +2092,13 @@ subroutine set_BBL_TKE(u, v, h, tv, fluxes, visc, G, GV, US, CS, OBC)
         ! Determine if grid point is an OBC
         has_obc = .false.
         if (local_open_u_BC) then
-          l_seg = OBC%segnum_u(I,j)
-          if (l_seg /= OBC_NONE) then
-            has_obc = OBC%segment(l_seg)%open
-          endif
+          l_seg = abs(OBC%segnum_u(I,j))
+          if (l_seg /= 0)  has_obc = OBC%segment(l_seg)%open
         endif
 
         ! Compute h based on OBC state
         if (has_obc) then
-          if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
             hvel = dz(i,j,k)
           else ! OBC_DIRECTION_W
             hvel = dz(i+1,j,k)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -506,8 +506,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
     if (associated(OBC)) then ; if (OBC%number_of_segments > 0) then
       ! Apply a zero gradient projection of thickness across OBC points.
       if (m==1) then
-        do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
+        do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= 0)) then
+          if (OBC%segnum_u(I,j) > 0) then  ! OBC_DIRECTION_E
             do k=1,nz
               h_at_vel(I,k) = h(i,j,k) ; h_vel(I,k) = h(i,j,k)
               dz_at_vel(I,k) = dz(i,j,k) ; dz_vel(I,k) = dz(i,j,k)
@@ -524,7 +524,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
             if (allocated(tv%SpV_avg)) then ; do k=1,nz
               SpV_vel(I,k) = tv%SpV_avg(i,j,k)
             enddo ; endif
-          elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
+          elseif (OBC%segnum_u(I,j) < 0) then  ! OBC_DIRECTION_W
             do k=1,nz
               h_at_vel(I,k) = h(i+1,j,k) ; h_vel(I,k) = h(i+1,j,k)
               dz_at_vel(I,k) = dz(i+1,j,k) ; dz_vel(I,k) = dz(i+1,j,k)
@@ -544,8 +544,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
           endif
         endif ; enddo
       else
-        do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
+        do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= 0)) then
+          if (OBC%segnum_v(i,J) > 0) then  ! OBC_DIRECTION_N
             do k=1,nz
               h_at_vel(i,k) = h(i,j,k) ; h_vel(i,k) = h(i,j,k)
               dz_at_vel(i,k) = dz(i,j,k) ; dz_vel(i,k) = dz(i,j,k)
@@ -562,7 +562,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
             if (allocated(tv%SpV_avg)) then ; do k=1,nz
               SpV_vel(i,k) = tv%SpV_avg(i,j,k)
             enddo ;  endif
-          elseif (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
+          elseif (OBC%segnum_v(i,J) < 0) then  ! OBC_DIRECTION_S
             do k=1,nz
               h_at_vel(i,k) = h(i,j+1,k) ; h_vel(i,k) = h(i,j+1,k)
               dz_at_vel(i,k) = dz(i,j+1,k) ; dz_vel(i,k) = dz(i,j+1,k)
@@ -1821,11 +1821,11 @@ function set_v_at_u(v, h, G, GV, i, j, k, mask2dCv, OBC)
   enddo ; enddo
 
   if (associated(OBC)) then ; if (OBC%number_of_segments > 0) then
-    do j0 = -1,0 ; do i0 = 0,1 ; if ((OBC%segnum_v(i+i0,J+j0) /= OBC_NONE)) then
+    do j0 = -1,0 ; do i0 = 0,1 ; if (OBC%segnum_v(i+i0,J+j0) /= 0) then
       i1 = i+i0 ; J1 = J+j0
-      if (OBC%segment(OBC%segnum_v(i1,j1))%direction == OBC_DIRECTION_N) then
+      if (OBC%segnum_v(i1,j1) > 0) then ! OBC_DIRECTION_N
         hwt(i0,j0) = 2.0 * h(i1,j1,k) * mask2dCv(i1,J1)
-      elseif (OBC%segment(OBC%segnum_v(i1,J1))%direction == OBC_DIRECTION_S) then
+      elseif (OBC%segnum_v(i1,J1) < 0) then !  OBC_DIRECTION_S
         hwt(i0,j0) = 2.0 * h(i1,J1+1,k) * mask2dCv(i1,J1)
       endif
     endif ; enddo ; enddo
@@ -1866,11 +1866,11 @@ function set_u_at_v(u, h, G, GV, i, j, k, mask2dCu, OBC)
   enddo ; enddo
 
   if (associated(OBC)) then ; if (OBC%number_of_segments > 0) then
-    do j0 = 0,1 ; do i0 = -1,0 ; if ((OBC%segnum_u(I+i0,j+j0) /= OBC_NONE)) then
+    do j0 = 0,1 ; do i0 = -1,0 ; if ((OBC%segnum_u(I+i0,j+j0) /= 0)) then
       I1 = I+i0 ; j1 = j+j0
-      if (OBC%segment(OBC%segnum_u(I1,j1))%direction == OBC_DIRECTION_E) then
+      if (OBC%segnum_u(I1,j1) > 0) then ! OBC_DIRECTION_E
         hwt(i0,j0) = 2.0 * h(I1,j1,k) * mask2dCu(I1,j1)
-      elseif (OBC%segment(OBC%segnum_u(I1,j1))%direction == OBC_DIRECTION_W) then
+      elseif (OBC%segnum_u(I1,j1) < 0) then ! OBC_DIRECTION_W
         hwt(i0,j0) = 2.0 * h(I1+1,j1,k) * mask2dCu(I1,j1)
       endif
     endif ; enddo ; enddo

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1504,15 +1504,15 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
 
     ! Project thickness outward across OBCs using a zero-gradient condition.
     if (associated(OBC)) then ; if (OBC%number_of_segments > 0) then
-      do I=Isq,Ieq ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
-        if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
+      do I=Isq,Ieq ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= 0)) then
+        if (OBC%segnum_u(I,j) > 0) then  ! OBC_DIRECTION_E
           do k=1,nz
             h_harm(I,k) = h(i,j,k) ; h_arith(I,k) = h(i,j,k) ; h_delta(I,k) = 0.
             dz_harm(I,k) = dz(i,j,k) ; dz_arith(I,k) = dz(i,j,k)
           enddo
           Dmin(I) = G%bathyT(i,j)
           zi_dir(I) = -1
-        elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
+        elseif (OBC%segnum_u(I,j) < 0) then  ! OBC_DIRECTION_W
           do k=1,nz
             h_harm(I,k) = h(i+1,j,k) ; h_arith(I,k) = h(i+1,j,k) ; h_delta(I,k) = 0.
             dz_harm(I,k) = dz(i+1,j,k) ; dz_arith(I,k) = dz(i+1,j,k)
@@ -1715,15 +1715,15 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
 
     ! Project thickness outward across OBCs using a zero-gradient condition.
     if (associated(OBC)) then ; if (OBC%number_of_segments > 0) then
-      do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
-        if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
+      do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= 0)) then
+        if (OBC%segnum_v(i,J) > 0) then  ! OBC_DIRECTION_N
           do k=1,nz
             h_harm(I,k) = h(i,j,k) ; h_arith(I,k) = h(i,j,k) ; h_delta(i,k) = 0.
             dz_harm(I,k) = dz(i,j,k) ; dz_arith(I,k) = dz(i,j,k)
           enddo
           Dmin(I) = G%bathyT(i,j)
           zi_dir(I) = -1
-        elseif (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
+        elseif (OBC%segnum_v(i,J) < 0) then  ! OBC_DIRECTION_S
           do k=1,nz
             h_harm(i,k) = h(i,j+1,k) ; h_arith(i,k) = h(i,j+1,k) ; h_delta(i,k) = 0.
             dz_harm(i,k) = dz(i,j+1,k) ; dz_arith(i,k) = dz(i,j+1,k)
@@ -2067,10 +2067,10 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
         Kv_add(i,K) = 0.5*(visc%Kv_shear(i,j,k) + visc%Kv_shear(i+1,j,k))
       endif ; enddo ; enddo
       if (do_OBCs) then
-        do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
+        do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= 0)) then
+          if (OBC%segnum_u(I,j) > 0) then  ! OBC_DIRECTION_E
             do K=2,nz ; Kv_add(i,K) = visc%Kv_shear(i,j,k) ; enddo
-          elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
+          elseif (OBC%segnum_u(I,j) < 0) then  ! OBC_DIRECTION_W
             do K=2,nz ; Kv_add(i,K) = visc%Kv_shear(i+1,j,k) ; enddo
           endif
         endif ; enddo
@@ -2083,10 +2083,10 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
         Kv_add(i,K) = 0.5*(visc%Kv_shear(i,j,k) + visc%Kv_shear(i,j+1,k))
       endif ; enddo ; enddo
       if (do_OBCs) then
-        do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
+        do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= 0)) then
+          if (OBC%segnum_v(i,J) > 0) then  ! OBC_DIRECTION_N
             do K=2,nz ; Kv_add(i,K) = visc%Kv_shear(i,j,k) ; enddo
-          elseif (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
+          elseif (OBC%segnum_v(i,J) < 0) then  ! OBC_DIRECTION_S
             do K=2,nz ; Kv_add(i,K) = visc%Kv_shear(i,j+1,k) ; enddo
           endif
         endif ; enddo
@@ -2223,10 +2223,10 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
           absf(I) = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
         endif ; enddo
         if (do_OBCs) then ; do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
+          if (OBC%segnum_u(I,j) > 0) then  ! OBC_DIRECTION_E
             u_star(I) = Ustar_2d(i,j)
             rho_av1(I) = 1.0 / tv%SpV_avg(i,j,1)
-          elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
+          elseif (OBC%segnum_u(I,j) < 0) then  ! OBC_DIRECTION_W
             u_star(I) = Ustar_2d(i+1,j)
             rho_av1(I) = 1.0 / tv%SpV_avg(i+1,j,1)
           endif
@@ -2237,11 +2237,11 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
           rho_av1(i) = 2.0 / (tv%SpV_avg(i,j,1) + tv%SpV_avg(i,j+1,1))
           absf(i) = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
         endif ; enddo
-        if (do_OBCs) then ; do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) then
+        if (do_OBCs) then ; do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= 0)) then
+          if (OBC%segnum_v(i,J) > 0) then  ! OBC_DIRECTION_N
             u_star(i) = Ustar_2d(i,j)
             rho_av1(i) = 1.0 / tv%SpV_avg(i,j,1)
-          elseif (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
+          elseif (OBC%segnum_v(i,J) < 0) then  ! OBC_DIRECTION_S
             u_star(i) = Ustar_2d(i,j+1)
             rho_av1(i) = 1.0 / tv%SpV_avg(i,j+1,1)
           endif
@@ -2256,22 +2256,18 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
           u_star(I) = 0.5*(Ustar_2d(i,j) + Ustar_2d(i+1,j))
           absf(I) = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
         endif ; enddo
-        if (do_OBCs) then ; do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) &
-            u_star(I) = Ustar_2d(i,j)
-          if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) &
-            u_star(I) = Ustar_2d(i+1,j)
+        if (do_OBCs) then ; do I=is,ie ; if (do_i(I) .and. (OBC%segnum_u(I,j) /= 0)) then
+          if (OBC%segnum_u(I,j) > 0) u_star(I) = Ustar_2d(i,j)    ! OBC_DIRECTION_E
+          if (OBC%segnum_u(I,j) < 0) u_star(I) = Ustar_2d(i+1,j)  ! OBC_DIRECTION_W
         endif ; enddo ; endif
       else
         do i=is,ie ; if (do_i(i)) then
           u_star(i) = 0.5*(Ustar_2d(i,j) + Ustar_2d(i,j+1))
           absf(i) = 0.5*(abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J)))
         endif ; enddo
-        if (do_OBCs) then ; do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= OBC_NONE)) then
-          if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_N) &
-            u_star(i) = Ustar_2d(i,j)
-          if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) &
-            u_star(i) = Ustar_2d(i,j+1)
+        if (do_OBCs) then ; do i=is,ie ; if (do_i(i) .and. (OBC%segnum_v(i,J) /= 0)) then
+          if (OBC%segnum_v(i,J) > 0) u_star(i) = Ustar_2d(i,j)    ! OBC_DIRECTION_N
+          if (OBC%segnum_v(i,J) < 0) u_star(i) = Ustar_2d(i,j+1)  ! OBC_DIRECTION_S
         endif ; enddo ; endif
       endif
       do I=is,ie

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -680,15 +680,12 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
 
     ! Update do_i so that nothing changes outside of the OBC (problem for interior OBCs only)
     if (associated(OBC)) then
-      if ((OBC%exterior_OBC_bug .eqv. .false.) .and. (OBC%OBC_pe)) then
+      if ((.not.OBC%exterior_OBC_bug) .and. (OBC%OBC_pe)) then
         if (OBC%specified_u_BCs_exist_globally .or. OBC%open_u_BCs_exist_globally) then
-          do i=is,ie-1 ; if (OBC%segnum_u(I,j) /= OBC_NONE) then
-            if (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_E) then
-              do_i(i+1,j) = .false.
-            elseif (OBC%segment(OBC%segnum_u(I,j))%direction == OBC_DIRECTION_W) then
-              do_i(i,j) = .false.
-            endif
-          endif ; enddo
+          do i=is,ie-1
+            if (OBC%segnum_u(I,j) > 0) do_i(i+1,j) = .false.  ! OBC_DIRECTION_E
+            if (OBC%segnum_u(I,j) < 0) do_i(i,j) = .false.    ! OBC_DIRECTION_W
+          enddo
         endif
       endif
     endif
@@ -1099,16 +1096,8 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
       if ((OBC%exterior_OBC_bug .eqv. .false.) .and. (OBC%OBC_pe)) then
         if (OBC%specified_v_BCs_exist_globally .or. OBC%open_v_BCs_exist_globally) then
           do i=is,ie
-            if (OBC%segnum_v(i,J-1) /= OBC_NONE) then
-              if (OBC%segment(OBC%segnum_v(i,J-1))%direction == OBC_DIRECTION_N) then
-                do_i(i,j) = .false.
-              endif
-            endif
-            if (OBC%segnum_v(i,J) /= OBC_NONE) then
-              if (OBC%segment(OBC%segnum_v(i,J))%direction == OBC_DIRECTION_S) then
-                do_i(i,j) = .false.
-              endif
-            endif
+            if (OBC%segnum_v(i,J-1) > 0) do_i(i,j) = .false.  ! OBC_DIRECTION_N
+            if (OBC%segnum_v(i,J) < 0) do_i(i,j) = .false.  ! OBC_DIRECTION_S
           enddo
         endif
       endif

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -9,7 +9,7 @@ use MOM_dyn_horgrid,    only : dyn_horgrid_type
 use MOM_error_handler,  only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
-use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE
+use MOM_open_boundary,  only : ocean_OBC_type
 use MOM_open_boundary,  only : OBC_segment_type, register_OBC
 use MOM_open_boundary,  only : OBC_registry_type
 use MOM_unit_scaling,   only : unit_scale_type
@@ -103,7 +103,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   if (turns == 0) then
     allocate(my_area(1:1,js:je), source=0.0)
     do j=segment%HI%jsc,segment%HI%jec ; do I=segment%HI%IscB,segment%HI%IecB
-      if (OBC%segnum_u(I,j) /= OBC_NONE) then ! (segment%direction == OBC_DIRECTION_E)
+      if (OBC%segnum_u(I,j) > 0) then ! (segment%direction == OBC_DIRECTION_E)
         do k=1,nz
           my_area(1,j) = my_area(1,j) + h(i,j,k)*(GV%H_to_m*US%m_to_Z)*G%dyCu(I,j)
         enddo
@@ -112,7 +112,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   elseif (turns == 1) then
     allocate(my_area(is:ie,1:1), source=0.0)
     do J=segment%HI%JscB,segment%HI%JecB ; do i=segment%HI%isc,segment%HI%iec
-      if (OBC%segnum_v(i,J) /= OBC_NONE) then ! (segment%direction == OBC_DIRECTION_N)
+      if (OBC%segnum_v(i,J) > 0) then ! (segment%direction == OBC_DIRECTION_N)
         do k=1,nz
           my_area(i,1) = my_area(i,1) + h(i,j,k)*(GV%H_to_m*US%m_to_Z)*G%dxCv(i,J)
         enddo
@@ -121,7 +121,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   elseif (turns == 2) then
     allocate(my_area(1:1,js:je), source=0.0)
     do j=segment%HI%jsc,segment%HI%jec ; do I=segment%HI%IscB,segment%HI%IecB
-      if (OBC%segnum_u(I,j) /= OBC_NONE) then ! (segment%direction == OBC_DIRECTION_W)
+      if (OBC%segnum_u(I,j) < 0) then ! (segment%direction == OBC_DIRECTION_W)
         do k=1,nz
           my_area(1,j) = my_area(1,j) + h(i+1,j,k)*(GV%H_to_m*US%m_to_Z)*G%dyCu(I,j)
         enddo
@@ -130,7 +130,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   elseif (turns == 3) then
     allocate(my_area(is:ie,1:1), source=0.0)
     do J=segment%HI%JscB,segment%HI%JecB ; do i=segment%HI%isc,segment%HI%iec
-      if (OBC%segnum_v(i,J) /= OBC_NONE) then ! (segment%direction == OBC_DIRECTION_S)
+      if (OBC%segnum_v(i,J) < 0) then ! (segment%direction == OBC_DIRECTION_S)
         do k=1,nz
           my_area(i,1) = my_area(i,1) + h(i,j+1,k)*(GV%H_to_m*US%m_to_Z)*G%dxCv(i,J)
         enddo


### PR DESCRIPTION
  This PR consists of a series of three commits that add extra information about the direction of OBCs at velocity points in the sign of `OBC%segnum_u` and `OBC%segnum_v`.  Instances where these arrays are used were modified in 11 modules, either to take their absolute value to find the segment number (in 5 files), or to use their sign to avoid looking into the direction inside of the segment type (in 10 files).  The resulting reduction in the use of multiply nested arrays of defined types should help address some of the issues we have been encountering with the code complexity interfering with the porting of MOM6 to work on GPUS.

  The second commit stores information about the range of loop indices where various orientations of OBCs are found on a local PE (including in its halos), and also stores logical flags about which PEs include which orientation of OBCs. The third commit uses this information to reduce the work being done to reset values at OBCs in 5 routines (`set_viscous_BBL()`, `vertvisc_coef()`, `find_coupling_coef()`, `calc_isoneutral_slopes()` and `ALE_remap_set_h_vel_OBC()`). With these changes, I am expecting that looping over `OBC%segnum_u` and `OBC%segnum_v` will be at least as efficient as working through a loop over the segment numbers in most places.

  All answers are bitwise identical, but there are 22 new scalar or logical elements and an important change to two elements of the publicly visible transparent `ocean_OBC_type`.  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@ec8d1683f Use OBC loop ranges on PE in 4 modules
 - NOAA-GFDL/MOM6@9d5a219c4 Add OBC loop ranges on PE
 - NOAA-GFDL/MOM6@aa06afbd3 +Signed OBC%segnum_u and OBC%segnum_v

