### PR TITLE
Fix for ice-shelf friction velocity bugs

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -372,7 +372,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
 
   !allocate(OS%sfc_state)
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, do_integrals=.true., &
-                              gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot)
+                              gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot, &
+                              use_iceshelves=OS%use_ice_shelf)
 
   if (present(wind_stagger)) then
     call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &

--- a/config_src/drivers/STALE_mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_ocean_model_mct.F90
@@ -362,7 +362,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   !   Consider using a run-time flag to determine whether to do the diagnostic
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, &
-                              do_integrals=.true., gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot)
+                              do_integrals=.true., gas_fields_ocn=gas_fields_ocn, &
+                              use_meltpot=use_melt_pot, use_iceshelves=OS%use_ice_shelf)
 
   call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
                             OS%forcing_CSp, OS%restore_salinity, OS%restore_temp)

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -387,7 +387,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, &
                               do_integrals=.true., gas_fields_ocn=gas_fields_ocn, &
-                              use_meltpot=use_melt_pot, use_marbl_tracers=OS%use_MARBL)
+                              use_meltpot=use_melt_pot, use_iceshelves=OS%use_ice_shelf, &
+                              use_marbl_tracers=OS%use_MARBL)
 
   call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
                             OS%forcing_CSp, OS%restore_salinity, OS%restore_temp, OS%use_waves)

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -209,7 +209,7 @@ type, public :: ice_shelf_CS ; private
              id_h_shelf = -1, id_dhdt_shelf, id_h_mask = -1, &
              id_surf_elev = -1, id_bathym = -1, &
              id_area_shelf_h = -1, &
-             id_ustar_shelf = -1, id_taux = -1, id_tauy = -1, id_shelf_mass = -1, id_mass_flux = -1, &
+             id_ustar_shelf = -1, id_shelf_mass = -1, id_mass_flux = -1, &
              id_shelf_sfc_mass_flux = -1, &
              id_vaf = -1, id_g_adott = -1, id_f_adott = -1, id_adott = -1, &
              id_bdott_melt = -1, id_bdott_accum = -1, id_bdott = -1, &
@@ -347,8 +347,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   real :: DwB_min      ! The change in wB_flux when it is wB_flux_min [Z2 T-3 ~> m2 s-3]
   real :: I_Gam_T, I_Gam_S  ! Terms that vary inversely with Gam_mol_T or Gam_mol_S and Gam_turb [nondim]
   real :: dG_dwB       ! The derivative of Gam_turb with wB [T3 Z-2 ~> s3 m-2]
-  real, dimension(SZDI_(CS%grid),SZDJ_(CS%grid)) :: &
-    taux2, tauy2 ! The squared surface stresses [R2 L2 Z2 T-4 ~> Pa2].
+  real :: taux2, tauy2 ! The squared surface stresses [R2 L2 Z2 T-4 ~> Pa2].
   real :: u2_av, v2_av ! The ice-area weighted average squared ocean velocities [L2 T-2 ~> m2 s-2]
   real :: asu1, asu2   ! Ocean areas covered by ice shelves at neighboring u-points [L2 ~> m2]
   real :: asv1, asv2   ! Ocean areas covered by ice shelves at neighboring v-points [L2 ~> m2]
@@ -453,9 +452,8 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     call pass_vector(sfc_state%taux_shelf, sfc_state%tauy_shelf, G%domain, TO_ALL, CGRID_NE)
   endif
   Irho0 = US%Z_to_L / CS%Rho_ocn
-  taux2(:,:)=0.0; tauy2(:,:)=0.0
   do j=js,je ; do i=is,ie ; if (fluxes%frac_shelf_h(i,j) > 0.0) then
-    u2_av = 0.0 ; v2_av = 0.0
+    taux2 = 0.0 ; tauy2 = 0.0 ; u2_av = 0.0 ; v2_av = 0.0
     asu1 = (ISS%area_shelf_h(i-1,j) + ISS%area_shelf_h(i,j))
     asu2 = (ISS%area_shelf_h(i,j) + ISS%area_shelf_h(i+1,j))
     asv1 = (ISS%area_shelf_h(i,j-1) + ISS%area_shelf_h(i,j))
