### PR TITLE
Wave drag in tensor form

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -624,6 +624,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                   ! This is nonzero mostly for a barotropic tidal body drag.
     Rayleigh_uv, & ! Same as Rayleigh_u but corresponding to the off-diagonal component if
                   ! the wave drag parameterization is in the tensor form [T-1 ~> s-1].
+    DuvDvv, &     ! A coefficient for the cross term if the wave drag is in the tensor form [nondim].
     DCor_u, &     ! An averaged total thickness at u points [H ~> m or kg m-2].
     Datu          ! Basin depth at u-velocity grid points times the y-grid
                   ! spacing [H L ~> m2 or kg m-1].
@@ -653,6 +654,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                   ! This is nonzero mostly for a barotropic tidal body drag.
     Rayleigh_vu, & ! Same as Rayleigh_v but corresponding to the off-diagonal component if
                   ! the wave drag parameterization is in the tensor form [T-1 ~> s-1].
+    DuvDuu, &     ! A coefficient for the cross term if the wave drag is in the tensor form [nondim].
     DCor_v, &     ! An averaged total thickness at v points [H ~> m or kg m-2].
     Datv          ! Basin depth at v-velocity grid points times the x-grid
                   ! spacing [H L ~> m2 or kg m-1].
@@ -742,6 +744,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   real :: u_max_cor, v_max_cor ! The maximum corrective velocities [L T-1 ~> m s-1].
   real :: uint_cor, vint_cor ! The maximum time-integrated corrective velocities [L ~> m].
   real :: Htot        ! The total thickness [H ~> m or kg m-2].
+  real :: Duu         ! A quantity derived from the 1st diagonal element of the wave drag tensor [nondim]
+  real :: Dvv         ! A quantity derived from the 2nd diagonal element of the wave drag tneosr [nondim]
+  real :: Duv         ! A quantity derived from the off-diagonal element of the wave drag tensor [nondim]
   real :: eta_cor_max ! The maximum fluid that can be added as a correction to eta [H ~> m or kg m-2].
   real :: accel_underflow ! An acceleration that is so small it should be zeroed out [L T-2 ~> m s-2].
   real :: h_a_neglect ! A cell volume or mass that is so small it is usually lost
@@ -871,9 +876,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (CS%linear_wave_drag) &
     call create_group_pass(CS%pass_eta_bt_rem, Rayleigh_u, Rayleigh_v, &
                     CS%BT_Domain, To_All+Scalar_Pair)
-  if (CS%tensor_wave_drag) &
+  if (CS%tensor_wave_drag) then
     call create_group_pass(CS%pass_eta_bt_rem, Rayleigh_uv, Rayleigh_vu, &
                     CS%BT_Domain, To_All+Scalar_Pair)
+    call create_group_pass(CS%pass_eta_bt_rem, DuvDvv, DuvDuu, &
+                    CS%BT_Domain, To_All+Scalar_Pair)
+  endif
 
   ! The following halo update is not needed without wide halos.  RWH
   if (((G%isd > CS%isdw) .or. (G%jsd > CS%jsdw)) .or. (Isq <= is-1) .or. (Jsq <= js-1)) &
@@ -1090,11 +1098,11 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (CS%tensor_wave_drag) then
     !$OMP parallel do default(shared)
     do j=CS%jsdw,CS%jedw ; do I=CS%isdw-1,CS%iedw
-      Rayleigh_uv(I,j) = 0.0
+      Rayleigh_uv(I,j) = 0.0 ; DuvDvv(I,j) = 0.0
     enddo ; enddo
     !$OMP parallel do default(shared)
     do J=CS%jsdw-1,CS%jedw ; do i=CS%isdw,CS%iedw
-      Rayleigh_vu(i,J) = 0.0
+      Rayleigh_vu(i,J) = 0.0 ; DuvDuu(i,J) = 0.0
     enddo ; enddo
   endif
 
@@ -1629,10 +1637,18 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       ! If Htot==0., linear wave drag is not used and Rayleigh_u = 0.0 (from initialization)
       ! and bt_rem_u is unmodified.
       if (Htot > 0.0) then
-        bt_rem_u(I,j) = bt_rem_u(I,j) * (Htot / (Htot + CS%lin_drag_u(I,j) * dtbt))
-        Rayleigh_u(I,j) = CS%lin_drag_u(I,j) / Htot
-        if (CS%lin_drag_uv(I,j) > 0.0) &
+        if (CS%lin_drag_uv(I,j) > 0.0) then
+          Duu = 1 + CS%lin_drag_u(I,j) * dtbt / Htot
+          Duv = CS%lin_drag_uv(I,j) * dtbt / Htot
+          Dvv = 1 + 0.25 * ((CS%lin_drag_v(i+1,J) + CS%lin_drag_v(i,J-1)) + &
+                            (CS%lin_drag_v(i,J) + CS%lin_drag_v(i+1,J-1))) * dtbt / Htot
+          DuvDvv(I,j) = Duv / Dvv
+          bt_rem_u(I,j) = bt_rem_u(I,j) * (Dvv / (Duu * Dvv - Duv * Duv))
           Rayleigh_uv(I,j) = CS%lin_drag_uv(I,j) / Htot
