### PR TITLE
makedep: Update interpreter directive to python3

### DIFF
--- a/ac/makedep
+++ b/ac/makedep
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 


### PR DESCRIPTION
The interpreter directive ("shebang") of makedep is updated to `python3`, rather than the version-agnostic `python`.

Although we never invoke the shebang of the script, there are OS environments out there which will object to any presence of a versionless python.  PEP 394 also strongly recommends the adoption of python3 as the executable name, regardless of Py2 support.