### PR TITLE
+Rotated and simpler OBC initialization

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -117,7 +117,8 @@ use MOM_open_boundary,         only : register_temp_salt_segments, update_segmen
 use MOM_open_boundary,         only : setup_OBC_tracer_reservoirs, fill_temp_salt_segments
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
 use MOM_open_boundary,         only : open_boundary_setup_vert, initialize_segment_data
-use MOM_open_boundary,         only : update_OBC_segment_data, rotate_OBC_config, rotate_OBC_init
+use MOM_open_boundary,         only : update_OBC_segment_data, rotate_OBC_config
+use MOM_open_boundary,         only : rotate_OBC_segment_fields, rotate_OBC_segment_tracer_registry
 use MOM_open_boundary,         only : open_boundary_halo_update, write_OBC_info, chksum_OBC_segments
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
@@ -2918,6 +2919,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     if (associated(OBC_in)) then
       allocate(CS%OBC)
       call rotate_OBC_config(OBC_in, dG_in, CS%OBC, dG, turns)
+      call rotate_OBC_segment_fields(OBC_in, G, CS%OBC)
     endif
 
     call destroy_dyn_horgrid(dG)
@@ -3098,20 +3100,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call mixedlayer_restrat_register_restarts(HI, GV, US, param_file, &
            CS%mixedlayer_restrat_CSp, restart_CSp)
 
-  if (CS%rotate_index .and. associated(OBC_in) .and. use_temperature) then
-    ! NOTE: register_temp_salt_segments includes allocation of tracer fields
-    !   along segments.  Bit reproducibility requires that MOM_initialize_state
-    !   be called on the input index map, so we must setup both OBC and OBC_in.
-    !
-    ! XXX: This call on OBC_in allocates the tracer fields on the unrotated
-    !   grid, but also incorrectly stores a pointer to a tracer_type for the
-    !   rotated registry (e.g. segment%tr_reg%Tr(n)%Tr) from CS%tracer_reg.
-    !
-    !   While incorrect and potentially dangerous, it does not seem that this
-    !   pointer is used during initialization, so we leave it for now.
-    call register_temp_salt_segments(GV, US, OBC_in, CS%tracer_Reg, param_file)
-  endif
-
   if (associated(CS%OBC)) then
     ! Set up remaining information about open boundary conditions that is needed for OBCs.
     ! Package specific changes to OBCs occur here.
@@ -3128,6 +3116,23 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     ! reservoirs are used.
     call open_boundary_register_restarts(HI, GV, US, CS%OBC, CS%tracer_Reg, &
                           param_file, restart_CSp, use_temperature)
+  endif
+
+  if (CS%rotate_index .and. associated(OBC_in) .and. use_temperature) then
+    ! NOTE: register_temp_salt_segments includes allocation of tracer fields
+    !   along segments.  Bit reproducibility requires that MOM_initialize_state
+    !   be called on the input index map, so we must setup both OBC and OBC_in.
+    !
+    ! XXX: This call on OBC_in allocates the tracer fields on the unrotated
+    !   grid, but also incorrectly stores a pointer to a tracer_type for the
+    !   rotated registry (e.g. segment%tr_reg%Tr(n)%Tr) from CS%tracer_reg.
+    !
+    !   While incorrect and potentially dangerous, it does not seem that this
+    !   pointer is used during initialization, so we leave it for now.
+    call register_temp_salt_segments(GV, US, OBC_in, CS%tracer_Reg, param_file)
+  endif
+  if (CS%rotate_index .and. associated(CS%OBC)) then
+    call rotate_OBC_segment_tracer_registry(OBC_in, G, CS%OBC)
   endif
 
   if (CS%debug_OBCs .and. associated(CS%OBC)) call write_OBC_info(CS%OBC, G, GV, US)
