### PR TITLE
Added the WENO schemes to reconstruct PV in MOM_CoriolisAdv

### DIFF
--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -37,11 +37,14 @@ type, public :: CoriolisAdv_CS ; private
                              !! - SADOURNY75_ENSTRO - Sadourny, JAS 1975, Enstrophy
                              !! - ARAKAWA_LAMB81    - Arakawa & Lamb, MWR 1981, Energy & Enstrophy
                              !! - ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with Arakawa & Hsu and Sadourny energy.
+                             !! - WENOVI7TH_PV_ENSTRO    - 7th-order WENO scheme for PV reconstruction
+                             !! - WENOVI7TH_ENSTRO       - 7th-order WENO scheme for absolute vorticity reconstruction
                              !! The default, SADOURNY75_ENERGY, is the safest choice then the
                              !! deformation radius is poorly resolved.
   integer :: KE_Scheme       !< KE_SCHEME selects the discretization for
                              !! the kinetic energy. Valid values are:
                              !!  KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
+  logical :: KE_use_limiter  !< If true, use the Koren limiter for KE_UP3 scheme
   integer :: PV_Adv_Scheme   !< PV_ADV_SCHEME selects the discretization for PV advection
                              !! Valid values are:
                              !! - PV_ADV_CENTERED - centered (aka Sadourny, 75)
@@ -73,6 +76,10 @@ type, public :: CoriolisAdv_CS ; private
                              !! relative to the other one is used.  This is only
                              !! available at present if Coriolis scheme is
                              !! SADOURNY75_ENERGY.
