### PR TITLE
Corrected unit descriptions in 64 comments

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -1184,9 +1184,9 @@ subroutine ALE_remap_velocities(CS, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, u
       ! First get barotropic component
       u_bt = 0.0
       do k=1,nz
-        u_bt = u_bt + h2(k) * u_tgt(k) ! Dimensions [H L T-1]
+        u_bt = u_bt + h2(k) * u_tgt(k) ! Dimensions [H L T-1 ~> m2 s-1 or kg m-1 s-1]
       enddo
-      u_bt = u_bt / (sum(h2(1:nz)) + GV%H_subroundoff) ! Dimensions return to [L T-1]
+      u_bt = u_bt / (sum(h2(1:nz)) + GV%H_subroundoff) ! Dimensions return to [L T-1 ~> m s-1]
       ! Next get baroclinic ke = \int (u-u_bt)^2 from source and target
       ke_c_src = 0.0
       ke_c_tgt = 0.0
@@ -1259,9 +1259,9 @@ subroutine ALE_remap_velocities(CS, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, u
       ! First get barotropic component
       v_bt = 0.0
       do k=1,nz
-        v_bt = v_bt + h2(k) * v_tgt(k) ! Dimensions [H L T-1]
+        v_bt = v_bt + h2(k) * v_tgt(k) ! Dimensions [H L T-1 ~> m2 s-1 or kg m-1 s-1]
       enddo
-      v_bt = v_bt / (sum(h2(1:nz)) + GV%H_subroundoff) ! Dimensions return to [L T-1]
+      v_bt = v_bt / (sum(h2(1:nz)) + GV%H_subroundoff) ! Dimensions return to [L T-1 ~> m s-1]
       ! Next get baroclinic ke = \int (u-u_bt)^2 from source and target
       ke_c_src = 0.0
       ke_c_tgt = 0.0
@@ -1607,11 +1607,11 @@ subroutine TS_PPM_edge_values( CS, S_t, S_b, T_t, T_b, G, GV, tv, h, bdry_extrap
   ! Local variables
   integer :: i, j, k
   real    :: hTmp(GV%ke) ! A 1-d copy of h [H ~> m or kg m-2]
-  real    :: tmp(GV%ke)  ! A 1-d copy of a column of temperature [degC] or salinity [ppt]
+  real    :: tmp(GV%ke)  ! A 1-d copy of a column of temperature [C ~> degC] or salinity [S ~> ppt]
   real, dimension(CS%nk,2) :: &
-      ppol_E            ! Edge value of polynomial in [degC] or [ppt]
+      ppol_E            ! Edge value of polynomial in [C ~> degC] or [S ~> ppt]
   real, dimension(CS%nk,3) :: &
-      ppol_coefs        ! Coefficients of polynomial, all in [degC] or [ppt]
+      ppol_coefs        ! Coefficients of polynomial, all in [C ~> degC] or [S ~> ppt]
   real :: h_neglect, h_neglect_edge ! Tiny thicknesses [H ~> m or kg m-2]
 
   if (CS%answer_date >= 20190101) then

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -217,7 +217,7 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
   integer :: np       ! Number of profiles,    for HYBRID_MAP
   integer :: nceiling ! ceiling  of map index, for HYBRID_MAP
   integer :: nfloor   ! floor    of map index, for HYBRID_MAP
-  real ::    nfrac    ! fraction of map index, for HYBRID_MAP
+  real ::    nfrac    ! fraction of map index, for HYBRID_MAP [nondim]
   character(len=80)  :: string, string2, varName ! Temporary strings
   character(len=40)  :: coord_units, coord_res_param ! Temporary strings
   character(len=MAX_PARAM_LENGTH) :: param_name
@@ -236,8 +236,8 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
                         ! maximum_depth is large [m] (not in Z).
   real :: nominalDepth  ! Depth of ocean bottom in thickness units (positive downward) [H ~> m or kg m-2]
   real :: depth_q       ! A depth scale factor [nondim]
-  real :: depth_s       ! The end of the shallow Z regime (m)
-  real :: depth_d       ! The start of the deep Z regime (m)
+  real :: depth_s       ! The end of the shallow Z regime [m]
+  real :: depth_d       ! The start of the deep Z regime [m]
   real :: adaptTimeRatio, adaptZoomCoeff ! Temporary variables for input parameters [nondim]
   real :: adaptBuoyCoeff, adaptAlpha     ! Temporary variables for input parameters [nondim]
   real :: adaptZoom  ! The thickness of the near-surface zooming region with the adaptive coordinate [H ~> m or kg m-2]
@@ -1208,7 +1208,7 @@ subroutine regridding_main( remapCS, CS, G, GV, US, h, tv, h_new, dzInterface, &
                                                                       !! coordinate [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),CS%nk+1),   intent(inout) :: dzInterface !< The change in position of each
                                                                       !! interface [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in   ) :: frac_shelf_h !< Fractional ice shelf coverage [nomdim]
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in   ) :: frac_shelf_h !< Fractional ice shelf coverage [nondim]
   logical, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                                     optional, intent(out  ) :: PCM_cell !< Use PCM remapping in cells where true
 
@@ -2416,7 +2416,7 @@ subroutine setCoordinateResolution_3d( dz_3d, CS, scale )
                                            !! dependent units, such as [m] for a z-coordinate or [kg m-3]
                                            !! for a density coordinate.
   type(regridding_CS), intent(inout) :: CS !< Regridding control structure
-  real,      optional, intent(in)    :: scale !< A scaling factor converting dz to coordRes [m -> Z]
+  real,      optional, intent(in)    :: scale !< A scaling factor converting dz to coordRes [Z m-1 ~> 1]
 
   if (.not.allocated(CS%coordinateResolution_3d)) &
       call MOM_error(FATAL,'setCoordinateResolution_3d: '//&
@@ -2457,7 +2457,7 @@ end subroutine set_target_densities_from_GV
 subroutine set_target_densities_3d( CS, G, scale, rho_int_3d )
   type(regridding_CS),  intent(inout) :: CS    !< Regridding control structure
   type(ocean_grid_type),intent(in)    :: G     !< Ocean grid structure
-  real,                 intent(in)    :: scale !< A scaling factor converting densities [kg m-3 -> R]
+  real,                 intent(in)    :: scale !< A scaling factor converting densities [R m3 kg-1 ~> 1]
   real, dimension(SZI_(G),SZJ_(G),CS%nk+1), intent(in) :: rho_int_3d !< Interface densities [kg m-3]
 
   if (.not.allocated(CS%target_density_3d)) &

--- a/src/ALE/Recon1d_type.F90
+++ b/src/ALE/Recon1d_type.F90
@@ -15,7 +15,7 @@ type, abstract :: Recon1d
 
   integer :: n = 0 !< Number of cells in column
   real, allocatable, dimension(:) :: u_mean !< Cell mean [A]
-  real :: h_neglect = 0. !< A negligibly small width used in cell reconstructions [same as h, H]
+  real :: h_neglect = 0. !< A negligibly small width used in cell reconstructions in the same units as h [H]
   logical :: check = .false. !< If true, enable some consistency checking
 
   logical :: debug = .false. !< If true, dump info as calculations are made (do not enable)
@@ -80,7 +80,7 @@ interface
   subroutine i_reconstruct(this, h, u)
     import :: Recon1d
     class(Recon1d), intent(inout) :: this !< This reconstruction
-    real,           intent(in)    :: h(*) !< Grid spacing (thickness) [typically H]
+    real,           intent(in)    :: h(*) !< Grid spacing (thickness), typically in [H]
     real,           intent(in)    :: u(*) !< Cell mean values [A]
   end subroutine i_reconstruct
 
@@ -122,7 +122,7 @@ interface
   logical function i_check_reconstruction(this, h, u)
     import :: Recon1d
     class(Recon1d), intent(in) :: this !< This reconstruction
-    real,           intent(in) :: h(*) !< Grid spacing (thickness) [typically H]
+    real,           intent(in) :: h(*) !< Grid spacing (thickness), typically in [H]
     real,           intent(in) :: u(*) !< Cell mean values [A]
   end function i_check_reconstruction
 
@@ -145,7 +145,7 @@ interface
   subroutine i_reconstruct_parent(this, h, u)
     import :: Recon1d
     class(Recon1d), intent(inout) :: this !< This reconstruction
-    real,           intent(in)    :: h(*) !< Grid spacing (thickness) [typically H]
+    real,           intent(in)    :: h(*) !< Grid spacing (thickness), typically in [H]
     real,           intent(in)    :: u(*) !< Cell mean values [A]
   end subroutine i_reconstruct_parent
 

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -1003,7 +1003,8 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   real, dimension(7)    :: x            ! Coordinate system with 0 at edges in the same units as h [H]
   real, parameter       :: C1_12 = 1.0 / 12.0   ! A rational parameter [nondim]
   real, parameter       :: C5_6 = 5.0 / 6.0     ! A rational parameter [nondim]
-  real                  :: dx, xavg     ! Differences and averages of successive values of x [same units as h]
+  real                  :: dx           ! Differences between successive values of x in the same units as h [H]
+  real                  :: xavg         ! Average of successive values of x in the same units as h [H]
   real, dimension(6,6)  :: Asys         ! The matrix that is being inverted for a solution,
                                         ! in units that might vary with the second (j) index as [H^j]
   real, dimension(6)    :: Bsys         ! The right hand side of the system to solve for C in various

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -335,19 +335,19 @@ subroutine build_and_interpolate_grid(CS, densities, n0, h0, x0, target_values, 
   integer,               intent(in)    :: n1  !< The number of points on the output grid
   real, dimension(n0),   intent(in)    :: densities !< Input cell densities [R ~> kg m-3]
   real, dimension(n1+1), intent(in)    :: target_values !< Target values of interfaces [R ~> kg m-3]
-  real, dimension(n0),   intent(in)    :: h0  !< Initial cell widths [H]
-  real, dimension(n0+1), intent(in)    :: x0  !< Source interface positions [H]
-  real, dimension(n1),   intent(inout) :: h1  !< Output cell widths [H]
-  real, dimension(n1+1), intent(inout) :: x1  !< Target interface positions [H]
+  real, dimension(n0),   intent(in)    :: h0  !< Initial cell widths usually in [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(n0+1), intent(in)    :: x0  !< Source interface positions [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(n1),   intent(inout) :: h1  !< Output cell widths [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(n1+1), intent(inout) :: x1  !< Target interface positions [H ~> m or kg m-2] or [Z ~> m]
   real,                  intent(in)    :: h_neglect !< A negligibly small width for the
-                                           !! purpose of cell reconstructions [H]
-                                           !! in the same units as h0.
-  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width
-                                           !! for the purpose of edge value calculations [H]
-                                           !! in the same units as h0.
+                                           !! purpose of cell reconstructions in the same
+                                           !! units as h0 [H ~> m or kg m-2] or [Z ~> m].
+  real,        optional, intent(in)    :: h_neglect_edge !< A negligibly small width for the
+                                           !! purpose of edge value calculations in the same
+                                           !! units as h0 [H ~> m or kg m-2] or [Z ~> m]
 
   real, dimension(n0,2) :: ppoly0_E   ! Polynomial edge values [R ~> kg m-3]
-  real, dimension(n0,2) :: ppoly0_S   ! Polynomial edge slopes [R H-1]
+  real, dimension(n0,2) :: ppoly0_S   ! Polynomial edge slopes [R H-1 ~> kg m-4 or m-1] or [R Z-1 ~> kg m-4]
   real, dimension(n0,DEGREE_MAX+1) :: ppoly0_C  ! Polynomial interpolant coeficients on the local 0-1 grid [R ~> kg m-3]
   integer :: degree
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -89,9 +89,9 @@ type, public :: thermo_var_ptrs
                          !! When conservative temperature is used, this is
                          !! constant and exactly 3991.86795711963 J degC-1 kg-1.
   logical :: T_is_conT = .false. !< If true, the temperature variable tv%T is
-                         !! actually the conservative temperature [degC].
+                         !! actually the conservative temperature [C ~> degC].
   logical :: S_is_absS = .false. !< If true, the salinity variable tv%S is
-                         !! actually the absolute salinity in units of [gSalt kg-1].
+                         !! actually the absolute salinity in units of [S ~> gSalt kg-1].
   real :: min_salinity   !< The minimum value of salinity when BOUND_SALINITY=True [S ~> ppt].
   real, allocatable, dimension(:,:,:) :: SpV_avg
                          !< The layer averaged in situ specific volume [R-1 ~> m3 kg-1].

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -2192,7 +2192,7 @@ end subroutine chksum_v_3d
 
 !> chksum1d does a checksum of a 1-dimensional array.
 subroutine chksum1d(array, mesg, start_i, end_i, compare_PEs, logunit)
-  real, dimension(:), intent(in) :: array   !< The array to be summed (index starts at 1) [abitrary].
+  real, dimension(:), intent(in) :: array   !< The array to be summed (index starts at 1) in arbitrary units [A].
   character(len=*),   intent(in) :: mesg    !< An identifying message.
   integer, optional,  intent(in) :: start_i !< The starting index for the sum (default 1)
   integer, optional,  intent(in) :: end_i   !< The ending index for the sum (default all)
@@ -2201,8 +2201,8 @@ subroutine chksum1d(array, mesg, start_i, end_i, compare_PEs, logunit)
   integer, optional,  intent(in) :: logunit !< IO unit for checksum logging
 
   integer :: is, ie, i, bc, sum1, sum_bc, ioUnit
-  real :: sum  ! The global sum of the array [arbitrary]
-  real, allocatable :: sum_here(:) ! The sum on each PE [arbitrary]
+  real :: sum  ! The global sum of the array [A]
+  real, allocatable :: sum_here(:) ! The sum on each PE [A]
   logical :: compare
   integer :: pe_num   ! pe number of the data
   integer :: nPEs     ! Total number of processsors
@@ -2253,12 +2253,12 @@ end subroutine chksum1d
 !> chksum2d does a checksum of all data in a 2-d array.
 subroutine chksum2d(array, mesg, logunit)
 
-  real, dimension(:,:), intent(in) :: array !< The array to be checksummed [arbitrary]
+  real, dimension(:,:), intent(in) :: array !< The array to be checksummed in arbitrary units [A]
   character(len=*),     intent(in) :: mesg  !< An identifying message
   integer,    optional, intent(in) :: logunit !< IO unit for checksum logging
 
   integer :: xs, xe, ys, ye, i, j, sum1, bc, iounit
-  real :: sum  ! The global sum of the array [arbitrary]
+  real :: sum  ! The global sum of the array [A]
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
 
@@ -2284,12 +2284,12 @@ end subroutine chksum2d
 !> chksum3d does a checksum of all data in a 2-d array.
 subroutine chksum3d(array, mesg, logunit)
 
-  real, dimension(:,:,:), intent(in) :: array !< The array to be checksummed [arbitrary]
+  real, dimension(:,:,:), intent(in) :: array !< The array to be checksummed in arbitrary units [A]
   character(len=*),       intent(in) :: mesg  !< An identifying message
   integer,      optional, intent(in) :: logunit !< IO unit for checksum logging
 
   integer :: xs, xe, ys, ye, zs, ze, i, j, k, bc, sum1, iounit
-  real :: sum  ! The global sum of the array [arbitrary]
+  real :: sum  ! The global sum of the array [A]
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
 
@@ -2315,7 +2315,7 @@ end subroutine chksum3d
 
 !> This function returns .true. if x is a NaN, and .false. otherwise.
 function is_NaN_0d(x)
-  real, intent(in) :: x !< The value to be checked for NaNs [arbitrary]
+  real, intent(in) :: x !< The value to be checked for NaNs in arbitrary units [A]
   logical :: is_NaN_0d
 
  !is_NaN_0d = (((x < 0.0) .and. (x >= 0.0)) .or. &
@@ -2331,7 +2331,7 @@ end function is_NaN_0d
 
 !> Returns .true. if any element of x is a NaN, and .false. otherwise.
 function is_NaN_1d(x, skip_mpp)
-  real, dimension(:), intent(in) :: x !< The array to be checked for NaNs [arbitrary]
+  real, dimension(:), intent(in) :: x !< The array to be checked for NaNs in arbitrary units [A]
   logical,  optional, intent(in) :: skip_mpp  !< If true, only check this array only
                                               !! on the local PE (default false).
   logical :: is_NaN_1d
@@ -2354,7 +2354,7 @@ end function is_NaN_1d
 
 !> Returns .true. if any element of x is a NaN, and .false. otherwise.
 function is_NaN_2d(x)
-  real, dimension(:,:), intent(in) :: x !< The array to be checked for NaNs [arbitrary]
+  real, dimension(:,:), intent(in) :: x !< The array to be checked for NaNs in arbitrary units [A]
   logical :: is_NaN_2d
 
   integer :: i, j, n
@@ -2371,7 +2371,7 @@ end function is_NaN_2d
 
 !> Returns .true. if any element of x is a NaN, and .false. otherwise.
 function is_NaN_3d(x)
-  real, dimension(:,:,:), intent(in) :: x !< The array to be checked for NaNs [arbitrary]
+  real, dimension(:,:,:), intent(in) :: x !< The array to be checked for NaNs in arbitrary units [A]
   logical :: is_NaN_3d
 
   integer :: i, j, k, n
@@ -2454,7 +2454,7 @@ function field_checksum_real_2d(field, pelist, mask_val, turns, unscale) &
   integer(kind=int64) :: chksum                     !< checksum of array
 
   ! Local variables
-  real, allocatable :: field_rot(:,:)  ! A rotated version of field, with the same units [arbitrary]
+  real, allocatable :: field_rot(:,:)  ! A rotated version of field, with the same units [A ~> a]
   integer :: qturns ! The number of quarter turns through which to rotate field
   logical :: do_unscale ! If true, unscale the variable before it is checksummed
 
@@ -2494,7 +2494,7 @@ function field_checksum_real_3d(field, pelist, mask_val, turns, unscale) &
   integer(kind=int64) :: chksum                     !< checksum of array
 
   ! Local variables
-  real, allocatable :: field_rot(:,:,:)  ! A rotated version of field, with the same units [arbitrary]
+  real, allocatable :: field_rot(:,:,:)  ! A rotated version of field, with the same units [A ~> a]
   integer :: qturns ! The number of quarter turns through which to rotate field
   logical :: do_unscale ! If true, unscale the variable before it is checksummed
 
@@ -2534,7 +2534,7 @@ function field_checksum_real_4d(field, pelist, mask_val, turns, unscale) &
   integer(kind=int64) :: chksum                     !< checksum of array
 
   ! Local variables
-  real, allocatable :: field_rot(:,:,:,:)  ! A rotated version of field, with the same units [arbitrary]
+  real, allocatable :: field_rot(:,:,:,:)  ! A rotated version of field, with the same units [A ~> a]
   integer :: qturns ! The number of quarter turns through which to rotate field
   logical :: do_unscale ! If true, unscale the variable before it is checksummed
 
@@ -2641,9 +2641,9 @@ end subroutine chk_sum_msg2
 subroutine chk_sum_msg3(fmsg, aMean, aMin, aMax, mesg, iounit)
   character(len=*), intent(in) :: fmsg !< A checksum code-location specific preamble
   character(len=*), intent(in) :: mesg !< An identifying message supplied by top-level caller
-  real,             intent(in) :: aMean !< The mean value of the array [arbitrary]
-  real,             intent(in) :: aMin !< The minimum value of the array [arbitrary]
-  real,             intent(in) :: aMax !< The maximum value of the array [arbitrary]
+  real,             intent(in) :: aMean !< The mean value of the array in arbitrary units [A]
+  real,             intent(in) :: aMin !< The minimum value of the array [A]
+  real,             intent(in) :: aMax !< The maximum value of the array [A]
   integer,          intent(in) :: iounit !< Checksum logger IO unit
 
   ! NOTE: We add zero to aMin and aMax to remove any negative zeros.
@@ -2676,7 +2676,7 @@ end subroutine chksum_error
 !> Does a bitcount of a number by first casting to an integer and then using BTEST
 !! to check bit by bit
 integer function bitcount(x)
-  real, intent(in) :: x !< Number to be bitcount [arbitrary]
+  real, intent(in) :: x !< Number to be bitcount in arbitrary units [A]
 
   integer, parameter :: xk = kind(x)  !< Kind type of x
 

--- a/src/framework/MOM_coms.F90
+++ b/src/framework/MOM_coms.F90
@@ -359,7 +359,7 @@ function reproducing_sum_3d(array, isr, ier, jsr, jer, sums, EFP_sum, EFP_lay_su
   integer,            optional, intent(in)  :: jer     !< The ending j-index of the sum, noting
                                                        !! that the array indices starts at 1
   real, dimension(:), optional, intent(out) :: sums    !< The sums by vertical layer in the same
-                                                       !! abitrary units as array [a] or [A ~> a]
+                                                       !! arbitrary units as array [a] or [A ~> a]
   type(EFP_type),     optional, intent(out) :: EFP_sum !< The result in extended fixed point format
   type(EFP_type), dimension(:), &
                       optional, intent(out) :: EFP_lay_sums !< The sums by vertical layer in EFP format
@@ -796,7 +796,7 @@ end subroutine EFP_assign
 !> Return the real number that an extended-fixed-point number corresponds with
 function EFP_to_real(EFP1)
   type(EFP_type), intent(inout) :: EFP1 !< The extended fixed point number being converted
-  real :: EFP_to_real  !< The real version of the number in abitrary units [a]
+  real :: EFP_to_real  !< The real version of the number in arbitrary units [a]
 
   call regularize_ints(EFP1%v)
   EFP_to_real = ints_to_real(EFP1%v)

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -495,7 +495,7 @@ end subroutine set_derived_dyn_horgrid
 
 !> Adcroft_reciprocal(x) = 1/x for |x|>0 or 0 for x=0.
 function Adcroft_reciprocal(val) result(I_val)
-  real, intent(in) :: val  !< The value being inverted in abitrary units [A ~> a]
+  real, intent(in) :: val  !< The value being inverted in arbitrary units [A ~> a]
   real :: I_val            !< The Adcroft reciprocal of val [A-1 ~> a-1].
 
   I_val = 0.0 ; if (val /= 0.0) I_val = 1.0/val

--- a/src/framework/MOM_intrinsic_functions.F90
+++ b/src/framework/MOM_intrinsic_functions.F90
@@ -117,7 +117,7 @@ end function cuberoot
 !> Rescale `a` to the range [0.125, 1) and compute its cube-root exponent.
 pure subroutine rescale_cbrt(a, x, e_r, s_a)
   real, intent(in) :: a
-    !< The real parameter to be rescaled for cube root in abitrary units cubed [A3]
+    !< The real parameter to be rescaled for cube root in arbitrary units cubed [A3]
   real, intent(out) :: x
     !< The rescaled value of a in the range from 0.125 < asx <= 1.0, in ambiguous units cubed [B3]
   integer(kind=int64), intent(out) :: e_r
@@ -168,7 +168,7 @@ pure function descale(x, e_a, s_a) result(a)
   integer(kind=int64), intent(in) :: s_a
     !< Sign bit of the unscaled value
   real :: a
-    !< Restored value with the corrected exponent and sign in abitrary units [A]
+    !< Restored value with the corrected exponent and sign in arbitrary units [A]
 
   integer(kind=int64) :: xb
     ! Bit-packed real number into integer form

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -1135,11 +1135,11 @@ end function Int_dj_dy
 
 !> Extrapolates missing metric data into all the halo regions.
 subroutine extrapolate_metric(var, jh, missing)
-  real, dimension(:,:), intent(inout) :: var     !< The array in which to fill in halos [abitrary]
+  real, dimension(:,:), intent(inout) :: var     !< The array in which to fill in halos in arbitrary units [A]
   integer,              intent(in)    :: jh      !< The size of the halos to be filled
-  real,       optional, intent(in)    :: missing !< The missing data fill value, 0 by default [abitrary]
+  real,       optional, intent(in)    :: missing !< The missing data fill value, 0 by default [A]
   ! Local variables
-  real :: badval ! A bad data value [abitrary]
+  real :: badval ! A bad data value [A]
   integer :: i, j
 
   badval = 0.0 ; if (present(missing)) badval = missing
@@ -1169,8 +1169,8 @@ end subroutine extrapolate_metric
 !> This function implements Adcroft's rule for reciprocals, namely that
 !!   Adcroft_Inv(x) = 1/x for |x|>0 or 0 for x=0.
 function Adcroft_reciprocal(val) result(I_val)
-  real, intent(in) :: val  !< The value being inverted [abitrary]
-  real :: I_val            !< The Adcroft reciprocal of val [abitrary-1]
+  real, intent(in) :: val  !< The value being inverted in arbitrary units [A]
+  real :: I_val            !< The Adcroft reciprocal of val [A-1]
 
   I_val = 0.0
   if (val /= 0.0) I_val = 1.0/val

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -488,7 +488,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
     u_star = max(CS%ustar_min, 0.5*(U_star_2d(i,j) + U_star_2d(i+1,j)))
 
     absf = 0.5*(abs(G%CoriolisBu(I,J-1)) + abs(G%CoriolisBu(I,J)))
-    ! Compute I_LFront = 1 / (frontal length scale) [m-1]
+    ! Compute I_LFront = 1 / (frontal length scale) [L-1 ~> m-1]
     lfront = 0.5 * (mle_fl_2d(i,j) + mle_fl_2d(i+1,j))
     ! Adcroft reciprocal
     I_LFront = 0.0 ; if (lfront /= 0.0) I_LFront = 1.0/lfront
@@ -577,7 +577,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
   !$OMP do
   do J=js-1,je ; do i=is,ie
     u_star = max(CS%ustar_min, 0.5*(U_star_2d(i,j) + U_star_2d(i,j+1)))
-    ! Compute I_LFront = 1 / (frontal length scale) [m-1]
+    ! Compute I_LFront = 1 / (frontal length scale) [L-1 ~> m-1]
     lfront = 0.5 * (mle_fl_2d(i,j) + mle_fl_2d(i,j+1))
     ! Adcroft reciprocal
     I_LFront = 0.0 ; if (lfront /= 0.0) I_LFront = 1.0/lfront
@@ -1183,7 +1183,7 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
 
 end subroutine mixedlayer_restrat_Bodner
 
-!> Two time-scale running mean [units of "signal" and "filtered"]
+!> Two time-scale running mean in the same arbitrary units as "signal" and "filtered"
 !!
 !! If signal > filtered, returns running-mean with time scale "tau_growing".
 !! If signal <= filtered, returns running-mean with time scale "tau_decaying".
@@ -1197,8 +1197,8 @@ end subroutine mixedlayer_restrat_Bodner
 !! rmean2ts with tau_growing=0 recovers the "resetting running mean" used in OM4.
 real elemental function rmean2ts(signal, filtered, tau_growing, tau_decaying, dt)
   ! Arguments
-  real, intent(in) :: signal       ! Unfiltered signal [arbitrary units]
-  real, intent(in) :: filtered     ! Current value of running mean [arbitrary units]
+  real, intent(in) :: signal       ! Unfiltered signal in arbitrary units [A]
+  real, intent(in) :: filtered     ! Current value of running mean in the same arbitrary units [A]
   real, intent(in) :: tau_growing  ! Time scale for growing signal [T ~> s]
   real, intent(in) :: tau_decaying ! Time scale for decaying signal [T ~> s]
   real, intent(in) :: dt           ! Time step [T ~> s]

--- a/src/parameterizations/lateral/MOM_spherical_harmonics.F90
+++ b/src/parameterizations/lateral/MOM_spherical_harmonics.F90
@@ -227,7 +227,7 @@ subroutine spherical_harmonics_init(G, param_file, CS)
 
   ! local variables
   real, parameter :: PI = 4.0*atan(1.0) ! 3.1415926... calculated as 4*atan(1) [nondim]
-  real, parameter :: RADIAN = PI / 180.0 ! Degree to Radian constant [rad/degree]
+  real, parameter :: RADIAN = PI / 180.0 ! Degree to Radian constant [radian degree-1]
   real, dimension(SZI_(G),SZJ_(G)) :: sin_clatT ! sine of colatitude at the t-cells [nondim].
   real :: Pmm_coef ! = sqrt{ 1.0/(4.0*PI) * prod[(2k+1)/2k)] } [nondim].
   integer :: is, ie, js, je

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -370,7 +370,8 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, BFlx_geothermal, halo)
   real,                                      intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
   type(geothermal_CS),                       intent(in)    :: CS !< Geothermal heating control struct
-  real, dimension(SZI_(G), SZJ_(G)),         intent(out)   :: BFlx_geothermal !< Geothermal Buoyancy Flux [m2 s-3]
+  real, dimension(SZI_(G), SZJ_(G)),         intent(out)   :: BFlx_geothermal !< Geothermal buoyancy flux
+                                                                 !! in [Z2 T-3 ~> m2 s-3]
   integer,                         optional, intent(in)    :: halo !< Halo width over which to work
 
 

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -719,7 +719,7 @@ end function CFC_cap_unit_tests
 logical function compare_values(verbose, test_name, calc, ans, limit)
   logical,             intent(in) :: verbose   !< If true, write results to stdout
   character(len=80),   intent(in) :: test_name !< Brief description of the unit test
-  real,                intent(in) :: calc      !< computed value in abitrary units [A]
+  real,                intent(in) :: calc      !< computed value in arbitrary units [A]
   real,                intent(in) :: ans       !< correct value [A]
   real,                intent(in) :: limit     !< value above which test fails [A]
 

--- a/src/user/MOM_controlled_forcing.F90
+++ b/src/user/MOM_controlled_forcing.F90
@@ -296,7 +296,7 @@ subroutine apply_ctrl_forcing(SST_anom, SSS_anom, SSS_mean, virt_heat, virt_prec
     m_u2 = periodic_int(m_st - 3.0, CS%num_cycle)
     m_u3 = periodic_int(m_st - 2.0, CS%num_cycle)
 
-    ! These loops restore the units of the CS%avg variables to [degC] or [ppt]
+    ! These loops restore the units of the CS%avg variables to [C ~> degC] or [S ~> ppt]
     if (CS%avg_time(m_u1) > 0.0) then
       do j=js,je ; do i=is,ie
         CS%avg_SST_anom(i,j,m_u1) = CS%avg_SST_anom(i,j,m_u1) / CS%avg_time(m_u1)


### PR DESCRIPTION
  Corrected the descriptions of units variables in 64 comments spread across 16 files, including a dozen instances where "arbitrary" was misspelled.  All answers are bitwise identical and only comments were changed.