### PR TITLE
(+) Decouple FMS infra from framework

### DIFF
--- a/config_src/infra/FMS1/MOM_interp_infra.F90
+++ b/config_src/infra/FMS1/MOM_interp_infra.F90
@@ -4,15 +4,14 @@ module MOM_interp_infra
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_domain_infra,    only : MOM_domain_type, domain2d
-use MOM_io,              only : axis_info
-use MOM_io,              only : set_axis_info
 use MOM_time_manager,    only : time_type
 use horiz_interp_mod,    only : horiz_interp_new, horiz_interp, horiz_interp_init, horiz_interp_type
 use mpp_io_mod,          only : axistype, mpp_get_axis_data, mpp_get_atts
 use time_interp_external_mod, only : time_interp_external
 use time_interp_external_mod, only : init_external_field, time_interp_external_init
 use time_interp_external_mod, only : get_external_field_size
-use time_interp_external_mod, only : get_external_field_axes, get_external_field_missing
+use time_interp_external_mod, only : get_external_field_axes
+use time_interp_external_mod, only : get_external_field_missing
 
 implicit none ; private
 
@@ -158,34 +157,13 @@ function get_extern_field_size(index)
 end function get_extern_field_size
 
 
-!> get axes of an external field from field index
-function get_extern_field_axes(index) result(axes)
+!> get size of an external field from field index
+function get_extern_field_axes(index)
 
-  integer, intent(in) :: index    !< FMS interpolation field index
-  type(axis_info) :: axes(4)      !< MOM IO field axes handle
+  integer, intent(in) :: index                !< field index
+  type(axistype) :: get_extern_field_axes(4)  !< field size
 
-  type(axistype), dimension(4) :: fms_axes(4)
-    ! FMS axis handles
-  character(len=32) :: name
-    ! Axis name
-  real, allocatable :: points(:)
-    ! Axis line points
-  integer :: length
-    ! Axis line point length
-  integer :: i
-    ! Loop index
-
-  fms_axes = get_external_field_axes(index)
-
-  do i = 1, 4
-    call mpp_get_atts(fms_axes(i), name=name, len=length)
-
-    allocate(points(length))
-    call mpp_get_axis_data(fms_axes(i), points)
-    call set_axis_info(axes(i), name=name, ax_data=points)
-
-    deallocate(points)
-  enddo
+  get_extern_field_axes = get_external_field_axes(index)
 end function get_extern_field_axes
 
 
@@ -202,25 +180,27 @@ end function get_extern_field_missing
 
 !> Get information about the external fields.
 subroutine get_external_field_info(field, size, axes, missing)
-  type(external_field),      intent(in)    :: field     !< Handle for time interpolated external
-                                                        !! field returned from a previous
-                                                        !! call to init_external_field()
-  integer,         optional, intent(inout) :: size(4)   !< Dimension sizes for the input data
-  type(axis_info), optional, intent(inout) :: axes(4)   !< Axis types for the input data
-  real,            optional, intent(inout) :: missing   !< Missing value for the input data
+  type(external_field), intent(in) :: field
+    !< Handle for time interpolated external field returned from a previous
+    !! call to init_external_field()
+  integer, optional, intent(inout) :: size(4)
+    !< Dimension sizes for the input data
+  type(axistype), optional, intent(inout) :: axes(4)
+    !< Axis types for the input data
+  real, optional, intent(inout) :: missing
+    !< Missing value for the input data
 
   if (present(size)) then
-    size(1:4) = get_extern_field_size(field%id)
+    size(:) = get_extern_field_size(field%id)
   endif
 
   if (present(axes)) then
-    axes(1:4) = get_extern_field_axes(field%id)
+    axes(:) = get_extern_field_axes(field%id)
   endif
 
   if (present(missing)) then
     missing = get_extern_field_missing(field%id)
   endif
-
 end subroutine get_external_field_info
 
 