+  logical, public :: USE_WENO !< If WENOVI7TH_PV_ENSTRO and WENOVI7TH_ENSTRO schemes are used,
+                              !! this will be passed to RK2 modules to enlarge the halo update size.
+  integer, public :: WENO_stencil  !< The size of WENO stencil
+  logical :: weno_velocity_smooth !< If true, use velocity to compute the smoothness indicator for WENO
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the timing of diagnostic output.
   !>@{ Diagnostic IDs
@@ -97,20 +104,28 @@ integer, parameter :: ROBUST_ENSTRO     = 3
 integer, parameter :: SADOURNY75_ENSTRO = 4
 integer, parameter :: ARAKAWA_LAMB81    = 5
 integer, parameter :: AL_BLEND          = 6
+integer, parameter :: wenovi7th_PV_ENSTRO = 7
+integer, parameter :: wenovi5th_PV_ENSTRO = 8
+integer, parameter :: wenovi3rd_PV_ENSTRO = 9
 character*(20), parameter :: SADOURNY75_ENERGY_STRING = "SADOURNY75_ENERGY"
 character*(20), parameter :: ARAKAWA_HSU_STRING = "ARAKAWA_HSU90"
 character*(20), parameter :: ROBUST_ENSTRO_STRING = "ROBUST_ENSTRO"
 character*(20), parameter :: SADOURNY75_ENSTRO_STRING = "SADOURNY75_ENSTRO"
 character*(20), parameter :: ARAKAWA_LAMB_STRING = "ARAKAWA_LAMB81"
 character*(20), parameter :: AL_BLEND_STRING = "ARAKAWA_LAMB_BLEND"
+character*(20), parameter :: WENOVI7TH_PV_ENSTRO_STRING = "WENOVI7TH_PV_ENSTRO"
+character*(20), parameter :: WENOVI5TH_PV_ENSTRO_STRING = "WENOVI5TH_PV_ENSTRO"
+character*(20), parameter :: WENOVI3RD_PV_ENSTRO_STRING = "WENOVI3RD_PV_ENSTRO"
 !>@}
 !>@{ Enumeration values for KE_Scheme
 integer, parameter :: KE_ARAKAWA        = 10
 integer, parameter :: KE_SIMPLE_GUDONOV = 11
 integer, parameter :: KE_GUDONOV        = 12
+integer, parameter :: KE_UP3            = 13
 character*(20), parameter :: KE_ARAKAWA_STRING = "KE_ARAKAWA"
 character*(20), parameter :: KE_SIMPLE_GUDONOV_STRING = "KE_SIMPLE_GUDONOV"
 character*(20), parameter :: KE_GUDONOV_STRING = "KE_GUDONOV"
+character*(20), parameter :: KE_UP3_STRING = "KE_UP3"
 !>@}
 !>@{ Enumeration values for PV_Adv_Scheme
 integer, parameter :: PV_ADV_CENTERED   = 21
@@ -148,6 +163,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     q, &        ! Layer potential vorticity [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
     qS, &       ! Layer Stokes vorticity [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
     Ih_q, &     ! The inverse of thickness interpolated to q points [H-1 ~> m-1 or m2 kg-1].
+    h_q, &      ! The thickness interpolated to q points [H-1 ~> m-1 or m2 kg-1].
     Area_q      ! The sum of the ocean areas at the 4 adjacent thickness points [L2 ~> m2].
 
   real, dimension(SZIB_(G),SZJ_(G)) :: &
@@ -203,6 +219,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                                  ! surrounding a q point [H L2 ~> m3 or kg].
   real :: vol_neglect            ! A volume so small that is expected to be
                                  ! lost in roundoff [H L2 ~> m3 or kg].
+  real :: area_neglect           ! An area so small that is expected to be
+                                 ! lost in roundoff [H L2 ~> m3 or kg].
   real :: temp1, temp2           ! Temporary variables [L2 T-2 ~> m2 s-2].
   real :: eps_vel                ! A tiny, positive velocity [L T-1 ~> m s-1].
 
@@ -227,6 +245,19 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: QUHeff,QVHeff ! More temporary variables [H L2 T-2 ~> m3 s-2 or kg s-2].
   integer :: i, j, k, n, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   logical :: Stokes_VF
+  real :: u_v, v_u, q_v, q_u ! u_v is the u velocity at v point, v_u is the v velocity at u point
+  real :: h_v, h_u      ! h_v is the thickness at v point, h_u is the thickness at u point
+  integer :: seventh_order, fifth_order, third_order, second_order ! Order of accuracy for the WENO calculations
+  real :: Ih_sum        ! Sum of inverse thickness at PV points [H-1 ~> m-1]
+  real :: Ih_third, Ih_fifth, Ih_seventh  ! Sum of inverse thickness at at 3rd-, 5th-, and 7th-WENO scheme points
+  real :: psi           ! Ratio of PV gradient for the Koren limiter [nondim]
+  real :: u_q8(8) ! Eight-point zonal velocity at WENO stencils [L T-1 ~> m s-1]
+  real :: u_q6(6) ! Six-point zonal velocity at WENO stencils [L T-1 ~> m s-1]
+  real :: u_q4(4) ! Four-point zonal velocity at WENO stencils [L T-1 ~> m s-1]
+  real :: v_q8(8) ! Eight-point meridional velocity at WENO stencils [L T-1 ~> m s-1]
+  real :: v_q6(6) ! Six-point meridional velocity at WENO stencils [L T-1 ~> m s-1]
+  real :: v_q4(4) ! Four-point meridional velocity at WENO stencils [L T-1 ~> m s-1]
+  integer :: stencil    ! Stencil size of WENO scheme
 
 ! To work, the following fields must be set outside of the usual
 ! is to ie range before this subroutine is called:
@@ -239,9 +270,19 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB ; nz = GV%ke
   vol_neglect = GV%H_subroundoff * (1e-4 * US%m_to_L)**2
+  area_neglect = (1e-4 * US%m_to_L)**2
   eps_vel = 1.0e-10*US%m_s_to_L_T
   h_tiny = GV%Angstrom_H  ! Perhaps this should be set to h_neglect instead.
 
+
+  stencil = CS%WENO_stencil
+  if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO .or. &
+       CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+    Isq = Isq - stencil + 1
+    Ieq = Ieq + stencil - 2
+    Jsq = Jsq - stencil + 1
+    Jeq = Jeq + stencil - 2
+  endif
   !$OMP parallel do default(private) shared(Isq,Ieq,Jsq,Jeq,G,Area_h)
   do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+2
     Area_h(i,j) = G%mask2dT(i,j) * G%areaT(i,j)
@@ -273,6 +314,14 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                   (Area_h(i+1,j) + Area_h(i,j+1))
   enddo ; enddo
 
+  if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO .or. &
+        CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+    Isq = Isq + stencil - 1
+    Ieq = Ieq - stencil + 2
+    Jsq = Jsq + stencil - 1
+    Jeq = Jeq - stencil + 2
+  endif
+
   Stokes_VF = .false.
   if (present(Waves)) then ; if (associated(Waves)) then
     Stokes_VF = Waves%Stokes_VF
@@ -280,9 +329,16 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
   !$OMP                        RV,PV,is,ie,js,je,Isq,Ieq,Jsq,Jeq,nz,vol_neglect,h_tiny,OBC,eps_vel, &
-  !$OMP                        pbv, Stokes_VF)
+  !$OMP                        area_neglect, pbv, Stokes_VF)
   do k=1,nz
 
+    if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO .or. &
+         CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+      Isq = Isq - stencil + 1
+      Ieq = Ieq + stencil - 2
+      Jsq = Jsq - stencil + 1
+      Jeq = Jeq + stencil - 2
+    endif
     ! Here the second order accurate layer potential vorticities, q,
     ! are calculated.  hq is  second order accurate in space.  Relative
     ! vorticity is second order accurate everywhere with free slip b.c.s,
@@ -487,6 +543,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
       hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
       Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
+      h_q(I,J) = (hArea_q) / (Area_q(I,J) + area_neglect)
       q(I,J) = abs_vort(I,J) * Ih_q(I,J)
     enddo; enddo
 
@@ -496,6 +553,14 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
         enddo; enddo
       endif
+    endif
+
+    if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO .or. &
+         CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+      Isq = Isq + stencil - 1
+      Ieq = Ieq - stencil + 2
+      Jsq = Jsq + stencil - 1
+      Jeq = Jeq - stencil + 2
     endif
 
     if (CS%id_rv > 0) then
@@ -712,6 +777,114 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAu(I,j,k) = (QVHeff / ( h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) ) * G%IdxCu(I,j)
         endif
       enddo ; enddo
+    elseif (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) then
+      do j=js,je ; do I=Isq,Ieq
+        v_u = 0.25*G%IdxCu(I,j)*((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
+        ! check whether there is masked land points in the stencil
+        third_order = (G%mask2dCu(I,j-2) * G%mask2dCu(I,j-1) * G%mask2dCu(I,j) * &
+                       G%mask2dCu(I,j+1) * G%mask2dCu(I,j+2))
+
+        fifth_order   = third_order * G%mask2dCu(I,j-3) * G%mask2dCu(I,j+3)
+        seventh_order = fifth_order * G%mask2dCu(I,j-4) * G%mask2dCu(I,j+4)
+
+
+        ! compute the masking to make sure that inland values are not used
+        if (seventh_order == 1) then
+          ! all values are valid, we use seventh order reconstruction
+          u_q8 = (u(I,j-4:j+3,k) + u(I,j-3:j+4,k)) * 0.5
+          call weno_seven_h_weight_reconstruction(abs_vort(I,J-4:J+3), &
+                                         h_q(I,J-4:J+3), &
+                                         u_q8, &
+                                         GV%H_subroundoff, v_u, q_u, cs%weno_velocity_smooth)
+          CAu(I,j,k) = (q_u * v_u)
+
+        elseif (fifth_order == 1) then
+          ! all values are valid, we use fifth order reconstruction
+          u_q6 = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
+          call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2), &
+                                        h_q(I,J-3:J+2), &
+                                        u_q6, &
+                                        GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
+          CAu(I,j,k) = (q_u * v_u)
+
+        elseif (third_order == 1) then
+          ! only the middle values are valid, we use third order reconstruction
+          u_q4 = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
+          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
+                                         h_q(I,J-2:J+1), &
+                                         u_q4, &
+                                         GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
+          CAu(I,j,k) = (q_u * v_u)
+        else ! Upwind first order
+          if (v_u>0.) then
+              q_u = q(I,J-1)
+          else
+              q_u = q(I,J)
+          endif
+          CAu(I,j,k) = (q_u * v_u)
+
+        endif
+      enddo ; enddo
+    elseif (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+      do j=js,je ; do I=Isq,Ieq
+        v_u = 0.25*G%IdxCu(I,j)*((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
+        third_order = (G%mask2dCu(I,j-2) * G%mask2dCu(I,j-1) * G%mask2dCu(I,j) * &
+                       G%mask2dCu(I,j+1) * G%mask2dCu(I,j+2))
+
+        fifth_order   = third_order * G%mask2dCu(I,j-3) * G%mask2dCu(I,j+3)
+
+        if (fifth_order == 1) then
+          ! all values are valid, we use fifth order reconstruction
+          u_q6 = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
+          call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2), &
+                                        h_q(I,J-3:J+2), &
+                                        u_q6, &
+                                        GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
+          CAu(I,j,k) = (q_u * v_u)
+
+        elseif (third_order == 1) then
+          ! only the middle values are valid, we use third order reconstruction
+          u_q4 = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
+          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
+                                         h_q(I,J-2:J+1), &
+                                         u_q4, &
+                                         GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
+          CAu(I,j,k) = (q_u * v_u)
+
+        else ! Upwind first order
+          if (v_u>0.) then
+              q_u = q(I,J-1)
+          else
+              q_u = q(I,J)
+          endif
+          CAu(I,j,k) = (q_u * v_u)
+        endif
+      enddo ; enddo
+    elseif (CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO) then
+      do j=js,je ; do I=Isq,Ieq
+        v_u = 0.25*G%IdxCu(I,j)*((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
+        third_order = (G%mask2dCu(I,j-2) * G%mask2dCu(I,j-1) * G%mask2dCu(I,j) * &
+                       G%mask2dCu(I,j+1) * G%mask2dCu(I,j+2))
+
+
+        if (third_order == 1) then
+          ! only the middle values are valid, we use third order reconstruction
+          u_q4 = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
+          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
+                                         h_q(I,J-2:J+1), &
+                                         u_q4, &
+                                         GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
+          CAu(I,j,k) = (q_u * v_u)
+
+        else ! Upwind first order
+          if (v_u>0.) then
+              q_u = q(I,J-1)
+          else
+              q_u = q(I,J)
+          endif
+          CAu(I,j,k) = (q_u * v_u)
+        endif
+      enddo ; enddo
     endif
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
@@ -835,6 +1008,124 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAv(i,J,k) = - QUHeff / &
                        (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
         endif
+      enddo ; enddo
+    ! Calculate the tendencies of meridional velocity due to the Coriolis
+    ! force and momentum advection.  On a Cartesian grid, this is
+    !     CAv = - q * uh - d(KE)/dy.
+    elseif (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) then
+      do J=Jsq,Jeq ; do i=is,ie
+        u_v = 0.25*G%IdyCv(i,J)*((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
+
+        ! check whether there is any masked land values within the stencils
+        third_order = (G%mask2dCv(i-2,J) * G%mask2dCv(i-1,J) * G%mask2dCv(i,J) * G%mask2dCv(i+1,J) * &
+                       G%mask2dCv(i+2,J))
+        fifth_order   = third_order * G%mask2dCv(i-3,J) * G%mask2dCv(i+3,J)
+        seventh_order = fifth_order * G%mask2dCv(i-4,J) * G%mask2dCv(i+4,J)
+
+
+
+        ! compute the masking to make sure that inland values are not used
+        if (seventh_order == 1) then
+          v_q8 = (v(i-4:i+3,J,k) + v(i-3:i+4,J,k)) * 0.5
+          ! all values are valid, we use seventh order reconstruction
+          call weno_seven_h_weight_reconstruction(abs_vort(I-4:I+3,J), &
+                                         h_q(I-4:I+3,J), &
+                                         v_q8, &
+                                         GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
+          CAv(i,J,k) = - (q_v * u_v)
+
+        elseif (fifth_order == 1) then
+          v_q6 = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
+          ! all values are valid, we use fifth order reconstruction
+          call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J), &
+                                        h_q(I-3:I+2,J), &
+                                        v_q6, &
+                                        GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
+          CAv(i,J,k) = - (q_v * u_v)
+
+        elseif (third_order == 1) then
+          v_q4 = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
+!          ! only the middle values are valid, we use third order reconstruction
+          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
+                                                 h_q(I-2:I+1,J), &
+                                                 v_q4, &
+                                                 GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
+          CAv(i,J,k) = - (q_v * u_v)
+        else ! Upwind first order!
+          if (u_v>0.) then
+              q_v = q(I-1,J)
+          else
+              q_v = q(I,J)
+          endif
+          CAv(i,J,k) = - (q_v * u_v)
+        endif
+
+      enddo ; enddo
+    elseif (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+      do J=Jsq,Jeq ; do i=is,ie
+        u_v = 0.25*G%IdyCv(i,J)*((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
+
+        third_order = (G%mask2dCv(i-2,J) * G%mask2dCv(i-1,J) * G%mask2dCv(i,J) * G%mask2dCv(i+1,J) * &
+                       G%mask2dCv(i+2,J))
+        fifth_order   = third_order * G%mask2dCv(i-3,J) * G%mask2dCv(i+3,J)
+
+
+        ! compute the masking to make sure that inland values are not used
+        if (fifth_order == 1) then
+          v_q6 = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
+          ! all values are valid, we use fifth order reconstruction
+          call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J), &
+                                        h_q(I-3:I+2,J), &
+                                        v_q6, &
+                                        GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
+          CAv(i,J,k) = - (q_v * u_v)
+
+        elseif (third_order == 1) then
+          v_q4 = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
+!          ! only the middle values are valid, we use third order reconstruction
+          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
+                                                 h_q(I-2:I+1,J), &
+                                                 v_q4, &
+                                                 GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
+          CAv(i,J,k) = - (q_v * u_v)
+
+        else
+          if (u_v>0.) then
+              q_v = q(I-1,J)
+          else
+              q_v = q(I,J)
+          endif
+          CAv(i,J,k) = - (q_v * u_v)
+        endif
+
+      enddo ; enddo
+    elseif (CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO) then
+      do J=Jsq,Jeq ; do i=is,ie
+        u_v = 0.25*G%IdyCv(i,J)*((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
+
+        third_order = (G%mask2dCv(i-2,J) * G%mask2dCv(i-1,J) * G%mask2dCv(i,J) * G%mask2dCv(i+1,J) * &
+                       G%mask2dCv(i+2,J))
+
+
+        ! compute the masking to make sure that inland values are not used
+        if (third_order == 1) then
+          v_q4 = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
+!          ! only the middle values are valid, we use third order reconstruction
+          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
+                                                 h_q(I-2:I+1,J), &
+                                                 v_q4, &
+                                                 GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
+          CAv(i,J,k) = - (q_v * u_v)
+
+        else
+          if (u_v>0.) then
+              q_v = q(I-1,J)
+          else
+              q_v = q(I,J)
+          endif
+          CAv(i,J,k) = - (q_v * u_v)
+        endif
+
       enddo ; enddo
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
@@ -985,6 +1276,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
   real :: um, up, vm, vp         ! Temporary variables [L T-1 ~> m s-1].
   real :: um2, up2, vm2, vp2     ! Temporary variables [L2 T-2 ~> m2 s-2].
   real :: um2a, up2a, vm2a, vp2a ! Temporary variables [L4 T-2 ~> m4 s-2].
+  real :: third_order_u, third_order_v  ! Product of mask values to determine the boundary
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, n
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -1022,6 +1314,86 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
       vm = 0.5*( v(i, J ,k) - ABS( v(i, J ,k) ) ) ; vm2a = vm*vm*G%areaCv(i, J )
       KE(i,j) = ( max(um2a,up2a) + max(vm2a,vp2a) )*0.5*G%IareaT(i,j)
     enddo ; enddo
+  elseif (CS%KE_Scheme == KE_UP3) then
+    ! The following discretization of KE is based on the one-dimensional third-order
+    ! upwind scheme which does not take horizontal grid factors into account
+    if (CS%KE_use_limiter) then
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        ! compute the masking to make sure that inland values are not used
+        third_order_u = (G%mask2dCu(I-2,j) * G%mask2dCu(I-1,j)* &
+                       G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
+
+        if (third_order_u == 1) then
+          up = (-u(I-2,j,k) + 7*u(I-1,j,k) + 7*u(I,j,k) - u(I+1,j,k))/12.
+          call UP3_Koren_limiter_reconstruction(u(I-2:I+1,j,k), up, um)
+        else
+          up = (u(I-1,j,k) + u(I,j,k))*0.5
+          if (up>0.) then
+            um = u(I-1,j,k)
+          elseif (up<0.) then
+            um = u(I,j,k)
+          else
+            um = up
+          endif
+        endif
+
+        third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
+                       G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
+        if (third_order_v ==1) then
+          vp = (-v(i,J-2,k) + 7*v(i,J-1,k) + 7*v(i,J,k) - v(i,J+1,k))/12.
+          call UP3_Koren_limiter_reconstruction(v(i,J-2:J+1,k), vp, vm)
+        else
+          vp = (v(i,J-1,k) + v(i,J,k))*0.5
+          if (vp>0.) then
+            vm = v(i,J-1,k)
+          elseif (vp<0.) then
+            vm = v(i,J,k)
+          else
+            vm = vp
+          endif
+        endif
+
+        KE(i,j) = ( um*um + vm*vm )*0.5
+      enddo ; enddo
+    else
+      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        ! compute the masking to make sure that inland values are not used
+        third_order_u = (G%mask2dCu(I-2,j) * G%mask2dCu(I-1,j)* &
+                       G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
+
+        if (third_order_u == 1) then
+          up = (-u(I-2,j,k) + 7*u(I-1,j,k) + 7*u(I,j,k) - u(I+1,j,k))/12.
+          call UP3_reconstruction(u(I-2:I+1,j,k), up, um)
+        else
+          up = (u(I-1,j,k) + u(I,j,k))*0.5
+          if (up>0.) then
+            um = u(I-1,j,k)
+          elseif (up<0.) then
+            um = u(I,j,k)
+          else
+            um = up
+          endif
+        endif
+
+        third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
+                       G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
+        if (third_order_v ==1) then
+          vp = (-v(i,J-2,k) + 7*v(i,J-1,k) + 7*v(i,J,k) - v(i,J+1,k))/12.
+          call UP3_reconstruction(v(i,J-2:J+1,k), vp, vm)
+        else
+          vp = (v(i,J-1,k) + v(i,J,k))*0.5
+          if (vp>0.) then
+            vm = v(i,J-1,k)
+          elseif (vp<0.) then
+            vm = v(i,J,k)
+          else
+            vm = vp
+          endif
+        endif
+
+        KE(i,j) = ( um*um + vm*vm )*0.5
+      enddo ; enddo
+    endif
   endif
 
   ! Term - d(KE)/dx.
@@ -1049,6 +1421,449 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
   endif
 
 end subroutine gradKE
+
+!> reconstruct the scalar (e.g., pv, vorticity) onto point i-1/2 using a third-order upwind scheme
+subroutine UP3_reconstruction(q4,u,qr)
+  real, intent(in)    :: q4(4)            !< Tracer values on points i-2, i-1, i, i+1 [A ~> a]
+  real, intent(in)    :: u                !< Relocity or thickness flux on point i-1/2
+                                          !! [l t-1 ~> m s-1] or [l2 t-1 ~> m2 s-1]
+  real, intent(inout) :: qr               !< Reconstructin of point i-1/2 [A ~> a]
+
+  if (u>0.) then
+    qr = (-q4(1) + 5.*q4(2) + 2.*q4(3))/6.
+  else
+    qr = (2.*q4(2) + 5.*q4(3) - q4(4))/6.
+  endif
+
+end subroutine UP3_reconstruction
+
+
+!> Reconstruct the scalar (e.g., PV, vorticity) onto point i-1/2
+!! using a third-order upwind scheme with the Koren flux limiter
+subroutine UP3_Koren_limiter_reconstruction(q4,u,qr)
+  real, intent(in)    :: q4(4)            !< Tracer values on points i-2, i-1, i, i+1 [A ~> a]
+  real, intent(in)    :: u                !< Velocity or thickness flux on point i-1/2
+                                          !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
+  real, intent(inout) :: qr               !< Reconstructin on point i-1/2 [A ~> a]
+  real                :: theta       ! Ratio of gradient [nondim]
+  real                :: psi         ! Limiter function [nondim]
+
+  if (u>0.) then
+    theta = (q4(2) - q4(1))/(q4(3) - q4(2) + 1e-20)
+    psi = max(0., min(1., 1/3. + 1/6.*theta, theta)) ! limiter introduced by Koren (1993)
+    qr = q4(2) + psi*(q4(3) - q4(2))
+  else
+    theta = (q4(4) - q4(3))/(q4(3) - q4(2) + 1e-20)
+    psi = max(0., min(1., 1/3. + 1/6.*theta, theta))
+    qr = q4(3) + psi*(q4(2) - q4(3))
+  endif
+
+end subroutine UP3_Koren_limiter_reconstruction
+
+
+
+!> Reconstruct the tracer (e.g., PV, vorticity) onto the point i-1/2 using a third-order WENO scheme
+!! This reconstruction is thickness-weighted
+subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
+                                              h_tiny, u, qr, velocity_smoothing)
+    real, intent(in)    :: q4(4)   !< Tracer value times thickness on points i-2, i-1, i, i+1 [A ~> a]
+    real, intent(in)    :: h4(4)   !< Thickness values on points i-2, i-1, i, i+1 [L ~> m]
+    real, optional, intent(in)    :: u4(4) !< Velocity values on points i-2, i-1, i, i+1
+                                                    !![L T-1 ~> m s-1]
+    real, intent(in)    :: h_tiny  !< A tiny thickness to prevent division by zero [L ~> m]
+    real, intent(in)    :: u              !< Velocity or thickness flux on point i-1/2
+                                          !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
+    real, intent(inout) :: qr             !< Reconstructin on point i-1/2 [A ~> a]
+    logical, intent(in) :: velocity_smoothing !< If true, use velocity to compute smoothness indicator
+    real :: vr                            ! Reconstruction of hq [A ~> a]
+    real :: hr                            ! Reconstruction of h [L ~> m]
+    real :: c0, c1                        ! Intermediate reconstruction of q [A ~> a]
+    real :: d0, d1                        ! Intermediate reconstruction of h [L ~> m]
+    real :: b0, b1                        ! Smoothness indicator [A ~> a]
+    real :: tau                           ! Temporary variables [nondim]
+    real :: w0, w1                        ! Weights [nondim]
+    real :: s                             ! Temporary variables [nondim]
+
+    if (u>0.) then
+      call weno_three_reconstruction_0(q4(2:3), c0) ! Reconstruction in the second upwind stencil
+      call weno_three_reconstruction_1(q4(1:2), c1) ! Reconstruction in the first upwind stencil
+
+      call weno_three_reconstruction_0(h4(2:3), d0)
+      call weno_three_reconstruction_1(h4(1:2), d1)
+      if (velocity_smoothing) then
+        call weno_three_weight(u4(2:3), b0)  ! Smoothness indicator the second upwind stencil
+        call weno_three_weight(u4(1:2), b1)  ! Smoothness indicator the first upwind stencil
+      else
+        call weno_three_weight(q4(2:3), b0)  ! Smoothness indicator the second upwind stencil
+        call weno_three_weight(q4(1:2), b1)  ! Smoothness indicator the first upwind stencil
+      endif
+    else
+      call weno_three_reconstruction_0(q4(3:2:-1), c0) ! Reconstruction in the second upwind stencil
+      call weno_three_reconstruction_1(q4(4:3:-1), c1) ! Reconstruction in the first upwind stencil
+
+      call weno_three_reconstruction_0(h4(3:2:-1), d0)
+      call weno_three_reconstruction_1(h4(4:3:-1), d1)
+      if (velocity_smoothing) then
+        call weno_three_weight(u4(3:2:-1), b0)  ! Smoothness indicator the second upwind stencil
+        call weno_three_weight(u4(4:3:-1), b1)  ! Smoothness indicator the first upwind stencil
+      else
+        call weno_three_weight(q4(3:2:-1), b0)  ! Smoothness indicator the second upwind stencil
+        call weno_three_weight(q4(4:3:-1), b1)  ! Smoothness indicator the first upwind stencil
+      endif
+    endif
+
+    tau = abs(b0-b1)
+    w0  = 2./3. * (1 + (tau / (b0 + 1e-20))**2)
+    w1  = 1./3. * (1 + (tau / (b1 + 1e-20))**2)
+
+    s = 1. / (w0 + w1)
+    w0 = w0 * s
+    w1 = w1 * s
+
+    vr = w0 * c0 + w1 * c1
+    hr = w0 * d0 + w1 * d1
+!    vr = min(max(q4(3), q4(2)), vr) ; vr = max(min(q4(3), q4(2)), vr) !Impose a monotonicity limiter
+    hr = min(max(h4(3), h4(2)), hr) ; hr = max(min(h4(3), h4(2)), hr) ! A monotonicity limiter
+
+    qr = vr / (hr + h_tiny)
+
+end subroutine weno_three_h_weight_reconstruction
+
+!> Compute weights for the two-point stencil of the third-order WENO scheme
+subroutine weno_three_weight(q2, w0)
+    real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
+    real, intent(inout) :: w0    !< Weight for this stencil [A ~> a]
+
+    w0 = q2(1) * q2(1) - 2 * q2(1) * q2(2) + q2(2) * q2(2)
+
+end subroutine weno_three_weight
+
+!> Reconstruction in the second upwind stencil of the third-order WENO scheme
+subroutine weno_three_reconstruction_0(q2, w0)
+    real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
+    real, intent(inout) :: w0    !< Reconstruction of the quantity [A ~> a]
+
+    w0 = (q2(1) + q2(2)) * 0.5
+
+end subroutine weno_three_reconstruction_0
+
+!> Reconstruction in the first upwind stencil for third-order WENO scheme
+subroutine weno_three_reconstruction_1(q2, w0)
+    real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
+    real, intent(inout) :: w0    !< Reconstruction of the quantity [A ~> a]
+
+    w0 = (- q2(1) + 3 * q2(2)) * 0.5
+
+end subroutine weno_three_reconstruction_1
+
+
+!> Reconstruct the tracer (e.g., PV, vorticity) onto point i-1/2 using a fifth-order WENO scheme
+!! The reconstruction is weighted by the thickness
+subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
+                                             h_tiny, u, qr, velocity_smoothing)
+    real, intent(in)    :: q6(6)
+    !< Tracer values on points i-3, i-2, i-1, i, i+1, i+2 [A ~> a]
+    real, intent(in)    :: h6(6)
+    !< Thickness values on points i-3, i-2, i-1, i, i+1, i+2 [L ~> m]
+    real, optional, intent(in)    :: u6(6)
+    !< Velocity values on points i-3, i-2, i-1, i, i+1, i+2 [L T-1 ~> m s-1]
+    real, intent(in)    :: h_tiny  !< A tiny thickness to prevent division by zero [L ~> m]
+    real, intent(in)    :: u                      !< Velocity or thickness flux on point i-1/2
+                                                  !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
+    logical, intent(in) :: velocity_smoothing     !< If ture, use velocity to compute the smoothness indicator
+    real, intent(inout) :: qr                     !< Reconstructin on point i-1/2 [A ~> a]
+    real :: vr                                    ! Reconstruction of hq [A ~> a]
+    real :: hr                                    ! Reconstruction of h [L ~> m]
+    real :: c0, c1, c2                            ! Intermediate reconstruction of hq[A ~> a]
+    real :: d0, d1, d2                            ! Intermediate reconstruction of h [L ~> m]
+    real :: b0, b1, b2                            ! Smoothness indicator [A ~> a]
+    real :: tau                                   ! Temporary variables [nondim]
+    real :: w0, w1, w2                            ! Weights [nondim]
+    real :: s                                     ! Temporary variables [nondim]
+
+    if (u>0.) then
+      call weno_five_reconstruction_0(q6(3:5), c0) ! Reconstruction in the third upwind stencil
+      call weno_five_reconstruction_1(q6(2:4), c1) ! Reconstruction in the second upwind stencil
+      call weno_five_reconstruction_2(q6(1:3), c2) ! Reconstruction in the first upwind stencil
+
+      call weno_five_reconstruction_0(h6(3:5), d0)
+      call weno_five_reconstruction_1(h6(2:4), d1)
+      call weno_five_reconstruction_2(h6(1:3), d2)
+      if (velocity_smoothing) then
+        call weno_five_weight_0(u6(3:5), b0)   ! Smoothness indicator of the third upwind stencil
+        call weno_five_weight_1(u6(2:4), b1)   ! Smoothness indicator of the second upwind stencil
+        call weno_five_weight_2(u6(1:3), b2)   ! Smoothness indicator of the first upwind stencil
+      else
+        call weno_five_weight_0(q6(3:5), b0)
+        call weno_five_weight_1(q6(2:4), b1)
+        call weno_five_weight_2(q6(1:3), b2)
+      endif
+    else
+      call weno_five_reconstruction_0(q6(4:2:-1), c0) ! Reconstruction in the third upwind stencil
+      call weno_five_reconstruction_1(q6(5:3:-1), c1) ! Reconstruction in the second upwind stencil
+      call weno_five_reconstruction_2(q6(6:4:-1), c2) ! Reconstruction in the first upwind stencil
+
+      call weno_five_reconstruction_0(h6(4:2:-1), d0)
+      call weno_five_reconstruction_1(h6(5:3:-1), d1)
+      call weno_five_reconstruction_2(h6(6:4:-1), d2)
+      if (velocity_smoothing) then
+        call weno_five_weight_0(u6(4:2:-1), b0) ! Smoothness indicator of the third upwind stencil
+        call weno_five_weight_1(u6(5:3:-1), b1) ! Smoothness indicator of the second upwind stencil
+        call weno_five_weight_2(u6(6:4:-1), b2) ! Smoothness indicator of the first upwind stencil
+      else
+        call weno_five_weight_0(q6(4:2:-1), b0)
+        call weno_five_weight_1(q6(5:3:-1), b1)
+        call weno_five_weight_2(q6(6:4:-1), b2)
+      endif
+    endif
+
+    tau = abs(b0 - b2)
+    w0  = 3./10. * (1 + (tau / (b0 + 1e-20))**2)
+    w1  = 3./5.  * (1 + (tau / (b1 + 1e-20))**2)
+    w2  = 1./10. * (1 + (tau / (b2 + 1e-20))**2)
+
+    s = 1. / (w0 + w1 + w2)
+    w0 = w0 * s
+    w1 = w1 * s
+    w2 = w2 * s
+
+    vr = w0 * c0 + w1 * c1 + w2 * c2
+    hr = w0 * d0 + w1 * d1 + w2 * d2
+!    vr = min(max(q6(3), q6(4)), vr) ; vr = max(min(q6(3), q6(4)), vr) !Impose a monotonicity limiter
+    hr = min(max(h6(3), h6(4)), hr) ; hr = max(min(h6(3), h6(4)), hr) !Impose a monotonicity limiter
+
+    qr = vr / (hr + h_tiny)
+
+end subroutine weno_five_h_weight_reconstruction
+
+!> Compute weights for the third upwind stencil of the fifth-order WENO scheme
+subroutine weno_five_weight_0(q3, w0)
+  real, intent(in) :: q3(3)       !< Tracer values on the three-point stencil [A ~> a]
+  real, intent(inout) :: w0       !< Weight for this stencil [A ~> a]
+
+  w0 = q3(1) * (10 * q3(1) - 31 * q3(2) + 11 * q3(3)) + &
+       q3(2) * (25 * q3(2) - 19 * q3(3)) + 4 * q3(3) * q3(3)
+
+end subroutine weno_five_weight_0
+
+!> Compute weights for the second upwind stencil of the fifth-order WENO scheme
+subroutine weno_five_weight_1(q3, w1)
+  real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
+  real, intent(inout) :: w1        !< Weight for this stencil [A ~> a]
+
+  w1 = q3(1) * (4 * q3(1) - 13 * q3(2) + 5 * q3(3)) + &
+       q3(2) * (13 * q3(2) - 13 * q3(3)) + 4 * q3(3) * q3(3)
+
+end subroutine weno_five_weight_1
+
+!> Compute weights for the first upwind stencil of the fifth-order WENO scheme
+subroutine weno_five_weight_2(q3, w2)
+  real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
+  real, intent(inout) :: w2        !< Weight for this stencil [A ~> a]
+
+  w2 = q3(1) * (4 * q3(1) - 19 * q3(2) + 11 * q3(3)) + &
+       q3(2) * (25 * q3(2) - 31 * q3(3)) + 10 * q3(3) * q3(3)
+
+end subroutine weno_five_weight_2
+
+!> Reconstruction in the third upwind stencil of the fifth-order WENO scheme
+subroutine weno_five_reconstruction_0(q3, p0)
+  real, intent(in) :: q3(3)        !< Tracer values on three points [A ~> a]
+  real, intent(inout) :: p0        !< Reconstruction of the quantity [A ~> a]
+
+  p0 = (2*q3(1) + 5*q3(2) - q3(3)) / 6.
+
+end subroutine weno_five_reconstruction_0
+
+!> Reconstruction in the second upwind stencil of the fifth-order WENO scheme
+subroutine weno_five_reconstruction_1(q3, p1)
+  real, intent(in) :: q3(3)         !< Tracer values on the three-point stencil [A ~> a]
+  real, intent(inout) :: p1         !< Reconstruction of the quantity [A ~> a]
+
+  p1 = (-q3(1) + 5*q3(2) + 2*q3(3)) / 6.
+
+end subroutine weno_five_reconstruction_1
+
+!> Reconstruction in the first upwind stencil of the fifth-order WENO scheme
+subroutine weno_five_reconstruction_2(q3, p2)
+  real, intent(in) :: q3(3)          !< Tracer values on the three-point stencil [A ~> a]
+  real, intent(inout) :: p2          !< Reconstruction of the quantity [A ~> a]
+
+  p2 = (2*q3(1) - 7*q3(2) + 11*q3(3)) / 6.
+
+end subroutine weno_five_reconstruction_2
+
+
+!> Reconstruct the tracer (e.g., PV, vorticity) onto point i-1/2 using a seventh-order WENO scheme
+!! This reconstruction computes a thickness weighted average of PV
+subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
+                                            h_tiny, u, qr, velocity_smoothing)
+  real, intent(in)    :: q8(8)
+  !< Tracer values on points i-4, i-3, i-2, i-1, i, i+1, i+2, i+3
+  real, intent(in)    :: h8(8)
+  !< Thickness on the same tracer points i-4, i-3, i-2, i-1, i, i+1, i+2, i+3 [L ~> m]
+  real, optional, intent(in)    :: u8(8)
+  !< Velocity values on points i-4, i-3, i-2, i-1, i, i+1, i+2, i+3 [L T-1 ~> m s-1]
+  real, intent(in)    :: h_tiny  !< A tiny thickness to prevent division by zero [L ~> m]
+  real, intent(in)    :: u    !< Velocity or thickness flux on point i-1/2
+                              !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
+  logical, intent(in) :: velocity_smoothing !< If true, use velocity to compute the smoothness indicator
+  real, intent(inout) :: qr   !< Reconstructin on point i-1/2 [A ~> a]
+  real :: vr                  ! Reconstruction of hq [A ~> a]
+  real :: hr                  ! Reconstruction of h [L ~> m]
+  real :: c0, c1, c2, c3      ! Intermediate reconstruction of hq [A ~> a]
+  real :: d0, d1, d2, d3      ! Intermediate reconstruction of h [L ~> m]
+  real :: b0, b1, b2, b3      ! Smoothness indicator [A ~> a]
+  real :: tau                 ! Temporary variables [nondim]
+  real :: w0, w1, w2, w3      ! Weights [nondim]
+  real :: s                   ! Temporary variables [nondim]
+
+  if (u>0.) then
+    call weno_seven_reconstruction_0(q8(4:7), c0) ! Reconstruction in the fourth upwind stencil
+    call weno_seven_reconstruction_1(q8(3:6), c1) ! Reconstruction in the third upwind stencil
+    call weno_seven_reconstruction_2(q8(2:5), c2) ! Reconstruction in the second upwind stencil
+    call weno_seven_reconstruction_3(q8(1:4), c3) ! Reconstruction in the first upwind stencil
+
+    call weno_seven_reconstruction_0(h8(4:7), d0) ! Reconstruction in the fourth upwind stencil
+    call weno_seven_reconstruction_1(h8(3:6), d1) ! Reconstruction in the third upwind stencil
+    call weno_seven_reconstruction_2(h8(2:5), d2) ! Reconstruction in the second upwind stencil
+    call weno_seven_reconstruction_3(h8(1:4), d3) ! Reconstruction in the first upwind stencil
+    if (velocity_smoothing) then
+      call weno_seven_weight_0(u8(4:7), b0)       ! Smoothness indicator of the fourth upwind stencil
+      call weno_seven_weight_1(u8(3:6), b1)       ! Smoothness indicator of the third upwind stencil
+      call weno_seven_weight_2(u8(2:5), b2)       ! Smoothness indicator of the second upwind stencil
+      call weno_seven_weight_3(u8(1:4), b3)       ! Smoothness indicator of the first upwind stencil
+    else
+      call weno_seven_weight_0(q8(4:7), b0)
+      call weno_seven_weight_1(q8(3:6), b1)
+      call weno_seven_weight_2(q8(2:5), b2)
+      call weno_seven_weight_3(q8(1:4), b3)
+    endif
+  else
+    call weno_seven_reconstruction_0(q8(5:2:-1), c0) ! Reconstruction in the fourth upwind stencil
+    call weno_seven_reconstruction_1(q8(6:3:-1), c1) ! Reconstruction in the third upwind stencil
+    call weno_seven_reconstruction_2(q8(7:4:-1), c2) ! Reconstruction in the second upwind stencil
+    call weno_seven_reconstruction_3(q8(8:5:-1), c3) ! Reconstruction in the first upwind stencil
+
+    call weno_seven_reconstruction_0(h8(5:2:-1), d0)
+    call weno_seven_reconstruction_1(h8(6:3:-1), d1)
+    call weno_seven_reconstruction_2(h8(7:4:-1), d2)
+    call weno_seven_reconstruction_3(h8(8:5:-1), d3)
+    if (velocity_smoothing) then
+      call weno_seven_weight_0(u8(5:2:-1), b0)    ! Smoothness indicator of the fourth upwind stencil
+      call weno_seven_weight_1(u8(6:3:-1), b1)    ! Smoothness indicator of the third upwind stencil
+      call weno_seven_weight_2(u8(7:4:-1), b2)    ! Smoothness indicator of the second upwind stencil
+      call weno_seven_weight_3(u8(8:5:-1), b3)    ! Smoothness indicator of the first upwind stencil
+    else
+      call weno_seven_weight_0(q8(5:2:-1), b0)
+      call weno_seven_weight_1(q8(6:3:-1), b1)
+      call weno_seven_weight_2(q8(7:4:-1), b2)
+      call weno_seven_weight_3(q8(8:5:-1), b3)
+    endif
+  endif
+
+  tau = abs(b0 + 3 * b1 - 3 * b2 - b3)
+  w0  = 4./35.  * (1 + (tau / (b0 + 1e-20))**2)
+  w1  = 18./35. * (1 + (tau / (b1 + 1e-20))**2)
+  w2  = 12./35. * (1 + (tau / (b2 + 1e-20))**2)
+  w3  = 1./35.  * (1 + (tau / (b3 + 1e-20))**2)
+
+  s = 1. / (w0 + w1 + w2 + w3)
+  w0 = w0 * s
+  w1 = w1 * s
+  w2 = w2 * s
+  w3 = w3 * s
+
+  vr = w0 * c0 + w1 * c1 + w2 * c2 + w3 * c3
+  hr = w0 * d0 + w1 * d1 + w2 * d2 + w3 * d3
+
+!  vr = min(max(q4, q5), vr) ; vr = max(min(q4, q5), vr)
+  hr = min(max(h8(4), h8(5)), hr) ; hr = max(min(h8(4), h8(5)), hr) ! Impose a monotonicity limiter
+
+  qr = vr / (hr + h_tiny)
+
+
+end subroutine weno_seven_h_weight_reconstruction
+
+!> Compute weights for the fourth upwind stencil of the seventh-order WENO scheme
+subroutine weno_seven_weight_0(q4, w0)
+  real, intent(in) :: q4(4)          !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: w0          !< Weight for this stencil [A ~> a]
+
+  w0 = q4(1) * (2.107 * q4(1) - 9.402 * q4(2) + 7.042 * q4(3) - 1.854 * q4(4)) + &
+     q4(2) * (11.003 * q4(2) - 17.246 * q4(3) + 4.642 * q4(4)) + &
+     q4(3) * (7.043 * q4(3) - 3.882 * q4(4)) + 0.547 * q4(4) * q4(4)
+
+end subroutine weno_seven_weight_0
+
+!> Compute weights for the third upwind stencil of the seventh-order WENO scheme
+subroutine weno_seven_weight_1(q4, w1)
+  real, intent(in) :: q4(4)          !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: w1          !< Weight for this stencil [A ~> a]
+
+  w1 = q4(1) * (0.547 * q4(1) - 2.522 * q4(2) + 1.922 * q4(3) - 0.494 * q4(4)) + &
+     q4(2) * (3.443 * q4(2) - 5.966 * q4(3) + 1.602 * q4(4)) + &
+     q4(3) * (2.843 * q4(3) - 1.642 * q4(4)) + 0.267 * q4(4) * q4(4)
+
+end subroutine weno_seven_weight_1
+
+!> Compute weights for the second upwind stencil of the seventh-order WENO scheme
+subroutine weno_seven_weight_2(q4, w2)
+  real, intent(in) :: q4(4)           !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: w2           !< Weight for this stencil [A ~> a]
+
+  w2 = q4(1) * (0.267 * q4(1) - 1.642 * q4(2) + 1.602 * q4(3) - 0.494 * q4(4)) + &
+     q4(2) * (2.843 * q4(2) - 5.966 * q4(3) + 1.922 * q4(4)) + &
+     q4(3) * (3.443 * q4(3) - 2.522 * q4(4)) + 0.547 * q4(4) * q4(4)
+
+end subroutine weno_seven_weight_2
+
+!> Compute weights for the first upwind stencil of the seventh-order WENO scheme
+subroutine weno_seven_weight_3(q4, w3)
+  real, intent(in) :: q4(4)           !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: w3           !< Weight for this stencil [A ~> a]
+
+  w3 = q4(1) * (0.547  * q4(1) - 3.882 * q4(2) + 4.642 * q4(3) - 1.854 * q4(4)) + &
+     q4(2) * (7.043 * q4(2) - 17.246 * q4(3) + 7.042 * q4(4)) + &
+     q4(3) * (11.003 * q4(3) - 9.402 * q4(4)) + 2.107 * q4(4) * q4(4)
+
+end subroutine weno_seven_weight_3
+
+!> Reconstruction in the fourth upwind stencil for seventh-order WENO scheme
+subroutine weno_seven_reconstruction_0(q4, p0)
+  real, intent(in) :: q4(4)            !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: p0            !< Reconstruction of the quantity [A ~> a]
+
+  p0 = (6 * q4(1) + 26 * q4(2) - 10 * q4(3) + 2 * q4(4)) / 24.0
+
+end subroutine weno_seven_reconstruction_0
+
+!> Reconstruction in the third upwind stencil for seventh-order WENO scheme
+subroutine weno_seven_reconstruction_1(q4, p1)
+  real, intent(in) :: q4(4)            !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: p1            !< Reconstruction of the quantity [A ~> a]
+
+  p1 = (-2 * q4(1) + 14 * q4(2) + 14 * q4(3) - 2 * q4(4)) / 24.0
+
+end subroutine weno_seven_reconstruction_1
+
+!> Reconstruction in the second upwind stencil for seventh-order WENO scheme
+subroutine weno_seven_reconstruction_2(q4, p2)
+  real, intent(in) :: q4(4)             !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: p2             !< Reconstruction of the quantity [A ~> a]
+
+  p2 = (2 * q4(1) - 10 * q4(2) + 26 * q4(3) + 6 * q4(4)) / 24.0
+
+end subroutine weno_seven_reconstruction_2
+
+!> Reconstruction in the first upwind stencil for seventh-order WENO scheme
+subroutine weno_seven_reconstruction_3(q4, p3)
+  real, intent(in) :: q4(4)            !< Tracer values on the four-point stencil [A ~> a]
+  real, intent(inout) :: p3            !< Reconstruction of the quantity [A ~> a]
+
+  p3 = (-6 * q4(1) + 26 * q4(2) - 46 * q4(3) + 50 * q4(4)) / 24.0
+
+end subroutine weno_seven_reconstruction_3
 
 !> Initializes the control structure for MOM_CoriolisAdv
 subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
@@ -1100,7 +1915,10 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
                  "\t SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons. \n"//&
                  "\t ARAKAWA_LAMB81    - Arakawa & Lamb, 1981; En. + Enst.\n"//&
                  "\t ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with \n"//&
-                 "\t                      Arakawa & Hsu and Sadourny energy", &
+                 "\t                      Arakawa & Hsu and Sadourny energy \n"//&
+                 "\t WENOVI5TH_PV_ENSTRO   - 5th-order WENO PV enstrophy \n"//&
+                 "\t WENOVI3RD_PV_ENSTRO   - 3rd-order WENO PV enstrophy \n"//&
+                 "\t WENOVI7TH_PV_ENSTRO  - 7th-order WENO PV enstrophy \n", &
                  default=SADOURNY75_ENERGY_STRING)
   tmpstr = uppercase(tmpstr)
   select case (tmpstr)
@@ -1117,11 +1935,34 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
     case (ROBUST_ENSTRO_STRING)
       CS%Coriolis_Scheme = ROBUST_ENSTRO
       CS%Coriolis_En_Dis = .false.
+    case (WENOVI7TH_PV_ENSTRO_STRING)
+      CS%Coriolis_Scheme = wenovi7th_PV_ENSTRO
+    case (WENOVI5TH_PV_ENSTRO_STRING)
+      CS%Coriolis_Scheme = wenovi5th_PV_ENSTRO
+    case (WENOVI3RD_PV_ENSTRO_STRING)
+      CS%Coriolis_Scheme = wenovi3rd_PV_ENSTRO
     case default
       call MOM_mesg('CoriolisAdv_init: Coriolis_Scheme ="'//trim(tmpstr)//'"', 0)
       call MOM_error(FATAL, "CoriolisAdv_init: Unrecognized setting "// &
             "#define CORIOLIS_SCHEME "//trim(tmpstr)//" found in input file.")
   end select
+
+  CS%USE_WENO = .false. ! Set it to be true only if 5th- or 7th-oder WENO schemes are used
+  CS%WENO_stencil = 0
+  if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO .or. &
+          CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO .or. CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO) then
+    call get_param(param_file, mdl, "WENO_VELOCITY_SMOOTH", CS%weno_velocity_smooth, &
+            "If true, use velocity to compute weighting for WENO. ", &
+                  default=.false.)
+    if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) then
+      CS%WENO_stencil = 4
+      CS%USE_WENO = .true.
+    elseif (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
+      CS%WENO_stencil = 3
+      CS%USE_WENO = .true.
+    endif
+  endif
+
   if (CS%Coriolis_Scheme == AL_BLEND) then
     call get_param(param_file, mdl, "CORIOLIS_BLEND_WT_LIN", CS%wt_lin_blend, &
                  "A weighting value for the ratio of inverse thicknesses, "//&
@@ -1162,18 +2003,26 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
   call get_param(param_file, mdl, "KE_SCHEME", tmpstr, &
                  "KE_SCHEME selects the discretization for acceleration "//&
                  "due to the kinetic energy gradient. Valid values are: \n"//&
-                 "\t KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV", &
+                 "\t KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV, KE_UP3", &
                  default=KE_ARAKAWA_STRING)
   tmpstr = uppercase(tmpstr)
   select case (tmpstr)
     case (KE_ARAKAWA_STRING); CS%KE_Scheme = KE_ARAKAWA
     case (KE_SIMPLE_GUDONOV_STRING); CS%KE_Scheme = KE_SIMPLE_GUDONOV
     case (KE_GUDONOV_STRING); CS%KE_Scheme = KE_GUDONOV
+    case (KE_UP3_STRING); CS%KE_Scheme = KE_UP3
     case default
       call MOM_mesg('CoriolisAdv_init: KE_Scheme ="'//trim(tmpstr)//'"', 0)
       call MOM_error(FATAL, "CoriolisAdv_init: "// &
                "#define KE_SCHEME "//trim(tmpstr)//" in input file is invalid.")
   end select
+
+  if (CS%KE_Scheme == KE_UP3) then
+    call get_param(param_file, mdl, "KE_USE_LIMITER", CS%KE_use_limiter, &
+            "If true, use Koren limiter for KE_UP3 scheme", &
+                  default=.True.)
+  endif
+
 
   ! Set PV_Adv_Scheme (selects discretization of PV advection)
   call get_param(param_file, mdl, "PV_ADV_SCHEME", tmpstr, &
@@ -1218,6 +2067,7 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
   CS%id_CAvS = register_diag_field('ocean_model', 'CAv_Stokes', diag%axesCvL, Time, &
      'Meridional Acceleration from Stokes Vorticity', 'm s-2', conversion=US%L_T2_to_m_s2)
   ! add to AD
+
 
   !CS%id_hf_gKEu = register_diag_field('ocean_model', 'hf_gKEu', diag%axesCuL, Time, &
   !   'Fractional Thickness-weighted Zonal Acceleration from Grad. Kinetic Energy', &

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -217,7 +217,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: vol_neglect            ! A volume so small that is expected to be
                                  ! lost in roundoff [H L2 ~> m3 or kg].
   real :: area_neglect           ! An area so small that is expected to be
-                                 ! lost in roundoff [H L2 ~> m3 or kg].
+                                 ! lost in roundoff [L2 ~> m2].
   real :: temp1, temp2           ! Temporary variables [L2 T-2 ~> m2 s-2].
   real :: eps_vel                ! A tiny, positive velocity [L T-1 ~> m s-1].
 
@@ -242,11 +242,10 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: QUHeff,QVHeff ! More temporary variables [H L2 T-2 ~> m3 s-2 or kg s-2].
   integer :: i, j, k, n, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   logical :: Stokes_VF
-  real :: u_v, v_u, q_v, q_u ! u_v is the u velocity at v point, v_u is the v velocity at u point
-  real :: h_v, h_u      ! h_v is the thickness at v point, h_u is the thickness at u point
+  real :: u_v, v_u      ! u_v is the u velocity at v point, v_u is the v velocity at u point [L T-1 ~> m s-1]
+  real :: q_v, q_u      ! PV at the u and v points [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1]
+  real :: h_v, h_u      ! h_v is the thickness at v point, h_u is the thickness at u point [H ~> m or kg m-2]
   integer :: seventh_order, fifth_order, third_order, second_order ! Order of accuracy for the WENO calculations
-  real :: Ih_sum        ! Sum of inverse thickness at PV points [H-1 ~> m-1]
-  real :: Ih_third, Ih_fifth, Ih_seventh  ! Sum of inverse thickness at at 3rd-, 5th-, and 7th-WENO scheme points
   real :: psi           ! Ratio of PV gradient for the Koren limiter [nondim]
   real :: u_q8(8) ! Eight-point zonal velocity at WENO stencils [L T-1 ~> m s-1]
   real :: u_q6(6) ! Six-point zonal velocity at WENO stencils [L T-1 ~> m s-1]

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -315,8 +315,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
   !$OMP                        RV,PV,is,ie,js,je,nz,vol_neglect,h_tiny,OBC,eps_vel, &
-  !$OMP                        area_neglect, pbv, Stokes_VF, stencil) &
-  !$OMP private(Isq,Ieq,Jsq,Jeq)
+  !$OMP                        area_neglect, pbv, Stokes_VF, stencil) 
+
   do k=1,nz
 
     Isq = G%IscB - stencil + 2
@@ -1259,6 +1259,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
   real :: um2a, up2a, vm2a, vp2a ! Temporary variables [L4 T-2 ~> m4 s-2].
   real :: third_order_u, third_order_v  ! Product of mask values to determine the boundary
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, n
+  real, parameter     :: C1_12 = 1.0/12.0   ! The ratio of 1/12 [nondim]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -1305,7 +1306,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
                        G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
 
         if (third_order_u == 1) then
-          up = (-u(I-2,j,k) + 7*u(I-1,j,k) + 7*u(I,j,k) - u(I+1,j,k))/12.
+          up = (7.0 * (u(I-1,j,k) + u(I,j,k)) - (u(I-2,j,k) + u(I+1,j,k))) * C1_12
           call UP3_Koren_limiter_reconstruction(u(I-2:I+1,j,k), up, um)
         else
           up = (u(I-1,j,k) + u(I,j,k))*0.5
@@ -1321,7 +1322,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
         third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
                        G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
         if (third_order_v ==1) then
-          vp = (-v(i,J-2,k) + 7*v(i,J-1,k) + 7*v(i,J,k) - v(i,J+1,k))/12.
+          vp = (7.0 * (v(i,J-1,k) + v(i,J,k)) - (v(i,J-2,k) + v(i,J+1,k))) * C1_12
           call UP3_Koren_limiter_reconstruction(v(i,J-2:J+1,k), vp, vm)
         else
           vp = (v(i,J-1,k) + v(i,J,k))*0.5
@@ -1334,7 +1335,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
           endif
         endif
 
-        KE(i,j) = ( um*um + vm*vm )*0.5
+        KE(i,j) = ( (um*um) + (vm*vm) )*0.5
       enddo ; enddo
     else
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -1343,7 +1344,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
                        G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
 
         if (third_order_u == 1) then
-          up = (-u(I-2,j,k) + 7*u(I-1,j,k) + 7*u(I,j,k) - u(I+1,j,k))/12.
+          up = (7.0 * (u(I-1,j,k) + u(I,j,k)) - (u(I-2,j,k) + u(I+1,j,k))) * C1_12
           call UP3_reconstruction(u(I-2:I+1,j,k), up, um)
         else
           up = (u(I-1,j,k) + u(I,j,k))*0.5
@@ -1359,7 +1360,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
         third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
                        G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
         if (third_order_v ==1) then
-          vp = (-v(i,J-2,k) + 7*v(i,J-1,k) + 7*v(i,J,k) - v(i,J+1,k))/12.
+          vp = (7.0 * (v(i,J-1,k) + v(i,J,k)) - (v(i,J-2,k) + v(i,J+1,k))) * C1_12
           call UP3_reconstruction(v(i,J-2:J+1,k), vp, vm)
         else
           vp = (v(i,J-1,k) + v(i,J,k))*0.5
@@ -1372,7 +1373,7 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
           endif
         endif
 
-        KE(i,j) = ( um*um + vm*vm )*0.5
+        KE(i,j) = ( (um*um) + (vm*vm) )*0.5
       enddo ; enddo
     endif
   endif
@@ -1412,9 +1413,9 @@ subroutine UP3_reconstruction(q4,u,qr)
   real, parameter :: C1_6 = 1.0/6.0       ! The ratio of 1/6 [nondim]
 
   if (u>0.) then
-    qr = (-q4(1) + 5.*q4(2) + 2.*q4(3)) * C1_6
+    qr = ((2.*q4(3) + 5.*q4(2)) - q4(1)) * C1_6
   else
-    qr = (2.*q4(2) + 5.*q4(3) - q4(4)) * C1_6
+    qr = ((2.*q4(2) + 5.*q4(3)) - q4(4)) * C1_6
   endif
 
 end subroutine UP3_reconstruction
@@ -1523,8 +1524,8 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     w0 = w0 * s   ! Weights of stencils
     w1 = w1 * s
 
-    vr = w0 * c0 + w1 * c1
-    hr = w0 * d0 + w1 * d1
+    vr = (w0 * c0) + (w1 * c1)
+    hr = (w0 * d0) + (w1 * d1)
 !    vr = min(max(q4(3), q4(2)), vr) ; vr = max(min(q4(3), q4(2)), vr) !Impose a monotonicity limiter
     hr = min(max(h4(3), h4(2)), hr) ; hr = max(min(h4(3), h4(2)), hr) ! A monotonicity limiter
 
@@ -1537,7 +1538,7 @@ subroutine weno_three_weight(q2, w0)
     real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
     real, intent(inout) :: w0    !< Smoothness indicator for this stencil [A2 ~> a2]
 
-    w0 = q2(1) * q2(1) - 2 * q2(1) * q2(2) + q2(2) * q2(2)
+    w0 = (q2(1) - q2(2))**2
 
 end subroutine weno_three_weight
 
@@ -1628,13 +1629,13 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     w1  = C3_5  * fac_fn(tau, b1)
     w2  = C1_10 * fac_fn(tau, b2)
 
-    s = 1. / (w0 + w1 + w2)
+    s = 1. / ((w0 + w1) + w2)
     w0 = w0 * s   ! Weights of stencils
     w1 = w1 * s
     w2 = w2 * s
 
-    vr = w0 * c0 + w1 * c1 + w2 * c2
-    hr = w0 * d0 + w1 * d1 + w2 * d2
+    vr = ((w0 * c0) + (w1 * c1)) + (w2 * c2)
+    hr = ((w0 * d0) + (w1 * d1)) + (w2 * d2)
 !    vr = min(max(q6(3), q6(4)), vr) ; vr = max(min(q6(3), q6(4)), vr) !Impose a monotonicity limiter
     hr = min(max(h6(3), h6(4)), hr) ; hr = max(min(h6(3), h6(4)), hr) !Impose a monotonicity limiter
 
@@ -1647,8 +1648,8 @@ subroutine weno_five_weight_0(q3, w0)
   real, intent(in) :: q3(3)       !< Tracer values on the three-point stencil [A ~> a]
   real, intent(inout) :: w0       !< Smoothness indicator for this stencil [A2 ~> a2]
 
-  w0 = q3(1) * (10 * q3(1) - 31 * q3(2) + 11 * q3(3)) + &
-       q3(2) * (25 * q3(2) - 19 * q3(3)) + 4 * q3(3) * q3(3)
+  w0 = (q3(1) * ((10 * q3(1) - 31 * q3(2)) + 11 * q3(3))) + &
+       ((q3(2) * (25 * q3(2) - 19 * q3(3))) + 4 * (q3(3) * q3(3)))
 
 end subroutine weno_five_weight_0
 
@@ -1657,8 +1658,8 @@ subroutine weno_five_weight_1(q3, w1)
   real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
   real, intent(inout) :: w1        !< Smoothness indicator for this stencil [A2 ~> a2]
 
-  w1 = q3(1) * (4 * q3(1) - 13 * q3(2) + 5 * q3(3)) + &
-       q3(2) * (13 * q3(2) - 13 * q3(3)) + 4 * q3(3) * q3(3)
+  w1 = (q3(1) * ((4 * q3(1) - 13 * q3(2)) + 5 * q3(3))) + &
+       ((q3(2) * (13 * q3(2) - 13 * q3(3))) + 4 * (q3(3) * q3(3)))
 
 end subroutine weno_five_weight_1
 
@@ -1667,8 +1668,8 @@ subroutine weno_five_weight_2(q3, w2)
   real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
   real, intent(inout) :: w2        !< Smoothness indicator for this stencil [A2 ~> a2]
 
-  w2 = q3(1) * (4 * q3(1) - 19 * q3(2) + 11 * q3(3)) + &
-       q3(2) * (25 * q3(2) - 31 * q3(3)) + 10 * q3(3) * q3(3)
+  w2 = (q3(1) * ((4 * q3(1) - 19 * q3(2)) + 11 * q3(3))) + &
+       ((q3(2) * (25 * q3(2) - 31 * q3(3))) + 10 * (q3(3) * q3(3)))
 
 end subroutine weno_five_weight_2
 
@@ -1678,7 +1679,7 @@ subroutine weno_five_reconstruction_0(q3, p0)
   real, intent(inout) :: p0        !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_6 = 1.0/6.0 ! One sixth [nondim]
 
-  p0 = (2*q3(1) + 5*q3(2) - q3(3)) * C1_6
+  p0 = ((2*q3(1) + 5*q3(2)) - q3(3)) * C1_6
 
 end subroutine weno_five_reconstruction_0
 
@@ -1688,7 +1689,7 @@ subroutine weno_five_reconstruction_1(q3, p1)
   real, intent(inout) :: p1         !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_6 = 1.0/6.0 ! One sixth [nondim]
 
-  p1 = (-q3(1) + 5*q3(2) + 2*q3(3)) * C1_6
+  p1 = ((-q3(1) + 5*q3(2)) + 2*q3(3)) * C1_6
 
 end subroutine weno_five_reconstruction_1
 
@@ -1698,7 +1699,7 @@ subroutine weno_five_reconstruction_2(q3, p2)
   real, intent(inout) :: p2          !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_6 = 1.0/6.0  ! One sixth [nondim]
 
-  p2 = (2*q3(1) - 7*q3(2) + 11*q3(3)) * C1_6
+  p2 = ((2*q3(1) - 7*q3(2)) + 11*q3(3)) * C1_6
 
 end subroutine weno_five_reconstruction_2
 
@@ -1781,14 +1782,14 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   w2  = C12_35 * fac_fn(tau, b2)
   w3  = C1_35  * fac_fn(tau, b3)
 
-  s = 1. / (w0 + w1 + w2 + w3)
+  s = 1. / ((w0 + w1) + (w2 + w3))
   w0 = w0 * s   ! Weights of the stencils
   w1 = w1 * s
   w2 = w2 * s
   w3 = w3 * s
 
-  vr = w0 * c0 + w1 * c1 + w2 * c2 + w3 * c3
-  hr = w0 * d0 + w1 * d1 + w2 * d2 + w3 * d3
+  vr = ((w0 * c0) + (w1 * c1)) + ((w2 * c2) + (w3 * c3))
+  hr = ((w0 * d0) + (w1 * d1)) + ((w2 * d2) + (w3 * d3))
 
 !  vr = min(max(q4, q5), vr) ; vr = max(min(q4, q5), vr)
   hr = min(max(h8(4), h8(5)), hr) ; hr = max(min(h8(4), h8(5)), hr) ! Impose a monotonicity limiter
@@ -1804,9 +1805,9 @@ subroutine weno_seven_weight_0(q4, w0)
   real, intent(inout) :: w0          !< Smoothness indicator for this stencil [A2 ~> a2]
 
   ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
-  w0 = q4(1) * (2.107 * q4(1) - 9.402 * q4(2) + 7.042 * q4(3) - 1.854 * q4(4)) + &
-     q4(2) * (11.003 * q4(2) - 17.246 * q4(3) + 4.642 * q4(4)) + &
-     q4(3) * (7.043 * q4(3) - 3.882 * q4(4)) + 0.547 * q4(4) * q4(4)
+  w0 = ((q4(1) * ((2.107 * q4(1) - 9.402 * q4(2)) + (7.042 * q4(3) - 1.854 * q4(4)))) + &
+     (q4(2) * ((11.003 * q4(2) - 17.246 * q4(3)) + 4.642 * q4(4)))) + &
+     ((q4(3) * (7.043 * q4(3) - 3.882 * q4(4))) + 0.547 * (q4(4) * q4(4)))
 
 end subroutine weno_seven_weight_0
 
@@ -1816,9 +1817,9 @@ subroutine weno_seven_weight_1(q4, w1)
   real, intent(inout) :: w1          !< Smoothness indicator for this stencil [A2 ~> a2]
 
   ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
-  w1 = q4(1) * (0.547 * q4(1) - 2.522 * q4(2) + 1.922 * q4(3) - 0.494 * q4(4)) + &
-     q4(2) * (3.443 * q4(2) - 5.966 * q4(3) + 1.602 * q4(4)) + &
-     q4(3) * (2.843 * q4(3) - 1.642 * q4(4)) + 0.267 * q4(4) * q4(4)
+  w1 = ((q4(1) * ((0.547 * q4(1) - 2.522 * q4(2)) + (1.922 * q4(3) - 0.494 * q4(4)))) + &
+     (q4(2) * ((3.443 * q4(2) - 5.966 * q4(3)) + 1.602 * q4(4)))) + &
+     ((q4(3) * (2.843 * q4(3) - 1.642 * q4(4))) + 0.267 * (q4(4) * q4(4)))
 
 end subroutine weno_seven_weight_1
 
@@ -1828,9 +1829,9 @@ subroutine weno_seven_weight_2(q4, w2)
   real, intent(inout) :: w2           !< Smoothness indicator for this stencil [A2 ~> a2]
 
   ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
-  w2 = q4(1) * (0.267 * q4(1) - 1.642 * q4(2) + 1.602 * q4(3) - 0.494 * q4(4)) + &
-     q4(2) * (2.843 * q4(2) - 5.966 * q4(3) + 1.922 * q4(4)) + &
-     q4(3) * (3.443 * q4(3) - 2.522 * q4(4)) + 0.547 * q4(4) * q4(4)
+  w2 = ((q4(1) * ((0.267 * q4(1) - 1.642 * q4(2)) + (1.602 * q4(3) - 0.494 * q4(4)))) + &
+     (q4(2) * ((2.843 * q4(2) - 5.966 * q4(3)) + 1.922 * q4(4)))) + &
+     ((q4(3) * (3.443 * q4(3) - 2.522 * q4(4))) + 0.547 * (q4(4) * q4(4)))
 
 end subroutine weno_seven_weight_2
 
@@ -1840,9 +1841,9 @@ subroutine weno_seven_weight_3(q4, w3)
   real, intent(inout) :: w3           !< Smoothness indicator for this stencil [A2 ~> a2]
 
   ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
-  w3 = q4(1) * (0.547  * q4(1) - 3.882 * q4(2) + 4.642 * q4(3) - 1.854 * q4(4)) + &
-     q4(2) * (7.043 * q4(2) - 17.246 * q4(3) + 7.042 * q4(4)) + &
-     q4(3) * (11.003 * q4(3) - 9.402 * q4(4)) + 2.107 * q4(4) * q4(4)
+  w3 = ((q4(1) * ((0.547  * q4(1) - 3.882 * q4(2)) + (4.642 * q4(3) - 1.854 * q4(4)))) + &
+     (q4(2) * ((7.043 * q4(2) - 17.246 * q4(3)) + 7.042 * q4(4)))) + &
+     ((q4(3) * (11.003 * q4(3) - 9.402 * q4(4))) + 2.107 * (q4(4) * q4(4)))
 
 end subroutine weno_seven_weight_3
 
@@ -1852,7 +1853,7 @@ subroutine weno_seven_reconstruction_0(q4, p0)
   real, intent(inout) :: p0            !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_24 = 1.0/24.0  ! One twenty fourth [nondim]
 
-  p0 = (6 * q4(1) + 26 * q4(2) - 10 * q4(3) + 2 * q4(4)) * C1_24
+  p0 = (((6 * q4(1) + 26 * q4(2)) - 10 * q4(3)) + 2 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_0
 
@@ -1862,7 +1863,7 @@ subroutine weno_seven_reconstruction_1(q4, p1)
   real, intent(inout) :: p1            !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_24 = 1.0/24.0  ! One twenty fourth [nondim]
 
-  p1 = (-2 * q4(1) + 14 * q4(2) + 14 * q4(3) - 2 * q4(4)) * C1_24
+  p1 = (14 * (q4(2) + q4(3)) - 2 * (q4(1) + q4(4))) * C1_24
 
 end subroutine weno_seven_reconstruction_1
 
@@ -1872,7 +1873,7 @@ subroutine weno_seven_reconstruction_2(q4, p2)
   real, intent(inout) :: p2             !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_24 = 1.0/24.0   ! One twenty fourth [nondim]
 
-  p2 = (2 * q4(1) - 10 * q4(2) + 26 * q4(3) + 6 * q4(4)) * C1_24
+  p2 = (((2 * q4(1) - 10 * q4(2)) + 26 * q4(3)) + 6 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_2
 
@@ -1882,7 +1883,7 @@ subroutine weno_seven_reconstruction_3(q4, p3)
   real, intent(inout) :: p3            !< Reconstruction of the quantity [A ~> a]
   real, parameter :: C1_24 = 1.0/24.0  ! One twenty fourth [nondim]
 
-  p3 = (-6 * q4(1) + 26 * q4(2) - 46 * q4(3) + 50 * q4(4)) * C1_24
+  p3 = (((-6 * q4(1) + 26 * q4(2)) - 46 * q4(3)) + 50 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_3
 

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -409,7 +409,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo
 
         if (CS%Coriolis_En_Dis) then
-          do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
+          do i = max(Isq,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
             if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
               vh_center(i,J) = (G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k)) * v(i,J,k) * h(i,j,k)
             else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
@@ -448,7 +448,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           endif
         enddo
         if (CS%Coriolis_En_Dis) then
-          do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
+          do j = max(Jsq,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
             if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
               uh_center(I,j) = (G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)) * u(I,j,k) * h(i,j,k)
             else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
@@ -502,7 +502,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       enddo; enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do J=Js_q,Je_q ; do I=Is_q,Ie_q
+          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
           enddo; enddo
         endif
@@ -513,7 +513,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       enddo; enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do J=Js_q,Je_q ; do I=Is_q,Ie_q
+          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
           enddo; enddo
         endif
@@ -533,7 +533,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do J=Js_q,Je_q ; do I=Is_q,Ie_q
+        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
           qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
         enddo; enddo
       endif

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -270,15 +270,12 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   eps_vel = 1.0e-10*US%m_s_to_L_T
   h_tiny = GV%Angstrom_H  ! Perhaps this should be set to h_neglect instead.
 
+  stencil = CoriolisAdv_stencil(CS)
 
-  stencil = 2
-  if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) stencil = 4
-  if (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) stencil = 3
-
-  Isq = Isq - stencil + 2
-  Ieq = Ieq + stencil - 2
-  Jsq = Jsq - stencil + 2
-  Jeq = Jeq + stencil - 2
+  Isq = G%IscB - stencil + 2
+  Ieq = G%IecB + stencil - 2
+  Jsq = G%JscB - stencil + 2
+  Jeq = G%JecB + stencil - 2
   !$OMP parallel do default(private) shared(Isq,Ieq,Jsq,Jeq,G,Area_h)
   do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+2
     Area_h(i,j) = G%mask2dT(i,j) * G%areaT(i,j)
@@ -310,10 +307,6 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                   (Area_h(i+1,j) + Area_h(i,j+1))
   enddo ; enddo
 
-  Isq = Isq + stencil - 2
-  Ieq = Ieq - stencil + 2
-  Jsq = Jsq + stencil - 2
-  Jeq = Jeq - stencil + 2
 
   Stokes_VF = .false.
   if (present(Waves)) then ; if (associated(Waves)) then
@@ -325,10 +318,10 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   !$OMP                        area_neglect, pbv, Stokes_VF)
   do k=1,nz
 
-    Isq = Isq - stencil + 2
-    Ieq = Ieq + stencil - 2
-    Jsq = Jsq - stencil + 2
-    Jeq = Jeq + stencil - 2
+    Isq = G%IscB - stencil + 2
+    Ieq = G%IecB + stencil - 2
+    Jsq = G%JscB - stencil + 2
+    Jeq = G%JecB + stencil - 2
     ! Here the second order accurate layer potential vorticities, q,
     ! are calculated.  hq is  second order accurate in space.  Relative
     ! vorticity is second order accurate everywhere with free slip b.c.s,
@@ -545,10 +538,10 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       endif
     endif
 
-    Isq = Isq + stencil - 2
-    Ieq = Ieq - stencil + 2
-    Jsq = Jsq + stencil - 2
-    Jeq = Jeq - stencil + 2
+    Isq = G%IscB
+    Ieq = G%IecB
+    Jsq = G%JscB
+    Jeq = G%JecB
 
     if (CS%id_rv > 0) then
       do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
@@ -778,7 +771,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         ! compute the masking to make sure that inland values are not used
         if (seventh_order == 1) then
           ! all values are valid, we use seventh order reconstruction
-          u_q8 = (u(I,j-4:j+3,k) + u(I,j-3:j+4,k)) * 0.5
+          u_q8(:) = (u(I,j-4:j+3,k) + u(I,j-3:j+4,k)) * 0.5
           call weno_seven_h_weight_reconstruction(abs_vort(I,J-4:J+3), &
                                          h_q(I,J-4:J+3), &
                                          u_q8, &
@@ -787,7 +780,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         elseif (fifth_order == 1) then
           ! all values are valid, we use fifth order reconstruction
-          u_q6 = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
+          u_q6(:) = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
           call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2), &
                                         h_q(I,J-3:J+2), &
                                         u_q6, &
@@ -796,7 +789,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         elseif (third_order == 1) then
           ! only the middle values are valid, we use third order reconstruction
-          u_q4 = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
+          u_q4(:) = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
           call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
                                          h_q(I,J-2:J+1), &
                                          u_q4, &
@@ -822,7 +815,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         if (fifth_order == 1) then
           ! all values are valid, we use fifth order reconstruction
-          u_q6 = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
+          u_q6(:) = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
           call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2), &
                                         h_q(I,J-3:J+2), &
                                         u_q6, &
@@ -831,7 +824,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         elseif (third_order == 1) then
           ! only the middle values are valid, we use third order reconstruction
-          u_q4 = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
+          u_q4(:) = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
           call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
                                          h_q(I,J-2:J+1), &
                                          u_q4, &
@@ -856,7 +849,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         if (third_order == 1) then
           ! only the middle values are valid, we use third order reconstruction
-          u_q4 = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
+          u_q4(:) = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
           call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
                                          h_q(I,J-2:J+1), &
                                          u_q4, &
@@ -1013,7 +1006,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         ! compute the masking to make sure that inland values are not used
         if (seventh_order == 1) then
-          v_q8 = (v(i-4:i+3,J,k) + v(i-3:i+4,J,k)) * 0.5
+          v_q8(:) = (v(i-4:i+3,J,k) + v(i-3:i+4,J,k)) * 0.5
           ! all values are valid, we use seventh order reconstruction
           call weno_seven_h_weight_reconstruction(abs_vort(I-4:I+3,J), &
                                          h_q(I-4:I+3,J), &
@@ -1022,7 +1015,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAv(i,J,k) = - (q_v * u_v)
 
         elseif (fifth_order == 1) then
-          v_q6 = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
+          v_q6(:) = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
           ! all values are valid, we use fifth order reconstruction
           call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J), &
                                         h_q(I-3:I+2,J), &
@@ -1031,7 +1024,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAv(i,J,k) = - (q_v * u_v)
 
         elseif (third_order == 1) then
-          v_q4 = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
+          v_q4(:) = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
 !          ! only the middle values are valid, we use third order reconstruction
           call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
                                                  h_q(I-2:I+1,J), &
@@ -1059,7 +1052,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         ! compute the masking to make sure that inland values are not used
         if (fifth_order == 1) then
-          v_q6 = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
+          v_q6(:) = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
           ! all values are valid, we use fifth order reconstruction
           call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J), &
                                         h_q(I-3:I+2,J), &
@@ -1068,7 +1061,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           CAv(i,J,k) = - (q_v * u_v)
 
         elseif (third_order == 1) then
-          v_q4 = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
+          v_q4(:) = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
 !          ! only the middle values are valid, we use third order reconstruction
           call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
                                                  h_q(I-2:I+1,J), &
@@ -1096,7 +1089,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         ! compute the masking to make sure that inland values are not used
         if (third_order == 1) then
-          v_q4 = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
+          v_q4(:) = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
 !          ! only the middle values are valid, we use third order reconstruction
           call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
                                                  h_q(I-2:I+1,J), &
@@ -1409,12 +1402,12 @@ subroutine gradKE(u, v, h, KE, KEx, KEy, k, OBC, G, GV, US, CS)
 
 end subroutine gradKE
 
-!> reconstruct the scalar (e.g., pv, vorticity) onto point i-1/2 using a third-order upwind scheme
+!> Reconstruct the scalar (e.g., pv, vorticity) onto point i-1/2 using a third-order upwind scheme
 subroutine UP3_reconstruction(q4,u,qr)
   real, intent(in)    :: q4(4)            !< Tracer values on points i-2, i-1, i, i+1 [A ~> a]
-  real, intent(in)    :: u                !< Relocity or thickness flux on point i-1/2
+  real, intent(in)    :: u                !< Velocity or thickness flux on point i-1/2
                                           !! [l t-1 ~> m s-1] or [l2 t-1 ~> m2 s-1]
-  real, intent(inout) :: qr               !< Reconstructin of point i-1/2 [A ~> a]
+  real, intent(inout) :: qr               !< Reconstruction of tracer q at point i-1/2 [A ~> a]
 
   if (u>0.) then
     qr = (-q4(1) + 5.*q4(2) + 2.*q4(3))/6.
@@ -1431,7 +1424,7 @@ subroutine UP3_Koren_limiter_reconstruction(q4,u,qr)
   real, intent(in)    :: q4(4)            !< Tracer values on points i-2, i-1, i, i+1 [A ~> a]
   real, intent(in)    :: u                !< Velocity or thickness flux on point i-1/2
                                           !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
-  real, intent(inout) :: qr               !< Reconstructin on point i-1/2 [A ~> a]
+  real, intent(inout) :: qr               !< Reconstruction of tracer q on point i-1/2 [A ~> a]
   real                :: theta       ! Ratio of gradient [nondim]
   real                :: psi         ! Limiter function [nondim]
 
@@ -1460,7 +1453,7 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     real, intent(in)    :: h_tiny  !< A tiny thickness to prevent division by zero [L ~> m]
     real, intent(in)    :: u              !< Velocity or thickness flux on point i-1/2
                                           !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
-    real, intent(inout) :: qr             !< Reconstructin on point i-1/2 [A ~> a]
+    real, intent(inout) :: qr             !< Reconstruction of tracer q on point i-1/2 [A ~> a]
     logical, intent(in) :: velocity_smoothing !< If true, use velocity to compute smoothness indicator
     real :: vr                            ! Reconstruction of hq [A ~> a]
     real :: hr                            ! Reconstruction of h [L ~> m]
@@ -1470,6 +1463,8 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     real :: tau                           ! Temporary variables [nondim]
     real :: w0, w1                        ! Weights [nondim]
     real :: s                             ! Temporary variables [nondim]
+    real, parameter :: C2_3 = 2.0/3.0     ! The ratio of 2/3 [nondim]
+    real, parameter :: C1_3 = 1.0/3.0     ! The ratio of 1/3 [nondim]
 
     if (u>0.) then
       call weno_three_reconstruction_0(q4(2:3), c0) ! Reconstruction in the second upwind stencil
@@ -1500,8 +1495,8 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     endif
 
     tau = abs(b0-b1)
-    w0  = 2./3. * (1 + (tau / (b0 + 1e-20))**2)
-    w1  = 1./3. * (1 + (tau / (b1 + 1e-20))**2)
+    w0  = C2_3 * (1 + (tau / (b0 + 1e-20))**2)
+    w1  = C1_3 * (1 + (tau / (b1 + 1e-20))**2)
 
     s = 1. / (w0 + w1)
     w0 = w0 * s
@@ -1519,7 +1514,7 @@ end subroutine weno_three_h_weight_reconstruction
 !> Compute weights for the two-point stencil of the third-order WENO scheme
 subroutine weno_three_weight(q2, w0)
     real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
-    real, intent(inout) :: w0    !< Weight for this stencil [A ~> a]
+    real, intent(inout) :: w0    !< Weight for this stencil [A2 ~> a2]
 
     w0 = q2(1) * q2(1) - 2 * q2(1) * q2(2) + q2(2) * q2(2)
 
@@ -1528,7 +1523,7 @@ end subroutine weno_three_weight
 !> Reconstruction in the second upwind stencil of the third-order WENO scheme
 subroutine weno_three_reconstruction_0(q2, w0)
     real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
-    real, intent(inout) :: w0    !< Reconstruction of the quantity [A ~> a]
+    real, intent(inout) :: w0    !< Reconstruction of the quantity [A2 ~> a2]
 
     w0 = (q2(1) + q2(2)) * 0.5
 
@@ -1558,7 +1553,7 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     real, intent(in)    :: u                      !< Velocity or thickness flux on point i-1/2
                                                   !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
     logical, intent(in) :: velocity_smoothing     !< If ture, use velocity to compute the smoothness indicator
-    real, intent(inout) :: qr                     !< Reconstructin on point i-1/2 [A ~> a]
+    real, intent(inout) :: qr                     !< Reconstruction of tracer q on point i-1/2 [A ~> a]
     real :: vr                                    ! Reconstruction of hq [A ~> a]
     real :: hr                                    ! Reconstruction of h [L ~> m]
     real :: c0, c1, c2                            ! Intermediate reconstruction of hq[A ~> a]
@@ -1567,6 +1562,9 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     real :: tau                                   ! Temporary variables [nondim]
     real :: w0, w1, w2                            ! Weights [nondim]
     real :: s                                     ! Temporary variables [nondim]
+    real, parameter :: C3_10 = 3.0/10.0           ! The ratio of 3/10 [nondim]
+    real, parameter :: C3_5 = 3.0/5.0             ! The ratio of 3/5 [nondim]
+    real, parameter :: C1_10 = 1.0/10.0           ! The ratio of 1/10 [nondim]
 
     if (u>0.) then
       call weno_five_reconstruction_0(q6(3:5), c0) ! Reconstruction in the third upwind stencil
@@ -1605,9 +1603,9 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     endif
 
     tau = abs(b0 - b2)
-    w0  = 3./10. * (1 + (tau / (b0 + 1e-20))**2)
-    w1  = 3./5.  * (1 + (tau / (b1 + 1e-20))**2)
-    w2  = 1./10. * (1 + (tau / (b2 + 1e-20))**2)
+    w0  = C3_10 * (1 + (tau / (b0 + 1e-20))**2)
+    w1  = C3_5  * (1 + (tau / (b1 + 1e-20))**2)
+    w2  = C1_10 * (1 + (tau / (b2 + 1e-20))**2)
 
     s = 1. / (w0 + w1 + w2)
     w0 = w0 * s
@@ -1626,7 +1624,7 @@ end subroutine weno_five_h_weight_reconstruction
 !> Compute weights for the third upwind stencil of the fifth-order WENO scheme
 subroutine weno_five_weight_0(q3, w0)
   real, intent(in) :: q3(3)       !< Tracer values on the three-point stencil [A ~> a]
-  real, intent(inout) :: w0       !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w0       !< Weight for this stencil [A2 ~> a2]
 
   w0 = q3(1) * (10 * q3(1) - 31 * q3(2) + 11 * q3(3)) + &
        q3(2) * (25 * q3(2) - 19 * q3(3)) + 4 * q3(3) * q3(3)
@@ -1636,7 +1634,7 @@ end subroutine weno_five_weight_0
 !> Compute weights for the second upwind stencil of the fifth-order WENO scheme
 subroutine weno_five_weight_1(q3, w1)
   real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
-  real, intent(inout) :: w1        !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w1        !< Weight for this stencil [A2 ~> a2]
 
   w1 = q3(1) * (4 * q3(1) - 13 * q3(2) + 5 * q3(3)) + &
        q3(2) * (13 * q3(2) - 13 * q3(3)) + 4 * q3(3) * q3(3)
@@ -1646,7 +1644,7 @@ end subroutine weno_five_weight_1
 !> Compute weights for the first upwind stencil of the fifth-order WENO scheme
 subroutine weno_five_weight_2(q3, w2)
   real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
-  real, intent(inout) :: w2        !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w2        !< Weight for this stencil [A2 ~> a2]
 
   w2 = q3(1) * (4 * q3(1) - 19 * q3(2) + 11 * q3(3)) + &
        q3(2) * (25 * q3(2) - 31 * q3(3)) + 10 * q3(3) * q3(3)
@@ -1657,8 +1655,9 @@ end subroutine weno_five_weight_2
 subroutine weno_five_reconstruction_0(q3, p0)
   real, intent(in) :: q3(3)        !< Tracer values on three points [A ~> a]
   real, intent(inout) :: p0        !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_6 = 1.0/6.0 ! One sixth [nondim]
 
-  p0 = (2*q3(1) + 5*q3(2) - q3(3)) / 6.
+  p0 = (2*q3(1) + 5*q3(2) - q3(3)) * C1_6
 
 end subroutine weno_five_reconstruction_0
 
@@ -1666,8 +1665,9 @@ end subroutine weno_five_reconstruction_0
 subroutine weno_five_reconstruction_1(q3, p1)
   real, intent(in) :: q3(3)         !< Tracer values on the three-point stencil [A ~> a]
   real, intent(inout) :: p1         !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_6 = 1.0/6.0 ! One sixth [nondim]
 
-  p1 = (-q3(1) + 5*q3(2) + 2*q3(3)) / 6.
+  p1 = (-q3(1) + 5*q3(2) + 2*q3(3)) * C1_6
 
 end subroutine weno_five_reconstruction_1
 
@@ -1675,8 +1675,9 @@ end subroutine weno_five_reconstruction_1
 subroutine weno_five_reconstruction_2(q3, p2)
   real, intent(in) :: q3(3)          !< Tracer values on the three-point stencil [A ~> a]
   real, intent(inout) :: p2          !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_6 = 1.0/6.0  ! One sixth [nondim]
 
-  p2 = (2*q3(1) - 7*q3(2) + 11*q3(3)) / 6.
+  p2 = (2*q3(1) - 7*q3(2) + 11*q3(3)) * C1_6
 
 end subroutine weno_five_reconstruction_2
 
@@ -1695,7 +1696,7 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   real, intent(in)    :: u    !< Velocity or thickness flux on point i-1/2
                               !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
   logical, intent(in) :: velocity_smoothing !< If true, use velocity to compute the smoothness indicator
-  real, intent(inout) :: qr   !< Reconstructin on point i-1/2 [A ~> a]
+  real, intent(inout) :: qr   !< Reconstruction of tracer q on point i-1/2 [A ~> a]
   real :: vr                  ! Reconstruction of hq [A ~> a]
   real :: hr                  ! Reconstruction of h [L ~> m]
   real :: c0, c1, c2, c3      ! Intermediate reconstruction of hq [A ~> a]
@@ -1704,6 +1705,10 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   real :: tau                 ! Temporary variables [nondim]
   real :: w0, w1, w2, w3      ! Weights [nondim]
   real :: s                   ! Temporary variables [nondim]
+  real, parameter :: C4_35 = 4.0/35.0 ! The ratio of 4/35 [nondim]
+  real, parameter :: C18_35 = 18.0/35.0 ! The ratio of 18/35 [nondim]
+  real, parameter :: C12_35 = 12.0/35.0 ! The ratio of 12/35 [nondim]
+  real, parameter :: C1_35 = 1.0/35.0   ! The ratio of 1/35 [nondim]
 
   if (u>0.) then
     call weno_seven_reconstruction_0(q8(4:7), c0) ! Reconstruction in the fourth upwind stencil
@@ -1750,10 +1755,10 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   endif
 
   tau = abs(b0 + 3 * b1 - 3 * b2 - b3)
-  w0  = 4./35.  * (1 + (tau / (b0 + 1e-20))**2)
-  w1  = 18./35. * (1 + (tau / (b1 + 1e-20))**2)
-  w2  = 12./35. * (1 + (tau / (b2 + 1e-20))**2)
-  w3  = 1./35.  * (1 + (tau / (b3 + 1e-20))**2)
+  w0  = C4_35  * (1 + (tau / (b0 + 1e-20))**2)
+  w1  = C18_35 * (1 + (tau / (b1 + 1e-20))**2)
+  w2  = C12_35 * (1 + (tau / (b2 + 1e-20))**2)
+  w3  = C1_35  * (1 + (tau / (b3 + 1e-20))**2)
 
   s = 1. / (w0 + w1 + w2 + w3)
   w0 = w0 * s
@@ -1775,7 +1780,7 @@ end subroutine weno_seven_h_weight_reconstruction
 !> Compute weights for the fourth upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_0(q4, w0)
   real, intent(in) :: q4(4)          !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w0          !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w0          !< Weight for this stencil [A2 ~> a2]
 
   w0 = q4(1) * (2.107 * q4(1) - 9.402 * q4(2) + 7.042 * q4(3) - 1.854 * q4(4)) + &
      q4(2) * (11.003 * q4(2) - 17.246 * q4(3) + 4.642 * q4(4)) + &
@@ -1786,7 +1791,7 @@ end subroutine weno_seven_weight_0
 !> Compute weights for the third upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_1(q4, w1)
   real, intent(in) :: q4(4)          !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w1          !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w1          !< Weight for this stencil [A2 ~> a2]
 
   w1 = q4(1) * (0.547 * q4(1) - 2.522 * q4(2) + 1.922 * q4(3) - 0.494 * q4(4)) + &
      q4(2) * (3.443 * q4(2) - 5.966 * q4(3) + 1.602 * q4(4)) + &
@@ -1797,7 +1802,7 @@ end subroutine weno_seven_weight_1
 !> Compute weights for the second upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_2(q4, w2)
   real, intent(in) :: q4(4)           !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w2           !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w2           !< Weight for this stencil [A2 ~> a2]
 
   w2 = q4(1) * (0.267 * q4(1) - 1.642 * q4(2) + 1.602 * q4(3) - 0.494 * q4(4)) + &
      q4(2) * (2.843 * q4(2) - 5.966 * q4(3) + 1.922 * q4(4)) + &
@@ -1808,7 +1813,7 @@ end subroutine weno_seven_weight_2
 !> Compute weights for the first upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_3(q4, w3)
   real, intent(in) :: q4(4)           !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w3           !< Weight for this stencil [A ~> a]
+  real, intent(inout) :: w3           !< Weight for this stencil [A2 ~> a2]
 
   w3 = q4(1) * (0.547  * q4(1) - 3.882 * q4(2) + 4.642 * q4(3) - 1.854 * q4(4)) + &
      q4(2) * (7.043 * q4(2) - 17.246 * q4(3) + 7.042 * q4(4)) + &
@@ -1820,8 +1825,9 @@ end subroutine weno_seven_weight_3
 subroutine weno_seven_reconstruction_0(q4, p0)
   real, intent(in) :: q4(4)            !< Tracer values on the four-point stencil [A ~> a]
   real, intent(inout) :: p0            !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_24 = 1.0/24.0  ! One twenty fourth [nondim]
 
-  p0 = (6 * q4(1) + 26 * q4(2) - 10 * q4(3) + 2 * q4(4)) / 24.0
+  p0 = (6 * q4(1) + 26 * q4(2) - 10 * q4(3) + 2 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_0
 
@@ -1829,8 +1835,9 @@ end subroutine weno_seven_reconstruction_0
 subroutine weno_seven_reconstruction_1(q4, p1)
   real, intent(in) :: q4(4)            !< Tracer values on the four-point stencil [A ~> a]
   real, intent(inout) :: p1            !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_24 = 1.0/24.0  ! One twenty fourth [nondim]
 
-  p1 = (-2 * q4(1) + 14 * q4(2) + 14 * q4(3) - 2 * q4(4)) / 24.0
+  p1 = (-2 * q4(1) + 14 * q4(2) + 14 * q4(3) - 2 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_1
 
@@ -1838,8 +1845,9 @@ end subroutine weno_seven_reconstruction_1
 subroutine weno_seven_reconstruction_2(q4, p2)
   real, intent(in) :: q4(4)             !< Tracer values on the four-point stencil [A ~> a]
   real, intent(inout) :: p2             !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_24 = 1.0/24.0   ! One twenty fourth [nondim]
 
-  p2 = (2 * q4(1) - 10 * q4(2) + 26 * q4(3) + 6 * q4(4)) / 24.0
+  p2 = (2 * q4(1) - 10 * q4(2) + 26 * q4(3) + 6 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_2
 
@@ -1847,8 +1855,9 @@ end subroutine weno_seven_reconstruction_2
 subroutine weno_seven_reconstruction_3(q4, p3)
   real, intent(in) :: q4(4)            !< Tracer values on the four-point stencil [A ~> a]
   real, intent(inout) :: p3            !< Reconstruction of the quantity [A ~> a]
+  real, parameter :: C1_24 = 1.0/24.0  ! One twenty fourth [nondim]
 
-  p3 = (-6 * q4(1) + 26 * q4(2) - 46 * q4(3) + 50 * q4(4)) / 24.0
+  p3 = (-6 * q4(1) + 26 * q4(2) - 46 * q4(3) + 50 * q4(4)) * C1_24
 
 end subroutine weno_seven_reconstruction_3
 

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -314,8 +314,9 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   endif ; endif
 
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
-  !$OMP                        RV,PV,is,ie,js,je,Isq,Ieq,Jsq,Jeq,nz,vol_neglect,h_tiny,OBC,eps_vel, &
-  !$OMP                        area_neglect, pbv, Stokes_VF, stencil)
+  !$OMP                        RV,PV,is,ie,js,je,nz,vol_neglect,h_tiny,OBC,eps_vel, &
+  !$OMP                        area_neglect, pbv, Stokes_VF, stencil) &
+  !$OMP private(Isq,Ieq,Jsq,Jeq)
   do k=1,nz
 
     Isq = G%IscB - stencil + 2
@@ -1457,7 +1458,7 @@ function fac_fn(tau, b) result(fac)
   real, intent(in)  :: b    !< The smoothness indicator [A ~> a]
   real :: fac               !< The factor for the weight [nondim]
 
-  fac = (1 + tau / b)**2; if (b == 0.) fac = 1.0e40
+  fac = 1.0e40; if (abs(b) > 1.0e-20*tau) fac = (1 + tau / b)**2
 
 end function fac_fn
 

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -315,7 +315,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
   !$OMP                        RV,PV,is,ie,js,je,nz,vol_neglect,h_tiny,OBC,eps_vel, &
-  !$OMP                        area_neglect, pbv, Stokes_VF, stencil) 
+  !$OMP                        area_neglect, pbv, Stokes_VF, stencil)
 
   do k=1,nz
 

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -241,6 +241,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: UHeff, VHeff  ! More temporary variables [H L2 T-1 ~> m3 s-1 or kg s-1].
   real :: QUHeff,QVHeff ! More temporary variables [H L2 T-2 ~> m3 s-2 or kg s-2].
   integer :: i, j, k, n, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+  integer :: Is_q, Ie_q, Js_q, Je_q  ! The scheme-dependent range of values at which vorticity is set.
   logical :: Stokes_VF
   real :: u_v, v_u      ! u_v is the u velocity at v point, v_u is the v velocity at u point [L T-1 ~> m s-1]
   real :: q_v, q_u      ! PV at the u and v points [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1]
@@ -272,27 +273,30 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   stencil = CoriolisAdv_stencil(CS)
 
-  Isq = G%IscB - stencil + 2
-  Ieq = G%IecB + stencil - 2
-  Jsq = G%JscB - stencil + 2
-  Jeq = G%JecB + stencil - 2
-  !$OMP parallel do default(private) shared(Isq,Ieq,Jsq,Jeq,G,Area_h)
-  do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+2
+  if ((CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) .or. (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) .or. &
+      (CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO)) then
+    Is_q = is - stencil ; Ie_q = ie + stencil - 1 ; Js_q = js - stencil ; Je_q = je + stencil - 1
+  else
+    Is_q = G%IscB - 1 ; Ie_q = G%IecB + 1 ; Js_q = G%JscB - 1 ; Je_q = G%JecB + 1
+  endif
+
+  !$OMP parallel do default(private) shared(Is_q,Ie_q,Js_q,Je_q,G,Area_h)
+  do j=Js_q,Je_q+1 ; do I=Is_q,Ie_q+1
     Area_h(i,j) = G%mask2dT(i,j) * G%areaT(i,j)
   enddo ; enddo
   if (associated(OBC)) then ; do n=1,OBC%number_of_segments
     if (.not. OBC%segment(n)%on_pe) cycle
     I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
-    if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
-      do i = max(Isq-1,OBC%segment(n)%HI%isd), min(Ieq+2,OBC%segment(n)%HI%ied)
+    if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
+      do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
           Area_h(i,j+1) = Area_h(i,j)
         else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
           Area_h(i,j) = Area_h(i,j+1)
         endif
       enddo
-    elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
-      do j = max(Jsq-1,OBC%segment(n)%HI%jsd), min(Jeq+2,OBC%segment(n)%HI%jed)
+    elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
+      do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
         if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
           Area_h(i+1,j) = Area_h(i,j)
         else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
@@ -301,8 +305,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       enddo
     endif
   enddo ; endif
-  !$OMP parallel do default(private) shared(Isq,Ieq,Jsq,Jeq,G,Area_h,Area_q)
-  do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+  !$OMP parallel do default(private) shared(Is_q,Ie_q,Js_q,Je_q,G,Area_h,Area_q)
+  do J=Js_q,Je_q ; do I=Is_q,Ie_q
     Area_q(i,j) = (Area_h(i,j) + Area_h(i+1,j+1)) + &
                   (Area_h(i+1,j) + Area_h(i,j+1))
   enddo ; enddo
@@ -314,15 +318,11 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   endif ; endif
 
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
-  !$OMP                        RV,PV,is,ie,js,je,nz,vol_neglect,h_tiny,OBC,eps_vel, &
-  !$OMP                        area_neglect, pbv, Stokes_VF, stencil)
+  !$OMP                        RV,PV,is,ie,js,je,Isq,Ieq,Jsq,Jeq,Is_q,Ie_q,Js_q,Je_q,nz,vol_neglect,&
+  !$OMP                        h_tiny,OBC,eps_vel,area_neglect,pbv,Stokes_VF,stencil)
 
   do k=1,nz
 
-    Isq = G%IscB - stencil + 2
-    Ieq = G%IecB + stencil - 2
-    Jsq = G%JscB - stencil + 2
-    Jeq = G%JecB + stencil - 2
     ! Here the second order accurate layer potential vorticities, q,
     ! are calculated.  hq is  second order accurate in space.  Relative
     ! vorticity is second order accurate everywhere with free slip b.c.s,
@@ -330,7 +330,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! First calculate the contributions to the circulation around the q-point.
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        do J=Js_q,Je_q ; do I=Is_q,Ie_q
           dvSdx(I,J) = (-Waves%us_y(i+1,J,k)*G%dyCv(i+1,J)) - &
                        (-Waves%us_y(i,J,k)*G%dyCv(i,J))
           duSdy(I,J) = (-Waves%us_x(I,j+1,k)*G%dxCu(I,j+1)) - &
@@ -338,28 +338,28 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo; enddo
       endif
       if (.not. Waves%Passive_Stokes_VF) then
-        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        do J=Js_q,Je_q ; do I=Is_q,Ie_q
           dvdx(I,J) = ((v(i+1,J,k)-Waves%us_y(i+1,J,k))*G%dyCv(i+1,J)) - &
                       ((v(i,J,k)-Waves%us_y(i,J,k))*G%dyCv(i,J))
           dudy(I,J) = ((u(I,j+1,k)-Waves%us_x(I,j+1,k))*G%dxCu(I,j+1)) - &
                       ((u(I,j,k)-Waves%us_x(I,j,k))*G%dxCu(I,j))
         enddo; enddo
       else
-        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        do J=Js_q,Je_q ; do I=Is_q,Ie_q
           dvdx(I,J) = (v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J))
           dudy(I,J) = (u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j))
         enddo; enddo
       endif
     else
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do J=Js_q,Je_q ; do I=Is_q,Ie_q
         dvdx(I,J) = (v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J))
         dudy(I,J) = (u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j))
       enddo; enddo
     endif
-    do J=Jsq-1,Jeq+1 ; do i=Isq-1,Ieq+2
+    do J=Js_q,Je_q ; do i=Is_q,Ie_q+1
       hArea_v(i,J) = 0.5*((Area_h(i,j) * h(i,j,k)) + (Area_h(i,j+1) * h(i,j+1,k)))
     enddo ; enddo
-    do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+1
+    do j=Js_q,Je_q+1 ; do I=Is_q,Ie_q
       hArea_u(I,j) = 0.5*((Area_h(i,j) * h(i,j,k)) + (Area_h(i+1,j) * h(i+1,j,k)))
     enddo ; enddo
 
@@ -377,7 +377,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (associated(OBC)) then ; do n=1,OBC%number_of_segments
       if (.not. OBC%segment(n)%on_pe) cycle
       I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
-      if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
+      if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
         if (OBC%zero_vorticity) then ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
           dvdx(I,J) = 0. ; dudy(I,J) = 0.
         enddo ; endif
@@ -400,7 +400,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo ; endif
 
         ! Project thicknesses across OBC points with a no-gradient condition.
-        do i = max(Isq-1,OBC%segment(n)%HI%isd), min(Ieq+2,OBC%segment(n)%HI%ied)
+        do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
           if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
             hArea_v(i,J) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j,k)
           else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
@@ -409,7 +409,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo
 
         if (CS%Coriolis_En_Dis) then
-          do i = max(Isq-1,OBC%segment(n)%HI%isd), min(Ieq+2,OBC%segment(n)%HI%ied)
+          do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
             if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
               vh_center(i,J) = (G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k)) * v(i,J,k) * h(i,j,k)
             else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
@@ -417,7 +417,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             endif
           enddo
         endif
-      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
+      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
         if (OBC%zero_vorticity) then ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
           dvdx(I,J) = 0. ; dudy(I,J) = 0.
         enddo ; endif
@@ -440,7 +440,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo ; endif
 
         ! Project thicknesses across OBC points with a no-gradient condition.
-        do j = max(Jsq-1,OBC%segment(n)%HI%jsd), min(Jeq+2,OBC%segment(n)%HI%jed)
+        do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
           if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
             hArea_u(I,j) = 0.5*(Area_h(i,j) + Area_h(i+1,j)) * h(i,j,k)
           else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
@@ -448,7 +448,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           endif
         enddo
         if (CS%Coriolis_En_Dis) then
-          do j = max(Jsq-1,OBC%segment(n)%HI%jsd), min(Jeq+2,OBC%segment(n)%HI%jed)
+          do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
             if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
               uh_center(I,j) = (G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)) * u(I,j,k) * h(i,j,k)
             else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
@@ -464,8 +464,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       ! Now project thicknesses across cell-corner points in the OBCs.  The two
       ! projections have to occur in sequence and can not be combined easily.
       I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
-      if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
-        do I = max(Isq-1,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
+      if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
+        do I = max(Is_q,OBC%segment(n)%HI%IsdB), min(Ie_q,OBC%segment(n)%HI%IedB)
           if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
             if (Area_h(i,j) + Area_h(i+1,j) > 0.0) then
               hArea_u(I,j+1) = hArea_u(I,j) * ((Area_h(i,j+1) + Area_h(i+1,j+1)) / &
@@ -478,8 +478,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
             else ; hArea_u(I,j) = 0.0 ; endif
           endif
         enddo
-      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
-        do J = max(Jsq-1,OBC%segment(n)%HI%JsdB), min(Jeq+1,OBC%segment(n)%HI%JedB)
+      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
+        do J = max(Js_q,OBC%segment(n)%HI%JsdB), min(Je_q,OBC%segment(n)%HI%JedB)
           if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
             if (Area_h(i,j) + Area_h(i,j+1) > 0.0) then
               hArea_v(i+1,J) = hArea_v(i,J) * ((Area_h(i+1,j) + Area_h(i+1,j+1)) / &
@@ -497,52 +497,48 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     enddo ; endif
 
     if (CS%no_slip) then
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do J=Js_q,Je_q ; do I=Is_q,Ie_q
         rel_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
       enddo; enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+          do J=Js_q,Je_q ; do I=Is_q,Ie_q
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
           enddo; enddo
         endif
       endif
     else
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      do J=Js_q,Je_q ; do I=Is_q,Ie_q
         rel_vort(I,J) = G%mask2dBu(I,J) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
       enddo; enddo
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+          do J=Js_q,Je_q ; do I=Is_q,Ie_q
             stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
           enddo; enddo
         endif
       endif
     endif
 
-    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+    do J=Js_q,Je_q ; do I=Is_q,Ie_q
       abs_vort(I,J) = G%CoriolisBu(I,J) + rel_vort(I,J)
     enddo ; enddo
 
-    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+    do J=Js_q,Je_q ; do I=Is_q,Ie_q
       hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
       Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
-      h_q(I,J) = (hArea_q) / max(Area_q(I,J), area_neglect)
+      h_q(I,J) = hArea_q / max(Area_q(I,J), area_neglect)
       q(I,J) = abs_vort(I,J) * Ih_q(I,J)
     enddo; enddo
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        do J=Js_q,Je_q ; do I=Is_q,Ie_q
           qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
         enddo; enddo
       endif
     endif
 
-    Isq = G%IscB
-    Ieq = G%IecB
-    Jsq = G%JscB
-    Jeq = G%JecB
 
     if (CS%id_rv > 0) then
       do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -1432,17 +1432,34 @@ subroutine UP3_Koren_limiter_reconstruction(q4,u,qr)
   real, parameter     :: C1_6 = 1.0/6.0   ! The ratio of 1/6 [nondim]
 
   if (u>0.) then
-    theta = (q4(2) - q4(1))/(q4(3) - q4(2) + 1e-20)
-    psi = max(0., min(1., C1_3 + C1_6*theta, theta)) ! limiter introduced by Koren (1993)
-    qr = q4(2) + psi*(q4(3) - q4(2))
+    if (q4(3) == q4(2)) then
+      qr = q4(2)
+    else 
+      theta = (q4(2) - q4(1))/(q4(3) - q4(2))
+      psi = max(0., min(1., C1_3 + C1_6*theta, theta)) ! limiter introduced by Koren (1993)
+      qr = q4(2) + psi*(q4(3) - q4(2))
+    endif
   else
-    theta = (q4(4) - q4(3))/(q4(3) - q4(2) + 1e-20)
-    psi = max(0., min(1., C1_3 + C1_6*theta, theta))
-    qr = q4(3) + psi*(q4(2) - q4(3))
+    if (q4(3) == q4(2)) then
+      qr = q4(3)
+    else
+      theta = (q4(4) - q4(3))/(q4(3) - q4(2))
+      psi = max(0., min(1., C1_3 + C1_6*theta, theta))
+      qr = q4(3) + psi*(q4(2) - q4(3))
+    endif
   endif
 
 end subroutine UP3_Koren_limiter_reconstruction
 
+!> Compute the factor for the WENO weights
+function fac_fn(tau, b) result(fac)
+  real, intent(in)  :: tau  !< Difference of the smoothness indicator [A ~> a]
+  real, intent(in)  :: b    !< The smoothness indicator [A ~> a]
+  real :: fac               !< The factor for the weight [nondim]
+
+  fac = (1 + tau / b)**2; if (b == 0.) fac = 1.0e40
+
+end function fac_fn
 
 
 !> Reconstruct the tracer (e.g., PV, vorticity) onto the point i-1/2 using a third-order WENO scheme
@@ -1463,7 +1480,7 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     real :: c0, c1                        ! Intermediate reconstruction of q [A ~> a]
     real :: d0, d1                        ! Intermediate reconstruction of h [L ~> m]
     real :: b0, b1                        ! Smoothness indicator [A ~> a]
-    real :: tau                           ! Temporary variables [nondim]
+    real :: tau                           ! Difference of smoothness indicator [A ~> a]
     real :: w0, w1                        ! Weights [nondim]
     real :: s                             ! Temporary variables [nondim]
     real, parameter :: C2_3 = 2.0/3.0     ! The ratio of 2/3 [nondim]
@@ -1498,8 +1515,8 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     endif
 
     tau = abs(b0-b1)
-    w0  = C2_3 * (1 + (tau / (b0 + 1e-20))**2)
-    w1  = C1_3 * (1 + (tau / (b1 + 1e-20))**2)
+    w0  = C2_3 * fac_fn(tau, b0) 
+    w1  = C1_3 * fac_fn(tau, b1)
 
     s = 1. / (w0 + w1)
     w0 = w0 * s
@@ -1562,7 +1579,7 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     real :: c0, c1, c2                            ! Intermediate reconstruction of hq[A ~> a]
     real :: d0, d1, d2                            ! Intermediate reconstruction of h [L ~> m]
     real :: b0, b1, b2                            ! Smoothness indicator [A ~> a]
-    real :: tau                                   ! Temporary variables [nondim]
+    real :: tau                                   ! Difference of smoothness indicators [A ~> a]
     real :: w0, w1, w2                            ! Weights [nondim]
     real :: s                                     ! Temporary variables [nondim]
     real, parameter :: C3_10 = 3.0/10.0           ! The ratio of 3/10 [nondim]
@@ -1606,9 +1623,9 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     endif
 
     tau = abs(b0 - b2)
-    w0  = C3_10 * (1 + (tau / (b0 + 1e-20))**2)
-    w1  = C3_5  * (1 + (tau / (b1 + 1e-20))**2)
-    w2  = C1_10 * (1 + (tau / (b2 + 1e-20))**2)
+    w0  = C3_10 * fac_fn(tau, b0)
+    w1  = C3_5  * fac_fn(tau, b1)
+    w2  = C1_10 * fac_fn(tau, b2)
 
     s = 1. / (w0 + w1 + w2)
     w0 = w0 * s
@@ -1705,7 +1722,7 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   real :: c0, c1, c2, c3      ! Intermediate reconstruction of hq [A ~> a]
   real :: d0, d1, d2, d3      ! Intermediate reconstruction of h [L ~> m]
   real :: b0, b1, b2, b3      ! Smoothness indicator [A ~> a]
-  real :: tau                 ! Temporary variables [nondim]
+  real :: tau                 ! Difference of smoothness indicators [A ~> a]
   real :: w0, w1, w2, w3      ! Weights [nondim]
   real :: s                   ! Temporary variables [nondim]
   real, parameter :: C4_35 = 4.0/35.0 ! The ratio of 4/35 [nondim]
@@ -1758,10 +1775,10 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   endif
 
   tau = abs((b0 - b3) + 3 * (b1 - b2))
-  w0  = C4_35  * (1 + (tau / (b0 + 1e-20))**2)
-  w1  = C18_35 * (1 + (tau / (b1 + 1e-20))**2)
-  w2  = C12_35 * (1 + (tau / (b2 + 1e-20))**2)
-  w3  = C1_35  * (1 + (tau / (b3 + 1e-20))**2)
+  w0  = C4_35  * fac_fn(tau, b0)
+  w1  = C18_35 * fac_fn(tau, b1)
+  w2  = C12_35 * fac_fn(tau, b2)
+  w3  = C1_35  * fac_fn(tau, b3)
 
   s = 1. / (w0 + w1 + w2 + w3)
   w0 = w0 * s

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -315,7 +315,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
   !$OMP                        RV,PV,is,ie,js,je,Isq,Ieq,Jsq,Jeq,nz,vol_neglect,h_tiny,OBC,eps_vel, &
-  !$OMP                        area_neglect, pbv, Stokes_VF)
+  !$OMP                        area_neglect, pbv, Stokes_VF, stencil)
   do k=1,nz
 
     Isq = G%IscB - stencil + 2
@@ -1519,7 +1519,7 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     w1  = C1_3 * fac_fn(tau, b1)
 
     s = 1. / (w0 + w1)
-    w0 = w0 * s
+    w0 = w0 * s   ! Weights of stencils
     w1 = w1 * s
 
     vr = w0 * c0 + w1 * c1
@@ -1531,10 +1531,10 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
 
 end subroutine weno_three_h_weight_reconstruction
 
-!> Compute weights for the two-point stencil of the third-order WENO scheme
+!> Compute the smoothness indicator for the two-point stencil of the third-order WENO scheme
 subroutine weno_three_weight(q2, w0)
     real, intent(in) :: q2(2)    !< Tracer values on the two-point stencil [A ~> a]
-    real, intent(inout) :: w0    !< Weight for this stencil [A2 ~> a2]
+    real, intent(inout) :: w0    !< Smoothness indicator for this stencil [A2 ~> a2]
 
     w0 = q2(1) * q2(1) - 2 * q2(1) * q2(2) + q2(2) * q2(2)
 
@@ -1628,7 +1628,7 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
     w2  = C1_10 * fac_fn(tau, b2)
 
     s = 1. / (w0 + w1 + w2)
-    w0 = w0 * s
+    w0 = w0 * s   ! Weights of stencils
     w1 = w1 * s
     w2 = w2 * s
 
@@ -1641,30 +1641,30 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
 
 end subroutine weno_five_h_weight_reconstruction
 
-!> Compute weights for the third upwind stencil of the fifth-order WENO scheme
+!> Compute the smoothness indicator for the third upwind stencil of the fifth-order WENO scheme
 subroutine weno_five_weight_0(q3, w0)
   real, intent(in) :: q3(3)       !< Tracer values on the three-point stencil [A ~> a]
-  real, intent(inout) :: w0       !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w0       !< Smoothness indicator for this stencil [A2 ~> a2]
 
   w0 = q3(1) * (10 * q3(1) - 31 * q3(2) + 11 * q3(3)) + &
        q3(2) * (25 * q3(2) - 19 * q3(3)) + 4 * q3(3) * q3(3)
 
 end subroutine weno_five_weight_0
 
-!> Compute weights for the second upwind stencil of the fifth-order WENO scheme
+!> Compute the smoothness indicator for the second upwind stencil of the fifth-order WENO scheme
 subroutine weno_five_weight_1(q3, w1)
   real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
-  real, intent(inout) :: w1        !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w1        !< Smoothness indicator for this stencil [A2 ~> a2]
 
   w1 = q3(1) * (4 * q3(1) - 13 * q3(2) + 5 * q3(3)) + &
        q3(2) * (13 * q3(2) - 13 * q3(3)) + 4 * q3(3) * q3(3)
 
 end subroutine weno_five_weight_1
 
-!> Compute weights for the first upwind stencil of the fifth-order WENO scheme
+!> Compute the smoothness indicator for the first upwind stencil of the fifth-order WENO scheme
 subroutine weno_five_weight_2(q3, w2)
   real, intent(in) :: q3(3)        !< Tracer values on the three-point stencil [A ~> a]
-  real, intent(inout) :: w2        !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w2        !< Smoothness indicator for this stencil [A2 ~> a2]
 
   w2 = q3(1) * (4 * q3(1) - 19 * q3(2) + 11 * q3(3)) + &
        q3(2) * (25 * q3(2) - 31 * q3(3)) + 10 * q3(3) * q3(3)
@@ -1781,7 +1781,7 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
   w3  = C1_35  * fac_fn(tau, b3)
 
   s = 1. / (w0 + w1 + w2 + w3)
-  w0 = w0 * s
+  w0 = w0 * s   ! Weights of the stencils
   w1 = w1 * s
   w2 = w2 * s
   w3 = w3 * s
@@ -1797,44 +1797,48 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
 
 end subroutine weno_seven_h_weight_reconstruction
 
-!> Compute weights for the fourth upwind stencil of the seventh-order WENO scheme
+!> Compute the smoothness indicator for the fourth upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_0(q4, w0)
   real, intent(in) :: q4(4)          !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w0          !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w0          !< Smoothness indicator for this stencil [A2 ~> a2]
 
+  ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
   w0 = q4(1) * (2.107 * q4(1) - 9.402 * q4(2) + 7.042 * q4(3) - 1.854 * q4(4)) + &
      q4(2) * (11.003 * q4(2) - 17.246 * q4(3) + 4.642 * q4(4)) + &
      q4(3) * (7.043 * q4(3) - 3.882 * q4(4)) + 0.547 * q4(4) * q4(4)
 
 end subroutine weno_seven_weight_0
 
-!> Compute weights for the third upwind stencil of the seventh-order WENO scheme
+!> Compute the smoothness indicator for the third upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_1(q4, w1)
   real, intent(in) :: q4(4)          !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w1          !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w1          !< Smoothness indicator for this stencil [A2 ~> a2]
 
+  ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
   w1 = q4(1) * (0.547 * q4(1) - 2.522 * q4(2) + 1.922 * q4(3) - 0.494 * q4(4)) + &
      q4(2) * (3.443 * q4(2) - 5.966 * q4(3) + 1.602 * q4(4)) + &
      q4(3) * (2.843 * q4(3) - 1.642 * q4(4)) + 0.267 * q4(4) * q4(4)
 
 end subroutine weno_seven_weight_1
 
-!> Compute weights for the second upwind stencil of the seventh-order WENO scheme
+!> Compute the smoothness indicator for the second upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_2(q4, w2)
   real, intent(in) :: q4(4)           !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w2           !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w2           !< Smoothness indicator for this stencil [A2 ~> a2]
 
+  ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
   w2 = q4(1) * (0.267 * q4(1) - 1.642 * q4(2) + 1.602 * q4(3) - 0.494 * q4(4)) + &
      q4(2) * (2.843 * q4(2) - 5.966 * q4(3) + 1.922 * q4(4)) + &
      q4(3) * (3.443 * q4(3) - 2.522 * q4(4)) + 0.547 * q4(4) * q4(4)
 
 end subroutine weno_seven_weight_2
 
-!> Compute weights for the first upwind stencil of the seventh-order WENO scheme
+!> Compute smoothness indicator for the first upwind stencil of the seventh-order WENO scheme
 subroutine weno_seven_weight_3(q4, w3)
   real, intent(in) :: q4(4)           !< Tracer values on the four-point stencil [A ~> a]
-  real, intent(inout) :: w3           !< Weight for this stencil [A2 ~> a2]
+  real, intent(inout) :: w3           !< Smoothness indicator for this stencil [A2 ~> a2]
 
+  ! Coefficients from Balsara and Shu (2000). The division by 1000 will be normalized out by fac_fn
   w3 = q4(1) * (0.547  * q4(1) - 3.882 * q4(2) + 4.642 * q4(3) - 1.854 * q4(4)) + &
      q4(2) * (7.043 * q4(2) - 17.246 * q4(3) + 7.042 * q4(4)) + &
      q4(3) * (11.003 * q4(3) - 9.402 * q4(4)) + 2.107 * q4(4) * q4(4)

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -37,8 +37,9 @@ type, public :: CoriolisAdv_CS ; private
                              !! - SADOURNY75_ENSTRO - Sadourny, JAS 1975, Enstrophy
                              !! - ARAKAWA_LAMB81    - Arakawa & Lamb, MWR 1981, Energy & Enstrophy
                              !! - ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with Arakawa & Hsu and Sadourny energy.
+                             !! - WENOVI3RD_PV_ENSTRO    - 3rd-order WENO scheme for PV reconstruction
+                             !! - WENOVI5TH_PV_ENSTRO    - 5th-order WENO scheme for PV reconstruction
                              !! - WENOVI7TH_PV_ENSTRO    - 7th-order WENO scheme for PV reconstruction
-                             !! - WENOVI7TH_ENSTRO       - 7th-order WENO scheme for absolute vorticity reconstruction
                              !! The default, SADOURNY75_ENERGY, is the safest choice then the
                              !! deformation radius is poorly resolved.
   integer :: KE_Scheme       !< KE_SCHEME selects the discretization for
@@ -311,7 +312,6 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                   (Area_h(i+1,j) + Area_h(i,j+1))
   enddo ; enddo
 
-
   Stokes_VF = .false.
   if (present(Waves)) then ; if (associated(Waves)) then
     Stokes_VF = Waves%Stokes_VF
@@ -320,7 +320,6 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
   !$OMP                        RV,PV,is,ie,js,je,Isq,Ieq,Jsq,Jeq,Is_q,Ie_q,Js_q,Je_q,nz,vol_neglect,&
   !$OMP                        h_tiny,OBC,eps_vel,area_neglect,pbv,Stokes_VF,stencil)
-
   do k=1,nz
 
     ! Here the second order accurate layer potential vorticities, q,
@@ -538,7 +537,6 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         enddo; enddo
       endif
     endif
-
 
     if (CS%id_rv > 0) then
       do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
@@ -1792,7 +1790,6 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
 
   qr = vr / max(hr, h_tiny)
 
-
 end subroutine weno_seven_h_weight_reconstruction
 
 !> Compute the smoothness indicator for the fourth upwind stencil of the seventh-order WENO scheme
@@ -2042,7 +2039,6 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
                   default=.True.)
   endif
 
-
   ! Set PV_Adv_Scheme (selects discretization of PV advection)
   call get_param(param_file, mdl, "PV_ADV_SCHEME", tmpstr, &
                  "PV_ADV_SCHEME selects the discretization for PV "//&
@@ -2086,7 +2082,6 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
   CS%id_CAvS = register_diag_field('ocean_model', 'CAv_Stokes', diag%axesCvL, Time, &
      'Meridional Acceleration from Stokes Vorticity', 'm s-2', conversion=US%L_T2_to_m_s2)
   ! add to AD
-
 
   !CS%id_hf_gKEu = register_diag_field('ocean_model', 'hf_gKEu', diag%axesCuL, Time, &
   !   'Fractional Thickness-weighted Zonal Acceleration from Grad. Kinetic Energy', &

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -1434,7 +1434,7 @@ subroutine UP3_Koren_limiter_reconstruction(q4,u,qr)
   if (u>0.) then
     if (q4(3) == q4(2)) then
       qr = q4(2)
-    else 
+    else
       theta = (q4(2) - q4(1))/(q4(3) - q4(2))
       psi = max(0., min(1., C1_3 + C1_6*theta, theta)) ! limiter introduced by Koren (1993)
       qr = q4(2) + psi*(q4(3) - q4(2))
@@ -1515,7 +1515,7 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
     endif
 
     tau = abs(b0-b1)
-    w0  = C2_3 * fac_fn(tau, b0) 
+    w0  = C2_3 * fac_fn(tau, b0)
     w1  = C1_3 * fac_fn(tau, b1)
 
     s = 1. / (w0 + w1)

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -526,7 +526,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
       hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
       Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
-      h_q(I,J) = (hArea_q) / (Area_q(I,J) + area_neglect)
+      h_q(I,J) = (hArea_q) / max(Area_q(I,J), area_neglect)
       q(I,J) = abs_vort(I,J) * Ih_q(I,J)
     enddo; enddo
 
@@ -1408,11 +1408,12 @@ subroutine UP3_reconstruction(q4,u,qr)
   real, intent(in)    :: u                !< Velocity or thickness flux on point i-1/2
                                           !! [l t-1 ~> m s-1] or [l2 t-1 ~> m2 s-1]
   real, intent(inout) :: qr               !< Reconstruction of tracer q at point i-1/2 [A ~> a]
+  real, parameter :: C1_6 = 1.0/6.0       ! The ratio of 1/6 [nondim]
 
   if (u>0.) then
-    qr = (-q4(1) + 5.*q4(2) + 2.*q4(3))/6.
+    qr = (-q4(1) + 5.*q4(2) + 2.*q4(3)) * C1_6
   else
-    qr = (2.*q4(2) + 5.*q4(3) - q4(4))/6.
+    qr = (2.*q4(2) + 5.*q4(3) - q4(4)) * C1_6
   endif
 
 end subroutine UP3_reconstruction
@@ -1425,16 +1426,18 @@ subroutine UP3_Koren_limiter_reconstruction(q4,u,qr)
   real, intent(in)    :: u                !< Velocity or thickness flux on point i-1/2
                                           !! [L T-1 ~> m s-1] or [L2 T-1 ~> m2 s-1]
   real, intent(inout) :: qr               !< Reconstruction of tracer q on point i-1/2 [A ~> a]
-  real                :: theta       ! Ratio of gradient [nondim]
-  real                :: psi         ! Limiter function [nondim]
+  real                :: theta            ! Ratio of gradient [nondim]
+  real                :: psi              ! Limiter function [nondim]
+  real, parameter     :: C1_3 = 1.0/3.0   ! The ratio of 1/3 [nondim]
+  real, parameter     :: C1_6 = 1.0/6.0   ! The ratio of 1/6 [nondim]
 
   if (u>0.) then
     theta = (q4(2) - q4(1))/(q4(3) - q4(2) + 1e-20)
-    psi = max(0., min(1., 1/3. + 1/6.*theta, theta)) ! limiter introduced by Koren (1993)
+    psi = max(0., min(1., C1_3 + C1_6*theta, theta)) ! limiter introduced by Koren (1993)
     qr = q4(2) + psi*(q4(3) - q4(2))
   else
     theta = (q4(4) - q4(3))/(q4(3) - q4(2) + 1e-20)
-    psi = max(0., min(1., 1/3. + 1/6.*theta, theta))
+    psi = max(0., min(1., C1_3 + C1_6*theta, theta))
     qr = q4(3) + psi*(q4(2) - q4(3))
   endif
 
@@ -1507,7 +1510,7 @@ subroutine weno_three_h_weight_reconstruction(q4, h4, u4, &
 !    vr = min(max(q4(3), q4(2)), vr) ; vr = max(min(q4(3), q4(2)), vr) !Impose a monotonicity limiter
     hr = min(max(h4(3), h4(2)), hr) ; hr = max(min(h4(3), h4(2)), hr) ! A monotonicity limiter
 
-    qr = vr / (hr + h_tiny)
+    qr = vr / max(hr, h_tiny)
 
 end subroutine weno_three_h_weight_reconstruction
 
@@ -1617,7 +1620,7 @@ subroutine weno_five_h_weight_reconstruction(q6, h6, u6, &
 !    vr = min(max(q6(3), q6(4)), vr) ; vr = max(min(q6(3), q6(4)), vr) !Impose a monotonicity limiter
     hr = min(max(h6(3), h6(4)), hr) ; hr = max(min(h6(3), h6(4)), hr) !Impose a monotonicity limiter
 
-    qr = vr / (hr + h_tiny)
+    qr = vr / max(hr, h_tiny)
 
 end subroutine weno_five_h_weight_reconstruction
 
@@ -1754,7 +1757,7 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
     endif
   endif
 
-  tau = abs(b0 + 3 * b1 - 3 * b2 - b3)
+  tau = abs((b0 - b3) + 3 * (b1 - b2))
   w0  = C4_35  * (1 + (tau / (b0 + 1e-20))**2)
   w1  = C18_35 * (1 + (tau / (b1 + 1e-20))**2)
   w2  = C12_35 * (1 + (tau / (b2 + 1e-20))**2)
@@ -1772,7 +1775,7 @@ subroutine weno_seven_h_weight_reconstruction(q8, h8, u8, &
 !  vr = min(max(q4, q5), vr) ; vr = max(min(q4, q5), vr)
   hr = min(max(h8(4), h8(5)), hr) ; hr = max(min(h8(4), h8(5)), hr) ! Impose a monotonicity limiter
 
-  qr = vr / (hr + h_tiny)
+  qr = vr / max(hr, h_tiny)
 
 
 end subroutine weno_seven_h_weight_reconstruction

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1039,10 +1039,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = h(i,j,k)
   enddo ; enddo ; enddo
-!    !$OMP parallel do default(shared)
-!    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-!      h_av(i,j,k) = h(i,j,k)
-!    enddo ; enddo ; enddo
 
   call do_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
   if (G%nonblocking_updates) then
@@ -1082,10 +1078,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
   enddo ; enddo ; enddo
-!    !$OMP parallel do default(shared)
-!    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-!      h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
-!    enddo ; enddo ; enddo
 
   if (G%nonblocking_updates) &
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
@@ -1653,7 +1645,6 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
                    success=read_h2, scale=1.0/GV%H_to_mks)
       if (read_uv .and. read_h2) then
         call pass_var(CS%h_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init)
-     !     call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
       else
         do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
         call continuity(CS%u_av, CS%v_av, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
@@ -1662,13 +1653,10 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
           CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
         enddo ; enddo ; enddo
         call pass_var(CS%h_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init)
- !         call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
 
       endif
       call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init, complete=.false.)
       call pass_vector(uh, vh, G%Domain, halo=cor_stencil, clock=id_clock_pass_init, complete=.true.)
- !       call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
- !       call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
       call CorAdCalc(CS%u_av, CS%v_av, CS%h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%ADp, &
                      G, GV, US, CS%CoriolisAdv, pbv) !, Waves=Waves)
       CS%CAu_pred_stored = .true.

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -45,7 +45,7 @@ use MOM_boundary_update,       only : update_OBC_data, update_OBC_CS
 use MOM_continuity,            only : continuity, continuity_CS
 use MOM_continuity,            only : continuity_init, continuity_stencil
 use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_CS
-use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end
+use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end, CoriolisAdv_stencil
 use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_debugging,             only : check_redundant
 use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
@@ -413,7 +413,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
                             ! in the  corrector step (not the predict)
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil, vel_stencil
-  integer :: WENO_stencil
+  integer :: cor_stencil
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -480,6 +480,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   obc_stencil = 2
+  cor_stencil = CoriolisAdv_stencil(CS%CoriolisAdv)
   if (associated(CS%OBC)) then
     if (CS%OBC%oblique_BCs_exist_globally) obc_stencil = 3
   endif
@@ -491,22 +492,13 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call create_group_pass(CS%pass_uvp, up, vp, G%Domain, halo=max(1,cont_stencil))
   call create_group_pass(CS%pass_uv, u_inst, v_inst, G%Domain, halo=max(2,cont_stencil))
 
-  if (CS%CoriolisAdv%USE_WENO) then
-    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-    call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=WENO_stencil)
-    call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(WENO_stencil,vel_stencil))
-    call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(WENO_stencil,vel_stencil))
-    call create_group_pass(CS%pass_h, h, g%domain, halo=max(WENO_stencil,cont_stencil))
-    call create_group_pass(CS%pass_av_uvh, u_av, v_av, g%domain, halo=max(WENO_stencil,vel_stencil))
-    call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(WENO_stencil,vel_stencil))
-  else
-    call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=2)
-    call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=vel_stencil)
-    call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=vel_stencil)
-    call create_group_pass(CS%pass_h, h, g%domain, halo=max(2,cont_stencil))
-    call create_group_pass(CS%pass_av_uvh, u_av, v_av, g%domain, halo=vel_stencil)
-    call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=vel_stencil)
-  endif
+  call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=cor_stencil)
+  call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(cor_stencil,vel_stencil))
+  call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,vel_stencil))
+  call create_group_pass(CS%pass_h, h, g%domain, halo=max(cor_stencil,cont_stencil))
+  call create_group_pass(CS%pass_av_uvh, u_av, v_av, g%domain, halo=max(cor_stencil,vel_stencil))
+  call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,vel_stencil))
+
   call cpu_clock_end(id_clock_pass)
   !--- end set up for group halo pass
 