@@ -463,19 +461,19 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     I_au = 0.0 ; if (asu1 + asu2 > 0.0) I_au = 1.0 / (asu1 + asu2)
     I_av = 0.0 ; if (asv1 + asv2 > 0.0) I_av = 1.0 / (asv1 + asv2)
     if (allocated(sfc_state%taux_shelf) .and. allocated(sfc_state%tauy_shelf)) then
-      taux2(i,j) = (((asu1 * (sfc_state%taux_shelf(I-1,j)**2)) + (asu2 * (sfc_state%taux_shelf(I,j)**2))  ) * I_au)
-      tauy2(i,j) = (((asv1 * (sfc_state%tauy_shelf(i,J-1)**2)) + (asv2 * (sfc_state%tauy_shelf(i,J)**2))  ) * I_av)
+      taux2 = (((asu1 * (sfc_state%taux_shelf(I-1,j)**2)) + (asu2 * (sfc_state%taux_shelf(I,j)**2))  ) * I_au)
+      tauy2 = (((asv1 * (sfc_state%tauy_shelf(i,J-1)**2)) + (asv2 * (sfc_state%tauy_shelf(i,J)**2))  ) * I_av)
     endif
     u2_av = (((asu1 * (sfc_state%u(I-1,j)**2)) + (asu2 * sfc_state%u(I,j)**2)) * I_au)
     v2_av = (((asv1 * (sfc_state%v(i,J-1)**2)) + (asv2 * sfc_state%v(i,J)**2)) * I_av)
 
-    if ((taux2(i,j) + tauy2(i,j) > 0.0) .and. .not.CS%ustar_shelf_from_vel) then
+    if ((taux2 + tauy2 > 0.0) .and. .not.CS%ustar_shelf_from_vel) then
       if (CS%ustar_max >= 0.0) then
         fluxes%ustar_shelf(i,j) = MIN(CS%ustar_max, MAX(CS%ustar_bg, US%L_to_Z * &
-            sqrt(Irho0 * sqrt(taux2(i,j) + tauy2(i,j)) + CS%cdrag*CS%utide(i,j)**2)))
+            sqrt(Irho0 * sqrt(taux2 + tauy2) + CS%cdrag*CS%utide(i,j)**2)))
       else
         fluxes%ustar_shelf(i,j) = MAX(CS%ustar_bg, US%L_to_Z * &
-            sqrt(Irho0 * sqrt(taux2(i,j) + tauy2(i,j)) + CS%cdrag*CS%utide(i,j)**2))
+            sqrt(Irho0 * sqrt(taux2 + tauy2) + CS%cdrag*CS%utide(i,j)**2))
       endif
     else   ! Take care of the cases when taux_shelf is not set or not allocated.
       fluxes%ustar_shelf(i,j) = MAX(CS%ustar_bg, US%L_TO_Z * &
@@ -946,10 +944,6 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   if (CS%id_shelf_mass > 0) call post_data(CS%id_shelf_mass, ISS%mass_shelf, CS%diag)
   if (CS%id_area_shelf_h > 0) call post_data(CS%id_area_shelf_h, ISS%area_shelf_h, CS%diag)
   if (CS%id_ustar_shelf > 0) call post_data(CS%id_ustar_shelf, fluxes%ustar_shelf, CS%diag)
-  if (allocated(sfc_state%taux_shelf) .and. allocated(sfc_state%tauy_shelf)) then
-    if (CS%id_taux > 0) call post_data(CS%id_taux, sqrt(taux2), CS%diag)
-    if (CS%id_tauy > 0) call post_data(CS%id_tauy, sqrt(tauy2), CS%diag)
-  endif
   if (CS%id_shelf_sfc_mass_flux > 0) call post_data(CS%id_shelf_sfc_mass_flux, fluxes%shelf_sfc_mass_flux, CS%diag)
 
   if (CS%id_melt > 0) call post_data(CS%id_melt, fluxes%iceshelf_melt, CS%diag)
@@ -2113,10 +2107,6 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
       'Heat conduction into ice shelf', 'W m-2', conversion=-US%QRZ_T_to_W_m2)
   CS%id_ustar_shelf = register_diag_field('ice_shelf_model', 'ustar_shelf', CS%diag%axesT1, CS%Time, &
       'Fric vel under shelf', 'm/s', conversion=US%Z_to_m*US%s_to_T)