+        else
+          bt_rem_u(I,j) = bt_rem_u(I,j) * (Htot / (Htot + CS%lin_drag_u(I,j) * dtbt))
+        endif
+        Rayleigh_u(I,j) = CS%lin_drag_u(I,j) / Htot
       endif
     endif ; enddo ; enddo
     !$OMP do
@@ -1643,10 +1659,18 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       ! If Htot==0., linear wave drag is not used and Rayleigh_v = 0.0 (from initialization)
       ! and bt_rem_v is unmodified.
       if (Htot > 0.0) then
-        bt_rem_v(i,J) = bt_rem_v(i,J) * (Htot / (Htot + CS%lin_drag_v(i,J) * dtbt))
-        Rayleigh_v(i,J) = CS%lin_drag_v(i,J) / Htot
-        if (CS%lin_drag_vu(i,J) > 0.0) &
+        if (CS%lin_drag_vu(i,J) > 0.0) then
+          Dvv = 1 + CS%lin_drag_v(i,J) * dtbt / Htot
+          Duv = CS%lin_drag_vu(i,J) * dtbt / Htot
+          Duu = 1 + 0.25 * ((CS%lin_drag_u(I-1,j) + CS%lin_drag_u(I,j+1)) + &
+                            (CS%lin_drag_u(I,j) + CS%lin_drag_u(I-1,j+1))) * dtbt / Htot
+          DuvDuu(i,J) = Duv / Duu
+          bt_rem_v(i,J) = bt_rem_v(i,J) * (Duu / (Duu * Dvv - Duv * Duv))
           Rayleigh_vu(i,J) = CS%lin_drag_vu(i,J) / Htot
+        else
+          bt_rem_v(i,J) = bt_rem_v(i,J) * (Htot / (Htot + CS%lin_drag_v(i,J) * dtbt))
+        endif
+        Rayleigh_v(i,J) = CS%lin_drag_v(i,J) / Htot
       endif
     endif ; enddo ; enddo
   endif
@@ -1929,7 +1953,7 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                 eta_PF_1, d_eta_PF, eta_src, dyn_coef_eta, uhbtav, vhbtav, u_accel_bt, v_accel_bt, &
                 f_4_u, f_4_v, bt_rem_u, bt_rem_v, &
                 BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, Rayleigh_u, Rayleigh_v, Rayleigh_uv, &
-                Rayleigh_vu, eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
+                Rayleigh_vu, DuvDvv, DuvDuu, eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
                 eta_sum, eta_wtd, ubt_wtd, vbt_wtd, Coru_avg, PFu_avg, LDu_avg, Corv_avg, PFv_avg, &
                 LDv_avg, use_BT_cont, interp_eta_PF, find_etaav, dt, dtbt, nstep, nfilter, &
                 wt_vel, wt_eta, wt_accel, wt_trans, wt_accel2, ADp, CS%BT_OBC, CS, G, MS, GV, US)
@@ -2321,7 +2345,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
                 eta_PF_1, d_eta_PF, eta_src, dyn_coef_eta, uhbtav, vhbtav, u_accel_bt, v_accel_bt, &
                 f_4_u, f_4_v, bt_rem_u, bt_rem_v, &
                 BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, Rayleigh_u, Rayleigh_v, Rayleigh_uv, &
-                Rayleigh_vu, eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
+                Rayleigh_vu, DuvDvv, DuvDuu, eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
                 eta_sum, eta_wtd, ubt_wtd, vbt_wtd, Coru_avg, PFu_avg, LDu_avg, Corv_avg, PFv_avg, &
                 LDv_avg, use_BT_cont, interp_eta_PF, find_etaav, dt, dtbt, nstep, nfilter, &
                 wt_vel, wt_eta, wt_accel, wt_trans, wt_accel2, ADp, BT_OBC, CS, G, MS, GV, US)
@@ -2420,6 +2444,10 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
   real, dimension(SZIW_(CS),SZJBW_(CS)), intent(in) :: &
     Rayleigh_vu   !< Same as Rayleigh_v but corresponding to the off-diagonal component if
                   !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
+  real, dimension(SZIBW_(CS),SZJW_(CS)), intent(in) :: &
+    DuvDvv        !< A coefficient for the cross term if the wave drag is in tensor form [nondim]
+  real, dimension(SZIW_(CS),SZJBW_(CS)), intent(in) :: &
+    DuvDuu        !< A coefficient for the cross term if the wave drag is in tensor form [nondim]
   real, dimension(SZIW_(CS),SZJW_(CS)), intent(inout) :: &
     eta_PF        !< The 2-D eta field (either SSH anomaly or column mass anomaly) that was used to
                   !! calculate the input pressure gradient accelerations [H ~> m or kg m-2]