@@ -821,19 +813,11 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   endif
 
   ! h_av = (h + hp)/2
-  if (CS%CoriolisAdv%USE_WENO) then
-    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-    call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js-WENO_stencil,je+WENO_stencil ; do i=is-WENO_stencil,ie+WENO_stencil
-      h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
-    enddo ; enddo ; enddo
-  else
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-      h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
-    enddo ; enddo ; enddo
-  endif
+  call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
+    h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
+  enddo ; enddo ; enddo
 
   ! The correction phase of the time step starts here.
   call enable_averages(dt, Time_local, CS%diag)
@@ -1051,18 +1035,14 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2)")
 
 ! Later, h_av = (h_in + h_out)/2, but for now use h_av to store h_in.
-  if (CS%CoriolisAdv%USE_WENO) then
-    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js-WENO_stencil,je+WENO_stencil ; do i=is-WENO_stencil,ie+WENO_stencil
-      h_av(i,j,k) = h(i,j,k)
-    enddo ; enddo ; enddo
-  else
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-      h_av(i,j,k) = h(i,j,k)
-    enddo ; enddo ; enddo
-  endif
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
+    h_av(i,j,k) = h(i,j,k)
+  enddo ; enddo ; enddo
+!    !$OMP parallel do default(shared)
+!    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+!      h_av(i,j,k) = h(i,j,k)
+!    enddo ; enddo ; enddo
 
   call do_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
   if (G%nonblocking_updates) then
