### PR TITLE
update t_dyn_rel_thermo after step_mom_dyn

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -971,6 +971,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       if (do_advection) then ! Do advective transport and lateral tracer mixing.
         call step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
+        CS%t_dyn_rel_thermo = 0.0 ! Tracer advection is now in sync with diabatic
         if (CS%diabatic_first .and. abs(CS%t_dyn_rel_thermo) > 1e-6*dt) call MOM_error(FATAL, &
                 "step_MOM: Mismatch between the dynamics and diabatic times "//&
                 "with DIABATIC_FIRST.")


### PR DESCRIPTION
With interspersed ocean/ice coupling, a full thermodynamic diabatic step is taken prior to updating the combined dynamics. The call to step_MOM after the thermodynamic update in this case calls step_MOM_tracer_dyn , at which point the tracer advection is in sync with the diabatic state. A reset of t_dyn_rel_thermo was missing. This will change answers to any existing CIOD cases. @theresa-cordero  If you agree with this change, do we want to add a bugfix flag? 