@@ -3309,9 +3314,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   if (associated(CS%OBC)) then
-    if (CS%rotate_index) then
-      call rotate_OBC_init(OBC_in, G, CS%OBC)
-    endif
     call MOM_initialize_OBCs(CS%h, CS%tv, CS%OBC, Time, G, GV, US, param_file, restart_CSp, CS%tracer_Reg)
   endif
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -118,7 +118,7 @@ use MOM_open_boundary,         only : setup_OBC_tracer_reservoirs
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
 use MOM_open_boundary,         only : open_boundary_setup_vert, initialize_segment_data
 use MOM_open_boundary,         only : update_OBC_segment_data, open_boundary_halo_update
-use MOM_open_boundary,         only : rotate_OBC_config, rotate_OBC_segment_fields
+use MOM_open_boundary,         only : rotate_OBC_config
 use MOM_open_boundary,         only : write_OBC_info, chksum_OBC_segments
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
@@ -2919,7 +2919,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     if (associated(OBC_in)) then
       allocate(CS%OBC)
       call rotate_OBC_config(OBC_in, dG_in, CS%OBC, dG, turns)
-      call rotate_OBC_segment_fields(OBC_in, G, CS%OBC)
     endif
 
     call destroy_dyn_horgrid(dG)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -112,7 +112,7 @@ use MOM_MEKE_types,            only : MEKE_type
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat, mixedlayer_restrat_init, mixedlayer_restrat_CS
 use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
 use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
-use MOM_open_boundary,         only : ocean_OBC_type
+use MOM_open_boundary,         only : ocean_OBC_type, open_boundary_end
 use MOM_open_boundary,         only : register_temp_salt_segments, update_segment_tracer_reservoirs
 use MOM_open_boundary,         only : setup_OBC_tracer_reservoirs
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
@@ -3263,6 +3263,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       call update_ALE_sponge_field(CS%ALE_sponge_CSp, S_in, G, GV, CS%S)
     endif
 
+   ! Deallocate the unrotated arrays and types that are no longer needed.
     deallocate(u_in)
     deallocate(v_in)
     deallocate(h_in)
@@ -3270,8 +3271,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       deallocate(T_in)
       deallocate(S_in)
     endif
-    if (use_ice_shelf) &
-      deallocate(frac_shelf_in, mass_shelf_in)
+    if (use_ice_shelf) deallocate(frac_shelf_in, mass_shelf_in)
+    if (associated(OBC_in)) call open_boundary_end(OBC_in)
+
   else  ! The model is being run without grid rotation.  This is true of all production runs.
     if (use_ice_shelf) then
       call initialize_ice_shelf(param_file, G, Time, ice_shelf_CSp, diag_ptr, Time_init, &
@@ -4545,6 +4547,7 @@ subroutine MOM_end(CS)
   DEALLOC_(CS%uh) ; DEALLOC_(CS%vh)
 
   if (associated(CS%update_OBC_CSp)) call OBC_register_end(CS%update_OBC_CSp)
+  if (associated(CS%OBC)) call open_boundary_end(CS%OBC)
 
   call verticalGridEnd(CS%GV)
   call MOM_grid_end(CS%G)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -116,9 +116,8 @@ use MOM_open_boundary,         only : ocean_OBC_type, open_boundary_end
 use MOM_open_boundary,         only : register_temp_salt_segments, update_segment_tracer_reservoirs
 use MOM_open_boundary,         only : setup_OBC_tracer_reservoirs
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
-use MOM_open_boundary,         only : open_boundary_setup_vert, initialize_segment_data
+use MOM_open_boundary,         only : initialize_segment_data, rotate_OBC_config
 use MOM_open_boundary,         only : update_OBC_segment_data, open_boundary_halo_update
-use MOM_open_boundary,         only : rotate_OBC_config
 use MOM_open_boundary,         only : write_OBC_info, chksum_OBC_segments
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
@@ -2895,10 +2894,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
   CS%HFrz = (US%Z_to_m * GV%m_to_H) * HFrz_z
 
-  ! Finish OBC configuration that depend on the vertical grid
   if (associated(OBC_in)) then
-    call open_boundary_setup_vert(GV, US, OBC_in)
-    ! This allocates the arrays on the segments for open boundary data
+    ! This call allocates the arrays on the segments for open boundary data and initializes the
+    ! relevant vertical remapping structures.   It can only occur after the vertical grid has been
+    ! initialized.
     call initialize_segment_data(G_in, GV, US, OBC_in, param_file)
   endif
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -126,7 +126,7 @@ use MOM_set_visc,              only : set_visc_register_restarts, remap_vertvisc
 use MOM_set_visc,              only : set_visc_init, set_visc_end
 use MOM_shared_initialization, only : write_ocean_geometry_file
 use MOM_sponge,                only : init_sponge_diags, sponge_CS
-use MOM_state_initialization,  only : MOM_initialize_state
+use MOM_state_initialization,  only : MOM_initialize_state, MOM_initialize_OBCs
 use MOM_stoch_eos,             only : MOM_stoch_eos_init, MOM_stoch_eos_run, MOM_stoch_eos_CS
 use MOM_stoch_eos,             only : stoch_EOS_register_restarts, post_stoch_EOS_diags, mom_calc_varT
 use MOM_sum_output,            only : write_energy, accumulate_net_input
@@ -3244,6 +3244,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
           sponge_in_CSp, ALE_sponge_in_CSp, oda_incupd_in_CSp, OBC_in, Time_in)
     endif
 
