### PR TITLE
*Update TC testing parameters for late 2025

### DIFF
--- a/.testing/tc0/MOM_input
+++ b/.testing/tc0/MOM_input
@@ -233,9 +233,11 @@ ENERGYSAVEDAYS = 1.0
 
 DIAG_AS_CHKSUM = True
 DEBUG = True
-GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-USE_GM_WORK_BUG = True          !   [Boolean] default = True
+
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 GUST_CONST = 0.02               !   [Pa] default = 0.02
-FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
 
+! These are no longer necessary, as they are using the default value.
+GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
+USE_GM_WORK_BUG = False         !   [Boolean] default = False
+USTAR_GUSTLESS_BUG = False      !   [Boolean] default = False

--- a/.testing/tc1.a/MOM_tc_variant
+++ b/.testing/tc1.a/MOM_tc_variant
@@ -1,2 +1,3 @@
-#override SPLIT=False
-#override UNSPLIT_DT_VISC_BUG = True      !   [Boolean] default = False
+#override SPLIT = False
+#override UNSPLIT_DT_VISC_BUG = False     !   [Boolean] default = False
+#override EQN_OF_STATE = "ROQUET_RHO"     ! default = "WRIGHT_FULL"

--- a/.testing/tc1.b/MOM_tc_variant
+++ b/.testing/tc1.b/MOM_tc_variant
@@ -1,3 +1,7 @@
-#override SPLIT=False
-#override USE_RK2=True
-#override UNSPLIT_DT_VISC_BUG = True      !   [Boolean] default = False
+#override SPLIT = False
+#override USE_RK2 = True
+#override UNSPLIT_DT_VISC_BUG = False     !   [Boolean] default = False
+
+! There may be a problem with one of these settings.
+! #override EQN_OF_STATE = "ROQUET_SPV"     ! default = "WRIGHT_FULL"
+! #override BOUSSINESQ = FALSE

--- a/.testing/tc1/MOM_input
+++ b/.testing/tc1/MOM_input
@@ -584,28 +584,27 @@ ENERGYSAVEDAYS = 0.125          !   [days] default = 3600.0
 DIAG_AS_CHKSUM = True
 DEBUG = True
 USE_PSURF_IN_EOS = False        !   [Boolean] default = False
-GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-USE_GM_WORK_BUG = True          !   [Boolean] default = True
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
-KAPPA_SHEAR_ALL_LAYER_TKE_BUG = True !   [Boolean] default = True
-BULKML_CONV_MOMENTUM_BUG = True !   [Boolean] default = True
 PEN_SW_ABSORB_MINTHICK = 0.001  !   [m] default = 0.001
 GUST_CONST = 0.02               !   [Pa] default = 0.02
-FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
 
 
-! Explicitly use the defaults from late 2024
-EQN_OF_STATE = "WRIGHT"     ! default = "WRIGHT_FULL"
-HOR_DIFF_ANSWER_DATE = 20240101
-HOR_DIFF_LIMIT_BUG = True
+! Updated defaults reflecting the model status in late 2025
+DRAG_DIFFUSIVITY_ANSWER_DATE = 20251231
+EQN_OF_STATE = "WRIGHT_FULL"     ! default = "WRIGHT_FULL"
+HOR_DIFF_ANSWER_DATE = 20251231
+MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = True !   [Boolean] default = True
 
-! Explicitly use the defaults from early 2025
-VISC_REM_BUG = True
-DRAG_DIFFUSIVITY_ANSWER_DATE = 20250101
-FRICTWORK_BUG = True
-HOR_DIFF_ANSWER_DATE = 20240101
-HOR_DIFF_LIMIT_BUG = True
-MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False
+! These are no longer necessary, as they are using the default value.
+HOR_DIFF_LIMIT_BUG = False      !   [Boolean] default = False
+GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
+USE_GM_WORK_BUG = False         !   [Boolean] default = False
+USTAR_GUSTLESS_BUG = False      !   [Boolean] default = False
+KAPPA_SHEAR_ITER_BUG = False    !   [Boolean] default = False
+KAPPA_SHEAR_ALL_LAYER_TKE_BUG = False !   [Boolean] default = False
+VISC_REM_BUG = False            !   [Boolean] default = False
+FRICTWORK_BUG = False           !   [Boolean] default = False
+BULKML_CONV_MOMENTUM_BUG = False !   [Boolean] default = False
+

--- a/.testing/tc2/MOM_input
+++ b/.testing/tc2/MOM_input
@@ -616,27 +616,29 @@ ENERGYSAVEDAYS = 0.5            !   [days] default = 3600.0
                                 ! energies of the run and other globally summed diagnostics.
 DIAG_AS_CHKSUM = True
 DEBUG = True
-USE_GM_WORK_BUG = False
+
 USE_PSURF_IN_EOS = False        !   [Boolean] default = False
-GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
 REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
-KAPPA_SHEAR_ALL_LAYER_TKE_BUG = True !   [Boolean] default = True
 USE_MLD_ITERATION = False       !   [Boolean] default = False
 PEN_SW_ABSORB_MINTHICK = 0.001  !   [m] default = 0.001
 GUST_CONST = 0.02               !   [Pa] default = 0.02
-FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
 
-! Explicitly use the defaults from late 2024
+! Updated defaults reflecting the model status in late 2025
 EQN_OF_STATE = "WRIGHT"     ! default = "WRIGHT_FULL"
-TIDES_ANSWER_DATE = 20230630
-NDIFF_ANSWER_DATE = 20240101
-BACKSCATTER_UNDERBOUND = True
+TIDES_ANSWER_DATE = 20251231
+NDIFF_ANSWER_DATE = 20251231
+DRAG_DIFFUSIVITY_ANSWER_DATE = 20251231
+MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = True !   [Boolean] default = True
 