--- a/config_src/infra/FMS1/MOM_io_infra.F90
+++ b/config_src/infra/FMS1/MOM_io_infra.F90
@@ -32,7 +32,8 @@ implicit none ; private
 public :: open_file, open_ASCII_file, file_is_open, close_file, flush_file, file_exists
 public :: get_file_info, get_file_fields, get_file_times, get_filename_suffix
 public :: read_field, read_vector, write_metadata, write_field
-public :: field_exists, get_field_atts, get_field_size, get_axis_data, read_field_chksum
+public :: field_exists, get_field_atts, get_field_size, read_field_chksum
+public :: get_axis_data, set_axis_data
 public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
 public :: stdout_if_root
 ! These types are inherited from underlying infrastructure code, to act as containers for
@@ -404,12 +405,33 @@ subroutine get_field_size(filename, fieldname, sizes, field_found, no_domain)
 end subroutine get_field_size
 
 !> Extracts and returns the axis data stored in an axistype.
-subroutine get_axis_data( axis, dat )
-  type(axistype),     intent(in)  :: axis !< An axis type
-  real, dimension(:), intent(out) :: dat  !< The data in the axis variable
+subroutine get_axis_data(axis, axis_name, axis_data)
+  type(axistype), intent(in) :: axis
+    !< Infra axis
+  character(len=256), intent(out) :: axis_name
+    !< Axis name
+  real, dimension(:), intent(out) :: axis_data
+    !< Axis points
 
-  call mpp_get_axis_data( axis, dat )
+  call mpp_get_atts(axis, name=axis_name)
+  call mpp_get_axis_data(axis, axis_data)
 end subroutine get_axis_data
+
+
+! NOTE: Unused, but provided to match the FMS2 API
+
+!> Return a new axistype based on axis specs
+subroutine set_axis_data(axis, axis_name, axis_data)
+  type(axistype), intent(inout) :: axis
+    !< Target axis
+  character(len=256), intent(in) :: axis_name
+    !< Target axis name
+  real, intent(in) :: axis_data(:)
+    !< Target axis values
+
+  call MOM_error(FATAL, "set_axis_data in FMS1 is not yet implemented.")
+end subroutine set_axis_data
+
 
 !> This routine uses the fms_io subroutine read_data to read a scalar named
 !! "fieldname" from a single or domain-decomposed file "filename".

--- a/config_src/infra/FMS2/MOM_interp_infra.F90
+++ b/config_src/infra/FMS2/MOM_interp_infra.F90
@@ -4,10 +4,10 @@ module MOM_interp_infra
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_domain_infra,    only : MOM_domain_type, domain2d
-use MOM_io,              only : axis_info
-use MOM_io,              only : get_var_axes_info
+use MOM_io_infra, only : axistype
+use MOM_io_infra, only : set_axis_data
 use MOM_time_manager,    only : time_type
-use MOM_error_handler, only : MOM_error, FATAL
+use MOM_error_infra, only : MOM_error => MOM_err, FATAL
 use MOM_string_functions, only : lowercase
 use horiz_interp_mod, only : horiz_interp_new, horiz_interp, horiz_interp_init, horiz_interp_type
 use netcdf_io_mod, only : FmsNetcdfFile_t, netcdf_file_open, netcdf_file_close
@@ -16,6 +16,17 @@ use time_interp_external2_mod, only : time_interp_external
 use time_interp_external2_mod, only : init_external_field, time_interp_external_init
 use time_interp_external2_mod, only : get_external_field_size
 use time_interp_external2_mod, only : get_external_field_missing
+
+! Use primitive netCDF, to replicate get_var_axes_info()
+use netcdf, only : nf90_open
+use netcdf, only : nf90_close
+use netcdf, only : nf90_inq_varid
+use netcdf, only : nf90_inquire_variable
+use netcdf, only : nf90_inquire_dimension
+use netcdf, only : nf90_get_var
+use netcdf, only : NF90_NOWRITE
+use netcdf, only : NF90_NOERR
+
 
 implicit none ; private
 
