### PR TITLE
Fixes a typo in Recon1d_PPM limiters

### DIFF
--- a/src/ALE/Recon1d_PPM_CW.F90
+++ b/src/ALE/Recon1d_PPM_CW.F90
@@ -158,7 +158,7 @@ subroutine reconstruct(this, h, u)
     u2 = u(k+1)
     a6 = 3.0 * ( ( u1 - this%ul(k) ) + ( u1 - this%ur(k) ) )
     du = this%ur(k) - this%ul(k)
-    if ( ( u2 - u1 ) * ( u1 - u0 ) <- 0.0 ) then ! Large scale extrema
+    if ( ( u2 - u1 ) * ( u1 - u0 ) <= 0.0 ) then ! Large scale extrema
       this%ul(k) = u1
       this%ur(k) = u1
     elseif ( du * a6 > du * du ) then ! Extrema on right

--- a/src/ALE/Recon1d_PPM_CWK.F90
+++ b/src/ALE/Recon1d_PPM_CWK.F90
@@ -143,7 +143,7 @@ subroutine reconstruct(this, h, u)
     u2 = u(k+1)
     a6 = 3.0 * ( ( u1 - this%ul(k) ) + ( u1 - this%ur(k) ) )
     du = this%ur(k) - this%ul(k)
-    if ( ( u2 - u1 ) * ( u1 - u0 ) <- 0.0 ) then ! Large scale extrema
+    if ( ( u2 - u1 ) * ( u1 - u0 ) <= 0.0 ) then ! Large scale extrema
       this%ul(k) = u1
       this%ur(k) = u1
     elseif ( du * a6 > du * du ) then ! Extrema on right

--- a/src/ALE/Recon1d_PPM_hybgen.F90
+++ b/src/ALE/Recon1d_PPM_hybgen.F90
@@ -134,7 +134,7 @@ subroutine reconstruct(this, h, u)
     a6 = 3.0 * ( ( u1 - this%ul(k) ) + ( u1 - this%ur(k) ) )
     a6 = 6.0 * u1 - 3.0 * ( this%ul(k) + this%ur(k) )
     du = this%ur(k) - this%ul(k)
-    if ( ( u2 - u1 ) * ( u1 - u0 ) <- 0.0 ) then ! Large scale extrema
+    if ( ( u2 - u1 ) * ( u1 - u0 ) <= 0.0 ) then ! Large scale extrema
       this%ul(k) = u1
       this%ur(k) = u1
     elseif ( du * a6 > du * du ) then ! Extrema on right


### PR DESCRIPTION
Thanks to both @alperaltuntas and @marshallward who noted that a PPM limiter has the expression `( u2 - u1 ) * ( u1 - u0 ) <- 0.0` which is interpreted as `( u2 - u1 ) * ( u1 - u0 ) < -0.0`. Needless to say, the intended code was `( u2 - u1 ) * ( u1 - u0 ) <= 0.0`.

The same typo was copied to three files.

The high-order estimate of edge value was previously bounded by (u2,u1) or (u1,u0). The missed conditions of either `( u2 - u1) == 0.` or `( u1 - u0 ) == 0.` would then have been caught by the subsequence test for an interior extrema. Thus, I think the cell was still limited to PCM appropriately. However, the typo obscured the intention of the limiter and I was lucky it still worked.