+    if (associated(OBC_in)) &
+      call MOM_initialize_OBCs(h_in, CS%tv, OBC_in, Time, G_in, GV, US, param_file, restart_CSp, CS%tracer_Reg)
+
     if (use_temperature) then
       CS%tv%T => CS%T
       CS%tv%S => CS%S
@@ -3290,7 +3293,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       deallocate(S_in)
     endif
     if (use_ice_shelf) &
-      deallocate(frac_shelf_in,mass_shelf_in)
+      deallocate(frac_shelf_in, mass_shelf_in)
   else  ! The model is being run without grid rotation.  This is true of all production runs.
     if (use_ice_shelf) then
       call initialize_ice_shelf(param_file, G, Time, ice_shelf_CSp, diag_ptr, Time_init, &
@@ -3307,6 +3310,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
           param_file, dirs, restart_CSp, CS%ALE_CSp, CS%tracer_Reg, &
           CS%sponge_CSp, CS%ALE_sponge_CSp, CS%oda_incupd_CSp, CS%OBC, Time_in)
     endif
+
+    if (associated(CS%OBC)) &
+      call MOM_initialize_OBCs(CS%h, CS%tv, CS%OBC, Time, G, GV, US, param_file, restart_CSp, CS%tracer_Reg)
 
     ! Reset the first direction if it was found in a restart file.
     if (CS%first_dir_restart > -1.0) then

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -40,7 +40,6 @@ implicit none ; private
 
 public open_boundary_apply_normal_flow
 public open_boundary_config
-public open_boundary_setup_vert
 public open_boundary_halo_update
 public open_boundary_query
 public open_boundary_end
@@ -794,42 +793,8 @@ subroutine open_boundary_config(G, US, param_file, OBC)
 
 end subroutine open_boundary_config
 
-!> Setup vertical remapping for open boundaries
-subroutine open_boundary_setup_vert(GV, US, OBC)
-  type(verticalGrid_type), intent(in)    :: GV  !< Container for vertical grid information
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
-  type(ocean_OBC_type),    pointer       :: OBC !< Open boundary control structure
 
