### PR TITLE
+Use I0 format to simplify integer output

### DIFF
--- a/src/ALE/MOM_hybgen_regrid.F90
+++ b/src/ALE/MOM_hybgen_regrid.F90
@@ -988,12 +988,12 @@ subroutine hybgen_column_regrid(CS, nk, thkbot, Rcv_tgt, &
     ! Verify that everything is consistent.
     do k=1,nk
       if (abs((h_col(k) - h_in(k)) + (dp_int(K) - dp_int(K+1))) > 1.0e-13*max(p_int(nk+1), CS%onem)) then
-        write(mesg, '("k ",i4," h ",es13.4," h_in ",es13.4, " dp ",2es13.4," err ",es13.4)') &
+        write(mesg, '("k ",I0," h ",es13.4," h_in ",es13.4, " dp ",2es13.4," err ",es13.4)') &
               k, h_col(k), h_in(k), dp_int(K), dp_int(K+1), (h_col(k) - h_in(k)) + (dp_int(K) - dp_int(K+1))
         call MOM_error(FATAL, "Mismatched thickness changes in hybgen_regrid: "//trim(mesg))
       endif
       if (h_col(k) < 0.0) then ! Could instead do: -1.0e-15*max(p_int(nk+1), CS%onem)) then
-        write(mesg, '("k ",i4," h ",es13.4," h_in ",es13.4, " dp ",2es13.4, " fixlay ",i4)') &
+        write(mesg, '("k ",I0," h ",es13.4," h_in ",es13.4, " dp ",2es13.4, " fixlay ",I0)') &
               k, h_col(k), h_in(k), dp_int(K), dp_int(K+1), fixlay
         call MOM_error(FATAL, "Significantly negative final thickness in hybgen_regrid: "//trim(mesg))
       endif

--- a/src/ALE/MOM_hybgen_unmix.F90
+++ b/src/ALE/MOM_hybgen_unmix.F90
@@ -274,18 +274,18 @@ subroutine hybgen_unmix(G, GV, US, CS, tv, Reg, ntr, h)
         Trh_tot_out(m) = Trh_tot_out(m) + h_col(k)*tracer(k,m)
       enddo ; enddo
       if (abs(Sh_tot_in - Sh_tot_out) > 1.e-15*(abs(Sh_tot_in) + abs(Sh_tot_out))) then
-        write(mesg, '("i,j=",2i8,"Sh_tot = ",2es17.8," err = ",es13.4)') &
+        write(mesg, '("i,j=",I0,",",I0," Sh_tot = ",2es17.8," err = ",es13.4)') &
               i, j, Sh_tot_in, Sh_tot_out, (Sh_tot_in - Sh_tot_out)
         call MOM_error(FATAL, "Mismatched column salinity in hybgen_unmix: "//trim(mesg))
       endif
       if (abs(Th_tot_in - Th_tot_out) > 1.e-10*(abs(Th_tot_in) + abs(Th_tot_out))) then
-        write(mesg, '("i,j=",2i8,"Th_tot = ",2es17.8," err = ",es13.4)') &
+        write(mesg, '("i,j=",I0,",",I0," Th_tot = ",2es17.8," err = ",es13.4)') &
               i, j, Th_tot_in, Th_tot_out, (Th_tot_in - Th_tot_out)
         call MOM_error(FATAL, "Mismatched column temperature in hybgen_unmix: "//trim(mesg))
       endif
       do m=1,ntr
         if (abs(Trh_tot_in(m) - Trh_tot_out(m)) > 1.e-10*(abs(Trh_tot_in(m)) + abs(Trh_tot_out(m)))) then
-          write(mesg, '("i,j=",2i8,"Trh_tot(",i2,") = ",2es17.8," err = ",es13.4)') &
+          write(mesg, '("i,j=",I0,",",I0," Trh_tot(",i0,") = ",2es17.8," err = ",es13.4)') &
                 i, j, m, Trh_tot_in(m), Trh_tot_out(m), (Trh_tot_in(m) - Trh_tot_out(m))
           call MOM_error(FATAL, "Mismatched column tracer in hybgen_unmix: "//trim(mesg))
         endif

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -574,12 +574,12 @@ subroutine check_reconstructions_1d(n0, h0, u0, deg, boundary_extrapolation, &
       u_min = min(u_l, u_c)
       u_max = max(u_l, u_c)
       if (ppoly_r_E(i0,1) < u_min) then
-        write(0,'(a,i4,5(1x,a,1pe24.16))') 'Left edge undershoot at',i0,'u(i0-1)=',u_l,'u(i0)=',u_c, &
+        write(0,'(a,I0,5(1x,a,1pe24.16))') 'Left edge undershoot at ',i0,'u(i0-1)=',u_l,'u(i0)=',u_c, &
                                            'edge=',ppoly_r_E(i0,1),'err=',ppoly_r_E(i0,1)-u_min
         problem_detected = .true.
       endif
       if (ppoly_r_E(i0,1) > u_max) then
-        write(0,'(a,i4,5(1x,a,1pe24.16))') 'Left edge overshoot at',i0,'u(i0-1)=',u_l,'u(i0)=',u_c, &
+        write(0,'(a,I0,5(1x,a,1pe24.16))') 'Left edge overshoot at ',i0,'u(i0-1)=',u_l,'u(i0)=',u_c, &
                                            'edge=',ppoly_r_E(i0,1),'err=',ppoly_r_E(i0,1)-u_max
         problem_detected = .true.
       endif
@@ -588,19 +588,19 @@ subroutine check_reconstructions_1d(n0, h0, u0, deg, boundary_extrapolation, &
       u_min = min(u_c, u_r)
       u_max = max(u_c, u_r)
       if (ppoly_r_E(i0,2) < u_min) then
-        write(0,'(a,i4,5(1x,a,1pe24.16))') 'Right edge undershoot at',i0,'u(i0)=',u_c,'u(i0+1)=',u_r, &
+        write(0,'(a,I0,5(1x,a,1pe24.16))') 'Right edge undershoot at ',i0,'u(i0)=',u_c,'u(i0+1)=',u_r, &
                                            'edge=',ppoly_r_E(i0,2),'err=',ppoly_r_E(i0,2)-u_min
         problem_detected = .true.
       endif
       if (ppoly_r_E(i0,2) > u_max) then
-        write(0,'(a,i4,5(1x,a,1pe24.16))') 'Right edge overshoot at',i0,'u(i0)=',u_c,'u(i0+1)=',u_r, &
+        write(0,'(a,I0,5(1x,a,1pe24.16))') 'Right edge overshoot at ',i0,'u(i0)=',u_c,'u(i0+1)=',u_r, &
                                            'edge=',ppoly_r_E(i0,2),'err=',ppoly_r_E(i0,2)-u_max
         problem_detected = .true.
       endif
     endif
     if (i0 > 1) then
       if ( (u_c-u_l)*(ppoly_r_E(i0,1)-ppoly_r_E(i0-1,2)) < 0.) then
-        write(0,'(a,i4,5(1x,a,1pe24.16))') 'Non-monotonic edges at',i0,'u(i0-1)=',u_l,'u(i0)=',u_c, &
+        write(0,'(a,I0,5(1x,a,1pe24.16))') 'Non-monotonic edges at',i0,'u(i0-1)=',u_l,'u(i0)=',u_c, &
                                            'right edge=',ppoly_r_E(i0-1,2),'left edge=',ppoly_r_E(i0,1)
         write(0,'(5(a,1pe24.16,1x))') 'u(i0)-u(i0-1)',u_c-u_l,'edge diff=',ppoly_r_E(i0,1)-ppoly_r_E(i0-1,2)
         problem_detected = .true.
@@ -611,7 +611,7 @@ subroutine check_reconstructions_1d(n0, h0, u0, deg, boundary_extrapolation, &
       write(0,'(3(a,1pe24.16,1x))') 'u_l=',u_l,'u_c=',u_c,'u_r=',u_r
       write(0,'(a4,10a24)') 'i0','h0(i0)','u0(i0)','left edge','right edge','Polynomial coefficients'
       do n = 1, n0
-        write(0,'(i4,1p10e24.16)') n,h0(n),u0(n),ppoly_r_E(n,1),ppoly_r_E(n,2),ppoly_r_coefs(n,:)
+        write(0,'(I0,1p10e24.16)') n,h0(n),u0(n),ppoly_r_E(n,1),ppoly_r_E(n,2),ppoly_r_coefs(n,:)
       enddo
       call MOM_error(FATAL, 'MOM_remapping, check_reconstructions_1d: '// &
                    'Edge values or polynomial coefficients were inconsistent!')
@@ -1861,7 +1861,7 @@ subroutine test_recon_consistency(test, scheme, n0, niter, h_neglect)
   integer :: iter ! Loop counter
   integer :: seed_size ! Number of integers used by seed
   integer, allocatable :: seed(:) ! Random number seed
-  character(len=8) :: label ! Generated label
+  character(len=16) :: label ! Generated label
 
   call initialize_remapping(remapCS, scheme, nk=n0, h_neglect=h_neglect, &
                             force_bounds_in_subcell=.false. )
@@ -1889,8 +1889,8 @@ subroutine test_recon_consistency(test, scheme, n0, niter, h_neglect)
 
   enddo
 
-  write(label(1:8),'(i8)') niter
-  call test%test( error, trim(adjustl(label))//' consistency tests of '//scheme )
+  write(label,'(I0)') niter
+  call test%test( error, trim(label)//' consistency tests of '//scheme )
 
   call remapCS%reconstruction%destroy()
 
@@ -1911,7 +1911,7 @@ subroutine test_preserve_uniform(test, scheme, n0, niter, h_neglect)
   integer :: iter ! Loop counter
   integer :: seed_size ! Number of integers used by seed
   integer, allocatable :: seed(:) ! Random number seed
-  character(len=8) :: label ! Generated label
+  character(len=16) :: label ! Generated label
 
   call initialize_remapping(remapCS, scheme, nk=n0, h_neglect=h_neglect, &
                             force_bounds_in_subcell=.true., &
@@ -1947,8 +1947,8 @@ subroutine test_preserve_uniform(test, scheme, n0, niter, h_neglect)
 
   enddo
 
-  write(label(1:8),'(i8)') niter
-  call test%test( error, trim(adjustl(label))//' uniformity tests of '//scheme )
+  write(label,'(I0)') niter
+  call test%test( error, trim(label)//' uniformity tests of '//scheme )
 
 end subroutine test_preserve_uniform
 
@@ -1970,7 +1970,7 @@ subroutine test_unchanged_grid(test, scheme, n0, niter, h_neglect)
   real :: u0(n0), u1(n0) ! Source and target values [A]
   logical :: error ! Indicates a divergence
   integer :: iter ! Loop counter
-  character(len=8) :: label ! Generated label
+  character(len=16) :: label ! Generated label
 
   call initialize_remapping(remapCS, scheme, nk=n0, h_neglect=h_neglect, &
                             force_bounds_in_subcell=.true., &
@@ -2000,8 +2000,8 @@ subroutine test_unchanged_grid(test, scheme, n0, niter, h_neglect)
 
   enddo
 
-  write(label(1:8),'(i8)') niter
-  call test%test( error, trim(adjustl(label))//' unchanged grid tests of '//scheme )
+  write(label,'(I0)') niter
+  call test%test( error, trim(label)//' unchanged grid tests of '//scheme )
 
   call remapCS%reconstruction%destroy()
 
@@ -2025,7 +2025,7 @@ subroutine compare_two_schemes(test, CS1, CS2, n0, n1, niter, msg)
   integer :: iter ! Loop counter
   integer :: seed_size ! Number of integers used by seed
   integer, allocatable :: seed(:) ! Random number seed
-  character(len=8) :: label ! Generated label
+  character(len=16) :: label ! Generated label
 
   call random_seed(size=seed_size)
   allocate( seed(seed_Size) )
@@ -2061,8 +2061,8 @@ subroutine compare_two_schemes(test, CS1, CS2, n0, n1, niter, msg)
     endif
   enddo
 
-  write(label(1:8),'(i8)') niter
-  call test%test( error, trim(adjustl(label))//' comparisons of '//msg )
+  write(label,'(I0)') niter
+  call test%test( error, trim(label)//' comparisons of '//msg )
 
 end subroutine compare_two_schemes
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -4300,7 +4300,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
             ig = i + G%HI%idg_offset ! Global i-index
             jg = j + G%HI%jdg_offset ! Global j-index
             if (use_temperature) then
-              write(msg(1:240),'(2(a,i4,1x),4(a,f8.3,1x),8(a,es11.4,1x))') &
+              write(msg(1:240),'(2(a,I0,1x),4(a,f8.3,1x),8(a,es11.4,1x))') &
                 'Extreme surface sfc_state detected: i=',ig,'j=',jg, &
                 'lon=',G%geoLonT(i,j), 'lat=',G%geoLatT(i,j), &
                 'x=',G%gridLonT(ig), 'y=',G%gridLatT(jg), &
@@ -4309,7 +4309,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
                 'U-=',US%L_T_to_m_s*sfc_state%u(I-1,j), 'U+=',US%L_T_to_m_s*sfc_state%u(I,j), &
                 'V-=',US%L_T_to_m_s*sfc_state%v(i,J-1), 'V+=',US%L_T_to_m_s*sfc_state%v(i,J)
             else
-              write(msg(1:240),'(2(a,i4,1x),4(a,f8.3,1x),6(a,es11.4))') &
+              write(msg(1:240),'(2(a,I0,1x),4(a,f8.3,1x),6(a,es11.4))') &
                 'Extreme surface sfc_state detected: i=',ig,'j=',jg, &
                 'lon=',G%geoLonT(i,j), 'lat=',G%geoLatT(i,j), &
                 'x=',G%gridLonT(ig), 'y=',G%gridLatT(jg), &
@@ -4326,8 +4326,8 @@ subroutine extract_surface_state(CS, sfc_state_in)
     enddo ; enddo
     call sum_across_PEs(numberOfErrors)
     if (numberOfErrors>0) then
-      write(msg(1:240),'(3(a,i9,1x))') 'There were a total of ',numberOfErrors, &
-          'locations detected with extreme surface values!'
+      write(msg(1:240),'(a,i0,a)') 'There were a total of ',numberOfErrors, &
+          ' locations detected with extreme surface values!'
       call MOM_error(FATAL, trim(msg))
     endif
   endif

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2800,7 +2800,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
 
     ! This might need to be moved outside of the OMP do loop directives.
     if (CS%debug_bt) then
-      write(mesg,'("BT vel update ",I4)') n
+      write(mesg,'("BT vel update ",I0)') n
       debug_halo = 0 ; if  (CS%debug_wide_halos) debug_halo = iev - ie
       call uvchksum(trim(mesg)//" PF[uv]", PFu, PFv, CS%debug_BT_HI, haloshift=debug_halo, &
                     symmetric=.true., unscale=US%L_T_to_m_s*US%s_to_T)
@@ -2888,7 +2888,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     endif
 
     if (CS%debug_bt) then
-      write(mesg,'("BT step ",I4)') n
+      write(mesg,'("BT step ",I0)') n
       call uvchksum(trim(mesg)//" [uv]bt", ubt, vbt, CS%debug_BT_HI, haloshift=debug_halo, &
                     symmetric=.true., unscale=US%L_T_to_m_s)
       call hchksum(eta, trim(mesg)//" eta", CS%debug_BT_HI, haloshift=debug_halo, unscale=GV%H_to_MKS)

--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -376,7 +376,7 @@ subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, GV, US, allowChange, pe
         write(0,'(a,2f12.5)') 'x,y=', G%geoLonT(i,j), G%geoLatT(i,j)
         write(0,'(a3,3a12)') 'k','h','Temp','Salt'
         do k = 1, nz
-          write(0,'(i3,3es12.4)') k, h(i,j,k), T_scale*Temp(i,j,k), S_scale*Salt(i,j,k)
+          write(0,'(I0," ",3es12.4)') k, h(i,j,k), T_scale*Temp(i,j,k), S_scale*Salt(i,j,k)
         enddo
         stop 'Extremum detected'
       endif
@@ -389,7 +389,7 @@ subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, GV, US, allowChange, pe
         write(0,'(a,2f12.5)') 'x,y=',G%geoLonT(i,j),G%geoLatT(i,j)
         write(0,'(a3,3a12)') 'k','h','Temp','Salt'
         do k = 1, nz
-          write(0,'(i3,3es12.4)') k, h(i,j,k), T_scale*Temp(i,j,k), S_scale*Salt(i,j,k)
+          write(0,'(I0," ",3es12.4)') k, h(i,j,k), T_scale*Temp(i,j,k), S_scale*Salt(i,j,k)
         enddo
         stop 'Negative thickness detected'
       endif

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2346,13 +2346,13 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
 
   if ((isl-stencil < G%isd) .or. (iel+stencil > G%ied)) then
     write(mesg,'("In MOM_continuity_PPM, PPM_reconstruction_x called with a ", &
-               & "x-halo that needs to be increased by ",i2,".")') &
+               & "x-halo that needs to be increased by ",I0,".")') &
                stencil + max(G%isd-isl,iel-G%ied)
     call MOM_error(FATAL,mesg)
   endif
   if ((jsl < G%jsd) .or. (jel > G%jed)) then
     write(mesg,'("In MOM_continuity_PPM, PPM_reconstruction_x called with a ", &
-               & "y-halo that needs to be increased by ",i2,".")') &
+               & "y-halo that needs to be increased by ",I0,".")') &
                max(G%jsd-jsl,jel-G%jed)
     call MOM_error(FATAL,mesg)
   endif
@@ -2500,13 +2500,13 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
 
   if ((isl < G%isd) .or. (iel > G%ied)) then
     write(mesg,'("In MOM_continuity_PPM, PPM_reconstruction_y called with a ", &
-               & "x-halo that needs to be increased by ",i2,".")') &
+               & "x-halo that needs to be increased by ",I0,".")') &
                max(G%isd-isl,iel-G%ied)
     call MOM_error(FATAL,mesg)
   endif
   if ((jsl-stencil < G%jsd) .or. (jel+stencil > G%jed)) then
     write(mesg,'("In MOM_continuity_PPM, PPM_reconstruction_y called with a ", &
-                 & "y-halo that needs to be increased by ",i2,".")') &
+                 & "y-halo that needs to be increased by ",I0,".")') &
                  stencil + max(G%jsd-jsl,jel-G%jed)
     call MOM_error(FATAL,mesg)
   endif

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -1042,7 +1042,7 @@ subroutine initialize_segment_data(GV, US, OBC, PF, turns)
           call MOM_error(FATAL," Unable to open OBC file " // trim(filename))
 
         if (OBC%brushcutter_mode .and. (modulo(siz(1),2) == 0 .or. modulo(siz(2),2) == 0)) then
-          write(mesg,'("Brushcutter mode sizes ", I0, I0)') siz(1), siz(2)
+          write(mesg, '("Brushcutter mode sizes ",I0," ",I0)') siz(1), siz(2)
           call MOM_error(WARNING, mesg // " " // trim(filename) // " " // trim(fieldname))
           call MOM_error(FATAL,'segment data are not on the supergrid')
         endif

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -157,8 +157,8 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
     call get_date(CS%Time, yr, mo, day, hr, minute, sec)
     call get_time((CS%Time - set_date(yr, 1, 1, 0, 0, 0)), sec, yearday)
     write (file,'(/,"--------------------------")')
-    write (file,'(/,"Time ",i5,i4,F6.2," U-velocity violation at ",I4,": ",2(I3), &
-        & " (",F7.2," E ",F7.2," N) Layers ",I3," to ",I3,". dt = ",1PG10.4)') &
+    write (file,'(/,"Time ",I0," ",I0," ",F6.2," U-velocity violation at ",I0,": ",I0,", ",I0, &
+        & " (",F7.2," E ",F7.2," N) Layers ",I0," to ",I0,". dt = ",1PG10.4)') &
         yr, yearday, (REAL(sec)/3600.0), pe_here(), I, j, &
         G%geoLonCu(I,j), G%geoLatCu(I,j), ks, ke, US%T_to_s*dt
 
@@ -497,8 +497,8 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
     call get_date(CS%Time, yr, mo, day, hr, minute, sec)
     call get_time((CS%Time - set_date(yr, 1, 1, 0, 0, 0)), sec, yearday)
     write (file,'(/,"--------------------------")')
-    write (file,'(/,"Time ",i5,i4,F6.2," V-velocity violation at ",I4,": ",2(I3), &
-        & " (",F7.2," E ",F7.2," N) Layers ",I3," to ",I3,". dt = ",1PG10.4)') &
+    write (file,'(/,"Time ",I0," ",I0," ",F6.2," V-velocity violation at ",I0,": ",I0,", ",I0, &
+        & " (",F7.2," E ",F7.2," N) Layers ",I0," to ",I0,". dt = ",1PG10.4)') &
         yr, yearday, (REAL(sec)/3600.0), pe_here(), i, J, &
         G%geoLonCv(i,J), G%geoLatCv(i,J), ks, ke, US%T_to_s*dt
 

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -140,11 +140,7 @@ subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer :: k
 
   do k=1,size(u_comp,3)
-    if (k < 10) then ; write(mesg_k,'(" Layer",i2," ")') k
-    elseif (k < 100) then ; write(mesg_k,'(" Layer",i3," ")') k
-    elseif (k < 1000) then ; write(mesg_k,'(" Layer",i4," ")') k
-    else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
-
+    write(mesg_k,'(" Layer ",i0," ")') k
     call check_redundant_vC2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
              v_comp(:,:,k), G, is, ie, js, je, direction, unscale)
   enddo
@@ -215,7 +211,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (u_resym(i,j) /= u_comp(i,j) .and. &
         redundant_prints(3) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," on pe ",I0)') &
            sc*u_comp(i,j), sc*u_resym(i,j), sc*(u_comp(i,j)-u_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(3) = redundant_prints(3) + 1
@@ -225,7 +221,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (v_resym(i,j) /= v_comp(i,j) .and. &
         redundant_prints(3) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," x,y = ",2(1pe12.4)," on pe ",I0)') &
            sc*v_comp(i,j), sc*v_resym(i,j), sc*(v_comp(i,j)-v_resym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
@@ -253,11 +249,7 @@ subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je, unscale)
   integer :: k
 
   do k=1,size(array,3)
-    if (k < 10) then ; write(mesg_k,'(" Layer",i2," ")') k
-    elseif (k < 100) then ; write(mesg_k,'(" Layer",i3," ")') k
-    elseif (k < 1000) then ; write(mesg_k,'(" Layer",i4," ")') k
-    else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
-
+    write(mesg_k,'(" Layer ",i0," ")') k
     call check_redundant_sB2d(trim(mesg)//trim(mesg_k), array(:,:,k), &
                               G, is, ie, js, je, unscale)
   enddo
@@ -320,7 +312,7 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je, unscale)
     if (a_resym(i,j) /= array(i,j) .and. &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" Redundant points",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," on pe ",I0)') &
            sc*array(i,j), sc*a_resym(i,j), sc*(array(i,j)-a_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
@@ -353,11 +345,7 @@ subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer :: k
 
   do k=1,size(u_comp,3)
-    if (k < 10) then ; write(mesg_k,'(" Layer",i2," ")') k
-    elseif (k < 100) then ; write(mesg_k,'(" Layer",i3," ")') k
-    elseif (k < 1000) then ; write(mesg_k,'(" Layer",i4," ")') k
-    else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
-
+    write(mesg_k,'(" Layer ",i0," ")') k
     call check_redundant_vB2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
              v_comp(:,:,k), G, is, ie, js, je, direction, unscale)
   enddo
@@ -429,7 +417,7 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (u_resym(i,j) /= u_comp(i,j) .and. &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," on pe ",I0)') &
            sc*u_comp(i,j), sc*u_resym(i,j), sc*(u_comp(i,j)-u_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
@@ -439,7 +427,7 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (v_resym(i,j) /= v_comp(i,j) .and. &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," x,y = ",2(1pe12.4)," on pe ",I0)') &
            sc*v_comp(i,j), sc*v_resym(i,j), sc*(v_comp(i,j)-v_resym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
@@ -466,11 +454,7 @@ subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je, unscale)
   integer :: k
 
   do k=1,size(array,3)
-    if (k < 10) then ; write(mesg_k,'(" Layer",i2," ")') k
-    elseif (k < 100) then ; write(mesg_k,'(" Layer",i3," ")') k
-    elseif (k < 1000) then ; write(mesg_k,'(" Layer",i4," ")') k
-    else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
-
+    write(mesg_k,'(" Layer ",i0," ")') k
     call check_redundant_sT2d(trim(mesg)//trim(mesg_k), array(:,:,k), &
                               G, is, ie, js, je, unscale)
   enddo
@@ -520,7 +504,7 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je, unscale)
     if (a_nonsym(i,j) /= array(i,j) .and. &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" Redundant points",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," on pe ",I0)') &
            sc*array(i,j), sc*a_nonsym(i,j), sc*(array(i,j)-a_nonsym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
@@ -553,11 +537,7 @@ subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   integer :: k
 
   do k=1,size(u_comp,3)
-    if (k < 10) then ; write(mesg_k,'(" Layer",i2," ")') k
-    elseif (k < 100) then ; write(mesg_k,'(" Layer",i3," ")') k
-    elseif (k < 1000) then ; write(mesg_k,'(" Layer",i4," ")') k
-    else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
-
+    write(mesg_k,'(" Layer ",i0," ")') k
     call check_redundant_vT2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
              v_comp(:,:,k), G, is, ie, js, je, direction, unscale)
   enddo
@@ -616,7 +596,7 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (u_nonsym(i,j) /= u_comp(i,j) .and. &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," on pe ",I0)') &
            sc*u_comp(i,j), sc*u_nonsym(i,j), sc*(u_comp(i,j)-u_nonsym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
@@ -626,7 +606,7 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (v_nonsym(i,j) /= v_comp(i,j) .and. &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
+                    & 1pe12.4," at i,j = ",I0,",",I0," x,y = ",2(1pe12.4)," on pe ",I0)') &
            sc*v_comp(i,j), sc*v_nonsym(i,j), sc*(v_comp(i,j)-v_nonsym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -853,10 +853,8 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   elseif (reday < 1.0e11) then ; write(day_str, '(F15.3)') reday
   else ;                         write(day_str, '(ES15.9)') reday ; endif
 
-  if     (n < 1000000)   then ; write(n_str, '(I6)')  n
-  elseif (n < 10000000)  then ; write(n_str, '(I7)')  n
-  elseif (n < 100000000) then ; write(n_str, '(I8)')  n
-  else                        ; write(n_str, '(I10)') n ; endif
+  if (n < 1000000) then ; write(n_str, '(I6)') n
+  else                  ; write(n_str, '(I0)') n ; endif
 
   date_str = trim(mesg_intro)//trim(day_str)
   if (date_stamped) &

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -2236,7 +2236,7 @@ subroutine chksum1d(array, mesg, start_i, end_i, compare_PEs, logunit)
       write(iounit, '(A40," bitcounts do not match across PEs: ",I12,1X,I12)') &
             mesg, sum1, nPEs*sum_bc
     do i=1,nPEs ; if (sum /= sum_here(i)) then
-      write(iounit, '(A40," PE ",i4," sum mismatches root_PE: ",3(ES22.13,1X))') &
+      write(iounit, '(A40," PE ",I0," sum mismatches root_PE: ",3(ES22.13,1X))') &
             mesg, i, sum_here(i), sum, sum_here(i)-sum
     endif ; enddo
   endif

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -878,7 +878,7 @@ subroutine EFP_list_sum_across_PEs(EFPs, nval, errors)
     do n=1,ni ; EFPs(i)%v(n) = ints(n,i) ; enddo
     if (present(errors)) errors(i) = overflow_error
     if (overflow_error) then
-      write (mesg,'("EFP_list_sum_across_PEs error at ",i6," val was ",ES12.6, ", prec_error = ",ES12.6)') &
+      write (mesg,'("EFP_list_sum_across_PEs error at ",i0," val was ",ES12.6, ", prec_error = ",ES12.6)') &
              i, EFP_to_real(EFPs(i)), real(prec_error)
       call MOM_error(WARNING, mesg)
     endif

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -245,10 +245,10 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
 
     ! Check the requirement of equal sized compute domains when STATIC_MEMORY_ is used.
     if ((MOD(NIGLOBAL, NIPROC) /= 0) .OR. (MOD(NJGLOBAL, NJPROC) /= 0)) then
-      write( char_xsiz, '(i4)' ) NIPROC
-      write( char_ysiz, '(i4)' ) NJPROC
-      write( char_niglobal, '(i4)' ) NIGLOBAL
-      write( char_njglobal, '(i4)' ) NJGLOBAL
+      write( char_xsiz, '(I0)' ) NIPROC
+      write( char_ysiz, '(I0)' ) NJPROC
+      write( char_niglobal, '(I0)' ) NIGLOBAL
+      write( char_njglobal, '(I0)' ) NJGLOBAL
       call MOM_error(WARNING, 'MOM_domains: Processor decomposition (NIPROC_,NJPROC_) = ('//&
               trim(char_xsiz)//','//trim(char_ysiz)//') does not evenly divide size '//&
               'set by preprocessor macro ('//trim(char_niglobal)//','//trim(char_njglobal)//').')
@@ -393,7 +393,7 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
 
     if (layout(1)*layout(2) /= PEs_used .and. (.not. mask_table_exists) ) then
       write(mesg,'("MOM_domains_init: The product of the two components of layout, ", &
-            &      2i4,", is not the number of PEs used, ",i5,".")') &
+            &      I0,", ",I0,", is not the number of PEs used, ",I0,".")') &
             layout(1), layout(2), PEs_used
       call MOM_error(FATAL, mesg)
     endif
@@ -409,8 +409,8 @@ subroutine MOM_domains_init(MOM_dom, param_file, symmetric, static_memory, &
 
   ! Idiot check that fewer PEs than columns have been requested
   if (layout(1)*layout(2) > n_global(1)*n_global(2))  then
-    write(mesg,'(a,2(i5,1x,a))') 'You requested to use', layout(1)*layout(2), &
-      'PEs but there are only', n_global(1)*n_global(2), 'columns in the model'
+    write(mesg,'(a,I0,a,I0,a)') 'You requested to use ', layout(1)*layout(2), &
+      ' PEs but there are only ', n_global(1)*n_global(2), ' columns in the model'
     call MOM_error(FATAL, mesg)
   endif
 

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -87,7 +87,7 @@ subroutine myStats(array, missing, G, k, mesg, unscale, full_halo)
   call min_across_PEs(minA)
   call max_across_PEs(maxA)
   if (is_root_pe()) then
-    write(lMesg(1:120),'(2(a,es12.4),a,i3,1x,a)') &
+    write(lMesg(1:120),'(2(a,es12.4),a,I0,1x,a)') &
          'init_from_Z: min=',minA*scl,' max=',maxA*scl,' Level=',k,trim(mesg)
     call MOM_mesg(lMesg,2)
   endif

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -777,7 +777,7 @@ function num_timelevels(filename, varname, min_dims) result(n_time)
 
   if (present(min_dims)) then
     if (ndims < min_dims-1) then
-      write(msg, '(I3)') min_dims
+      write(msg, '(I0)') min_dims
       call MOM_error(WARNING, "num_timelevels: variable "//trim(varname)//" in file "//&
           trim(filename)//" has fewer than min_dims = "//trim(msg)//" dimensions.")
       n_time = -1
@@ -3072,7 +3072,7 @@ function ensembler(name, ens_no_in) result(en_nm)
     ens_no = get_ensemble_id()
   endif
 
-  write(ens_num_char, '(I10)') ens_no ; ens_num_char = adjustl(ens_num_char)
+  write(ens_num_char, '(I0)') ens_no
   do
     is = index(en_nm,"%E")
     if (is == 0) exit

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1558,8 +1558,8 @@ logical function size_mismatch_3d(var_a, var_b, turns, size_msg)
                          (size(var_a,2) /= size(var_b,1)) .or. &
                          (size(var_a,3) /= size(var_b,3)) )
   endif
-  write(size_msg, '(3(I8), " vs ", 3(I8))') size(var_a,1), size(var_a,2), size(var_a,3), &
-                                           size(var_b,1), size(var_b,2), size(var_b,3)
+  write(size_msg, '(3(1x,I0), " vs ", 3(1x,I0))') size(var_a,1), size(var_a,2), size(var_a,3), &
+                                                  size(var_b,1), size(var_b,2), size(var_b,3)
 end function size_mismatch_3d
 
 
@@ -1687,11 +1687,7 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
 
     restartpath = trim(directory) // trim(restartname)
 
-    if (num_files < 10) then
-      write(suffix,'("_",I1)') num_files
-    else
-      write(suffix,'("_",I2)') num_files
-    endif
+    write(suffix,'("_",I0)') num_files
 
     length = len_trim(restartpath)
     if (length < 3) then  ! This case is very uncommon but this test avoids segmentation-faults.
@@ -1723,15 +1719,15 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
       endif
       if (verbose) then
         if (pos == CENTER) then
-          write(mesg, '(" is in CENTER position, checksum range ",4(I8))') isL, ieL, jsL, jeL
+          write(mesg, '(" is in CENTER position, checksum range",4(1x,I0))') isL, ieL, jsL, jeL
         elseif (pos == CORNER) then
-          write(mesg, '(" is in CORNER position, checksum range ",4(I8))') isL, ieL, jsL, jeL
+          write(mesg, '(" is in CORNER position, checksum range",4(1x,I0))') isL, ieL, jsL, jeL
         elseif (pos == NORTH_FACE) then
-          write(mesg, '(" is in NORTH_FACE position, checksum range ",4(I8))') isL, ieL, jsL, jeL
+          write(mesg, '(" is in NORTH_FACE position, checksum range",4(1x,I0))') isL, ieL, jsL, jeL
         elseif (pos == EAST_FACE) then
-          write(mesg, '(" is in EAST_FACE position, checksum range ",4(I8))') isL, ieL, jsL, jeL
+          write(mesg, '(" is in EAST_FACE position, checksum range",4(1x,I0))') isL, ieL, jsL, jeL
         else
-          write(mesg, '(" is in another position, ",I4,", checksum range ",4(I8))') pos, isL, ieL, jsL, jeL
+          write(mesg, '(" is in another position, ",I0,", checksum range",4(1x,I0))') pos, isL, ieL, jsL, jeL
         endif
         call MOM_mesg(trim(var_name)//mesg)
       endif
@@ -1858,8 +1854,7 @@ subroutine restore_state(filename, directory, day, G, CS)
     exit
   enddo
 
-  if (n>num_file) call MOM_error(WARNING,"MOM_restart: " // &
-                                 "No times found in restart files.")
+  if (n>num_file) call MOM_error(WARNING, "MOM_restart: No times found in restart files.")
 
   ! Check the remaining files for different times and issue a warning
   ! if they differ from the first time.
@@ -1871,9 +1866,9 @@ subroutine restore_state(filename, directory, day, G, CS)
       deallocate(time_vals)
 
       if (t1 /= t2 .and. is_root_PE()) then
-        write(mesg,'("WARNING: Restart file ",I2," has time ",F10.4,"whereas &
-         &simulation is restarted at ",F10.4," (differing by ",F10.4,").")')&
-               m,t1,t2,t1-t2
+        write(mesg,'("WARNING: Restart file ",I0," has time ",F10.4,"whereas &
+              &simulation is restarted at ",F10.4," (differing by ",F10.4,").")') &
+              m, t1, t2, t1-t2
         call MOM_error(WARNING, "MOM_restart: "//mesg)
       endif
     enddo
@@ -2149,11 +2144,7 @@ function open_restart_units(filename, directory, G, CS, IO_handles, file_paths, 
         endif
         filepath = trim(directory) // trim(restartname)
 
-        if (num_restart < 10) then
-          write(suffix,'("_",I1)') num_restart
-        else
-          write(suffix,'("_",I2)') num_restart
-        endif
+        write(suffix,'("_",I0)') num_restart
         if (num_restart > 0) filepath = trim(filepath) // suffix
 
         filepath = trim(filepath)//".nc"
@@ -2201,10 +2192,10 @@ function open_restart_units(filename, directory, G, CS, IO_handles, file_paths, 
         if (present(global_files)) global_files(nf) = .true.
         if (present(file_paths)) file_paths(nf) = filepath
         if (is_root_pe() .and. (present(IO_handles))) &
-          call MOM_error(NOTE,"MOM_restart: MOM run restarted using : "//trim(filepath))
+          call MOM_error(NOTE, "MOM_restart: MOM run restarted using : "//trim(filepath))
       else
         if (present(IO_handles)) &
-          call MOM_error(WARNING,"MOM_restart: Unable to find restart file : "//trim(filepath))
+          call MOM_error(WARNING, "MOM_restart: Unable to find restart file : "//trim(filepath))
       endif
 
     endif
@@ -2405,8 +2396,7 @@ subroutine restart_error(CS)
   if (CS%novars > CS%max_fields) then
     write(num,'(I0)') CS%novars
     call MOM_error(FATAL,"MOM_restart: Too many fields registered for " // &
-           "restart.  Set MAX_FIELDS to be at least " // &
-           trim(adjustl(num)) // " in the MOM input file.")
+           "restart.  Set MAX_FIELDS to be at least "//trim(num)//" in the MOM input file.")
   else
     call MOM_error(FATAL,"MOM_restart: Unspecified fatal error.")
   endif

--- a/src/framework/MOM_unique_scales.F90
+++ b/src/framework/MOM_unique_scales.F90
@@ -59,8 +59,8 @@ subroutine check_scaling_uniqueness(component, descs, weights, key, scales, max_
   enddo
 
   if (verbosity >= 7) then
-    write(mesg, '(I8)') ns
-    call MOM_mesg(trim(component)//": Extracted "//trim(adjustl(mesg))//" unit combinations from the list.")
+    write(mesg, '(I0)') ns
+    call MOM_mesg(trim(component)//": Extracted "//trim(mesg)//" unit combinations from the list.")
     mesg = "Dim Key:  ["
     do i=1,ndims ; mesg = trim(mesg)//"  "//trim(key(i)) ; enddo
     mesg = trim(mesg)//"]:"
@@ -117,7 +117,7 @@ subroutine check_scaling_uniqueness(component, descs, weights, key, scales, max_
       endif
       if (better_cost == 0) exit
       if (verbosity >= 7) then
-        write(mesg, '("Iteration ",I2," scaling cost reduced from ",I8," with original scales to ", I8)') &
+        write(mesg, '("Iteration ",I0," scaling cost reduced from ",I0," with original scales to ", I0)') &
                     itt, orig_cost, better_cost
         call MOM_mesg(trim(component)//": "//trim(mesg)//" with revised scaling factors.")
       endif
@@ -126,15 +126,15 @@ subroutine check_scaling_uniqueness(component, descs, weights, key, scales, max_
       test_cost = non_unique_scales(prev_scales, list, descs, weights, silent=(verbosity<4))
       mesg = trim(component)//": Suggested improved scales: "
       do i=1,ndims ; if ((prev_scales(i) /= scales(i)) .and. (scales(i) /= 0)) then
-        write(msg_frag, '(I3)') prev_scales(i)
-        mesg = trim(mesg)//" "//trim(key(i))//"_RESCALE_POWER = "//trim(adjustl(msg_frag))
+        write(msg_frag, '(I0)') prev_scales(i)
+        mesg = trim(mesg)//" "//trim(key(i))//"_RESCALE_POWER = "//trim(msg_frag)
       endif ; enddo
       call MOM_mesg(mesg)
 
-      write(mesg, '(I8)') orig_cost
-      write(msg_frag, '(I8)') test_cost
-      mesg = trim(component)//": Scaling overlaps reduced from "//trim(adjustl(mesg))//&
-             " with original scales to "//trim(adjustl(msg_frag))//" with suggested scales."
+      write(mesg, '(I0)') orig_cost
+      write(msg_frag, '(I0)') test_cost
+      mesg = trim(component)//": Scaling overlaps reduced from "//trim(mesg)//&
+             " with original scales to "//trim(msg_frag)//" with suggested scales."
       call MOM_mesg(mesg)
     endif
 
@@ -194,9 +194,9 @@ subroutine encode_dim_powers(scaling, key, dim_powers)
       if (verify(fragment(ipow:), numbers) == 0) then
         read(fragment(ipow:),*) dp
         dimnm = fragment(:ipow-1)
-        ! write(mesg, '(I3)') dp
+        ! write(mesg, '(I0)') dp
         ! call MOM_mesg("Parsed fragment "//trim(fragment)//" from "//trim(scaling)//&
-        !               " as "//trim(dimnm)//trim(adjustl(mesg)))
+        !               " as "//trim(dimnm)//trim(mesg))
       else
         dimnm = fragment
         dp = 1
@@ -317,9 +317,9 @@ integer function non_unique_scales(scales, list, descs, weights, silent)
       ! the likelihood that these factors would be combined in an expression.
       non_unique_scales = min(non_unique_scales + wt_merge(n) * wt_merge(m), 99999999)
       if (verbose) then
-        write(mesg, '(I8)') res_pow(n)
+        write(mesg, '(I0)') res_pow(n)
         call MOM_mesg("The factors "//trim(descs(n))//" and "//trim(descs(m))//" both scale to "//&
-                      trim(adjustl(mesg))//" for the given powers.")
+                      trim(mesg)//" for the given powers.")
 
         ! call MOM_mesg("Powers ["//trim(int_array_msg(list(:,n)))//"] and ["//&
         !                    trim(int_array_msg(list(:,m)))//"] with rescaling by ["//&
@@ -343,8 +343,7 @@ function int_array_msg(array)
   if (ni < 1) return
 
   do i=1,ni
-    write(msg_frag, '(I8)') array(i)
-    msg_frag = adjustl(msg_frag)
+    write(msg_frag, '(I0)') array(i)
     if (i == 1) then
       int_array_msg = trim(msg_frag)
     else

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -1299,10 +1299,8 @@ subroutine write_ice_shelf_energy(CS, G, US, mass, area, day, time_step)
     elseif (reday < 1.0e11) then ; write(day_str, '(F15.3)') reday
     else ;                         write(day_str, '(ES15.9)') reday ; endif
 
-    if     (CS%prev_IS_energy_calls < 1000000)   then ; write(n_str, '(I6)') CS%prev_IS_energy_calls
-    elseif (CS%prev_IS_energy_calls < 10000000)  then ; write(n_str, '(I7)') CS%prev_IS_energy_calls
-    elseif (CS%prev_IS_energy_calls < 100000000) then ; write(n_str, '(I8)') CS%prev_IS_energy_calls
-    else                        ; write(n_str, '(I10)') CS%prev_IS_energy_calls ; endif
+    if (CS%prev_IS_energy_calls < 1000000) then ; write(n_str, '(I6)') CS%prev_IS_energy_calls
+    else ; write(n_str, '(I0)') CS%prev_IS_energy_calls ; endif
 
     write(CS%IS_fileenergy_ascii,'(A,",",A,", En ",ES22.16,", M ",ES11.5)') &
       trim(n_str), trim(day_str), US%L_T_to_m_s**2*KE_tot/mass_tot, US%RZL2_to_kg*mass_tot

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -756,14 +756,14 @@ subroutine set_grid_metrics_mercator(G, param_file, US)
     y_q = find_root(Int_dj_dy, dy_dj, GP, jd, 0.0, -1.0*PI_2, PI_2, itt2)
     G%gridLatB(J) = y_q*180.0/PI
     ! if (is_root_pe()) &
-    !   write(stdout, '("J, y_q = ",I4,ES14.4," itts = ",I4)')  j, y_q, itt2
+    !   write(stdout, '("J, y_q = ",I0,", ",ES14.4," itts = ",I0)')  j, y_q, itt2
   enddo
   do j=G%jsg,G%jeg
     jd = fnRef + (j - jRef) - 0.5
     y_h = find_root(Int_dj_dy, dy_dj, GP, jd, 0.0, -1.0*PI_2, PI_2, itt1)
     G%gridLatT(j) = y_h*180.0/PI
     ! if (is_root_pe()) &
-    !   write(stdout, '("j, y_h = ",I4,ES14.4," itts = ",I4)')  j, y_h, itt1
+    !   write(stdout, '("j, y_h = ",I0,", ",ES14.4," itts = ",I0)')  j, y_h, itt1
   enddo
   do J=JsdB+J_off,JedB+J_off
     jd = fnRef + (J - jRef)
@@ -963,7 +963,7 @@ function find_root( fn, dy_df, GP, fnval, y1, ymin, ymax, ittmax)
     fnbot = fn(ybot,GP) - fnval
 
     if ((itt > 50) .and. (fnbot > 0.0)) then
-      write(warnmesg, '("PE ",I2," unable to find bottom bound for grid function. &
+      write(warnmesg, '("PE ",I0," unable to find bottom bound for grid function. &
         &x = ",ES10.4,", xmax = ",ES10.4,", fn = ",ES10.4,", dfn_dx = ",ES10.4,&
         &", seeking fn = ",ES10.4," - fn = ",ES10.4,".")') &
           pe_here(),ybot,ymin,fn(ybot,GP),dy_df(ybot,GP),fnval, fnbot
@@ -983,7 +983,7 @@ function find_root( fn, dy_df, GP, fnval, y1, ymin, ymax, ittmax)
     fntop = fn(ytop,GP) - fnval
 
     if ((itt > 50) .and. (fntop < 0.0)) then
-      write(warnmesg, '("PE ",I2," unable to find top bound for grid function. &
+      write(warnmesg, '("PE ",I0," unable to find top bound for grid function. &
         &x = ",ES10.4,", xmax = ",ES10.4,", fn = ",ES10.4,", dfn_dx = ",ES10.4, &
         &", seeking fn = ",ES10.4," - fn = ",ES10.4,".")') &
           pe_here(),ytop,ymax,fn(ytop,GP),dy_df(ytop,GP),fnval,fntop
@@ -994,7 +994,7 @@ function find_root( fn, dy_df, GP, fnval, y1, ymin, ymax, ittmax)
   ! Find the root using a bracketed variant of Newton's method, starting
   ! with a false-positon method first guess.
   if ((fntop < 0.0) .or. (fnbot > 0.0) .or. (ytop < ybot)) then
-    write(warnmesg, '("PE ",I2," find_root failed to bracket function. y = ",&
+    write(warnmesg, '("PE ",I0," find_root failed to bracket function. y = ",&
               &2ES10.4,", fn = ",2ES10.4,".")') pe_here(),ybot,ytop,fnbot,fntop
     call MOM_error(FATAL, warnmesg)
   endif

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -593,9 +593,9 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
     if ( use_temperature ) call hchksum(tv%T, "MOM_initialize_state: T ", G%HI, haloshift=1, unscale=US%C_to_degC)
     if ( use_temperature ) call hchksum(tv%S, "MOM_initialize_state: S ", G%HI, haloshift=1, unscale=US%S_to_ppt)
     if ( use_temperature .and. debug_layers) then ; do k=1,nz
-      write(mesg,'("MOM_IS: T[",I2,"]")') k
+      write(mesg,'("MOM_IS: T[",I0,"]")') k
       call hchksum(tv%T(:,:,k), mesg, G%HI, haloshift=1, unscale=US%C_to_degC)
-      write(mesg,'("MOM_IS: S[",I2,"]")') k
+      write(mesg,'("MOM_IS: S[",I0,"]")') k
       call hchksum(tv%S(:,:,k), mesg, G%HI, haloshift=1, unscale=US%S_to_ppt)
     enddo ; endif
   endif
@@ -877,7 +877,7 @@ subroutine initialize_thickness_from_file(h, depth_tot, G, GV, US, param_file, f
 
       if ((inconsistent > 0) .and. (is_root_pe())) then
         write(mesg,'("Thickness initial conditions are inconsistent ",'// &
-                 '"with topography in ",I8," places.")') inconsistent
+                 '"with topography in ",I0," places.")') inconsistent
         call MOM_error(WARNING, mesg)
       endif
     endif
@@ -922,7 +922,7 @@ subroutine adjustEtaToFitBathymetry(G, GV, US, eta, h, ht, dZ_ref_eta)
   call sum_across_PEs(contractions)
   if ((contractions > 0) .and. (is_root_pe())) then
     write(mesg,'("Thickness initial conditions were contracted ",'// &
-               '"to fit topography in ",I8," places.")') contractions
+               '"to fit topography in ",I0," places.")') contractions
     call MOM_error(WARNING, 'adjustEtaToFitBathymetry: '//mesg)
   endif
 
@@ -960,7 +960,7 @@ subroutine adjustEtaToFitBathymetry(G, GV, US, eta, h, ht, dZ_ref_eta)
   call sum_across_PEs(dilations)
   if ((dilations > 0) .and. (is_root_pe())) then
     write(mesg,'("Thickness initial conditions were dilated ",'// &
-               '"to fit topography in ",I8," places.")') dilations
+               '"to fit topography in ",I0," places.")') dilations
     call MOM_error(WARNING, 'adjustEtaToFitBathymetry: '//mesg)
   endif
 
@@ -3023,7 +3023,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
 
       if ((inconsistent > 0) .and. (is_root_pe())) then
         write(mesg, '("Thickness initial conditions are inconsistent ",'// &
-                    '"with topography in ",I5," places.")') inconsistent
+                    '"with topography in ",I0," places.")') inconsistent
         call MOM_error(WARNING, mesg)
       endif
     endif

--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -278,7 +278,7 @@ subroutine set_up_oda_incupd_field(sp_val, G, GV, CS)
 
   CS%fldno = CS%fldno + 1
   if (CS%fldno > MAX_FIELDS_) then
-    write(mesg,'("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease &
+    write(mesg,'("Increase MAX_FIELDS_ to at least ",I0," in MOM_memory.h or decrease &
            &the number of fields increments in the call to &
            &initialize_oda_incupd." )') CS%fldno
     call MOM_error(FATAL,"set_up_oda_incupd_field: "//mesg)

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1655,23 +1655,23 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
          enddo
 
          if (abs(verif_N -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)') i, j, verif_N
+           write(stdout,'(I0,", ",I0,F18.10)') i, j, verif_N
            call MOM_error(FATAL, "mismatch integral for N profile")
          endif
          if (abs(verif_N2 -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)') i, j, verif_N2
+           write(stdout,'(I0,", ",I0,F18.10)') i, j, verif_N2
            call MOM_error(FATAL, "mismatch integral for N2 profile")
          endif
          if (abs(verif_bbl -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)') i, j, verif_bbl
+           write(stdout,'(I0,", ",I0,F18.10)') i, j, verif_bbl
            call MOM_error(FATAL, "mismatch integral for bbl profile")
          endif
          if (abs(verif_stl1 -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)') i, j, verif_stl1
+           write(stdout,'(I0,", ",I0,F18.10)') i, j, verif_stl1
            call MOM_error(FATAL, "mismatch integral for stl1 profile")
          endif
          if (abs(verif_stl2 -1.0) > threshold_verif) then
-           write(stdout,'(I5,I5,F18.10)') i, j, verif_stl2
+           write(stdout,'(I0,", ",I0,F18.10)') i, j, verif_stl2
            call MOM_error(FATAL, "mismatch integral for stl2 profile")
          endif
 
@@ -3021,13 +3021,13 @@ subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, simple_2nd, adv_limiter)
 
   if ((isl-stencil < G%isd) .or. (iel+stencil > G%ied)) then
     write(mesg,'("In MOM_internal_tides, PPM_reconstruction_x called with a ", &
-               & "x-halo that needs to be increased by ",i2,".")') &
+               & "x-halo that needs to be increased by ",I0,".")') &
                stencil + max(G%isd-isl,iel-G%ied)
     call MOM_error(FATAL,mesg)
   endif
   if ((jsl < G%jsd) .or. (jel > G%jed)) then
     write(mesg,'("In MOM_internal_tides, PPM_reconstruction_x called with a ", &
-               & "y-halo that needs to be increased by ",i2,".")') &
+               & "y-halo that needs to be increased by ",I0,".")') &
                max(G%jsd-jsl,jel-G%jed)
     call MOM_error(FATAL,mesg)
   endif
@@ -3108,13 +3108,13 @@ subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, simple_2nd, adv_limiter)
 
   if ((isl < G%isd) .or. (iel > G%ied)) then
     write(mesg,'("In MOM_internal_tides, PPM_reconstruction_y called with a ", &
-               & "x-halo that needs to be increased by ",i2,".")') &
+               & "x-halo that needs to be increased by ",I0,".")') &
                max(G%isd-isl,iel-G%ied)
     call MOM_error(FATAL,mesg)
   endif
   if ((jsl-stencil < G%jsd) .or. (jel+stencil > G%jed)) then
     write(mesg,'("In MOM_internal_tides, PPM_reconstruction_y called with a ", &
-                 & "y-halo that needs to be increased by ",i2,".")') &
+                 & "y-halo that needs to be increased by ",I0,".")') &
                  stencil + max(G%jsd-jsl,jel-G%jed)
     call MOM_error(FATAL,mesg)
   endif

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -364,7 +364,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
     do j=js,je ; do i=is,ie
       if ((G%mask2dT(i,j) > 0.0) .and. (mle_fl_2d(i,j) < 0.0)) then
         write(mesg,'(" Time_interp negative MLE frontal-length scale of ",(1pe12.4)," at i,j = ",&
-                  & 2(i3), "lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
+                  & I0,", ",I0," lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
                   mle_fl_2d(i,j), i, j, G%geoLonT(i,j), G%geoLatT(i,j)
         call MOM_error(FATAL, "MOM_mixed_layer_restrat mixedlayer_restrat_OM4: "//trim(mesg))
       endif

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -366,8 +366,8 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS)
                    old_name='TIDE_SAL_SCALAR_VALUE')
 
   if (nc > MAX_CONSTITUENTS) then
-    write(mesg,'("Increase MAX_CONSTITUENTS in MOM_tidal_forcing.F90 to at least",I3, &
-                &"to accommodate all the registered tidal constituents.")') nc
+    write(mesg,'("Increase MAX_CONSTITUENTS in MOM_tidal_forcing.F90 to at least ",I0, &
+                &" to accommodate all the registered tidal constituents.")') nc
     call MOM_error(FATAL, "MOM_tidal_forcing"//mesg)
   endif
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -728,7 +728,7 @@ subroutine set_up_ALE_sponge_field_fixed(sp_val, G, GV, f_ptr, CS,  &
 
   CS%fldno = CS%fldno + 1
   if (CS%fldno > MAX_FIELDS_) then
-    write(mesg,'("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease &
+    write(mesg,'("Increase MAX_FIELDS_ to at least ",I0," in MOM_memory.h or decrease &
            &the number of fields to be damped in the call to &
            &initialize_ALE_sponge." )') CS%fldno
     call MOM_error(FATAL,"set_up_ALE_sponge_field: "//mesg)
@@ -794,7 +794,7 @@ subroutine set_up_ALE_sponge_field_varying(filename, fieldname, Time, G, GV, US,
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   CS%fldno = CS%fldno + 1
   if (CS%fldno > MAX_FIELDS_) then
-    write(mesg, '("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease "//&
+    write(mesg, '("Increase MAX_FIELDS_ to at least ",I0," in MOM_memory.h or decrease "//&
         &"the number of fields to be damped in the call to initialize_ALE_sponge." )') CS%fldno
     call MOM_error(FATAL,"set_up_ALE_sponge_field: "//mesg)
   endif

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -648,7 +648,7 @@ subroutine set_pen_shortwave(optics, fluxes, G, GV, US, CS, opacity, tracer_flow
       do j=js,je ; do i=is,ie
         if ((G%mask2dT(i,j) > 0.0) .and. (chl_2d(i,j) < 0.0)) then
           write(mesg,'(" Time_interp negative chl of ",(1pe12.4)," at i,j = ",&
-                    & 2(i3), "lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
+                    & I0,", ",I0," lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
                      chl_2d(i,j), i, j, G%geoLonT(i,j), G%geoLatT(i,j)
           call MOM_error(FATAL, "MOM_diabatic_aux set_pen_shortwave: "//trim(mesg))
         endif
@@ -1337,7 +1337,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
     enddo
 
     if (numberOfGroundings - maxGroundings > 0) then
-      write(mesg, '(i4)') numberOfGroundings - maxGroundings
+      write(mesg, '(I0)') numberOfGroundings - maxGroundings
       call MOM_error(WARNING, "MOM_diabatic_aux:F90, applyBoundaryFluxesInOut(): "//&
                               trim(mesg) // " groundings remaining")
     endif

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -327,7 +327,7 @@ subroutine opacity_from_chl(optics, sw_total, sw_vis_dir, sw_vis_dif, sw_nir_dir
     do k=1,nz ; do j=js,je ; do i=is,ie
       if ((G%mask2dT(i,j) > 0.0) .and. (chl_3d(i,j,k) < 0.0)) then
         write(mesg,'(" Negative chl_3d of ",(1pe12.4)," found at i,j,k = ", &
-                  & 3(1x,i3), " lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
+                  & 3(1x,I0), " lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
                    chl_3d(i,j,k), i, j, k, G%geoLonT(i,j), G%geoLatT(i,j)
         call MOM_error(FATAL, "MOM_opacity opacity_from_chl: "//trim(mesg))
       endif
@@ -337,7 +337,7 @@ subroutine opacity_from_chl(optics, sw_total, sw_vis_dir, sw_vis_dif, sw_nir_dir
     do j=js,je ; do i=is,ie
       if ((G%mask2dT(i,j) > 0.0) .and. (chl_2d(i,j) < 0.0)) then
         write(mesg,'(" Negative chl_2d of ",(1pe12.4)," at i,j = ", &
-                  & 2(i3), "lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
+                  & I0,", ",I0," lon/lat = ",(1pe12.4)," E ", (1pe12.4), " N.")') &
                    chl_data(i,j), i, j, G%geoLonT(i,j), G%geoLatT(i,j)
         call MOM_error(FATAL, "MOM_opacity opacity_from_chl: "//trim(mesg))
       endif
@@ -1299,12 +1299,12 @@ subroutine opacity_init(Time, G, GV, US, param_file, diag, CS, optics)
   CS%id_sw_vis_pen = register_diag_field('ocean_model', 'SW_vis_pen', diag%axesT1, Time, &
       'Visible penetrating shortwave radiation flux into ocean', 'W m-2', conversion=US%QRZ_T_to_W_m2)
   do n=1,optics%nbands
-    write(bandnum,'(i3)') n
-    shortname = 'opac_'//trim(adjustl(bandnum))
-    longname = 'Opacity for shortwave radiation in band '//trim(adjustl(bandnum)) &
-      // ', saved as L^-1 tanh(Opacity * L) for L = 10^-10 m'
+    write(bandnum,'(I0)') n
+    shortname = 'opac_'//trim(bandnum)
+    longname = 'Opacity for shortwave radiation in band '//trim(bandnum)// &
+               ', saved as L^-1 tanh(Opacity * L) for L = 10^-10 m'
     CS%id_opacity(n) = register_diag_field('ocean_model', shortname, diag%axesTL, Time, &
-      longname, 'm-1', conversion=US%m_to_Z)
+        longname, 'm-1', conversion=US%m_to_Z)
   enddo
 
   if (CS%opacity_scheme == OHLMANN_03) then

--- a/src/parameterizations/vertical/MOM_sponge.F90
+++ b/src/parameterizations/vertical/MOM_sponge.F90
@@ -222,7 +222,7 @@ subroutine set_up_sponge_field(sp_val, f_ptr, G, GV, nlay, CS, sp_val_i_mean)
   CS%fldno = CS%fldno + 1
 
   if (CS%fldno > MAX_FIELDS_) then
-    write(mesg,'("Increase MAX_FIELDS_ to at least ",I3," in MOM_memory.h or decrease &
+    write(mesg,'("Increase MAX_FIELDS_ to at least ",I0," in MOM_memory.h or decrease &
            &the number of fields to be damped in the call to &
            &initialize_sponge." )') CS%fldno
     call MOM_error(FATAL,"set_up_sponge_field: "//mesg)
@@ -241,8 +241,8 @@ subroutine set_up_sponge_field(sp_val, f_ptr, G, GV, nlay, CS, sp_val_i_mean)
   CS%var(CS%fldno)%p => f_ptr
 
   if (nlay/=CS%nz) then
-    write(mesg,'("Danger: Sponge reference fields require nz (",I3,") layers.&
-        & A field with ",I3," layers was passed to set_up_sponge_field.")') &
+    write(mesg,'("Danger: Sponge reference fields require nz (",I0,") layers.&
+        & A field with ",I0," layers was passed to set_up_sponge_field.")') &
           CS%nz, nlay
     if (is_root_pe()) call MOM_error(WARNING, "set_up_sponge_field: "//mesg)
   endif

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -127,8 +127,7 @@ function register_DOME_tracer(G, GV, US, param_file, CS, tr_Reg, restart_CS)
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR), source=0.0)
 
   do m=1,NTR
-    if (m < 10) then ; write(name,'("tr_D",I1.1)') m
-    else ; write(name,'("tr_D",I2.2)') m ; endif
+    write(name,'("tr_D",I0)') m
     write(longname,'("Concentration of DOME Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
     if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -112,8 +112,7 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR), source=0.0)
 
   do m=1,NTR
-    if (m < 10) then ; write(name,'("tr_D",I1.1)') m
-    else ; write(name,'("tr_D",I2.2)') m ; endif
+    write(name,'("tr_D",I0)') m
     write(longname,'("Concentration of ISOMIP Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
     if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -1750,7 +1750,7 @@ subroutine find_neutral_surface_positions_discontinuous(CS, nk, &
                                      Tr(kl_right, ki_right), Sr(kl_right, ki_right), Pres_r(kl_right,ki_right), &
                                      Tl(kl_left, ki_left),   Sl(kl_left, ki_left)  , Pres_l(kl_left,ki_left),   &
                                      dRho)
-      if (CS%debug) write(stdout,'(A,I2,A,E12.4,A,I2,A,I2,A,I2,A,I2)') &
+      if (CS%debug) write(stdout,'(A,I0,A,E12.4,A,I0,A,I0,A,I0,A,I0)') &
           "k_surface=",k_surface, "  dRho=",CS%R_to_kg_m3*dRho, &
           "kl_left=",kl_left, "  ki_left=",ki_left, "  kl_right=",kl_right, "  ki_right=",ki_right
       ! Which column has the lighter surface for the current indexes, kr and kl
@@ -1783,8 +1783,8 @@ subroutine find_neutral_surface_positions_discontinuous(CS, nk, &
         KoL(k_surface) = kl_left
 
         if (CS%debug) then
-          write(stdout,'(A,I2)') "Searching left layer ", kl_left
-          write(stdout,'(A,I2,1X,I2)') "Searching from right: ", kl_right, ki_right
+          write(stdout,'(A,I0)') "Searching left layer ", kl_left
+          write(stdout,'(A,I0,1X,I0)') "Searching from right: ", kl_right, ki_right
           write(stdout,*) "Temp/Salt Reference: ", Tr(kl_right,ki_right), Sr(kl_right,ki_right)
           write(stdout,*) "Temp/Salt Top L: ", Tl(kl_left,1), Sl(kl_left,1)
           write(stdout,*) "Temp/Salt Bot L: ", Tl(kl_left,2), Sl(kl_left,2)
@@ -1806,8 +1806,8 @@ subroutine find_neutral_surface_positions_discontinuous(CS, nk, &
         KoR(k_surface) = kl_right
 
         if (CS%debug) then
-          write(stdout,'(A,I2)') "Searching right layer ", kl_right
-          write(stdout,'(A,I2,1X,I2)') "Searching from left: ", kl_left, ki_left
+          write(stdout,'(A,I0)') "Searching right layer ", kl_right
+          write(stdout,'(A,I0,1X,I0)') "Searching from left: ", kl_left, ki_left
           write(stdout,*) "Temp/Salt Reference: ", Tl(kl_left,ki_left), Sl(kl_left,ki_left)
           write(stdout,*) "Temp/Salt Top L: ", Tr(kl_right,1), Sr(kl_right,1)
           write(stdout,*) "Temp/Salt Bot L: ", Tr(kl_right,2), Sr(kl_right,2)
@@ -1819,7 +1819,7 @@ subroutine find_neutral_surface_positions_discontinuous(CS, nk, &
       else
         stop 'Else what?'
       endif
-      if (CS%debug)  write(stdout,'(A,I3,A,ES16.6,A,I2,A,ES16.6)') "KoL:", KoL(k_surface), " PoL:", PoL(k_surface), &
+      if (CS%debug)  write(stdout,'(A,I3,A,ES16.6,A,I0,A,ES16.6)') "KoL:", KoL(k_surface), " PoL:", PoL(k_surface), &
                      "     KoR:", KoR(k_surface), " PoR:", PoR(k_surface)
     endif
     ! Effective thickness
@@ -3225,11 +3225,11 @@ logical function test_data1d(verbose, nk, Po, Ptrue, title)
     do k = 1,nk
       if (Po(k) /= Ptrue(k)) then
         test_data1d = .true.
-        write(stdunit,'(a,i2,2(1x,a,f20.16),1x,a,1pe22.15,1x,a)') &
+        write(stdunit,'(a,I0,2(1x,a,f20.16),1x,a,1pe22.15,1x,a)') &
               'k=',k,'Po=',Po(k),'Ptrue=',Ptrue(k),'err=',Po(k)-Ptrue(k),'WRONG!'
       else
         if (verbose) &
-          write(stdunit,'(a,i2,2(1x,a,f20.16),1x,a,1pe22.15)') &
+          write(stdunit,'(a,I0,2(1x,a,f20.16),1x,a,1pe22.15)') &
                 'k=',k,'Po=',Po(k),'Ptrue=',Ptrue(k),'err=',Po(k)-Ptrue(k)
       endif
     enddo
@@ -3260,10 +3260,10 @@ logical function test_data1di(verbose, nk, Po, Ptrue, title)
     do k = 1,nk
       if (Po(k) /= Ptrue(k)) then
         test_data1di = .true.
-        write(stdunit,'(a,i2,2(1x,a,i5),1x,a)') 'k=',k,'Io=',Po(k),'Itrue=',Ptrue(k),'WRONG!'
+        write(stdunit,'(a,I0,2(1x,a,i5),1x,a)') 'k=',k,'Io=',Po(k),'Itrue=',Ptrue(k),'WRONG!'
       else
         if (verbose) &
-          write(stdunit,'(a,i2,2(1x,a,i5))') 'k=',k,'Io=',Po(k),'Itrue=',Ptrue(k)
+          write(stdunit,'(a,I0,2(1x,a,i5))') 'k=',k,'Io=',Po(k),'Itrue=',Ptrue(k)
       endif
     enddo
   endif

--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -633,7 +633,7 @@ subroutine applyTracerBoundaryFluxesInOut(G, GV, Tr, dt, fluxes, h, evap_CFL_lim
     enddo
 
     if (numberOfGroundings - maxGroundings > 0) then
-      write(mesg, '(i4)') numberOfGroundings - maxGroundings
+      write(mesg, '(I0)') numberOfGroundings - maxGroundings
       call MOM_error(WARNING, "MOM_tracer_vertical.F90, applyTracerBoundaryFluxesInOut(): "//&
                               trim(mesg) // " groundings remaining", all_print=.true.)
     endif

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -848,24 +848,24 @@ subroutine store_stocks(pkg_name, ns, names, units, values, index, stock_values,
   integer :: n
 
   if ((index > 0) .and. (ns > 0)) then
-    write(ind_text,'(i8)') index
+    write(ind_text,'(I0)') index
     if (ns > 1) then
       call MOM_error(FATAL,"Tracer package "//trim(pkg_name)//&
           " is not permitted to return more than one value when queried"//&
-          " for specific stock index "//trim(adjustl(ind_text))//".")
+          " for specific stock index "//trim(ind_text)//".")
     elseif (ns+ns_tot > 1) then
       call MOM_error(FATAL,"Tracer packages "//trim(pkg_name)//" and "//&
           trim(set_pkg_name)//" both attempted to set values for"//&
-          " specific stock index "//trim(adjustl(ind_text))//".")
+          " specific stock index "//trim(ind_text)//".")
     else
       set_pkg_name = pkg_name
     endif
   endif
 
   if (ns_tot+ns > max_ns) then
-    write(ns_text,'(i8)') ns_tot+ns ; write(max_text,'(i8)') max_ns
+    write(ns_text,'(I0)') ns_tot+ns ; write(max_text,'(I0)') max_ns
     call MOM_error(FATAL,"Attempted to return more tracer stock values (at least "//&
-      trim(adjustl(ns_text))//") than the size "//trim(adjustl(max_text))//&
+      trim(ns_text)//") than the size "//trim(max_text)//&
       "of the smallest value, name, or units array.")
   endif
 

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -141,7 +141,7 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   if (.not. associated(Reg)) call tracer_registry_init(param_file, Reg)
 
   if (Reg%ntr>=MAX_FIELDS_) then
-    write(mesg,'("Increase MAX_FIELDS_ in MOM_memory.h to at least ",I3," to allow for &
+    write(mesg,'("Increase MAX_FIELDS_ in MOM_memory.h to at least ",I0," to allow for &
         &all the tracers being registered via register_tracer.")') Reg%ntr+1
     call MOM_error(FATAL,"MOM register_tracer: "//mesg)
   endif
@@ -980,9 +980,9 @@ subroutine tracer_registry_init(param_file, Reg)
 
   init_calls = init_calls + 1
   if (init_calls > 1) then
-    write(mesg,'("tracer_registry_init called ",I3, &
+    write(mesg,'("tracer_registry_init called ",I0, &
       &" times with different registry pointers.")') init_calls
-    if (is_root_pe()) call MOM_error(WARNING,"MOM_tracer"//mesg)
+    if (is_root_pe()) call MOM_error(WARNING,"MOM_tracer "//mesg)
   endif
 
 end subroutine tracer_registry_init

--- a/src/tracer/RGC_tracer.F90
+++ b/src/tracer/RGC_tracer.F90
@@ -119,8 +119,7 @@ function register_RGC_tracer(G, GV, param_file, CS, tr_Reg, restart_CS)
   endif
 
   do m=1,NTR
-    if (m < 10) then ; write(name,'("tr_RGC",I1.1)') m
-    else ; write(name,'("tr_RGC",I2.2)') m ; endif
+    write(name,'("tr_RGC",I0)') m
     write(longname,'("Concentration of RGC Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -131,8 +131,7 @@ function register_advection_test_tracer(G, GV, param_file, CS, tr_Reg, restart_C
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR), source=0.0)
 
   do m=1,NTR
-    if (m < 10) then ; write(name,'("tr",I1.1)') m
-    else ; write(name,'("tr",I2.2)') m ; endif
+    write(name,'("tr",I0)') m
     write(longname,'("Concentration of Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
     if (GV%Boussinesq) then ; flux_units = "kg kg-1 m3 s-1"

--- a/src/tracer/tracer_example.F90
+++ b/src/tracer/tracer_example.F90
@@ -116,8 +116,7 @@ function USER_register_tracer_example(G, GV, US, param_file, CS, tr_Reg, restart
   allocate(CS%tr(isd:ied,jsd:jed,nz,NTR), source=0.0)
 
   do m=1,NTR
-    if (m < 10) then ; write(name,'("tr",I1.1)') m
-    else ; write(name,'("tr",I2.2)') m ; endif
+    write(name,'("tr",I0)') m
     write(longname,'("Concentration of Tracer ",I2.2)') m
     CS%tr_desc(m) = var_desc(name, units="kg kg-1", longname=longname, caller=mdl)
 

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -504,8 +504,7 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, US, PF, tr_Reg)
   ! All tracers but the first have 0 concentration in their inflows. As 0 is the
   ! default value for the inflow concentrations, the following calls are unnecessary.
   do m=2,tr_Reg%ntr
-    if (m < 10) then ; write(name,'("tr_D",I1.1)') m
-    else ; write(name,'("tr_D",I2.2)') m ; endif
+    write(name,'("tr_D",I0)') m
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
     call register_segment_tracer(tr_ptr, ntr_id, PF, GV, OBC%segment(1), OBC_scalar=0.0)
   enddo

--- a/src/user/MOM_controlled_forcing.F90
+++ b/src/user/MOM_controlled_forcing.F90
@@ -485,8 +485,7 @@ subroutine register_ctrl_forcing_restarts(G, US, param_file, CS, restart_CS)
     allocate(CS%avg_SSS_anom(isd:ied,jsd:jed,CS%num_cycle), source=0.0)
     allocate(CS%avg_SSS(isd:ied,jsd:jed,CS%num_cycle), source=0.0)
 
-    write (period_str, '(i8)') CS%num_cycle
-    period_str = trim('p ')//trim(adjustl(period_str))
+    write (period_str, '("p ",I0)') CS%num_cycle
 
     call register_restart_field(CS%heat_cyc, "Ctrl_heat_cycle", .false., restart_CS, &
                   longname="Cyclical Control Heating", &


### PR DESCRIPTION
  Use the I0 format that was introduced with Fortran 95 in 155 lines scattered across 40 files to simplify or shorten some error messages.  In 21 cases, `adjustl()` calls that are no longer necessary for intended formatting were also eliminated.  These changes have the effect of ensuring that there are still appropriate messages if there are, for example, more than 99 vertical layers or 9999 points (total) in a horizontal directions or more than 9999 PEs.  In 15 cases, this change allowed for the elimination or reduction of if tests that formatted output based on the size of an integer.  All answers are bitwise identical but there there may be some minor formatting changes in some error messages.