@@ -2759,22 +2787,22 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
       ! On odd-steps, update v first.
       call btloop_update_v(dtbt, ubt, vbt, v_accel_bt, Cor_v, PFv, isv-1, iev+1, jsv-1, jev, &
                            f_4_v, bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, Rayleigh_vu, &
-                           wt_accel(n), G, US, CS)
+                           DuvDuu, wt_accel(n), G, US, CS)
 
       ! Now update the zonal velocity.
       call btloop_update_u(dtbt, ubt, vbt, u_accel_bt, Cor_u, PFu, isv-1, iev, jsv, jev, &
                            f_4_u, bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, Rayleigh_uv, &
-                           wt_accel(n), G, US, CS)
+                           DuvDvv, wt_accel(n), G, US, CS)
 
     else
       ! On even steps, update u first.
       call btloop_update_u(dtbt, ubt, vbt, u_accel_bt, Cor_u, PFu, isv-1, iev, jsv-1, jev+1, &
                            f_4_u, bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, Rayleigh_uv, &
-                           wt_accel(n), G, US, CS)
+                           DuvDvv, wt_accel(n), G, US, CS)
       ! Now update the meridional velocity.
       call btloop_update_v(dtbt, ubt, vbt, v_accel_bt, Cor_v, PFv, isv, iev, jsv-1, jev, &
                            f_4_v, bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, Rayleigh_vu, &
-                           wt_accel(n), G, US, CS, Cor_bracket_bug=CS%use_old_coriolis_bracket_bug)
+                           DuvDuu, wt_accel(n), G, US, CS, Cor_bracket_bug=CS%use_old_coriolis_bracket_bug)
     endif
 
     ! Determine the transports based on the updated velocities when no OBCs are applied
@@ -3431,7 +3459,7 @@ end subroutine btloop_add_dyn_PF
 subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
                            Cor_v, PFv, is_v, ie_v, Js_v, Je_v, f_4_v, &
                            bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, Rayleigh_vu, &
-                           wt_accel_n, G, US, CS, Cor_bracket_bug)
+                           DuvDuu, wt_accel_n, G, US, CS, Cor_bracket_bug)
   type(ocean_grid_type),   intent(inout) :: G     !< The ocean's grid structure.
   type(barotropic_CS),     intent(inout) :: CS    !< Barotropic control structure
   real, dimension(SZIBW_(CS),SZJW_(CS)), intent(in) :: &
@@ -3473,6 +3501,8 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
   real, dimension(SZIW_(CS),SZJBW_(CS)), intent(in) :: &
     Rayleigh_vu   !< Same as Rayleigh_v but corresponding to the off-diagonal component if
                   !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
+  real, dimension(SZIW_(CS),SZJBW_(CS)), intent(in) :: &
+    DuvDuu        !< A coefficient for the cross term if the wave drag is in tensor form [nondim]
   real,    intent(in) :: wt_accel_n  !< The raw or relative weights of each of the barotropic timesteps
                   !! in determining the average accelerations [nondim]
   real,    intent(in) :: dtbt !< The barotropic time step [T ~> s].
@@ -3483,7 +3513,7 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
   ! Local variables
   logical :: use_bracket_bug
   integer :: i, j
-  real :: Drag_v  !< Linear wave drag applied to the u-velocity [L T-2 ~> m s-2]
+  real :: ubt_on_v !< zonal velocity on the v-grid points [L T-2 ~> m s-2]
 
   use_bracket_bug = .false. ; if (present(Cor_bracket_bug)) use_bracket_bug = Cor_bracket_bug
 
@@ -3513,7 +3543,15 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
   enddo ; enddo
   !$OMP end do nowait
 
-  if (CS%linear_wave_drag) then
+  if (CS%tensor_wave_drag) then
+    !$OMP do schedule(static)
+    do J=Js_v,Je_v ; do i=is_v,ie_v
+      ubt_on_v = 0.25 * ((ubt(I-1,j) + ubt(I,j+1)) + (ubt(I,j) + ubt(I-1,j+1)))
+      vbt(i,J) = vbt(i,J) - bt_rem_v(i,J) * DuvDuu(i,J) * ubt_on_v
+      v_accel_bt(i,J) = v_accel_bt(i,J) + wt_accel_n * &
+          ((Cor_v(i,J) + PFv(i,J)) - (vbt(i,J) * Rayleigh_v(i,J) + ubt_on_v * Rayleigh_vu(i,J)))
+    enddo ; enddo
+  elseif (CS%linear_wave_drag) then
     !$OMP do schedule(static)
     do J=Js_v,Je_v ; do i=is_v,ie_v
       v_accel_bt(i,J) = v_accel_bt(i,J) + wt_accel_n * &
@@ -3526,22 +3564,13 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
     enddo ; enddo
   endif
 
-  if (CS%tensor_wave_drag) then
-    !$OMP do schedule(static)
-    do J=Js_v,Je_v ; do i=is_v,ie_v
-      Drag_v = 0.25 * ((ubt(I-1,j) + ubt(I,j+1)) + (ubt(I,j) + ubt(I-1,j+1))) * Rayleigh_vu(i,J)
-      vbt(i,J) = vbt(i,J) - bt_rem_v(i,J) * dtbt * Drag_v
-      v_accel_bt(i,J) = v_accel_bt(i,J) - wt_accel_n * Drag_v
-    enddo ; enddo
-  endif
-
 end subroutine btloop_update_v
 
 !> Update zonal velocity.
 subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
                            Cor_u, PFu, Is_u, Ie_u, js_u, je_u, f_4_u, &
                            bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, Rayleigh_uv, &