-  ! Local variables
-  real :: dz_neglect, dz_neglect_edge ! Small thicknesses in vertical height units [Z ~> m]
-
-  if (associated(OBC)) then
-    if (OBC%number_of_segments > 0) then
-      if (GV%Boussinesq .and. (OBC%remap_answer_date < 20190101)) then
-        dz_neglect = US%m_to_Z * 1.0e-30 ; dz_neglect_edge = US%m_to_Z * 1.0e-10
-      elseif (GV%semi_Boussinesq .and. (OBC%remap_answer_date < 20190101)) then
-        dz_neglect = GV%kg_m2_to_H*GV%H_to_Z * 1.0e-30 ; dz_neglect_edge = GV%kg_m2_to_H*GV%H_to_Z * 1.0e-10
-      else
-        dz_neglect = GV%dZ_subroundoff ; dz_neglect_edge = GV%dZ_subroundoff
-      endif
-      allocate(OBC%remap_z_CS)
-      call initialize_remapping(OBC%remap_z_CS, OBC%remappingScheme, boundary_extrapolation=.false., &
-                 check_reconstruction=OBC%check_reconstruction, check_remapping=OBC%check_remapping, &
-                 om4_remap_via_sub_cells=OBC%om4_remap_via_sub_cells, &
-                 force_bounds_in_subcell=OBC%force_bounds_in_subcell, answer_date=OBC%remap_answer_date, &
-                 h_neglect=dz_neglect, h_neglect_edge=dz_neglect_edge)
-      allocate(OBC%remap_h_CS)
-      call initialize_remapping(OBC%remap_h_CS, OBC%remappingScheme, boundary_extrapolation=.false., &
-                 check_reconstruction=OBC%check_reconstruction, check_remapping=OBC%check_remapping, &
-                 om4_remap_via_sub_cells=OBC%om4_remap_via_sub_cells, &
-                 force_bounds_in_subcell=OBC%force_bounds_in_subcell, answer_date=OBC%remap_answer_date, &
-                 h_neglect=GV%H_subroundoff, h_neglect_edge=GV%H_subroundoff)
-    endif
-  endif
-
-end subroutine open_boundary_setup_vert
-
-!> Allocate space for reading OBC data from files. It sets up the required vertical
+!> Set up vertical remapping and allocate space for reading OBC data from files. It sets up the required vertical
 !! remapping. In the process, it does funky stuff with the MPI processes.
 subroutine initialize_segment_data(G, GV, US, OBC, PF)
   type(ocean_grid_type),        intent(in)    :: G   !< Ocean grid structure
@@ -844,6 +809,7 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
   character(len=20)  :: segnam, suffix
   character(len=32)  :: fieldname
   real               :: value  ! A value that is parsed from the segment data string [various units]
+  real :: dz_neglect, dz_neglect_edge ! Small thicknesses in vertical height units [Z ~> m]
   character(len=32), dimension(MAX_OBC_FIELDS) :: fields  ! segment field names
   character(len=128) :: inputdir
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
@@ -860,6 +826,30 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
   integer :: IO_needs(2) ! Sums to determine global OBC data use and update patterns.
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+
+  if (OBC%number_of_segments > 0) then
+    ! Set up vertical remapping for open boundaries.  Remapping happens independently on each PE,
+    ! so this block could be skipped for PEs without open boundary conditions that use remapping.
+    if (GV%Boussinesq .and. (OBC%remap_answer_date < 20190101)) then
+      dz_neglect = US%m_to_Z * 1.0e-30 ; dz_neglect_edge = US%m_to_Z * 1.0e-10
+    elseif (GV%semi_Boussinesq .and. (OBC%remap_answer_date < 20190101)) then
+      dz_neglect = GV%kg_m2_to_H*GV%H_to_Z * 1.0e-30 ; dz_neglect_edge = GV%kg_m2_to_H*GV%H_to_Z * 1.0e-10
+    else
+      dz_neglect = GV%dZ_subroundoff ; dz_neglect_edge = GV%dZ_subroundoff
+    endif
+    allocate(OBC%remap_z_CS)
+    call initialize_remapping(OBC%remap_z_CS, OBC%remappingScheme, boundary_extrapolation=.false., &
+               check_reconstruction=OBC%check_reconstruction, check_remapping=OBC%check_remapping, &
+               om4_remap_via_sub_cells=OBC%om4_remap_via_sub_cells, &
+               force_bounds_in_subcell=OBC%force_bounds_in_subcell, answer_date=OBC%remap_answer_date, &
+               h_neglect=dz_neglect, h_neglect_edge=dz_neglect_edge)
+    allocate(OBC%remap_h_CS)
+    call initialize_remapping(OBC%remap_h_CS, OBC%remappingScheme, boundary_extrapolation=.false., &
+               check_reconstruction=OBC%check_reconstruction, check_remapping=OBC%check_remapping, &
+               om4_remap_via_sub_cells=OBC%om4_remap_via_sub_cells, &
+               force_bounds_in_subcell=OBC%force_bounds_in_subcell, answer_date=OBC%remap_answer_date, &
+               h_neglect=GV%H_subroundoff, h_neglect_edge=GV%H_subroundoff)
+  endif
 
   ! There is a problem with the order of the OBC initialization
   ! with respect to ALE_init. Currently handling this by copying the

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -233,7 +233,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   real    :: normal_sign ! A variable that corrects the sign of normal velocities for rotation [nondim]
   real    :: trans_sign  ! A variable that corrects the sign of transverse velocities for rotation [nondim]
   type(OBC_segment_type), pointer :: segment => NULL()
