### PR TITLE
+Do not call write_ocean_geometry_file from MOM_initialize_fixed

### DIFF
--- a/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
@@ -43,6 +43,7 @@ program Shelf_main
   use MOM_io,              only : APPEND_FILE, READONLY_FILE, SINGLE_FILE
   use MOM_open_boundary,   only : ocean_OBC_type
   use MOM_restart,         only : save_restart
+  use MOM_shared_initialization, only : write_ocean_geometry_file
   use MOM_string_functions,only : uppercase
   use MOM_time_manager,    only : time_type, set_date, get_date
   use MOM_time_manager,    only : real_to_time, time_type_to_real
@@ -268,7 +269,10 @@ program Shelf_main
   call clone_MOM_domain(ocn_grid%Domain, dG%Domain)
 
   ! Initialize the ocean grid and topography.
-  call MOM_initialize_fixed(dG, US, OBC, param_file, .true., dirs%output_directory)
+  call MOM_initialize_fixed(dG, US, OBC, param_file)
+  ! Write out all of the grid data used by this run.
+  call write_ocean_geometry_file(dG, param_file, dirs%output_directory, US=US)
+
   call MOM_grid_init(ocn_grid, param_file, US, HI)
   call copy_dyngrid_to_MOM_grid(dG, ocn_grid, US)
   call destroy_dyn_horgrid(dG)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2875,7 +2875,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call MOM_grid_init(G_in, param_file, US, HI_in, bathymetry_at_vel=bathy_at_vel)
 
   ! Allocate initialize time-invariant MOM variables.
-  call MOM_initialize_fixed(dG_in, US, OBC_in, param_file, .false., dirs%output_directory)
+  call MOM_initialize_fixed(dG_in, US, OBC_in, param_file)
 
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
@@ -3152,7 +3152,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                           local_indexing=.not.global_indexing)
       call create_dyn_horgrid(dG_unmasked_in, HI_in_unmasked, bathymetry_at_vel=bathy_at_vel)
       call clone_MOM_domain(MOM_dom_unmasked, dG_unmasked_in%Domain)
-      call MOM_initialize_fixed(dG_unmasked_in, US, OBC_in, param_file, .false., dirs%output_directory)
+      call MOM_initialize_fixed(dG_unmasked_in, US, OBC_in, param_file)
       call write_ocean_geometry_file(dG_unmasked_in, param_file, dirs%output_directory, US=US, geom_file=geom_file)
       call deallocate_MOM_domain(MOM_dom_unmasked)
       call destroy_dyn_horgrid(dG_unmasked_in)

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -24,7 +24,7 @@ use MOM_shared_initialization, only : set_rotation_planetary, set_rotation_beta_
 use MOM_shared_initialization, only : reset_face_lengths_named, reset_face_lengths_file, reset_face_lengths_list
 use MOM_shared_initialization, only : read_face_length_list, set_velocity_depth_max, set_velocity_depth_min
 use MOM_shared_initialization, only : set_subgrid_topo_at_vel_from_file
-use MOM_shared_initialization, only : compute_global_grid_integrals, write_ocean_geometry_file
+use MOM_shared_initialization, only : compute_global_grid_integrals
 use MOM_unit_scaling, only : unit_scale_type
 
 use user_initialization, only : user_initialize_topography
@@ -51,14 +51,12 @@ contains
 ! -----------------------------------------------------------------------------
 !> MOM_initialize_fixed sets up time-invariant quantities related to MOM6's
 !!   horizontal grid, bathymetry, and the Coriolis parameter.
-subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
+subroutine MOM_initialize_fixed(G, US, OBC, PF)
   type(dyn_horgrid_type),  intent(inout) :: G    !< The ocean's grid structure.
   type(unit_scale_type),   intent(in)    :: US   !< A dimensional unit scaling type
   type(ocean_OBC_type),    pointer       :: OBC  !< Open boundary structure.
   type(param_file_type),   intent(in)    :: PF   !< A structure indicating the open file
                                                  !! to parse for model parameter values.
-  logical,                 intent(in)    :: write_geom !< If true, write grid geometry files.
-  character(len=*),        intent(in)    :: output_dir !< The directory into which to write files.
 
   ! Local variables
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
@@ -174,9 +172,6 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF, write_geom, output_dir)
 
 ! Compute global integrals of grid values for later use in scalar diagnostics !
   call compute_global_grid_integrals(G, US=US)
-
-! Write out all of the grid data used by this run.
-  if (write_geom) call write_ocean_geometry_file(G, PF, output_dir, US=US)
 
   call callTree_leave('MOM_initialize_fixed()')
 

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -47,7 +47,7 @@ use MOM_grid_initialize, only : set_grid_metrics
 use MOM_hor_index, only : hor_index_type, hor_index_init
 use MOM_dyn_horgrid, only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
 use MOM_transcribe_grid, only : copy_dyngrid_to_MOM_grid, copy_MOM_grid_to_dyngrid
-use MOM_fixed_initialization, only : MOM_initialize_fixed, MOM_initialize_topography
+use MOM_fixed_initialization, only : MOM_initialize_topography
 use MOM_coord_initialization, only : MOM_initialize_coord
 use MOM_file_parser, only : read_param, get_param, param_file_type
 use MOM_string_functions, only : lowercase


### PR DESCRIPTION
  Removed the option to call `write_ocean_geometry_file()` from within `MOM_initialize_fixed()`.  This option was only being exercised in one of the three places where `MOM_initialize_fixed()` was being called, and by doing so it precluded the possibility of specifying an alternative name for this file. Removing this option eliminates two arguments to `MOM_initialize_fixed()`, but it requires the addition of a new call to `write_ocean_geometry_file()` directly from `shelf_main()` in `ice_shelf_driver.F90`.  All answers are bitwise identical, but there is a simplification in the arguments to a publicly visible routine.