-                           wt_accel_n, G, US, CS)
+                           DuvDvv, wt_accel_n, G, US, CS)
   type(ocean_grid_type),   intent(inout) :: G     !< The ocean's grid structure.
   type(barotropic_CS),     intent(inout) :: CS    !< Barotropic control structure
   real,    intent(in) :: dtbt     !< The barotropic time step [T ~> s].
@@ -3584,6 +3613,8 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
   real, dimension(SZIBW_(CS),SZJW_(CS)), intent(in) :: &
     Rayleigh_uv   !< Same as Rayleigh_u but corresponding to the off-diagonal component if
                   !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
+  real, dimension(SZIBW_(CS),SZJW_(CS)), intent(in) :: &
+    DuvDvv        !< A coefficient for the cross term if the wave drag is in tensor form [nondim]
   real,    intent(in) :: wt_accel_n  !< The raw or relative weights of each of the barotropic timesteps
                                   !! in determining the average accelerations [nondim]
   type(unit_scale_type),   intent(in)  :: US      !< A dimensional unit scaling type
@@ -3591,7 +3622,7 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
   ! Local variables
   real :: vel_prev    ! The previous velocity [L T-1 ~> m s-1].
   integer :: i, j
-  real :: Drag_u  !< Linear wave drag applied to the v-velocity [L T-2 ~> m s-2]
+  real :: vbt_on_u !< Meridional velocity on the u-grid points [L T-2 ~> m s-2]
 
   !$OMP do schedule(static)
   do j=js_u,je_u ; do I=Is_u,Ie_u
@@ -3605,7 +3636,15 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
   enddo ; enddo
   !$OMP end do nowait
 
-  if (CS%linear_wave_drag) then
+  if (CS%tensor_wave_drag) then
+    !$OMP do schedule(static)
+    do j=js_u,je_u ; do I=Is_u,Ie_u
+      vbt_on_u = 0.25 * ((vbt(i+1,J) + vbt(i,J-1)) + (vbt(i,J) + vbt(i+1,J-1)))
+      ubt(I,j) = ubt(I,j) - bt_rem_u(I,j) * DuvDvv(I,j) * vbt_on_u
+      u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel_n * &
+          ((Cor_u(I,j) + PFu(I,j)) - (ubt(I,j) * Rayleigh_u(I,j) + vbt_on_u * Rayleigh_uv(I,j)))
+    enddo ; enddo
+  elseif (CS%linear_wave_drag) then
     !$OMP do schedule(static)
     do j=js_u,je_u ; do I=Is_u,Ie_u
       u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel_n * &
@@ -3618,15 +3657,6 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
       u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel_n * (Cor_u(I,j) + PFu(I,j))
     enddo ; enddo
     !$OMP end do nowait
-  endif
-
-  if (CS%tensor_wave_drag) then
-    !$OMP do schedule(static)
-    do j=js_u,je_u ; do I=Is_u,Ie_u
-      Drag_u = 0.25 * ((vbt(i+1,J) + vbt(i,J-1)) + (vbt(i,J) + vbt(i+1,J-1))) * Rayleigh_uv(I,j)
-      ubt(I,j) = ubt(I,j) - bt_rem_u(I,j) * dtbt * Drag_u
-      u_accel_bt(I,j) = u_accel_bt(I,j) - wt_accel_n * Drag_u
-    enddo ; enddo
   endif
 
 end subroutine btloop_update_u

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -119,6 +119,10 @@ type, public :: barotropic_CS ; private
   real, allocatable, dimension(:,:) :: lin_drag_u
           !< A spatially varying linear drag coefficient acting on the zonal barotropic flow
           !! [H T-1 ~> m s-1 or kg m-2 s-1].
+  real, allocatable, dimension(:,:) :: lin_drag_uv
+          !< A spatially varying linear drag coefficient acting on the zonal barotropic flow
+          !! due to the meridional barotropic flow, representing the off-diagonal component
+          !! of the wave drag tensor [H T-1 ~> m s-1 or kg m-2 s-1].
   real, allocatable, dimension(:,:) :: ubt_IC
           !< The barotropic solvers estimate of the zonal velocity that will be the initial
           !! condition for the next call to btstep [L T-1 ~> m s-1].
@@ -127,8 +131,12 @@ type, public :: barotropic_CS ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_) :: IDatv
           !< Inverse of the basin depth at v grid points [Z-1 ~> m-1].
   real, allocatable, dimension(:,:) :: lin_drag_v
-          !< A spatially varying linear drag coefficient acting on the zonal barotropic flow
+          !< A spatially varying linear drag coefficient acting on the meridional barotropic flow
           !! [H T-1 ~> m s-1 or kg m-2 s-1].
+  real, allocatable, dimension(:,:) :: lin_drag_vu
+          !< A spatially varying linear drag coefficient acting on the meridional barotropic flow
+          !! due to the zonal barotropic flow, representing the off-diagonal component of the wave
+          !! drag tensor [H T-1 ~> m s-1 or kg m-2 s-1].
   real, allocatable, dimension(:,:) :: vbt_IC
           !< The barotropic solvers estimate of the zonal velocity that will be the initial
           !! condition for the next call to btstep [L T-1 ~> m s-1].