-  integer :: unrot_dir ! The unrotated direction of the segmetn
+  integer :: unrot_dir ! The unrotated direction of the segment
   integer :: turns    ! Number of index quarter turns
   integer :: i, j, k, n, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB, isq, ieq, jsq, jeq, is_vel, ie_vel, js_vel, je_vel


### PR DESCRIPTION
  This PR consists of a series of 8 commits that simplify the calls used to initialize the OBCs, including initializing the OBCs directly on the rotated grid when grid rotation is in use.  This includes moving the code that initializes the OBCs out of `MOM_initialize_state()` and into the new subroutine `MOM_initialize_OBCs()`.  The code that sets up the OBCs was rearranged and consolidated into fewer blocks of code, including the combination of the functionality that had previously been provided by the separate OBC routines into other closely related routines and the elimination of some functionality that is no longer need with this simpler structure.  As a result, the publicly visible OBC interface to `rotate_OBC_init()`, `set_tracer_data()` and `open_boundary_setup_vert()` were eliminated altoghether. Several of the commits are intermediate steps introducing new subroutines that are subsequently removed, but these intermediate stages may be useful for debugging any problems that may arise.  There are also new calls to `open_boundary_end()` to manage OBC memory use.

  Most of the changes only relate to the case where grid rotation is being used for debugging,  and none of these changes will have any impact on cases that do not use open boundary conditions.  It has been verified that the OBCs still pass all of the grid rotation tests that they did previously.  All answers are bitwise identical, but there are several changes to publicly visible interfaces, including the addition of one new interface and the removal of three others.

The specific commits in this PR include:

 - NOAA-GFDL/MOM6@7bf96c63e +Open_boundary_setup_vert in init_segment_data
 - NOAA-GFDL/MOM6@c2a5382ee +Rotate_OBC_segment_fields in rotate_OBC_config
 - NOAA-GFDL/MOM6@e89d87495 Deallocate OBC memory with open_boundary_end
 - NOAA-GFDL/MOM6@b55748eed +Eliminate rotate_OBC_segment_tracer_registry
 - NOAA-GFDL/MOM6@44c6f2a0c +Rename and split rotate_OBC_init()
 - NOAA-GFDL/MOM6@62f478d1f Call MOM_initialize_OBCs with the rotated OBC type
 - NOAA-GFDL/MOM6@35e8cded3 Move calls out of MOM_initialize_OBCs
 - NOAA-GFDL/MOM6@39da6deb5 +Split MOM_initialize_OBCs from MOM_init_state