@@ -1098,18 +1078,14 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   endif
 
 ! h_av = (h_in + h_out)/2 . Going in to this line, h_av = h_in.
-  if (CS%CoriolisAdv%USE_WENO) then
-    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js-WENO_stencil,je+WENO_stencil ; do i=is-WENO_stencil,ie+WENO_stencil
-      h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
-    enddo ; enddo ; enddo
-  else
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-      h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
-    enddo ; enddo ; enddo
-  endif
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
+    h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
+  enddo ; enddo ; enddo
+!    !$OMP parallel do default(shared)
+!    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+!      h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
+!    enddo ; enddo ; enddo
 
   if (G%nonblocking_updates) &
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
@@ -1449,7 +1425,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
                           ! recreate the bugs, or if false bugs are only used if actively selected.
   logical :: visc_rem_bug ! Stores the value of runtime paramter VISC_REM_BUG.
-  integer :: WENO_stencil
+  integer :: cor_stencil
 
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
@@ -1465,6 +1441,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
     return
   endif
   CS%module_is_initialized = .true.
+
 
   CS%diag => diag
 
@@ -1601,6 +1578,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
+  cor_stencil = CoriolisAdv_stencil(CS%CoriolisAdv)
   if (CS%calculate_SAL) call SAL_init(h, tv, G, GV, US, param_file, CS%SAL_CSp, restart_CS)
   if (CS%use_tides) then
     call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp, CS%HA_CSp)
