### PR TITLE
Bugfix for default TIDES_ANSWER_DATE in SAL

### DIFF
--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -2078,16 +2078,16 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, ADp, SAL
                  "If true, apply tidal momentum forcing.", default=.false.)
   if (CS%tides) then
     call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
-                 "This sets the default value for the various _ANSWER_DATE parameters.", &
-                 default=99991231)
+                   "This sets the default value for the various _ANSWER_DATE parameters.", &
+                   default=99991231)
     call get_param(param_file, mdl, "TIDES_ANSWER_DATE", CS%tides_answer_date, "The vintage of "//&
-                  "self-attraction and loading (SAL) and tidal forcing calculations.  Setting "//&
-                  "dates before 20230701 recovers old answers (Boussinesq and non-Boussinesq "//&
-                  "modes) when SAL is part of the tidal forcing calculation.  The answer "//&
-                  "difference is only at bit level and due to a reordered summation.  Setting "//&
-                  "dates before 20250201 recovers answers (Boussinesq mode) that interface "//&
-                  "heights are modified before pressure force integrals are calculated.", &
-                  default=default_answer_date, do_not_log=(.not.CS%tides))
+                   "self-attraction and loading (SAL) and tidal forcing calculations.  Setting "//&
+                   "dates before 20230701 recovers old answers (Boussinesq and non-Boussinesq "//&
+                   "modes) when SAL is part of the tidal forcing calculation.  The answer "//&
+                   "difference is only at bit level and due to a reordered summation.  Setting "//&
+                   "dates before 20250201 recovers answers (Boussinesq mode) that interface "//&
+                   "heights are modified before pressure force integrals are calculated.", &
+                   default=default_answer_date, do_not_log=(.not.CS%tides))
   endif
   call get_param(param_file, mdl, "CALCULATE_SAL", CS%calculate_SAL, &
                  "If true, calculate self-attraction and loading.", default=CS%tides)

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -205,7 +205,7 @@ subroutine SAL_init(h, tv, G, GV, US, param_file, CS, restart_CS)
   type(vardesc) :: vars(1)            ! used to write ref_pbot file
   type(MOM_field) :: fields(1)        ! used to write ref_pbot file
   logical :: calculate_sal, tides, use_tidal_sal_file
-  integer :: tides_answer_date ! Recover old answers with tides
+  integer :: default_answer_date, tides_answer_date ! Recover old answers with tides
   real :: sal_scalar_value ! Scaling SAL factors [nondim]
   integer :: isd, ied, jsd, jed
 
@@ -267,8 +267,12 @@ subroutine SAL_init(h, tv, G, GV, US, param_file, CS, restart_CS)
     end select
     call pass_var(CS%pbot_ref, G%Domain)
   endif
-  call get_param(param_file, '', "TIDES_ANSWER_DATE", tides_answer_date, default=20230630, &
-                 do_not_log=.True.) ! used to check SAL_USE_BPA
+
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231, do_not_log=.True.) ! used to check SAL_USE_BPA
+  call get_param(param_file, '', "TIDES_ANSWER_DATE", tides_answer_date, &
+                 default=default_answer_date, do_not_log=.True.) ! used to check SAL_USE_BPA
   if (tides_answer_date<=20250131 .and. CS%use_bpa) &
     call MOM_error(FATAL, trim(mdl) // ", SAL_init: SAL_USE_BPA needs to be false to recover "//&
                    "tide answers before 20250131.")


### PR DESCRIPTION
Fix a bug that the recently changed default answer date for TIDES_ANSWER_DATE is not properly applied to MOM_self_attr_load. TIDES_ANSWER_DATE is used in MOM_self_attr_load to check if SAL_USE_BPA is used after a timestamp, so its default should be consistent with MOM_PressureForce_FV.