@@ -153,10 +164,115 @@ end function get_extern_field_size
 
 !> get axes of an external field from field index
 function get_extern_field_axes(field) result(axes)
-  type(external_field), intent(in) :: field   !< Field handle
-  type(axis_info), dimension(4) :: axes        !< Field axes
+  type(external_field), intent(in) :: field
+    !< Field handle
+  type(axistype), dimension(4) :: axes
+    !< Field axes
 
-  call get_var_axes_info(field%filename, field%label, axes)
+  integer :: ndims
+    ! Number of variable dimensions
+  integer, allocatable :: dims(:)
+    ! netCDF dimension IDs of variable
+  character(len=256) :: dim_name
+    ! Dimension name
+  integer :: dim_len
+    ! Dimension length
+  integer :: var_dim
+    ! netCDF ID of the variable associated with dimension of the same name
+  real, allocatable :: axis_points(:)
+    ! Axis values
+
+  integer :: ncid
+    ! netCDF file ID
+  integer :: varid
+    ! netCDF variable ID
+  integer :: rc
+    ! netCDF return code
+
+  ! netCDF requires the following to be length-1 arrays
+  integer :: nc_start(1)
+    ! netCDF start index
+  integer :: nc_count(1)
+    ! netCDF index count
+
+  integer :: d
+    ! Dimension index
+  character(len=2) :: d_str
+    ! Display string of d
+
+  ! This is a reimplementation of get_var_axes_info(), maybe it can be used
+  ! by the existing get_var_axes_info() ?
+
+  ! Open field%filename
+  rc = nf90_open(trim(field%filename), NF90_NOWRITE, ncid)
+  if (rc /= NF90_NOERR) &
+    call MOM_error(FATAL, "Error opening file " // trim(field%filename) // ".")
+
+  ! Use field%label to get the netCDF varid
+  rc = nf90_inq_varid(ncid, trim(field%label), varid)
+  if (rc /= NF90_NOERR) &
+    call MOM_error(FATAL, "Error finding variable " // trim(field%label) &
+        // " in " // trim(field%filename) // ".")
+
+  ! Use the varid to get the number of dims (ndims) and their IDs (dims(:))
+  !   Verify that ndims >= 3
+  rc = nf90_inquire_variable(ncid, varid, ndims=ndims)
+  if (rc /= NF90_NOERR) &
+    call MOM_error(FATAL, "Error querying variable " // trim(field%label) &
+        // " in " // trim(field%filename) // ".")
+
+  if (ndims < 3) &
+    call MOM_error(FATAL, trim(field%label) // " in " // trim(field%filename) &
+        // " has too few dimensions to be read as a 3D array.")
+
+  allocate(dims(ndims))
+
+  rc = nf90_inquire_variable(ncid, varid, dimids=dims)
+  if (rc /= NF90_NOERR) &
+    call MOM_error(FATAL, "Error querying variable " // trim(field%label) &
+        // " in " // trim(field%filename) // ".")
+
+  do d=1,ndims
+    ! Determine the name of each dimension
+    rc = nf90_inquire_dimension(ncid, dims(d), dim_name, len=dim_len)
+    if (rc /= NF90_NOERR) then
+      write(d_str, '(i0)') d
+      call MOM_error(FATAL, "Error querying dimension " // trim(d_str) &
+          // " of " // trim(field%label) // " in " // trim(field%filename) &
+          // ".")
+    endif
+
+    ! Now locate a variable with the same name as the dimension (e.g. "x")
+    rc = nf90_inq_varid(ncid, dim_name, var_dim)
+    if (rc /= NF90_NOERR) &
+      call MOM_error(FATAL, "Error finding dimension variable " &
+          // trim(dim_name) // " of " // trim(field%label) // " in " &
+          // trim(field%filename))
+
+    allocate(axis_points(dim_len))
+
+    ! Get the dimensional axis values
+    nc_start(1) = 1
+    nc_count(1) = dim_len
+    rc = nf90_get_var(ncid, var_dim, axis_points, nc_start, nc_count)
+    if (rc /= NF90_NOERR) &
+      call MOM_error(FATAL, "Error reading dimension " // trim(dim_name) &
+          // " axis data of " // trim(field%label) // " in " &
+          // trim(field%filename))
+
+    ! write via set_axis_info() equivalent for axistype
+    call set_axis_data(axes(d), dim_name, axis_points)
+
+    deallocate(axis_points)
+  enddo
+
+  deallocate(dims)
+
+  ! Close external file
+  rc = nf90_close(ncid)
+  if (rc /= NF90_NOERR) &
+    call MOM_error(FATAL, "Error closing file "//trim(field%filename)//".")
+
 end function get_extern_field_axes
 
 
@@ -173,25 +289,27 @@ end function get_extern_field_missing
 
 !> Get information about the external fields.
 subroutine get_external_field_info(field, size, axes, missing)
-  type(external_field),                   intent(in)    :: field    !< Handle for time interpolated external
-                                                                    !! field returned from a previous
-                                                                    !! call to init_external_field()
-  integer,         dimension(4), optional, intent(inout) :: size    !< Dimension sizes for the input data
-  type(axis_info), dimension(4), optional, intent(inout) :: axes    !< Axis types for the input data
-  real,                          optional, intent(inout) :: missing !< Missing value for the input data
+  type(external_field), intent(in) :: field
+    !< handle for time interpolated external field returned from a previous
+    !! call to init_external_field()
+  integer, optional, intent(inout) :: size(4)
+    !< Dimension sizes for the input data
+  type(axistype), optional, intent(inout) :: axes(4)
+    !< Axis types for the input data
+  real, optional, intent(inout) :: missing
+    !< Missing value for the input data
 
   if (present(size)) then
-    size(1:4) = get_extern_field_size(field%id)
+    size(:) = get_extern_field_size(field%id)
   endif
 
   if (present(axes)) then
-    axes(1:4) = get_extern_field_axes(field)
+    axes(:) = get_extern_field_axes(field)
   endif
 
   if (present(missing)) then
     missing = get_extern_field_missing(field%id)
   endif
-
 end subroutine get_external_field_info
 
 

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -6,8 +6,6 @@ module MOM_io_infra
 use MOM_domain_infra,     only : MOM_domain_type, rescale_comp_data, AGRID, BGRID_NE, CGRID_NE
 use MOM_domain_infra,     only : domain2d, domain1d, CENTER, CORNER, NORTH_FACE, EAST_FACE
 use MOM_error_infra,      only : MOM_error=>MOM_err, NOTE, FATAL, WARNING, is_root_PE
-use MOM_string_functions, only : lowercase
-
 use fms2_io_mod,          only : fms2_open_file => open_file, check_if_open, fms2_close_file => close_file
 use fms2_io_mod,          only : fms2_flush_file => flush_file
 use fms2_io_mod,          only : FmsNetcdfDomainFile_t, FmsNetcdfFile_t, fms2_read_data => read_data
@@ -46,7 +44,8 @@ integer, parameter :: MULTIPLE = 401
 public :: open_file, open_ASCII_file, file_is_open, close_file, flush_file, file_exists
 public :: get_file_info, get_file_fields, get_file_times, get_filename_suffix
 public :: read_field, read_vector, write_metadata, write_field
-public :: field_exists, get_field_atts, get_field_size, get_axis_data, read_field_chksum
+public :: field_exists, get_field_atts, get_field_size, read_field_chksum
+public :: get_axis_data, set_axis_data
 public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
 public :: stdout_if_root
 ! These types act as containers for information about files, fields and axes, respectively,
@@ -716,19 +715,49 @@ end function find_index
 
 
 !> Extracts and returns the axis data stored in an axistype.
-subroutine get_axis_data( axis, dat )
-  type(axistype),     intent(in)  :: axis !< An axis type
-  real, dimension(:), intent(out) :: dat  !< The data in the axis variable
+subroutine get_axis_data(axis, axis_name, axis_data)
+  type(axistype), intent(in) :: axis
+    !< Infra axis
+  character(len=256), intent(out) :: axis_name
+    !< Axis name
+  real, dimension(:), intent(out) :: axis_data
+    !< Axis points
 
   integer :: i
 
-  ! This routine might not be needed for MOM6.
   if (allocated(axis%ax_data)) then
-    if (size(axis%ax_data) > size(dat)) call MOM_error(FATAL, &
-      "get_axis_data called with too small of an output data array for "//trim(axis%name))
-    do i=1,size(axis%ax_data) ; dat(i) = axis%ax_data(i) ; enddo
+    if (size(axis%ax_data) > size(axis_data)) &
+      call MOM_error(FATAL, "get_axis_data called with too small of an " &
+          // "output data array for " // trim(axis%name) // ".")
+    do i=1,size(axis%ax_data)
+      axis_data(i) = axis%ax_data(i)
+    enddo
   endif
+
+  axis_name = axis%name
 end subroutine get_axis_data
+
+
+!> Return a new axistype based on axis specs
+subroutine set_axis_data(axis, axis_name, axis_data)
+  type(axistype), intent(inout) :: axis
+    !< Target axis
+  character(len=256), intent(in) :: axis_name
+    !< Target axis name
+  real, intent(in) :: axis_data(:)
+    !< Target axis values
+
+  axis%name = axis_name
+
+  if (allocated(axis%ax_data)) deallocate(axis%ax_data)
+  allocate(axis%ax_data(size(axis_data)))
+
+  axis%ax_data(:) = axis_data(:)
+
+  ! NOTE: We do not yet consider domain-decomposed axes.
+  axis%domain_decomposed = .false.
+end subroutine set_axis_data
+
 
 !> This routine uses the fms_io subroutine read_data to read a scalar named
 !! "fieldname" from a single or domain-decomposed file "filename".
@@ -2035,5 +2064,26 @@ function find_unlimited_dimension_name(fileobj) result(label)
   if (.not. allocated(label)) &
     label = ''
 end function find_unlimited_dimension_name
+
+! NOTE: `lowercase is duplicated from `src/framework/MOM_string_functions.F90`
+!   in order to avoid any dependency of the infra on the framework.
+
+!> Return a string in which all uppercase letters have been replaced by
+!! their lowercase counterparts.
+function lowercase(input_string)
+  character(len=*),     intent(in) :: input_string !< The string to modify
+  character(len=len(input_string)) :: lowercase !< The modified output string
+!   This function returns a string in which all uppercase letters have been
+! replaced by their lowercase counterparts.  It is loosely based on the
+! lowercase function in mpp_util.F90.
+  integer, parameter :: co=iachar('a')-iachar('A') ! case offset
+  integer :: k
+
+  lowercase = input_string
+  do k=1, len_trim(input_string)
+    if (lowercase(k:k) >= 'A' .and. lowercase(k:k) <= 'Z') &
+        lowercase(k:k) = achar(ichar(lowercase(k:k))+co)
+  enddo
+end function lowercase
 
 end module MOM_io_infra

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -16,7 +16,7 @@ use MOM_grid,          only : ocean_grid_type
 use MOM_interpolate,   only : time_interp_external
 use MOM_interp_infra,  only : run_horiz_interp, build_horiz_interp_weights
 use MOM_interp_infra,  only : horiz_interp_type, horizontal_interp_init
-use MOM_interp_infra,  only : get_external_field_info
+use MOM_interpolate,   only : get_external_field_info
 use MOM_interp_infra,  only : external_field
 use MOM_time_manager,  only : time_type
 use MOM_io,            only : axis_info, get_axis_info, get_var_axes_info, MOM_read_data

--- a/src/framework/MOM_interpolate.F90
+++ b/src/framework/MOM_interpolate.F90
@@ -7,9 +7,13 @@ use MOM_array_transform, only : allocate_rotated_array, rotate_array
 use MOM_error_handler,   only : MOM_error, FATAL
 use MOM_interp_infra,    only : time_interp_extern, init_external_field=>init_extern_field
 use MOM_interp_infra,    only : time_interp_external_init=>time_interp_extern_init
-use MOM_interp_infra,    only : horiz_interp_type, get_external_field_info
+use MOM_interp_infra,    only : horiz_interp_type
+use MOM_interp_infra,    only : get_external_field_info_infra => get_external_field_info
 use MOM_interp_infra,    only : run_horiz_interp, build_horiz_interp_weights
 use MOM_interp_infra,    only : external_field
+use MOM_io_infra,        only : axistype
+use MOM_io_infra,        only : get_axis_data
+use MOM_io,              only : axis_info, set_axis_info
 use MOM_time_manager, only : time_type, set_date, operator(+), operator(<), operator(>)
 
 implicit none ; private
@@ -26,7 +30,8 @@ type, public :: forcing_timeseries_dataset
     type(time_type) :: m2d_offset    !< add to model time to get data time
 end type forcing_timeseries_dataset
 
-public :: time_interp_external, init_external_field, time_interp_external_init, get_external_field_info
+public :: time_interp_external, init_external_field, time_interp_external_init
+public :: get_external_field_info
 public :: horiz_interp_type, run_horiz_interp, build_horiz_interp_weights
 public :: external_field
 public :: forcing_timeseries_set_time_type_vars
@@ -276,5 +281,46 @@ function map_model_time_to_forcing_time(Time, forcing_dataset)
   endif
 
 end function map_model_time_to_forcing_time
+
+
+subroutine get_external_field_info(field, size, axes, missing)
+  type(external_field), intent(in) :: field
+    !< Handle for time interpolated external field returned from a previous
+    !! call to init_external_field()
+  integer, optional, intent(inout) :: size(4)
+    !< Dimension sizes for the input data
+  type(axis_info), optional, intent(inout) :: axes(4)
+    !< Axis types for the input data
+  real, optional, intent(inout) :: missing
+    !< Missing value for the input data
+
+  type(axistype) :: axes_infra(4)
+    ! Axis as represented in the infra
+  character(len=256) :: axis_name
+    ! Axis name
+  real, allocatable :: ax_data(:)
+    ! Axis points
+
+  integer :: n
+    ! Axis index
+
+  if (present(axes)) then
+    call get_external_field_info_infra(field, size=size, axes=axes_infra, &
+        missing=missing)
+    ! TODO: Most of these methods were written to expect four dimensions.
+    ! I would not expect a generic field to be well-behaved, but I am unsure
+    ! how to validate such a field.
+    do n=1,4
+      ! Convert axistype to axis_info
+      allocate(ax_data(size(n)))
+      call get_axis_data(axes_infra(n), axis_name, ax_data)
+      call set_axis_info(axes(n), trim(axis_name), ax_data=ax_data)
+      deallocate(ax_data)
+    enddo
+  else
+    call get_external_field_info_infra(field, size=size, missing=missing)
+  endif
+end subroutine get_external_field_info
+
 
 end module MOM_interpolate

--- a/src/framework/MOM_netcdf.F90
+++ b/src/framework/MOM_netcdf.F90
@@ -799,7 +799,7 @@ subroutine check_netcdf_call(ncerr, header, message)
   character(len=:), allocatable :: errmsg
     ! Full error message, including netCDF message
 
-  if (ncerr /= nf90_noerr) then
+  if (ncerr /= NF90_NOERR) then
     errmsg = trim(header) // ": " // trim(message) // new_line('/') &
       // trim(nf90_strerror(ncerr))
     call MOM_error(FATAL, errmsg)

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -15,9 +15,10 @@ use MOM_ensemble_manager, only : get_ensemble_id, get_ensemble_size
 use MOM_ensemble_manager, only : get_ensemble_pelist, get_ensemble_filter_pelist
 use MOM_error_handler, only : stdout, stdlog, MOM_error
 use MOM_io, only : SINGLE_FILE
-use MOM_interp_infra, only : init_extern_field, get_external_field_info
+use MOM_interp_infra, only : init_extern_field
 use MOM_interp_infra, only : time_interp_extern
 use MOM_interpolate, only : external_field
+use MOM_interpolate, only : get_external_field_info
 use MOM_remapping,    only : remappingSchemesDoc
 use MOM_time_manager, only : time_type, real_to_time, get_date
 use MOM_time_manager, only : operator(+), operator(>=), operator(/=)

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -21,7 +21,8 @@ use MOM_error_handler, only : MOM_error, FATAL, NOTE, WARNING, is_root_pe
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
 use MOM_horizontal_regridding, only : horiz_interp_and_extrap_tracer
-use MOM_interpolate,   only : init_external_field, get_external_field_info, time_interp_external_init
+use MOM_interpolate,   only : init_external_field, time_interp_external_init
+use MOM_interpolate,   only : get_external_field_info
 use MOM_interpolate,   only : external_field
 use MOM_io,            only : axis_info
 use MOM_remapping,     only : remapping_cs, remapping_core_h, initialize_remapping


### PR DESCRIPTION
This patch undoes a coupling of the FMS infra layer to the MOM6 framework code.

In the current FMS infra layers, the `get_extern_field_info()` and `init_extern_field()` functions require content defined in
`src/framework`.   This prevents the development of new
independent infra layers, which much also depend on infra-agnostic
content.

In particular, the FMS2 implementation of `get_extern_field_axes()` relies exclusively on the framework function, `get_var_axes_info()`.

Both frameworks also return the `axes_info` type, a MOM-defined axis descriptor, rather than the infra `axistype`.

This patch resolves these inconsistencies.

* `axis_info` no longer appears at infra-level.  All relevant functions now reference `axistype`.

* `src/framework/MOM_io.F90` now provide functions for translating `axistype` to `axis_info`.

Some specific changes are summarized below.

* `get_external_field_info` is now a framework-level function of `MOM_interpolate.F90` , using infra-level implementations of `get_extern_field_(size|axes|missing)`.  Each is now explicitly defined at the infra-level.

* The FMS2 `get_external_field_axes` is now an entirely new function, and is largely a duplicate of `get_var_axes_info()`.  The major difference is that it returns a list of `axistype`.  It also replaces the fixed x-y-z fetch with a slightly more generic list of axes.

  (It still requires at least three dimensions, however.)

* FMS2 `MOM_io_infra.F90` now has `set_axis_data()`, used by `

* `set_axis_data` is only used internally by the FMS2 infra.  It is included in FMS1 but raises an nonimplementation error.

Note the following minor API changes:

* In `get_extern_field_info`, the optional `size` argument was renamed to `sizes` to avoid conflict with the `size()` intrinsic.

* The `name` argument was added to `get_axis_data`.  It is now the second argument, to match the style of existing functions, and size was moved to the third argument.

We did not make any effort to preserve the existing API with optional arguments.  These functions only appear in a very small number of functions, and do not appear in any driver/cap, and should not affect any existing models.  (But if I'm proven wrong, we can revert the change.)

Other minor framework references have been removed.

* `MOM_error` and `FATAL` now refernce their `MOM_error_infra` equivalents.

* `lowercase`, which was previously only defined in FMS1, has been added to the FMS2 infra.  Note that this is a duplication of the function in `src/framework/MOM_string_functions.F90`.