### PR TITLE
+Set masks with OBCs and avoid projecting data for OBCs

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -2198,6 +2198,7 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv, US)
     segment => OBC%segment(n)
     if (.not. (segment%on_pe .and. segment%open)) cycle
     ! Set the OBCmask values to help eliminate certain terms at u- or v- OBC points.
+    ! Testing suggests this could be applied at all u- or v- OBC points without changing answers.
     if (segment%is_E_or_W) then
       I=segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -61,7 +61,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
   ! Local variables
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
-  logical            :: read_porous_file
+  logical            :: read_porous_file, OBC_projection_bug, open_corners, enable_bugs
   character(len=40)  :: mdl = "MOM_fixed_initialization" ! This module's name.
   integer :: I, J
   logical :: debug
@@ -91,11 +91,23 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
   call open_boundary_config(G, US, PF, OBC)
 
   ! Make bathymetry consistent with open boundaries
-  call open_boundary_impose_normal_slope(OBC, G, G%bathyT)
+  call get_param(PF, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
+                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
+  call get_param(PF, mdl, "OBC_PROJECTION_BUG", OBC_projection_bug, &
+                 "If false, use only interior ocean points at OBCs to specify several "//&
+                 "calculations at OBC points, and it avoids applying a land mask at the bay-like "//&
+                 "intersection of orthogonal OBC segments.  Otherwise the calculation of terms "//&
+                 "like the potential vorticity used in the barotropic solver relies on bathymetry "//&
+                 "or other fields being projected outward across OBCs.  This option changes "//&
+                 "answers for some configurations that use OBCs.", &
+                 default=enable_bugs, do_not_log=.not.associated(OBC))
+  open_corners = .not.OBC_projection_bug
 
   ! This call sets masks that prohibit flow over any point interpreted as land
   if (associated(OBC)) then
-    call initialize_masks(G, PF, US, OBC_dir_u=OBC%segnum_u, OBC_dir_v=OBC%segnum_v)
+    if (OBC_projection_bug) &
+      call open_boundary_impose_normal_slope(OBC, G, G%bathyT)
+    call initialize_masks(G, PF, US, OBC_dir_u=OBC%segnum_u, OBC_dir_v=OBC%segnum_v, open_corner_OBCs=open_corners)
   else
     call initialize_masks(G, PF, US)
   endif

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -94,7 +94,11 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
   call open_boundary_impose_normal_slope(OBC, G, G%bathyT)
 
   ! This call sets masks that prohibit flow over any point interpreted as land
-  call initialize_masks(G, PF, US)
+  if (associated(OBC)) then
+    call initialize_masks(G, PF, US, OBC_dir_u=OBC%segnum_u, OBC_dir_v=OBC%segnum_v)
+  else
+    call initialize_masks(G, PF, US)
+  endif
 
   ! Make OBC mask consistent with land mask
   call open_boundary_impose_land_mask(OBC, G, G%areaCu, G%areaCv, US)

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -1182,16 +1182,33 @@ end function Adcroft_reciprocal
 !! flow over any points which are shallower than Dmask and permit an
 !! appropriate treatment of the boundary conditions.  mask2dCu and mask2dCv
 !! are 0.0 at any points adjacent to a land point.  mask2dBu is 0.0 at
-!! any land or boundary point.  For points in the interior, mask2dCu,
-!! mask2dCv, and mask2dBu are all 1.0.
-subroutine initialize_masks(G, PF, US)
+!! any land or boundary point.  For points in the ocean interior or at open boundary
+!! condition points, mask2dCu, mask2dCv, and mask2dBu are all 1.0.
+subroutine initialize_masks(G, PF, US, OBC_dir_u, OBC_dir_v, open_corner_OBCs)
   type(dyn_horgrid_type), intent(inout) :: G  !< The dynamic horizontal grid type
   type(param_file_type),  intent(in)    :: PF !< Parameter file structure
   type(unit_scale_type),  intent(in)    :: US !< A dimensional unit scaling type
+  integer, dimension(G%IsdB:G%IedB,G%jsd:G%jed), &
+                optional, intent(in)    :: OBC_dir_u  !< Trinary values that indicate whether there
+                                              !! is an open boundary condition at zonal velocity
+                                              !! faces and their orientation, with 0 for no OBC,
+                                              !! a positive value for an Eastern OBC and
+                                              !! a negative value for a Western OBC.
+  integer, dimension(G%isd:G%ied,G%JsdB:G%JedB), &
+                optional, intent(in)    :: OBC_dir_v  !< Trinary values that indicate whether there
+                                              !! is an open boundary condition at zonal velocity
+                                              !! faces and their orientation, with 0 for no OBC,
+                                              !! a positive value for a Northern OBC and
+                                              !! a negative value for a Southern OBC.
+  logical,      optional, intent(in)   :: open_corner_OBCs  !< If present and true, the bay-like corner
+                                              !! between two orthogonal open boundary segments is open,
+                                              !! otherwise it is closed.
+
   ! Local variables
   real :: Dmask      ! The depth for masking in the same units as G%bathyT [Z ~> m].
   real :: min_depth  ! The minimum ocean depth in the same units as G%bathyT [Z ~> m].
   real :: mask_depth ! The depth shallower than which to mask a point as land [Z ~> m].
+  logical :: open_corners ! If true, the bay-like corner between two orthogonal open boundary segments is open
   character(len=40)  :: mdl = "MOM_grid_init initialize_masks"
   integer :: i, j
 
@@ -1212,6 +1229,8 @@ subroutine initialize_masks(G, PF, US)
   Dmask = mask_depth
   if (mask_depth == -9999.0*US%m_to_Z) Dmask = min_depth
 
+  open_corners = .false. ; if (present(open_corner_OBCs)) open_corners = open_corner_OBCs
+
   G%mask2dCu(:,:) = 0.0 ; G%mask2dCv(:,:) = 0.0 ; G%mask2dBu(:,:) = 0.0
 
   ! Construct the h-point or T-point mask
@@ -1229,6 +1248,20 @@ subroutine initialize_masks(G, PF, US)
     else
       G%mask2dCu(I,j) = 1.0
     endif
+  enddo ; enddo
+
+  if (present(OBC_dir_u)) then
+    do j=G%jsd,G%jed ; do I=G%isd,G%ied-1
+      if (OBC_dir_u(I,j) > 0) then
+        if (G%bathyT(i,j) > Dmask) G%mask2dCu(I,j) = 1.0
+      endif
+      if (OBC_dir_u(I,j) < 0) then
+        if (G%bathyT(i+1,j) > Dmask) G%mask2dCu(I,j) = 1.0
+      endif
+    enddo ; enddo
+  endif
+
+  do j=G%jsd,G%jed ; do I=G%isd,G%ied-1
     ! This mask may be revised later after the open boundary positions are specified.
     G%OBCmaskCu(I,j) = G%mask2dCu(I,j)
   enddo ; enddo
@@ -1239,18 +1272,59 @@ subroutine initialize_masks(G, PF, US)
     else
       G%mask2dCv(i,J) = 1.0
     endif
+  enddo ; enddo
+
+  if (present(OBC_dir_v)) then
+    do J=G%jsd,G%jed-1 ; do i=G%isd,G%ied
+      if (OBC_dir_v(i,J) > 0) then
+        if (G%bathyT(i,j) > Dmask) G%mask2dCv(i,J) = 1.0
+      endif
+      if (OBC_dir_v(i,J) < 0) then
+        if (G%bathyT(i,j+1) > Dmask) G%mask2dCv(i,J) = 1.0
+      endif
+    enddo ; enddo
+  endif
+
+  do J=G%jsd,G%jed-1 ; do i=G%isd,G%ied
     ! This mask may be revised later after the open boundary positions are specified.
     G%OBCmaskCv(i,J) = G%mask2dCv(i,J)
   enddo ; enddo
 
+  ! The mask at the vertex can be determined from the masks at the faces.
+  ! This works at interior ocean points or at convex OBC points.
   do J=G%jsd,G%jed-1 ; do I=G%isd,G%ied-1
-    if ((G%bathyT(i+1,j) <= Dmask) .or. (G%bathyT(i+1,j+1) <= Dmask) .or. &
-        (G%bathyT(i,j) <= Dmask) .or. (G%bathyT(i,j+1) <= Dmask)) then
-      G%mask2dBu(I,J) = 0.0
-    else
-      G%mask2dBu(I,J) = 1.0
-    endif
+    G%mask2dBu(I,J) = (G%mask2dCu(I,j) * G%mask2dCu(I,j+1)) * (G%mask2dCv(i,J) * G%mask2dCv(i+1,J))
   enddo ; enddo
+
+  ! This block resets masks at the vertices when there are OBCs.  The right logic is that if there
+  ! are 2 or more unmasked OBCs, this point should be open, but to recreate the previous answers,
+  if (present(OBC_dir_u)) then
+    do J=G%jsd,G%jed-1 ; do I=G%isd,G%ied-1
+      ! These are conditions to set open vertex points on a straight north-south coastline
+      if ((G%mask2dCu(I,j) * OBC_dir_u(I,j)) * (G%mask2dCu(I,j+1) * OBC_dir_u(I,j+1)) > 0.) &
+        G%mask2dBu(I,J) = 1.0
+    enddo ; enddo
+  endif
+  if (present(OBC_dir_v)) then
+    do J=G%jsd,G%jed-1 ; do I=G%isd,G%ied-1
+      ! These are conditions to set open vertex points on a straight east-west coastline
+      if ((G%mask2dCv(i,J) * OBC_dir_v(i,J)) * (G%mask2dCv(i+1,J) * OBC_dir_v(i+1,J)) > 0.) &
+        G%mask2dBu(I,J) = 1.0
+    enddo ; enddo
+  endif
+  if (open_corners .and. present(OBC_dir_u) .and. present(OBC_dir_v)) then
+    do J=G%jsd,G%jed-1 ; do I=G%isd,G%ied-1
+      ! These are the 4 conditions to set an open point in a concave (bay-like) corner
+      if ((G%mask2dCu(I,j+1) * OBC_dir_u(I,j+1) < 0.) .and. (G%mask2dCv(i+1,J) * OBC_dir_v(i+1,J) < 0.)) &
+         G%mask2dBu(I,J) = 1.0  ! Southwestern corner
+      if ((G%mask2dCu(I,j+1) * OBC_dir_u(I,j+1) > 0.) .and. (G%mask2dCv(i,J) * OBC_dir_v(i,J) < 0.)) &
+         G%mask2dBu(I,J) = 1.0  ! Southeastern corner
+      if ((G%mask2dCu(I,j) * OBC_dir_u(I,j) < 0.) .and. (G%mask2dCv(i+1,J) * OBC_dir_v(i+1,J) > 0.)) &
+         G%mask2dBu(I,J) = 1.0  ! Northwestern corner
+      if ((G%mask2dCu(I,j) * OBC_dir_u(I,j) > 0.) .and. (G%mask2dCv(i,J) * OBC_dir_v(i,J) > 0.)) &
+         G%mask2dBu(I,J) = 1.0  ! Northeastern corner
+    enddo ; enddo
+  endif
 
   call pass_var(G%mask2dBu, G%Domain, position=CORNER)
   call pass_vector(G%mask2dCu, G%mask2dCv, G%Domain, To_All+Scalar_Pair, CGRID_NE)


### PR DESCRIPTION
  This PR consists of two commits, the first of which adds the ability to take open boundary conditions into account when setting up the masks, by providing the new optional arguments `OBC_dir_u` and `OBC_dir_v` in calls to `initialize_masks()`.  The second adds the option to avoid using exterior data at open boundary condition points, and to avoid projecting information outside across open boundary condition faces.  The second commit also includes the run-time configurable option to set the corner point land-mask at the bay-like intersection of open boundary conditions to be unmasked so that open boundary conditions can be applied there, using capabilities that were added in the first commit.

  The option to avoid projecting data to the exterior behind OBC faces is enabled by setting the new runtime parameter `OBC_PROJECTION_BUG = False`.  To implement these changes, the weights for the barotropic solver to use when interpolating total thickness onto vorticity points to calculate the barotropic potential vorticity for use in the Coriolis scheme are now being stored in the new `q_wt` element in the barotropic control structure.  These weights are set up during initialization with information about open boundary conditions optionally taken into account.  In addition the total thicknesses at open boundary velocity points that are combined with the potential vorticities to give the barotropic Coriolis terms are always taken from the interior of an OBC face.  Some inconsistencies in the units of a negligible but positive cell volume in the denominator of the barotropic PVs were also corrected in a way that will not change answers when dimensional rescaling is not being applied.

  By default all answers are bitwise identical, but answers in cases with open boundary conditions do change when these new capabilities are enabled, and there is a new parameter in the MOM_parameter_doc files for cases that use open boundary conditions.  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@30ff9d922 +Optionally avoid projecting data for OBCs
 - NOAA-GFDL/MOM6@1343eb200 +Use OBCs to set masks