@@ -270,6 +278,9 @@ type, public :: barotropic_CS ; private
                              !! average of the layer viscous remnants after a baroclinic timestep.
   logical :: linear_wave_drag  !< If true, apply a linear drag to the barotropic
                              !! velocities, using rates set by lin_drag_u & _v
+                             !! divided by the depth of the ocean.
+  logical :: tensor_wave_drag  !< If true, include off-diagonal terms of the wave drag tensor,
+                             !! with rates set by lin_drag_uv & _vu
                              !! divided by the depth of the ocean.
   logical :: linearized_BT_PV  !< If true, the PV and interface thicknesses used
                              !! in the barotropic Coriolis calculation is time
@@ -611,6 +622,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                   ! that introduced directly into the barotropic solver rather than coming in via
                   ! the visc_rem_u arrays from the layered equations [T-1 ~> s-1].
                   ! This is nonzero mostly for a barotropic tidal body drag.
+    Rayleigh_uv, & ! Same as Rayleigh_u but corresponding to the off-diagonal component if
+                  ! the wave drag parameterization is in the tensor form [T-1 ~> s-1].
     DCor_u, &     ! An averaged total thickness at u points [H ~> m or kg m-2].
     Datu          ! Basin depth at u-velocity grid points times the y-grid
                   ! spacing [H L ~> m2 or kg m-1].
@@ -638,6 +651,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
                   ! that introduced directly into the barotropic solver rather than coming
                   ! in via the visc_rem_v arrays from the layered equations [T-1 ~> s-1].
                   ! This is nonzero mostly for a barotropic tidal body drag.
+    Rayleigh_vu, & ! Same as Rayleigh_v but corresponding to the off-diagonal component if
+                  ! the wave drag parameterization is in the tensor form [T-1 ~> s-1].
     DCor_v, &     ! An averaged total thickness at v points [H ~> m or kg m-2].
     Datv          ! Basin depth at v-velocity grid points times the x-grid
                   ! spacing [H L ~> m2 or kg m-1].
@@ -856,6 +871,9 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   if (CS%linear_wave_drag) &
     call create_group_pass(CS%pass_eta_bt_rem, Rayleigh_u, Rayleigh_v, &
                     CS%BT_Domain, To_All+Scalar_Pair)
+  if (CS%tensor_wave_drag) &
+    call create_group_pass(CS%pass_eta_bt_rem, Rayleigh_uv, Rayleigh_vu, &
+                    CS%BT_Domain, To_All+Scalar_Pair)
 
   ! The following halo update is not needed without wide halos.  RWH
   if (((G%isd > CS%isdw) .or. (G%jsd > CS%jsdw)) .or. (Isq <= is-1) .or. (Jsq <= js-1)) &
@@ -1066,6 +1084,17 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
     !$OMP parallel do default(shared)
     do J=CS%jsdw-1,CS%jedw ; do i=CS%isdw,CS%iedw
       Rayleigh_v(i,J) = 0.0
+    enddo ; enddo
+  endif
+
+  if (CS%tensor_wave_drag) then
+    !$OMP parallel do default(shared)
+    do j=CS%jsdw,CS%jedw ; do I=CS%isdw-1,CS%iedw
+      Rayleigh_uv(I,j) = 0.0
+    enddo ; enddo
+    !$OMP parallel do default(shared)
+    do J=CS%jsdw-1,CS%jedw ; do i=CS%isdw,CS%iedw
+      Rayleigh_vu(i,J) = 0.0
     enddo ; enddo
   endif
 
@@ -1602,6 +1631,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       if (Htot > 0.0) then
         bt_rem_u(I,j) = bt_rem_u(I,j) * (Htot / (Htot + CS%lin_drag_u(I,j) * dtbt))
         Rayleigh_u(I,j) = CS%lin_drag_u(I,j) / Htot
+        if (CS%lin_drag_uv(I,j) > 0.0) &
+          Rayleigh_uv(I,j) = CS%lin_drag_uv(I,j) / Htot
       endif
     endif ; enddo ; enddo
     !$OMP do
@@ -1614,6 +1645,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
       if (Htot > 0.0) then
         bt_rem_v(i,J) = bt_rem_v(i,J) * (Htot / (Htot + CS%lin_drag_v(i,J) * dtbt))
         Rayleigh_v(i,J) = CS%lin_drag_v(i,J) / Htot
+        if (CS%lin_drag_vu(i,J) > 0.0) &
+          Rayleigh_vu(i,J) = CS%lin_drag_vu(i,J) / Htot
       endif
     endif ; enddo ; enddo
   endif
@@ -1895,8 +1928,8 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, forces, pbce, 
   call btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL_v, eta_IC, &
                 eta_PF_1, d_eta_PF, eta_src, dyn_coef_eta, uhbtav, vhbtav, u_accel_bt, v_accel_bt, &
                 f_4_u, f_4_v, bt_rem_u, bt_rem_v, &
-                BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, Rayleigh_u, Rayleigh_v, &
-                eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
+                BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, Rayleigh_u, Rayleigh_v, Rayleigh_uv, &
+                Rayleigh_vu, eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
                 eta_sum, eta_wtd, ubt_wtd, vbt_wtd, Coru_avg, PFu_avg, LDu_avg, Corv_avg, PFv_avg, &
                 LDv_avg, use_BT_cont, interp_eta_PF, find_etaav, dt, dtbt, nstep, nfilter, &
                 wt_vel, wt_eta, wt_accel, wt_trans, wt_accel2, ADp, CS%BT_OBC, CS, G, MS, GV, US)