-! Explicitly use the defaults from early 2025
-VISC_REM_BUG = True
-DRAG_DIFFUSIVITY_ANSWER_DATE = 20250101
-FRICTWORK_BUG = True
-NDIFF_ANSWER_DATE = 20240101
-MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False
+! These are no longer necessary, as they are using the default value.
+GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
+USE_GM_WORK_BUG = False         !   [Boolean] default = False
+USTAR_GUSTLESS_BUG = False      !   [Boolean] default = False
+KAPPA_SHEAR_ITER_BUG = False    !   [Boolean] default = False
+KAPPA_SHEAR_ALL_LAYER_TKE_BUG = False !   [Boolean] default = False
+VISC_REM_BUG = False            !   [Boolean] default = False
+FRICTWORK_BUG = False           !   [Boolean] default = False
+
+
+BACKSCATTER_UNDERBOUND = True

--- a/.testing/tc2/MOM_tc_variant
+++ b/.testing/tc2/MOM_tc_variant
@@ -10,3 +10,6 @@ TIDE_Q1 = True
 TIDE_MF = True
 TIDE_MM = True
 TIDE_SAL_SCALAR_VALUE = 1.
+BT_STRONG_DRAG = True           !   [Boolean] default = False
+RESCALE_STRONG_DRAG = True      !   [Boolean] default = False
+

--- a/.testing/tc3/MOM_input
+++ b/.testing/tc3/MOM_input
@@ -473,15 +473,18 @@ ENERGYSAVEDAYS = 3.0            !   [hours] default = 1.44E+04
 DIAG_AS_CHKSUM = True
 DEBUG = True
 OBC_RADIATION_MAX = 10.0        !   [nondim] default = 10.0
-GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
-USE_GM_WORK_BUG = True          !   [Boolean] default = True
-USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
-KAPPA_SHEAR_ALL_LAYER_TKE_BUG = True !   [Boolean] default = True
-GUST_CONST = 0.02               !   [Pa] default = 0.02
-FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
 
-! Explicitly use the defaults from early 2025
-VISC_REM_BUG = True
-DRAG_DIFFUSIVITY_ANSWER_DATE = 20250101
-FRICTWORK_BUG = True
+USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
+GUST_CONST = 0.02               !   [Pa] default = 0.02
+
+! Updated defaults reflecting the model status in late 2025
+DRAG_DIFFUSIVITY_ANSWER_DATE = 20251231
+
+! These are no longer necessary, as they are using the default value.
+GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
+USE_GM_WORK_BUG = False         !   [Boolean] default = False
+USTAR_GUSTLESS_BUG = False      !   [Boolean] default = False
+KAPPA_SHEAR_ITER_BUG = False    !   [Boolean] default = False
+KAPPA_SHEAR_ALL_LAYER_TKE_BUG = False !   [Boolean] default = False
+VISC_REM_BUG = False            !   [Boolean] default = False
+FRICTWORK_BUG = False           !   [Boolean] default = False

--- a/.testing/tc4/MOM_input
+++ b/.testing/tc4/MOM_input
@@ -92,10 +92,6 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !     USER - call a user modified routine.
 F_0 = 1.0E-04                   !   [s-1] default = 0.0
                                 ! The reference value of the Coriolis parameter with the betaplane option.
-GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = False
-                                ! If true, use an older algorithm to calculate the sine and cosines needed
-                                ! rotate between grid-oriented directions and true north and east.  Differences
-                                ! arise at the tripolar fold.
 
 ! === module MOM_tracer_registry ===
 
@@ -234,9 +230,6 @@ KV = 1.0E-04                    !   [m2 s-1]
 ! === module MOM_thickness_diffuse ===
 KHTH = 500.0                    !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
-USE_GM_WORK_BUG = True          !   [Boolean] default = False
-                                ! If true, compute the top-layer work tendency on the u-grid with the incorrect
-                                ! sign, for legacy reproducibility.
 
 ! === module MOM_porous_barriers ===
 
@@ -381,9 +374,6 @@ WIND_CONFIG = "zero"            !
                                 ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
-FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = True
-                                ! If true correct a bug in the time-averaging of the gustless wind friction
-                                ! velocity
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 0.25                   !   [days]
@@ -412,11 +402,15 @@ DEBUG = True
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
-KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
-KAPPA_SHEAR_ALL_LAYER_TKE_BUG = True !   [Boolean] default = True
 USE_MLD_ITERATION = False       !   [Boolean] default = False
 
-! Explicitly use the defaults from early 2025
-VISC_REM_BUG = True
-FRICTWORK_BUG = True
-MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False
+MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = True !   [Boolean] default = True
+
+! These are no longer necessary, as they are using the default value.
+GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
+USE_GM_WORK_BUG = False         !   [Boolean] default = False
+USTAR_GUSTLESS_BUG = False      !   [Boolean] default = False
+KAPPA_SHEAR_ITER_BUG = False    !   [Boolean] default = False
+KAPPA_SHEAR_ALL_LAYER_TKE_BUG = False !   [Boolean] default = False
+VISC_REM_BUG = False            !   [Boolean] default = False
+FRICTWORK_BUG = False           !   [Boolean] default = False


### PR DESCRIPTION
  Updated the values of about 23 parameters (many of which are repeated across several TC test cases) used in the TC testing to test the most recent versions of code that is selected with ANSWER_DATE flags and to avoid testing the buggy versions of code that is regulated by _BUG flags.  This includes some changes to broaden the range of equations of state that are being tested and to test some newer versions.  This does change the details of the TC tests, but they should (and do) still pass TC regression tests across code versions.