@@ -1674,12 +1652,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
                    filename=dirs%input_filename, directory=dirs%restart_input_dir, &
                    success=read_h2, scale=1.0/GV%H_to_mks)
       if (read_uv .and. read_h2) then
-        if (CS%CoriolisAdv%USE_WENO) then
-          WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-          call pass_var(CS%h_av, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init)
-        else
-          call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
-        endif
+        call pass_var(CS%h_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init)
+     !     call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
       else
         ! The computation domain size might need to be increased for the WENO schemes
         do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
@@ -1688,22 +1662,14 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
         do k=1,nz ; do j=jsd,jed ; do i=isd,ied
           CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
         enddo ; enddo ; enddo
-        if (CS%CoriolisAdv%USE_WENO) then
-          WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-          call pass_var(CS%h_av, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init)
-        else
-          call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
-        endif
+        call pass_var(CS%h_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init)
+ !         call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
 
       endif
-      if (CS%CoriolisAdv%USE_WENO) then
-        WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
-        call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init, complete=.false.)
-        call pass_vector(uh, vh, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init, complete=.true.)
-      else
-        call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
-        call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
-      endif
+      call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init, complete=.false.)
+      call pass_vector(uh, vh, G%Domain, halo=cor_stencil, clock=id_clock_pass_init, complete=.true.)
+ !       call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
+ !       call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
       call CorAdCalc(CS%u_av, CS%v_av, CS%h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%ADp, &
                      G, GV, US, CS%CoriolisAdv, pbv) !, Waves=Waves)
       CS%CAu_pred_stored = .true.

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1655,7 +1655,6 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
         call pass_var(CS%h_av, G%Domain, halo=cor_stencil, clock=id_clock_pass_init)
      !     call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
       else
