### PR TITLE
Add conditional halo pass for frazil inside make_frazil

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -767,7 +767,10 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
   if (therm_reset) then
     CS%time_in_thermo_cycle = 0.0
-    if (associated(CS%tv%frazil))        CS%tv%frazil(:,:)        = 0.0
+    if (associated(CS%tv%frazil)) then
+      CS%tv%frazil(:,:) = 0.0
+      CS%tv%frazil_was_reset = .true.
+    endif
     if (associated(CS%tv%salt_deficit))  CS%tv%salt_deficit(:,:)  = 0.0
     if (associated(CS%tv%TempxPmE))      CS%tv%TempxPmE(:,:)      = 0.0
     if (associated(CS%tv%internal_heat)) CS%tv%internal_heat(:,:) = 0.0
@@ -2985,7 +2988,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   if (use_p_surf_in_EOS) allocate(CS%tv%p_surf(isd:ied,jsd:jed), source=0.0)
-  if (use_frazil) allocate(CS%tv%frazil(isd:ied,jsd:jed), source=0.0)
+  if (use_frazil) then
+    allocate(CS%tv%frazil(isd:ied,jsd:jed), source=0.0)
+    CS%tv%frazil_was_reset = .true.
+  endif
   if (bound_salinity) allocate(CS%tv%salt_deficit(isd:ied,jsd:jed), source=0.0)
 
   allocate(CS%Hml(isd:ied,jsd:jed), source=0.0)

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -101,8 +101,9 @@ type, public :: thermo_var_ptrs
   ! These arrays are accumulated fluxes for communication with other components.
   real, dimension(:,:), pointer :: frazil => NULL()
                          !< The energy needed to heat the ocean column to the
-                         !! freezing point since calculate_surface_state was2
+                         !! freezing point since calculate_surface_state was
                          !! last called [Q Z R ~> J m-2].
+  logical :: frazil_was_reset !< If true, frazil has not accumulated since it was last reset.
   real, dimension(:,:), pointer :: salt_deficit => NULL()
                          !<   The salt needed to maintain the ocean column
                          !! at a minimum salinity of MIN_SALINITY since the last time

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -8,7 +8,6 @@ use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,     only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
 use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type
-use MOM_domains,       only : pass_var
 use MOM_EOS,           only : calculate_density, calculate_TFreeze, EOS_domain
 use MOM_EOS,           only : calculate_specific_vol_derivs, calculate_density_derivs
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, callTree_showQuery
@@ -108,7 +107,7 @@ contains
 !! This subroutine warms any water that is colder than the (currently
 !! surface) freezing point up to the freezing point and accumulates
 !! the required heat (in [Q R Z ~> J m-2]) in tv%frazil.
-subroutine make_frazil(h, tv, G, GV, US, CS, p_surf, halo, frazil_halo_pass)
+subroutine make_frazil(h, tv, G, GV, US, CS, p_surf, halo)
   type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
@@ -121,7 +120,6 @@ subroutine make_frazil(h, tv, G, GV, US, CS, p_surf, halo, frazil_halo_pass)
   real, dimension(SZI_(G),SZJ_(G)), &
                  optional, intent(in)    :: p_surf !< The pressure at the ocean surface [R L2 T-2 ~> Pa].
   integer,       optional, intent(in)    :: halo !< Halo width over which to calculate frazil
-  logical,       optional, intent(in)    :: frazil_halo_pass !< Indicates if frazil should be updated in halos
   ! Local variables
   real, dimension(SZI_(G)) :: &
     fraz_col, & ! The accumulated heat requirement due to frazil [Q R Z ~> J m-2].
@@ -138,15 +136,6 @@ subroutine make_frazil(h, tv, G, GV, US, CS, p_surf, halo, frazil_halo_pass)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   if (present(halo)) then
     is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
-    ! Frazil needs a halo pass only when all of the following are true:
-    ! (1) frazil is calculated and applied in the halo (e.g., vertex_shear is true)
-    ! (2) the thermodynamic loop is called more than once before passing frazil to the sea-ice (dt_therm<dt_cpld)
-    ! (3) reclaim_frazil is true
-    ! (4) a previous make_frazil was called after the diabatic loop and before T&S were updated in halos.
-    if (present(frazil_halo_pass)) then
-      if ( CS%reclaim_frazil .and. (.not.tv%frazil_was_reset) .and. frazil_halo_pass) &
-        call pass_var(tv%frazil, G%domain, halo=halo)
-    endif
   endif
 
   call cpu_clock_begin(id_clock_frazil)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -374,9 +374,9 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
     endif
 
     if (associated(fluxes%p_surf_full)) then
-      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, fluxes%p_surf_full, halo=CS%halo_TS_diff)
+      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, fluxes%p_surf_full, halo=CS%halo_TS_diff, frazil_halo_pass = .true.)
     else
-      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, halo=CS%halo_TS_diff)
+      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, halo=CS%halo_TS_diff, frazil_halo_pass = .true.)
     endif
     if (showCallTree) call callTree_waypoint("done with 1st make_frazil (diabatic)")
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -374,10 +374,9 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
     endif
 
     if (associated(fluxes%p_surf_full)) then
-      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, fluxes%p_surf_full, halo=CS%halo_TS_diff, &
-                       frazil_halo_pass = .true.)
+      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, fluxes%p_surf_full, halo=CS%halo_TS_diff)
     else
-      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, halo=CS%halo_TS_diff, frazil_halo_pass = .true.)
+      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, halo=CS%halo_TS_diff)
     endif
     if (showCallTree) call callTree_waypoint("done with 1st make_frazil (diabatic)")
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -374,7 +374,8 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
     endif
 
     if (associated(fluxes%p_surf_full)) then
-      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, fluxes%p_surf_full, halo=CS%halo_TS_diff, frazil_halo_pass = .true.)
+      call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, fluxes%p_surf_full, halo=CS%halo_TS_diff, &
+                       frazil_halo_pass = .true.)
     else
       call make_frazil(h, tv, G, GV, US, CS%diabatic_aux_CSp, halo=CS%halo_TS_diff, frazil_halo_pass = .true.)
     endif


### PR DESCRIPTION
Frazil may need an extra halo pass, but only when all of the following are true: 
(1) frazil is calculated and applied in the halo (e.g., vertex_shear is true) 
(2) the thermodynamic loop is called more than once before passing frazil to the sea-ice (dt_therm<dt_cpld) 
(3) reclaim_frazil is true
(4) a previous make_frazil was called after the diabatic loop and before T&S were updated in halos.

This commit adds the halo pass inside make_frazil since it is where we can know all of these conditions at once.  We needed to add a flag to know if frazil was reset (which happens every timestep if dt_therm>=dt_cpld), in which case the halo pass would be unnecessary.  We needed an optional argument for make_frazil so we could flag to only do this update on the first call to make_frazil (which is needed because the previous call to make_frazil was after the diabatic loop, condition 4).

We could have achieved the same result by adding one new halo pass in diabatic_driver right before line 376 (requiring only one line of new code), but it would unnecessarily invoke a halo pass when all the above conditions were not achieved.  

Without this new code, the model does not conserve or reproduce across layouts when dt_therm<dt_cpld, vertex_shear is True, and reclaim_frazil is True.