### PR TITLE
Fix frazil halo update bug when unallocated

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1966,7 +1966,8 @@ subroutine post_diabatic_halo_updates(CS, G, GV, US, u, v, h, tv)
   call create_group_pass(pass_uv_T_S_h, h, G%Domain, halo=dynamics_stencil)
   call do_group_pass(pass_uv_T_S_h, G%Domain, clock=id_clock_pass)
 
-  if ((.not.tv%frazil_was_reset) .and. CS%vertex_shear) call pass_var(tv%frazil, G%Domain, halo=1)
+  if (associated(tv%frazil) .and. (.not.tv%frazil_was_reset) .and. CS%vertex_shear) &
+    call pass_var(tv%frazil, G%Domain, halo=1)
 
   ! Update derived thermodynamic quantities.
   if (allocated(tv%SpV_avg)) then


### PR DESCRIPTION
If FRAZIL=False tv%frazil is not allocated but its halo might still be updated in post_diabatic_halo_updates, which will fail.

If FRAZIL=True, no answers are changed.

If FRAZIL=False, no answers from before this bug was introduced are changed.