-        ! The computation domain size might need to be increased for the WENO schemes
         do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
         call continuity(CS%u_av, CS%v_av, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
         call pass_var(h_tmp, G%Domain, clock=id_clock_pass_init)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -495,6 +495,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=cor_stencil)
   call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(cor_stencil,vel_stencil))
   call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,vel_stencil))
+  if (cor_stencil > 2) then
+    call create_group_pass(CS%pass_hp_uv, h, G%Domain, halo=cor_stencil)
+  endif
   call create_group_pass(CS%pass_h, h, g%domain, halo=max(cor_stencil,cont_stencil))
   call create_group_pass(CS%pass_av_uvh, u_av, v_av, g%domain, halo=max(cor_stencil,vel_stencil))
   call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,vel_stencil))
@@ -813,7 +816,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   endif
 
   ! h_av = (h + hp)/2
-  call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
   !$OMP parallel do default(shared)
   do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -413,6 +413,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
                             ! in the  corrector step (not the predict)
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil, vel_stencil
+  integer :: WENO_stencil
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -488,14 +489,24 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call create_group_pass(CS%pass_visc_rem, CS%visc_rem_u, CS%visc_rem_v, G%Domain, &
                          To_All+SCALAR_PAIR, CGRID_NE, halo=max(1,cont_stencil))
   call create_group_pass(CS%pass_uvp, up, vp, G%Domain, halo=max(1,cont_stencil))