@@ -2287,8 +2320,8 @@ end subroutine btstep
 subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL_v, eta_IC, &
                 eta_PF_1, d_eta_PF, eta_src, dyn_coef_eta, uhbtav, vhbtav, u_accel_bt, v_accel_bt, &
                 f_4_u, f_4_v, bt_rem_u, bt_rem_v, &
-                BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, Rayleigh_u, Rayleigh_v, &
-                eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
+                BT_force_u, BT_force_v, Cor_ref_u, Cor_ref_v, Rayleigh_u, Rayleigh_v, Rayleigh_uv, &
+                Rayleigh_vu, eta_PF, gtot_E, gtot_W, gtot_N, gtot_S, SpV_col_avg, dgeo_de, &
                 eta_sum, eta_wtd, ubt_wtd, vbt_wtd, Coru_avg, PFu_avg, LDu_avg, Corv_avg, PFv_avg, &
                 LDv_avg, use_BT_cont, interp_eta_PF, find_etaav, dt, dtbt, nstep, nfilter, &
                 wt_vel, wt_eta, wt_accel, wt_trans, wt_accel2, ADp, BT_OBC, CS, G, MS, GV, US)
@@ -2381,6 +2414,12 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     Rayleigh_v    !< A Rayleigh drag timescale operating at v-points for drag parameterizations
                   !! that introduced directly into the barotropic solver rather than coming
                   !! in via the visc_rem_v arrays from the layered equations [T-1 ~> s-1]
+  real, dimension(SZIBW_(CS),SZJW_(CS)), intent(in) :: &
+    Rayleigh_uv   !< Same as Rayleigh_u but corresponding to the off-diagonal component if
+                  !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
+  real, dimension(SZIW_(CS),SZJBW_(CS)), intent(in) :: &
+    Rayleigh_vu   !< Same as Rayleigh_v but corresponding to the off-diagonal component if
+                  !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
   real, dimension(SZIW_(CS),SZJW_(CS)), intent(inout) :: &
     eta_PF        !< The 2-D eta field (either SSH anomaly or column mass anomaly) that was used to
                   !! calculate the input pressure gradient accelerations [H ~> m or kg m-2]
@@ -2719,22 +2758,22 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     if (v_first) then
       ! On odd-steps, update v first.
       call btloop_update_v(dtbt, ubt, vbt, v_accel_bt, Cor_v, PFv, isv-1, iev+1, jsv-1, jev, &
-                           f_4_v, bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, &
+                           f_4_v, bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, Rayleigh_vu, &
                            wt_accel(n), G, US, CS)
 
       ! Now update the zonal velocity.
       call btloop_update_u(dtbt, ubt, vbt, u_accel_bt, Cor_u, PFu, isv-1, iev, jsv, jev, &
-                           f_4_u, bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, &
+                           f_4_u, bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, Rayleigh_uv, &
                            wt_accel(n), G, US, CS)
 
     else
       ! On even steps, update u first.
       call btloop_update_u(dtbt, ubt, vbt, u_accel_bt, Cor_u, PFu, isv-1, iev, jsv-1, jev+1, &
-                           f_4_u, bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, &
+                           f_4_u, bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, Rayleigh_uv, &
                            wt_accel(n), G, US, CS)
       ! Now update the meridional velocity.
       call btloop_update_v(dtbt, ubt, vbt, v_accel_bt, Cor_v, PFv, isv, iev, jsv-1, jev, &
-                           f_4_v, bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, &
+                           f_4_v, bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, Rayleigh_vu, &
                            wt_accel(n), G, US, CS, Cor_bracket_bug=CS%use_old_coriolis_bracket_bug)
     endif
 
@@ -2959,6 +2998,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
         !$OMP end do nowait
       endif
 
+      ! This does not include contribution from off-diagonal components of a wave drag tensor.
       if (CS%linear_wave_drag) then
         if ((CS%id_LDu_bt > 0) .or. (associated(ADp%bt_lwd_u))) then
           !$OMP do
@@ -3390,7 +3430,7 @@ end subroutine btloop_add_dyn_PF
 !> Update meridional velocity.
 subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
                            Cor_v, PFv, is_v, ie_v, Js_v, Je_v, f_4_v, &
-                           bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, &
+                           bt_rem_v, BT_force_v, Cor_ref_v, Rayleigh_v, Rayleigh_vu, &
                            wt_accel_n, G, US, CS, Cor_bracket_bug)
   type(ocean_grid_type),   intent(inout) :: G     !< The ocean's grid structure.
   type(barotropic_CS),     intent(inout) :: CS    !< Barotropic control structure
@@ -3430,6 +3470,9 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
     Rayleigh_v    !< A Rayleigh drag timescale operating at v-points for drag parameterizations
                   !! that introduced directly into the barotropic solver rather than coming
                   !! in via the visc_rem_v arrays from the layered equations [T-1 ~> s-1]
