### PR TITLE
*Fix OBC v-velocity masking bug under ice shelves

### DIFF
--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2101,7 +2101,7 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) mask_u(I,j+1) = 0.0
         if (OBC%segment(n)%direction == OBC_DIRECTION_S) mask_u(I,j) = 0.0
       enddo
-    elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= je)) then
+    elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= ie)) then
       do J = max(js-1,OBC%segment(n)%HI%JsdB), min(je,OBC%segment(n)%HI%JedB)
         if (OBC%segment(n)%direction == OBC_DIRECTION_E) mask_v(i+1,J) = 0.0
         if (OBC%segment(n)%direction == OBC_DIRECTION_W) mask_v(i,J) = 0.0


### PR DESCRIPTION
  Fix a bug in determining where to apply OBC-related masking when interpolating v-velocities to u-points to calculate the surface friction velocity under ice shelves.  It would usually only arise at eastward OBCs under ice-shelves, but it could also occur for westward OBCs that are within a few points of the western side of the domain.  This bug breaks rotational symmetry and reproducibility across processor counts and layout when there are any open boundary conditions under ice shelves.  However, there are no reports of the detection of any such problems, and I am unaware of any cases using open boundary conditions under ice shelves, so it seems very likely that there are no existing MOM6 configurations that would trigger this specific bug.  Given all these considerations and the resulting expectation that it is exceptionally unlikely that fixing this bug would impact any existing work, rather than introducing a bug-fix runtime parameter to retain this bug, this commit simply fixes it with the obvious single-character correction.