-  call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=2)
-  call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=vel_stencil)
-  call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=vel_stencil)
-
   call create_group_pass(CS%pass_uv, u_inst, v_inst, G%Domain, halo=max(2,cont_stencil))
-  call create_group_pass(CS%pass_h, h, G%Domain, halo=max(2,cont_stencil))
-  call create_group_pass(CS%pass_av_uvh, u_av, v_av, G%Domain, halo=vel_stencil)
-  call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=vel_stencil)
+
+  if (CS%CoriolisAdv%USE_WENO) then
+    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+    call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=WENO_stencil)
+    call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(WENO_stencil,vel_stencil))
+    call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(WENO_stencil,vel_stencil))
+    call create_group_pass(CS%pass_h, h, g%domain, halo=max(WENO_stencil,cont_stencil))
+    call create_group_pass(CS%pass_av_uvh, u_av, v_av, g%domain, halo=max(WENO_stencil,vel_stencil))
+    call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(WENO_stencil,vel_stencil))
+  else
+    call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=2)
+    call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=vel_stencil)
+    call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=vel_stencil)
+    call create_group_pass(CS%pass_h, h, g%domain, halo=max(2,cont_stencil))
+    call create_group_pass(CS%pass_av_uvh, u_av, v_av, g%domain, halo=vel_stencil)
+    call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=vel_stencil)
+  endif
   call cpu_clock_end(id_clock_pass)
   !--- end set up for group halo pass
 