+  real, dimension(SZIW_(CS),SZJBW_(CS)), intent(in) :: &
+    Rayleigh_vu   !< Same as Rayleigh_v but corresponding to the off-diagonal component if
+                  !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
   real,    intent(in) :: wt_accel_n  !< The raw or relative weights of each of the barotropic timesteps
                   !! in determining the average accelerations [nondim]
   real,    intent(in) :: dtbt !< The barotropic time step [T ~> s].
@@ -3440,6 +3483,7 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
   ! Local variables
   logical :: use_bracket_bug
   integer :: i, j
+  real :: Drag_v  !< Linear wave drag applied to the u-velocity [L T-2 ~> m s-2]
 
   use_bracket_bug = .false. ; if (present(Cor_bracket_bug)) use_bracket_bug = Cor_bracket_bug
 
@@ -3482,12 +3526,21 @@ subroutine btloop_update_v(dtbt, ubt, vbt, v_accel_bt, &
     enddo ; enddo
   endif
 
+  if (CS%tensor_wave_drag) then
+    !$OMP do schedule(static)
+    do J=Js_v,Je_v ; do i=is_v,ie_v
+      Drag_v = 0.25 * ((ubt(I-1,j) + ubt(I,j+1)) + (ubt(I,j) + ubt(I-1,j+1))) * Rayleigh_vu(i,J)
+      vbt(i,J) = vbt(i,J) - bt_rem_v(i,J) * dtbt * Drag_v
+      v_accel_bt(i,J) = v_accel_bt(i,J) - wt_accel_n * Drag_v
+    enddo ; enddo
+  endif
+
 end subroutine btloop_update_v
 
 !> Update zonal velocity.
 subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
                            Cor_u, PFu, Is_u, Ie_u, js_u, je_u, f_4_u, &
-                           bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, &
+                           bt_rem_u, BT_force_u, Cor_ref_u, Rayleigh_u, Rayleigh_uv, &
                            wt_accel_n, G, US, CS)
   type(ocean_grid_type),   intent(inout) :: G     !< The ocean's grid structure.
   type(barotropic_CS),     intent(inout) :: CS    !< Barotropic control structure
@@ -3528,6 +3581,9 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
     Rayleigh_u    !< A Rayleigh drag timescale operating at u-points for drag parameterizations
                   !! that introduced directly into the barotropic solver rather than coming
                   !! in via the visc_rem_u arrays from the layered equations [T-1 ~> s-1].
+  real, dimension(SZIBW_(CS),SZJW_(CS)), intent(in) :: &
+    Rayleigh_uv   !< Same as Rayleigh_u but corresponding to the off-diagonal component if
+                  !! the wave drag parameterization is in the tensor form [T-1 ~> s-1]
   real,    intent(in) :: wt_accel_n  !< The raw or relative weights of each of the barotropic timesteps
                                   !! in determining the average accelerations [nondim]
   type(unit_scale_type),   intent(in)  :: US      !< A dimensional unit scaling type
@@ -3535,6 +3591,7 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
   ! Local variables
   real :: vel_prev    ! The previous velocity [L T-1 ~> m s-1].
   integer :: i, j
+  real :: Drag_u  !< Linear wave drag applied to the v-velocity [L T-2 ~> m s-2]
 
   !$OMP do schedule(static)
   do j=js_u,je_u ; do I=Is_u,Ie_u