-  CS%id_taux = register_diag_field('ice_shelf_model', 'taux_shelf', CS%diag%axesT1, CS%Time, &
-      'x-surface stress under the ice shelf', 'Pa', conversion=US%RLZ_T2_to_Pa)
-  CS%id_tauy = register_diag_field('ice_shelf_model', 'tauy_shelf', CS%diag%axesT1, CS%Time, &
-      'y-surface stress under the ice shelf', 'Pa', conversion=US%RLZ_T2_to_Pa)
   if (CS%active_shelf_dynamics) then
     CS%id_h_mask = register_diag_field('ice_shelf_model', 'h_mask', CS%diag%axesT1, CS%Time, &
        'ice shelf thickness mask', 'none', conversion=1.0)

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -197,6 +197,7 @@ type, public :: ice_shelf_CS ; private
                                          !! divided by the von Karman constant VK [nondim]. Was 1/8.
   real :: Vk                             !< Von Karman's constant [nondim]
   real :: Rc                             !< critical flux Richardson number [nondim]
+  logical :: ustar_from_vel_bugfix       !< If true, fixes ustar from ocean velocity bug
   logical :: buoy_flux_itt_bugfix        !< If true, fixes buoyancy iteration bug
   logical :: salt_flux_itt_bugfix        !< If true, fixes salt iteration bug
   real :: buoy_flux_tol                  !< Fractional buoyancy iteration tolerance for convergence [nondim]
@@ -465,7 +466,11 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
       tauy2 = (((asv1 * (sfc_state%tauy_shelf(i,J-1)**2)) + (asv2 * (sfc_state%tauy_shelf(i,J)**2))  ) * I_av)
     endif
     u2_av = (((asu1 * (sfc_state%u(I-1,j)**2)) + (asu2 * sfc_state%u(I,j)**2)) * I_au)
-    v2_av = (((asv1 * (sfc_state%v(i,J-1)**2)) + (asv2 * sfc_state%v(i,J)**2)) * I_av)
+    if (CS%ustar_from_vel_bugfix) then
+      v2_av = (((asv1 * (sfc_state%v(i,J-1)**2)) + (asv2 * sfc_state%v(i,J)**2)) * I_av)
+    else
+      v2_av = (((asv1 * (sfc_state%v(i,J-1)**2)) + (asu2 * sfc_state%v(i,J)**2)) * I_av)
+    endif
 
     if ((taux2 + tauy2 > 0.0) .and. .not.CS%ustar_shelf_from_vel) then
       if (CS%ustar_max >= 0.0) then
@@ -1792,6 +1797,9 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   call get_param(param_file, mdl, "ICE_SHELF_RC", CS%Rc, &
                  "Critical flux Richardson number for ice melt ", &
                  units="nondim", default=0.20)