@@ -805,13 +816,24 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (G%nonblocking_updates) then
     call start_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
+  else
+    call do_group_pass(CS%pass_av_uvh, G%domain, clock=id_clock_pass)
   endif
 
   ! h_av = (h + hp)/2
-  !$OMP parallel do default(shared)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-    h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
-  enddo ; enddo ; enddo
+  if (CS%CoriolisAdv%USE_WENO) then
+    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+    call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-WENO_stencil,je+WENO_stencil ; do i=is-WENO_stencil,ie+WENO_stencil
+      h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
+    enddo ; enddo ; enddo
+  else
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+      h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
+    enddo ; enddo ; enddo
+  endif
 
   ! The correction phase of the time step starts here.
   call enable_averages(dt, Time_local, CS%diag)
@@ -1029,10 +1051,18 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2)")
 
 ! Later, h_av = (h_in + h_out)/2, but for now use h_av to store h_in.
-  !$OMP parallel do default(shared)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-    h_av(i,j,k) = h(i,j,k)
-  enddo ; enddo ; enddo
+  if (CS%CoriolisAdv%USE_WENO) then
+    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-WENO_stencil,je+WENO_stencil ; do i=is-WENO_stencil,ie+WENO_stencil
+      h_av(i,j,k) = h(i,j,k)
+    enddo ; enddo ; enddo
+  else
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+      h_av(i,j,k) = h(i,j,k)
+    enddo ; enddo ; enddo
+  endif
 
   call do_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
   if (G%nonblocking_updates) then
@@ -1068,10 +1098,18 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   endif
 
 ! h_av = (h_in + h_out)/2 . Going in to this line, h_av = h_in.
-  !$OMP parallel do default(shared)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-    h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
-  enddo ; enddo ; enddo
+  if (CS%CoriolisAdv%USE_WENO) then
+    WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-WENO_stencil,je+WENO_stencil ; do i=is-WENO_stencil,ie+WENO_stencil
+      h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
+    enddo ; enddo ; enddo
+  else
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+      h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
+    enddo ; enddo ; enddo
+  endif
 
   if (G%nonblocking_updates) &
     call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
@@ -1411,6 +1449,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
                           ! recreate the bugs, or if false bugs are only used if actively selected.
   logical :: visc_rem_bug ! Stores the value of runtime paramter VISC_REM_BUG.
+  integer :: WENO_stencil
 
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
   integer :: IsdB, IedB, JsdB, JedB
@@ -1635,17 +1674,36 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
                    filename=dirs%input_filename, directory=dirs%restart_input_dir, &
                    success=read_h2, scale=1.0/GV%H_to_mks)
       if (read_uv .and. read_h2) then
-        call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
+        if (CS%CoriolisAdv%USE_WENO) then
+          WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+          call pass_var(CS%h_av, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init)
+        else
+          call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
+        endif
       else
+        ! The computation domain size might need to be increased for the WENO schemes
         do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
         call continuity(CS%u_av, CS%v_av, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
         call pass_var(h_tmp, G%Domain, clock=id_clock_pass_init)
         do k=1,nz ; do j=jsd,jed ; do i=isd,ied
           CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
         enddo ; enddo ; enddo
+        if (CS%CoriolisAdv%USE_WENO) then
+          WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+          call pass_var(CS%h_av, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init)
+        else
+          call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
+        endif
+
       endif
-      call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
-      call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
+      if (CS%CoriolisAdv%USE_WENO) then
+        WENO_stencil = CS%CoriolisAdv%WENO_stencil + 1
+        call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init, complete=.false.)
+        call pass_vector(uh, vh, G%Domain, halo=WENO_stencil, clock=id_clock_pass_init, complete=.true.)
+      else
+        call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
+        call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
+      endif
       call CorAdCalc(CS%u_av, CS%v_av, CS%h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%ADp, &
                      G, GV, US, CS%CoriolisAdv, pbv) !, Waves=Waves)
       CS%CAu_pred_stored = .true.

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -263,7 +263,6 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   type(group_pass_type) :: pass_hp_uv    !< Structure for group halo pass
   type(group_pass_type) :: pass_hp_uhvh  !< Structure for group halo pass
   type(group_pass_type) :: pass_h_uv     !< Structure for group halo pass
-  type(group_pass_type) :: pass_h        !< Structure for group halo pass
 
 end type MOM_dyn_split_RK2b_CS
 
@@ -485,8 +484,11 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 
   call create_group_pass(CS%pass_hp_uhvh, hp, G%Domain, halo=cor_stencil)
   call create_group_pass(CS%pass_hp_uhvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,obc_stencil))
+  if (cor_stencil > 2) then
+    call create_group_pass(CS%pass_hp_uhvh, u_av, v_av, G%Domain, halo=max(cor_stencil,obc_stencil))
+    call create_group_pass(CS%pass_hp_uhvh, h, G%Domain, halo=cor_stencil)
+  endif
 
-  call create_group_pass(CS%pass_h, h, g%domain, halo=max(cor_stencil,cont_stencil))
   call create_group_pass(CS%pass_h_uv, h, G%Domain, halo=max(cor_stencil,cont_stencil))
   call create_group_pass(CS%pass_h_uv, u_av, v_av, G%Domain, halo=max(cor_stencil,obc_stencil))
   call create_group_pass(CS%pass_h_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,obc_stencil))
@@ -545,13 +547,12 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
     call open_boundary_zero_normal_flow(CS%OBC, G, GV, CS%PFu, CS%PFv)
 
   if (G%nonblocking_updates) then
-    call complete_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
+    call complete_group_pass(CS%pass_hp_uhvh, G%Domain, clock=id_clock_pass)
     call start_group_pass(CS%pass_eta, G%Domain, clock=id_clock_pass)
   else
-    call do_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
+    call do_group_pass(CS%pass_hp_uhvh, G%Domain, clock=id_clock_pass)
   endif
 
-  call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
   !$OMP parallel do default(shared)
   do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -46,7 +46,7 @@ use MOM_boundary_update,       only : update_OBC_data, update_OBC_CS
 use MOM_continuity,            only : continuity, continuity_CS
 use MOM_continuity,            only : continuity_init, continuity_stencil
 use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_CS
-use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end
+use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end, CoriolisAdv_stencil
 use MOM_debugging,             only : check_redundant
 use MOM_grid,                  only : ocean_grid_type
 use MOM_harmonic_analysis,     only : harmonic_analysis_CS
@@ -263,6 +263,7 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   type(group_pass_type) :: pass_hp_uv    !< Structure for group halo pass
   type(group_pass_type) :: pass_hp_uhvh  !< Structure for group halo pass
   type(group_pass_type) :: pass_h_uv     !< Structure for group halo pass
+  type(group_pass_type) :: pass_h        !< Structure for group halo pass
 
 end type MOM_dyn_split_RK2b_CS
 
@@ -402,6 +403,7 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil
+  integer :: cor_stencil
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -466,6 +468,7 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 
   cont_stencil = continuity_stencil(CS%continuity_CSp)
   obc_stencil = 2
+  cor_stencil = CoriolisAdv_stencil(CS%CoriolisAdv)
   if (associated(CS%OBC)) then
     if (CS%OBC%oblique_BCs_exist_globally) obc_stencil = 3
   endif
@@ -476,16 +479,17 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
   call create_group_pass(CS%pass_uvp, up, vp, G%Domain, halo=max(1,cont_stencil))
   call create_group_pass(CS%pass_uv_inst, u_inst, v_inst, G%Domain, halo=max(2,cont_stencil))
 
-  call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=2)
-  call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(2,obc_stencil))
-  call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+  call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=cor_stencil)
+  call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(cor_stencil,obc_stencil))
+  call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,obc_stencil))
 
-  call create_group_pass(CS%pass_hp_uhvh, hp, G%Domain, halo=2)
-  call create_group_pass(CS%pass_hp_uhvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+  call create_group_pass(CS%pass_hp_uhvh, hp, G%Domain, halo=cor_stencil)
+  call create_group_pass(CS%pass_hp_uhvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,obc_stencil))
 
-  call create_group_pass(CS%pass_h_uv, h, G%Domain, halo=max(2,cont_stencil))
-  call create_group_pass(CS%pass_h_uv, u_av, v_av, G%Domain, halo=max(2,obc_stencil))
-  call create_group_pass(CS%pass_h_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+  call create_group_pass(CS%pass_h, h, g%domain, halo=max(cor_stencil,cont_stencil))
+  call create_group_pass(CS%pass_h_uv, h, G%Domain, halo=max(cor_stencil,cont_stencil))
+  call create_group_pass(CS%pass_h_uv, u_av, v_av, G%Domain, halo=max(cor_stencil,obc_stencil))
+  call create_group_pass(CS%pass_h_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(cor_stencil,obc_stencil))
 
   call cpu_clock_end(id_clock_pass)
   !--- end set up for group halo pass
@@ -541,14 +545,15 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
     call open_boundary_zero_normal_flow(CS%OBC, G, GV, CS%PFu, CS%PFv)
 
   if (G%nonblocking_updates) then
-    call complete_group_pass(CS%pass_hp_uhvh, G%Domain, clock=id_clock_pass)
+    call complete_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
     call start_group_pass(CS%pass_eta, G%Domain, clock=id_clock_pass)
   else
-    call do_group_pass(CS%pass_hp_uhvh, G%Domain, clock=id_clock_pass)
+    call do_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
   endif
 
+  call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
   !$OMP parallel do default(shared)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
   enddo ; enddo ; enddo
 
@@ -803,7 +808,7 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 
   ! h_av = (h + hp)/2
   !$OMP parallel do default(shared)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
   enddo ; enddo ; enddo
 

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -73,7 +73,7 @@ use MOM_ALE, only : ALE_CS
 use MOM_boundary_update, only : update_OBC_data, update_OBC_CS
 use MOM_barotropic, only : barotropic_CS
 use MOM_continuity, only : continuity, continuity_init, continuity_CS, continuity_stencil
-use MOM_CoriolisAdv, only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS
+use MOM_CoriolisAdv, only : CorAdCalc, CoriolisAdv_init, CoriolisAdv_CS, CoriolisAdv_stencil
 use MOM_debugging, only : check_redundant
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
@@ -252,9 +252,11 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   real :: dt_visc   ! The time step for a part of the update due to viscosity [T ~> s]
   logical :: dyn_p_surf
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+  integer :: cor_stencil  ! Stencil size for Coriolis schemes [nondim]
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   dt_pred = dt * CS%BE
+  cor_stencil = CoriolisAdv_stencil(CS%CoriolisAdv) 
 
   h_av(:,:,:) = 0; hp(:,:,:) = 0
   up(:,:,:) = 0
@@ -292,12 +294,16 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   ! and could/should be optimized out. -AJA
   call continuity(u_in, v_in, h_in, hp, uh, vh, dt_pred, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
   call cpu_clock_end(id_clock_continuity)
-  call pass_var(hp, G%Domain, clock=id_clock_pass)
-  call pass_vector(uh, vh, G%Domain, clock=id_clock_pass)
+  call pass_var(hp, G%Domain, halo=cor_stencil, clock=id_clock_pass)
+  call pass_vector(uh, vh, G%Domain, halo=cor_stencil, clock=id_clock_pass)
+  if (cor_stencil > 2) then
+    call pass_vector(u_in, v_in, G%Domain, halo=cor_stencil, clock=id_clock_pass)
+    call pass_var(h_in, G%Domain, halo=cor_stencil, clock=id_clock_pass)
+  endif
 
 ! h_av = (h + hp)/2  (used in PV denominator)
   call cpu_clock_begin(id_clock_mom_update)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = (h_in(i,j,k) + hp(i,j,k)) * 0.5
   enddo ; enddo ; enddo
   call cpu_clock_end(id_clock_mom_update)
@@ -362,11 +368,17 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   call cpu_clock_begin(id_clock_continuity)
   call continuity(up, vp, h_in, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
   call cpu_clock_end(id_clock_continuity)
-  call pass_var(hp, G%Domain, clock=id_clock_pass)
-  call pass_vector(uh, vh, G%Domain, clock=id_clock_pass)
+  if (cor_stencil > 2) then
+    call pass_var(hp, G%Domain, halo=cor_stencil, clock=id_clock_pass)
+    call pass_vector(uh, vh, G%Domain, clock=id_clock_pass)
+    call pass_vector(up, vp, G%Domain, halo=cor_stencil, clock=id_clock_pass)
+  else
+    call pass_var(hp, G%Domain, clock=id_clock_pass)
+    call pass_vector(uh, vh, G%Domain, clock=id_clock_pass)
+  endif
 
 ! h_av <- (h + hp)/2   (centered at n-1/2)
-  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+  do k=1,nz ; do j=js-cor_stencil,je+cor_stencil ; do i=is-cor_stencil,ie+cor_stencil
     h_av(i,j,k) = (h_in(i,j,k) + hp(i,j,k)) * 0.5
   enddo ; enddo ; enddo
 

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -256,7 +256,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   dt_pred = dt * CS%BE
-  cor_stencil = CoriolisAdv_stencil(CS%CoriolisAdv) 
+  cor_stencil = CoriolisAdv_stencil(CS%CoriolisAdv)
 
   h_av(:,:,:) = 0; hp(:,:,:) = 0
   up(:,:,:) = 0

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -174,7 +174,6 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, US, param_file, just_read)
                           ! higher values use mathematically equivalent expressions that are fully
                           ! rescalable.
   integer :: i, j, k, is, ie, js, je, nz, m
-!  logical :: just_read    ! If true, just read parameters but set nothing.
   logical :: reentrant_y  ! If true, model is re-entrant in the y direction
   character(len=40)  :: mdl = "Phillips_initialize_velocity" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -58,7 +58,6 @@ subroutine Phillips_initialize_thickness(h, depth_tot, G, GV, US, param_file, ju
   real :: half_depth      ! The depth where the stratification is centered [Z ~> m]
   real :: km_to_grid_unit ! The conversion factor from km to the units of latitude, often 1 [nondim],
                           ! but this could be 1000 [m km-1]
-  logical :: just_read    ! If true, just read parameters but set nothing.
   logical :: reentrant_y  ! If true, model is re-entrant in the y direction
   character(len=40)  :: mdl = "Phillips_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
@@ -175,7 +174,7 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, US, param_file, just_read)
                           ! higher values use mathematically equivalent expressions that are fully
                           ! rescalable.
   integer :: i, j, k, is, ie, js, je, nz, m
-  logical :: just_read    ! If true, just read parameters but set nothing.
+!  logical :: just_read    ! If true, just read parameters but set nothing.
   logical :: reentrant_y  ! If true, model is re-entrant in the y direction
   character(len=40)  :: mdl = "Phillips_initialize_velocity" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -58,6 +58,7 @@ subroutine Phillips_initialize_thickness(h, depth_tot, G, GV, US, param_file, ju
   real :: half_depth      ! The depth where the stratification is centered [Z ~> m]
   real :: km_to_grid_unit ! The conversion factor from km to the units of latitude, often 1 [nondim],
                           ! but this could be 1000 [m km-1]
+  logical :: just_read    ! If true, just read parameters but set nothing.
   logical :: reentrant_y  ! If true, model is re-entrant in the y direction
   character(len=40)  :: mdl = "Phillips_initialize_thickness" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
@@ -174,6 +175,7 @@ subroutine Phillips_initialize_velocity(u, v, G, GV, US, param_file, just_read)
                           ! higher values use mathematically equivalent expressions that are fully
                           ! rescalable.
   integer :: i, j, k, is, ie, js, je, nz, m
+  logical :: just_read    ! If true, just read parameters but set nothing.
   logical :: reentrant_y  ! If true, model is re-entrant in the y direction
   character(len=40)  :: mdl = "Phillips_initialize_velocity" ! This subroutine's name.
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke


### PR DESCRIPTION
Added a 7th-, 5th- and 3rd-order WENO schemes to reconstruct the PV and added the Koren scheme to reconstruct the kinetic energy in MOM_CoriolisAdv. These schemes, especially the 7th-order WENO + Koren, have been tested in idealized and realistic MOM6 simulations. Compared with the existing Coriolis schemes, the new schemes substantially reduce dispersive errors and yield numerically stable simulation without using any lateral (Laplacian or biharmonic) viscosities. Additionally, mesoscale eddies are better resolved and become more energetic with the new scheme. A manuscript documenting the numerics and the idealized simulation results has been submitted to JAMES (https://doi.org/10.22541/essoar.175339141.10871701/v1). Here are a few technical details for the new schemes:

    - Set CORIOLIS_SCHEME = "WENOVI7TH_PV_ENSTRO", "WENOVI5TH_PV_ENSTRO", "WENOVI3RD_PV_ENSTRO" to use a 7th-, 5th-, and 3rd-order WENO scheme, respectively, to reconstruct PV.
    - Set KE_SCHEME = "KE_UP3" to use a third-order upwind scheme with the Koren flux limiter to reconstruct the kinetic energy. Set KE_USE_LIMITER = False (default is True) to not use the flux limiter. The KE_UP3 scheme is recommended to be used along with the WENO Coriolis schemes.
    - Set WENO_VELOCITY_SMOOTH = True to use the velocity field to estimate the smoothness indicator for WENO. This scheme tends to yield higher-order of accuracy and thus more energetic eddy fields.
    - The WENO schemes conduct a thickness-weighted reconstruction for PV to avoid PV singularities.
    - The order of WENO is reduced to 5th, 3rd, and 1st subsequently when it approaches lateral boundaries
    - The halo size is 5 and 4 for the 7th- and 5th-order WENO schemes. When they are used, parameters USE_WENO and WENO_stencil are passed to MOM_dynamics_split_RK2 to increase the halo update size. Only MOM_dynamics_split_RK2 is changed now, while the other RK2 modules will need to be updated later.