### PR TITLE
Inline harmonic analysis

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1047,6 +1047,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
                           G, GV, US, CS%diagnostics_CSp)
       call post_tracer_diagnostics_at_sync(CS%Tracer_reg, h, CS%diag_pre_sync, CS%diag, G, GV, CS%t_dyn_rel_diag)
       call diag_copy_diag_to_storage(CS%diag_pre_sync, h, CS%diag)
+      if (associated(CS%HA_CSp)) call HA_accum('ssh', ssh, Time_local, G, CS%HA_CSp)
       if (showCallTree) call callTree_waypoint("finished calculate_diagnostic_fields (step_MOM)")
       call disable_averaging(CS%diag)
       CS%t_dyn_rel_diag = 0.0
@@ -1069,7 +1070,6 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ssh(i,j) = CS%ssh_rint(i,j)*I_wt_ssh
       CS%ave_ssh_ibc(i,j) = ssh(i,j)
     enddo ; enddo
-    if (associated(CS%HA_CSp)) call HA_accum('ssh', ssh, Time_local, G, CS%HA_CSp)
     if (do_dyn) then
       call adjust_ssh_for_p_atm(CS%tv, G, GV, US, CS%ave_ssh_ibc, forces%p_surf_SSH, &
                                 CS%calc_rho_for_sea_lev)

--- a/src/diagnostics/MOM_harmonic_analysis.F90
+++ b/src/diagnostics/MOM_harmonic_analysis.F90
@@ -264,7 +264,7 @@ subroutine HA_init(Time, US, param_file, nc, CS)
 
   ! Register variables/fields to be analyzed
   call get_param(param_file, mdl, "HA_SSH", HA_ssh, &
-                 "If true, perform harmonic analysis of sea serface height.", default=.false.)
+                 "If true, perform harmonic analysis of sea surface height.", default=.false.)
   if (HA_ssh) call HA_register('ssh', 'h', CS)
   call get_param(param_file, mdl, "HA_UBT", HA_ubt, &
                  "If true, perform harmonic analysis of zonal barotropic velocity.", default=.false.)


### PR DESCRIPTION
Moving HA_accum for SSH into the n-loop, so that harmonic analysis is performed on the instantaneous SSH instead of the time-averaged SSH after the n-loop. My test case does not show any noticeable difference but I think this would make the harmonic analysis more accurate if relatively larger time steps are used.