+  call get_param(param_file, mdl, "ICE_SHELF_USTAR_FROM_VEL_BUGFIX", CS%ustar_from_vel_bugfix, &
+                 "Bug fix for ice-area weighting of squared ocean velocities "//&
+                 "used to calculate friction velocity under ice shelves", default=.false.)
   call get_param(param_file, mdl, "ICE_SHELF_BUOYANCY_FLUX_ITT_BUGFIX", CS%buoy_flux_itt_bugfix, &
                  "Bug fix of buoyancy iteration", default=.true., old_name="ICE_SHELF_BUOYANCY_FLUX_ITT_BUG")
   call get_param(param_file, mdl, "ICE_SHELF_SALT_FLUX_ITT_BUGFIX", CS%salt_flux_itt_bugfix, &

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -209,7 +209,7 @@ type, public :: ice_shelf_CS ; private
              id_h_shelf = -1, id_dhdt_shelf, id_h_mask = -1, &
              id_surf_elev = -1, id_bathym = -1, &
              id_area_shelf_h = -1, &
-             id_ustar_shelf = -1, id_shelf_mass = -1, id_mass_flux = -1, &
+             id_ustar_shelf = -1, id_taux = -1, id_tauy = -1, id_shelf_mass = -1, id_mass_flux = -1, &
              id_shelf_sfc_mass_flux = -1, &
              id_vaf = -1, id_g_adott = -1, id_f_adott = -1, id_adott = -1, &
              id_bdott_melt = -1, id_bdott_accum = -1, id_bdott = -1, &
@@ -347,7 +347,8 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   real :: DwB_min      ! The change in wB_flux when it is wB_flux_min [Z2 T-3 ~> m2 s-3]
   real :: I_Gam_T, I_Gam_S  ! Terms that vary inversely with Gam_mol_T or Gam_mol_S and Gam_turb [nondim]
   real :: dG_dwB       ! The derivative of Gam_turb with wB [T3 Z-2 ~> s3 m-2]
-  real :: taux2, tauy2 ! The squared surface stresses [R2 L2 Z2 T-4 ~> Pa2].
+  real, dimension(SZDI_(CS%grid),SZDJ_(CS%grid)) :: &
+    taux2, tauy2 ! The squared surface stresses [R2 L2 Z2 T-4 ~> Pa2].
   real :: u2_av, v2_av ! The ice-area weighted average squared ocean velocities [L2 T-2 ~> m2 s-2]
   real :: asu1, asu2   ! Ocean areas covered by ice shelves at neighboring u-points [L2 ~> m2]
   real :: asv1, asv2   ! Ocean areas covered by ice shelves at neighboring v-points [L2 ~> m2]
@@ -452,8 +453,9 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     call pass_vector(sfc_state%taux_shelf, sfc_state%tauy_shelf, G%domain, TO_ALL, CGRID_NE)
   endif
   Irho0 = US%Z_to_L / CS%Rho_ocn
+  taux2(:,:)=0.0; tauy2(:,:)=0.0
   do j=js,je ; do i=is,ie ; if (fluxes%frac_shelf_h(i,j) > 0.0) then
-    taux2 = 0.0 ; tauy2 = 0.0 ; u2_av = 0.0 ; v2_av = 0.0
+    u2_av = 0.0 ; v2_av = 0.0
     asu1 = (ISS%area_shelf_h(i-1,j) + ISS%area_shelf_h(i,j))
     asu2 = (ISS%area_shelf_h(i,j) + ISS%area_shelf_h(i+1,j))
     asv1 = (ISS%area_shelf_h(i,j-1) + ISS%area_shelf_h(i,j))
@@ -461,19 +463,19 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     I_au = 0.0 ; if (asu1 + asu2 > 0.0) I_au = 1.0 / (asu1 + asu2)
     I_av = 0.0 ; if (asv1 + asv2 > 0.0) I_av = 1.0 / (asv1 + asv2)
     if (allocated(sfc_state%taux_shelf) .and. allocated(sfc_state%tauy_shelf)) then
-      taux2 = (((asu1 * (sfc_state%taux_shelf(I-1,j)**2)) + (asu2 * (sfc_state%taux_shelf(I,j)**2))  ) * I_au)
-      tauy2 = (((asv1 * (sfc_state%tauy_shelf(i,J-1)**2)) + (asv2 * (sfc_state%tauy_shelf(i,J)**2))  ) * I_av)
+      taux2(i,j) = (((asu1 * (sfc_state%taux_shelf(I-1,j)**2)) + (asu2 * (sfc_state%taux_shelf(I,j)**2))  ) * I_au)
+      tauy2(i,j) = (((asv1 * (sfc_state%tauy_shelf(i,J-1)**2)) + (asv2 * (sfc_state%tauy_shelf(i,J)**2))  ) * I_av)
     endif
     u2_av = (((asu1 * (sfc_state%u(I-1,j)**2)) + (asu2 * sfc_state%u(I,j)**2)) * I_au)
-    v2_av = (((asv1 * (sfc_state%v(i,J-1)**2)) + (asu2 * sfc_state%v(i,J)**2)) * I_av)
+    v2_av = (((asv1 * (sfc_state%v(i,J-1)**2)) + (asv2 * sfc_state%v(i,J)**2)) * I_av)
 
-    if ((taux2 + tauy2 > 0.0) .and. .not.CS%ustar_shelf_from_vel) then
+    if ((taux2(i,j) + tauy2(i,j) > 0.0) .and. .not.CS%ustar_shelf_from_vel) then
       if (CS%ustar_max >= 0.0) then
         fluxes%ustar_shelf(i,j) = MIN(CS%ustar_max, MAX(CS%ustar_bg, US%L_to_Z * &
-            sqrt(Irho0 * sqrt(taux2 + tauy2) + CS%cdrag*CS%utide(i,j)**2)))
+            sqrt(Irho0 * sqrt(taux2(i,j) + tauy2(i,j)) + CS%cdrag*CS%utide(i,j)**2)))
       else
         fluxes%ustar_shelf(i,j) = MAX(CS%ustar_bg, US%L_to_Z * &
-            sqrt(Irho0 * sqrt(taux2 + tauy2) + CS%cdrag*CS%utide(i,j)**2))
+            sqrt(Irho0 * sqrt(taux2(i,j) + tauy2(i,j)) + CS%cdrag*CS%utide(i,j)**2))
       endif
     else   ! Take care of the cases when taux_shelf is not set or not allocated.
       fluxes%ustar_shelf(i,j) = MAX(CS%ustar_bg, US%L_TO_Z * &
@@ -944,6 +946,10 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   if (CS%id_shelf_mass > 0) call post_data(CS%id_shelf_mass, ISS%mass_shelf, CS%diag)
   if (CS%id_area_shelf_h > 0) call post_data(CS%id_area_shelf_h, ISS%area_shelf_h, CS%diag)
   if (CS%id_ustar_shelf > 0) call post_data(CS%id_ustar_shelf, fluxes%ustar_shelf, CS%diag)
+  if (allocated(sfc_state%taux_shelf) .and. allocated(sfc_state%tauy_shelf)) then
+    if (CS%id_taux > 0) call post_data(CS%id_taux, sqrt(taux2), CS%diag)
+    if (CS%id_tauy > 0) call post_data(CS%id_tauy, sqrt(tauy2), CS%diag)
+  endif
   if (CS%id_shelf_sfc_mass_flux > 0) call post_data(CS%id_shelf_sfc_mass_flux, fluxes%shelf_sfc_mass_flux, CS%diag)
 
   if (CS%id_melt > 0) call post_data(CS%id_melt, fluxes%iceshelf_melt, CS%diag)
@@ -2107,6 +2113,10 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
       'Heat conduction into ice shelf', 'W m-2', conversion=-US%QRZ_T_to_W_m2)
   CS%id_ustar_shelf = register_diag_field('ice_shelf_model', 'ustar_shelf', CS%diag%axesT1, CS%Time, &
       'Fric vel under shelf', 'm/s', conversion=US%Z_to_m*US%s_to_T)
+  CS%id_taux = register_diag_field('ice_shelf_model', 'taux_shelf', CS%diag%axesT1, CS%Time, &
+      'x-surface stress under the ice shelf', 'Pa', conversion=US%RLZ_T2_to_Pa)
+  CS%id_tauy = register_diag_field('ice_shelf_model', 'tauy_shelf', CS%diag%axesT1, CS%Time, &
+      'y-surface stress under the ice shelf', 'Pa', conversion=US%RLZ_T2_to_Pa)
   if (CS%active_shelf_dynamics) then
     CS%id_h_mask = register_diag_field('ice_shelf_model', 'h_mask', CS%diag%axesT1, CS%Time, &
        'ice shelf thickness mask', 'none', conversion=1.0)


### PR DESCRIPTION
Fixed an incorrect area used to calculate cell-centered ocean surface velocity under the ice shelf, which can impact the calculation of ice-shelf friction velocity. Added missing flags to some `allocate_surface_state` calls so that `sfc_state%taux_shelf` and `sfc_state%tauy_shelf` are allocated. This is required for the surface-stress-based (rather than surface-velocity-based) calculation of ice-shelf friction velocity. Also added `taux_shelf` and `tauy_shelf` as diagnostics for the ocean surface stress under the ice shelf.