@@ -3561,6 +3618,15 @@ subroutine btloop_update_u(dtbt, ubt, vbt, u_accel_bt, &
       u_accel_bt(I,j) = u_accel_bt(I,j) + wt_accel_n * (Cor_u(I,j) + PFu(I,j))
     enddo ; enddo
     !$OMP end do nowait
+  endif
+
+  if (CS%tensor_wave_drag) then
+    !$OMP do schedule(static)
+    do j=js_u,je_u ; do I=Is_u,Ie_u
+      Drag_u = 0.25 * ((vbt(i+1,J) + vbt(i,J-1)) + (vbt(i,J) + vbt(i+1,J-1))) * Rayleigh_uv(I,j)
+      ubt(I,j) = ubt(I,j) - bt_rem_u(I,j) * dtbt * Drag_u
+      u_accel_bt(I,j) = u_accel_bt(I,j) - wt_accel_n * Drag_u
+    enddo ; enddo
   endif
 
 end subroutine btloop_update_u
@@ -5526,11 +5592,15 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   character(len=200) :: wave_drag_file ! The file from which to read the wave
                                        ! drag piston velocity.
   character(len=80)  :: wave_drag_var  ! The wave drag piston velocity variable
-                                       ! name in wave_drag_file.
+                                       ! name in wave_drag_file (scalar form).
   character(len=80)  :: wave_drag_u    ! The wave drag piston velocity variable
-                                       ! name in wave_drag_file.
+                                       ! name in wave_drag_file (directional form).
   character(len=80)  :: wave_drag_v    ! The wave drag piston velocity variable
-                                       ! name in wave_drag_file.
+                                       ! name in wave_drag_file (directional form).
+  character(len=80)  :: wave_drag_uv   ! The wave drag piston velocity variable
+                                       ! name in wave_drag_file (tensor form).
+  character(len=80)  :: wave_drag_vu   ! The wave drag piston velocity variable
+                                       ! name in wave_drag_file (tensor form).
   real :: mean_SL     ! The mean sea level that is used along with the bathymetry to estimate the
                       ! geometry when LINEARIZED_BT_CORIOLIS is true or BT_NONLIN_STRESS is false [Z ~> m].
   real :: Z_to_H      ! A local unit conversion factor [H Z-1 ~> nondim or kg m-3]
@@ -5831,6 +5901,20 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   call get_param(param_file, mdl, "BT_WAVE_DRAG_V", wave_drag_v, &
                  "The name of the variable in BT_WAVE_DRAG_FILE with the "//&
                  "barotropic linear wave drag piston velocities at v points.", &
+                 default="", do_not_log=.not.CS%linear_wave_drag)
+  call get_param(param_file, mdl, "BT_WAVE_DRAG_UV", wave_drag_uv, &
+                 "The name of the variable in BT_WAVE_DRAG_FILE with the "//&
+                 "barotropic linear wave drag piston velocities at u points "//&
+                 "due to the v-veolcity. "//&
+                 "This is the off-diagonal component of the wave drag tensor. "//&
+                 "If unspecified, the wave drag will be in the scalar form.", &
+                 default="", do_not_log=.not.CS%linear_wave_drag)
+  call get_param(param_file, mdl, "BT_WAVE_DRAG_VU", wave_drag_vu, &
+                 "The name of the variable in BT_WAVE_DRAG_FILE with the "//&
+                 "barotropic linear wave drag piston velocities at v points "// &
+                 "due to the u-veolcity. "//&
+                 "This is the off-diagonal component of the wave drag tensor. "// &
+                 "If unspecified, the wave drag will be in the scalar form.", &
                  default="", do_not_log=.not.CS%linear_wave_drag)
   call get_param(param_file, mdl, "BT_WAVE_DRAG_SCALE", wave_drag_scale, &
                  "A scaling factor for the barotropic linear wave drag "//&
@@ -6177,9 +6261,13 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     call do_group_pass(pass_q_D_Cor, CS%BT_Domain)
   endif
 
+  CS%tensor_wave_drag = .false.
+
   if (CS%linear_wave_drag) then
     allocate(CS%lin_drag_u(IsdB:IedB,jsd:jed), source=0.0)
     allocate(CS%lin_drag_v(isd:ied,JsdB:JedB), source=0.0)
+    allocate(CS%lin_drag_uv(IsdB:IedB,jsd:jed), source=0.0)
+    allocate(CS%lin_drag_vu(isd:ied,JsdB:JedB), source=0.0)
 
     if (len_trim(wave_drag_file) > 0) then
       inputdir = "." ;  call get_param(param_file, mdl, "INPUTDIR", inputdir)
@@ -6192,6 +6280,17 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
         call MOM_read_data(wave_drag_file, wave_drag_v, CS%lin_drag_v, G%Domain, &
                            position=NORTH_FACE, scale=wave_drag_scale*GV%m_to_H*US%T_to_s)
         call pass_vector(CS%lin_drag_u, CS%lin_drag_v, G%domain, direction=To_All+SCALAR_PAIR)
+
+        ! Read off-diagonal components of the wave drag tensor, if present
+        if (len_trim(wave_drag_uv) > 0 .and. len_trim(wave_drag_vu) > 0) then
+          CS%tensor_wave_drag = .true.
+
+          call MOM_read_data(wave_drag_file, wave_drag_uv, CS%lin_drag_uv, G%Domain, &
+                             position=EAST_FACE, scale=wave_drag_scale*GV%m_to_H*US%T_to_s)
+          call MOM_read_data(wave_drag_file, wave_drag_vu, CS%lin_drag_vu, G%Domain, &
+                             position=NORTH_FACE, scale=wave_drag_scale*GV%m_to_H*US%T_to_s)
+          call pass_vector(CS%lin_drag_uv, CS%lin_drag_vu, G%domain, direction=To_All+SCALAR_PAIR)
+        endif ! (len_trim(wave_drag_uv) > 0 .and. len_trim(wave_drag_vu) > 0)
       else
         allocate(lin_drag_h(isd:ied,jsd:jed), source=0.0)
 
@@ -6530,6 +6629,8 @@ subroutine barotropic_end(CS)
   if (allocated(CS%vbt_IC)) deallocate(CS%vbt_IC)
   if (allocated(CS%lin_drag_u)) deallocate(CS%lin_drag_u)
   if (allocated(CS%lin_drag_v)) deallocate(CS%lin_drag_v)
+  if (allocated(CS%lin_drag_uv)) deallocate(CS%lin_drag_uv)
+  if (allocated(CS%lin_drag_vu)) deallocate(CS%lin_drag_vu)
 
   if (associated(CS%debug_BT_HI)) deallocate(CS%debug_BT_HI)
   call deallocate_MOM_domain(CS%BT_domain)


### PR DESCRIPTION
This commit allows the linear wave drag to be implemented in tensor form, by incorporating the off-diagonal components of the wave drag tensor into the barotropic solver.

This is part of the Pull Request I opened earlier (#961), but is relevant to the linear wave drag only. I'll open a separate PR for the frequency-dependent drag later.