### PR TITLE
Add t17d and t20d diagnostics

### DIFF
--- a/src/ALE/Recon1d_PCM.F90
+++ b/src/ALE/Recon1d_PCM.F90
@@ -19,6 +19,7 @@ public PCM
 !!   average()                 *locally defined
 !!   f()                       *locally defined
 !!   dfdx()                    *locally defined
+!! - x()                       *locally defined
 !!   check_reconstruction()    *locally defined
 !!   unit_tests()              *locally defined
 !!   destroy()                 *locally defined
@@ -38,6 +39,8 @@ contains
   procedure :: f => f
   !> Implementation of the derivative of the PCM reconstruction at a point [A]
   procedure :: dfdx => dfdx
+  !> Implementation of solver for x: f(x)=t
+  procedure :: x => x
   !> Implementation of deallocation for PCM
   procedure :: destroy => destroy
   !> Implementation of check reconstruction for the PCM reconstruction
@@ -106,6 +109,24 @@ real function dfdx(this, k, x)
   dfdx = 0.
 
 end function dfdx
+
+!> Solver for x: f(x)=t
+real function x(this, k, t)
+  class(PCM), intent(in) :: this !< This reconstruction
+  integer,    intent(in) :: k    !< Cell number
+  real,       intent(in) :: t    !< Value to solve for [A]
+  real :: slp  ! Difference across cell [A]
+
+  slp = this%u_mean(min(k+1,this%n)) - this%u_mean(max(k-1,1))
+  if ( abs(slp) > 0. ) slp = sign(1., slp)
+  x = 0.5 ! Fall back if t==u_mean
+  ! if t>u_mean & slp=1 then x=1
+  ! if t<u_mean & slp=1 then x=0
+  ! if t>u_mean & slp=-1 then x=0
+  ! if t<u_mean & slp=-1 then x=1
+  ! if slp=0 then x=0.5
+  if ( abs(t - this%u_mean(k)) > 0. ) x = 0.5 + slp * sign(0.5, t - this%u_mean(k))
+end function x
 
 !> Average between xa and xb for cell k of a 1D PCM reconstruction [A]
 real function average(this, k, xa, xb)
@@ -182,6 +203,16 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%real_arr(3, ul, (/0.,0.,0./), 'dfdx on left edge')
   call test%real_arr(3, um, (/0.,0.,0./), 'dfdx in center')
   call test%real_arr(3, ur, (/0.,0.,0./), 'dfdx on right edge')
+
+  call test%real_scalar( this%x(1,0.), 0., 'f-1(1,0)=0')
+  call test%real_scalar( this%x(1,1.), 0.5, 'f-1(1,1)=0.5')
+  call test%real_scalar( this%x(1,3.), 1., 'f-1(1,3)=1')
+  call test%real_scalar( this%x(2,1.), 0., 'f-1(2,1)=0')
+  call test%real_scalar( this%x(2,3.), 0.5, 'f-1(2,3)=0.5')
+  call test%real_scalar( this%x(2,5.), 1., 'f-1(2,5)=1')
+  call test%real_scalar( this%x(3,3.), 0., 'f-1(3,3)=0')
+  call test%real_scalar( this%x(3,5.), 0.5, 'f-1(3,5)=0.5')
+  call test%real_scalar( this%x(3,7.), 1., 'f-1(3,7)=1')
 
   do k = 1, 3
     um(k) = this%average(k, 0.5, 0.75)

--- a/src/ALE/Recon1d_PLM_CW.F90
+++ b/src/ALE/Recon1d_PLM_CW.F90
@@ -25,6 +25,7 @@ public PLM_CW, testing
 !! - average()                 *locally defined
 !! - f()                       *locally defined
 !! - dfdx()                    *locally defined
+!! - x()                       *locally defined
 !! - check_reconstruction()    *locally defined
 !! - unit_tests()              *locally defined
 !! - destroy()                 *locally defined
@@ -47,6 +48,8 @@ contains
   procedure :: f => f
   !> Implementation of the derivative of the PLM_CW reconstruction at a point [A]
   procedure :: dfdx => dfdx
+  !> Implementation of solver for x: f(x)=t
+  procedure :: x => x
   !> Implementation of deallocation for PLM_CW
   procedure :: destroy => destroy
   !> Implementation of check reconstruction for the PLM_CW reconstruction
@@ -196,6 +199,31 @@ real function dfdx(this, k, x)
 
 end function dfdx
 
+!> Solver for x such that f(x)=t
+real function x(this, k, t)
+  class(PLM_CW), intent(in) :: this !< This reconstruction
+  integer,       intent(in) :: k    !< Cell number
+  real,          intent(in) :: t    !< Value to solve for [A]
+  real :: slp ! Difference across cell [A]
+
+  slp = this%ur(k) - this%ul(k)
+  if ( abs(slp) > 0. ) then
+    x = ( t - this%ul(k) ) / slp
+    x = max( 0., min( x, 1. ) )
+  else
+    slp = this%ul(min(k+1,this%n)) - this%ur(max(k-1,1))
+    if ( abs(slp) > 0. ) slp = sign(1., slp)
+    x = 0.5 ! Fall back if t==u_mean
+    ! if t>u_mean & slp=1 then x=1
+    ! if t<u_mean & slp=1 then x=0
+    ! if t>u_mean & slp=-1 then x=0
+    ! if t<u_mean & slp=-1 then x=1
+    ! if t=u_mean then slp=0
+    ! if slp=0 then x=0.5
+    if ( abs(t - this%u_mean(k)) > 0. ) x = 0.5 + slp * sign(0.5, t - this%u_mean(k))
+  endif
+end function x
+
 !> Average between xa and xb for cell k of a 1D PLM reconstruction [A]
 real function average(this, k, xa, xb)
   class(PLM_CW), intent(in) :: this !< This reconstruction
@@ -335,6 +363,16 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%real_arr(3, ul, (/0.,2.,0./), 'dfdx on left edge')
   call test%real_arr(3, um, (/0.,2.,0./), 'dfdx in center')
   call test%real_arr(3, ur, (/0.,2.,0./), 'dfdx on right edge')
+
+  call test%real_scalar( this%x(1,0.), 0., 'f-1(1,0)=0')
+  call test%real_scalar( this%x(1,1.), 0.5, 'f-1(1,1)=0.5')
+  call test%real_scalar( this%x(1,3.), 1., 'f-1(1,3)=1')
+  call test%real_scalar( this%x(2,1.), 0., 'f-1(2,1)=0')
+  call test%real_scalar( this%x(2,3.), 0.5, 'f-1(2,3)=0.5')
+  call test%real_scalar( this%x(2,5.), 1., 'f-1(2,5)=1')
+  call test%real_scalar( this%x(3,3.), 0., 'f-1(3,3)=0')
+  call test%real_scalar( this%x(3,5.), 0.5, 'f-1(3,5)=0.5')
+  call test%real_scalar( this%x(3,7.), 1., 'f-1(3,7)=1')
 
   do k = 1, 3
     um(k) = this%average(k, 0.5, 0.75) ! Average from x=0.25 to 0.75 in each cell

--- a/src/ALE/Recon1d_PLM_CWK.F90
+++ b/src/ALE/Recon1d_PLM_CWK.F90
@@ -31,6 +31,7 @@ public PLM_CWK, testing
 !! - average()              -> recon1d_plm_cw.average()
 !! - f()                    -> recon1d_plm_cw.f()
 !! - dfdx()                 -> recon1d_plm_cw.dfdx()
+!! - x()                    -> recon1d_plm_cw.x()
 !! - check_reconstruction() -> recon1d_plm_cw.check_reconstruction()
 !! - unit_tests()           -> recon1d_plm_cw.unit_tests()
 !! - destroy()              -> recon1d_plm_cw.destroy()

--- a/src/ALE/Recon1d_PLM_WLS.F90
+++ b/src/ALE/Recon1d_PLM_WLS.F90
@@ -17,6 +17,7 @@ public PLM_WLS, testing
 !! - average()                 *locally defined
 !! - f()                       *locally defined
 !! - dfdx()                    *locally defined
+!! - x()                    -> recon1d_type.x()
 !! - check_reconstruction()    *locally defined
 !! - unit_tests()              *locally defined
 !! - destroy()                 *locally defined
@@ -370,6 +371,16 @@ logical function unit_tests(this, verbose, stdout, stderr)
     um(k) = this%average(k, 0.5, 0.75) ! Average from x=0.5 to 0.75 in each cell
   enddo
   call test%real_arr(3, um, (/1.25,3.25,5.25/), "Return interval average")
+
+  call test%real_scalar( this%x(1,0.), 0., 'f-1(1,0)=0')
+  call test%real_scalar( this%x(1,1.), 0.5, 'f-1(1,1)=0.5')
+  call test%real_scalar( this%x(1,3.), 1., 'f-1(1,3)=1')
+  call test%real_scalar( this%x(2,1.), 0., 'f-1(2,1)=0')
+  call test%real_scalar( this%x(2,3.), 0.5, 'f-1(2,3)=0.5')
+  call test%real_scalar( this%x(2,5.), 1., 'f-1(2,5)=1')
+  call test%real_scalar( this%x(3,3.), 0., 'f-1(3,3)=0')
+  call test%real_scalar( this%x(3,5.), 0.5, 'f-1(3,5)=0.5')
+  call test%real_scalar( this%x(3,7.), 1., 'f-1(3,7)=1')
 
   call this%destroy()
   deallocate( um, ul, ur, ull, urr )

--- a/src/ALE/Recon1d_PLM_hybgen.F90
+++ b/src/ALE/Recon1d_PLM_hybgen.F90
@@ -31,6 +31,7 @@ public PLM_hybgen, testing
 !! - average()                 *locally defined
 !! - f()                       *locally defined
 !! - dfdx()                    *locally defined
+!! - x()                    -> recon1d_plm_cw.x()
 !! - check_reconstruction()    *locally defined
 !! - unit_tests()              *locally defined
 !! - destroy()                 *locally defined
@@ -359,6 +360,16 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%real_arr(3, ul, (/0.,2.,0./), 'dfdx on left edge')
   call test%real_arr(3, um, (/0.,2.,0./), 'dfdx in center')
   call test%real_arr(3, ur, (/0.,2.,0./), 'dfdx on right edge')
+
+  call test%real_scalar( this%x(1,0.), 0., 'f-1(1,0)=0')
+  call test%real_scalar( this%x(1,1.), 0.5, 'f-1(1,1)=0.5')
+  call test%real_scalar( this%x(1,3.), 1., 'f-1(1,3)=1')
+  call test%real_scalar( this%x(2,1.), 0., 'f-1(2,1)=0')
+  call test%real_scalar( this%x(2,3.), 0.5, 'f-1(2,3)=0.5')
+  call test%real_scalar( this%x(2,5.), 1., 'f-1(2,5)=1')
+  call test%real_scalar( this%x(3,3.), 0., 'f-1(3,3)=0')
+  call test%real_scalar( this%x(3,5.), 0.5, 'f-1(3,5)=0.5')
+  call test%real_scalar( this%x(3,7.), 1., 'f-1(3,7)=1')
 
   do k = 1, 3
     um(k) = this%average(k, 0.5, 0.75) ! Average from x=0.25 to 0.75 in each cell

--- a/src/ALE/Recon1d_PPM_CW.F90
+++ b/src/ALE/Recon1d_PPM_CW.F90
@@ -28,6 +28,7 @@ public PPM_CW, testing
 !! - average()                 *locally defined
 !! - f()                       *locally defined
 !! - dfdx()                    *locally defined
+!! - x()                       *locally defined
 !! - check_reconstruction()    *locally defined
 !! - unit_tests()              *locally defined
 !! - destroy()                 *locally defined
@@ -51,6 +52,8 @@ contains
   procedure :: f => f
   !> Implementation of the derivative of the PPM_CW reconstruction at a point [A]
   procedure :: dfdx => dfdx
+  !> Implementation of solver for x: f(x)=t
+! procedure :: x => x
   !> Implementation of deallocation for PPM_CW
   procedure :: destroy => destroy
   !> Implementation of check reconstruction for the PPM_CW reconstruction
@@ -154,7 +157,7 @@ subroutine reconstruct(this, h, u)
   this%ur(n) = u(n) ! PCM
   this%ul(n) = u(n) ! PCM
 
-  do K = 2, n ! K=2 is interface between cells 1 and 2
+  do K = 2, n-1 ! K=2 is interface between cells 1 and 2
     u0 = u(k-1)
     u1 = u(k)
     u2 = u(k+1)
@@ -335,6 +338,7 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%set( stdout=stdout ) ! Sets the stdout channel in test
   call test%set( stderr=stderr ) ! Sets the stderr channel in test
   call test%set( verbose=verbose ) ! Sets the verbosity flag in test
+call test%set( stop_instantly=.true. )
 
   if (verbose) write(stdout,'(a)') 'PPM_CW:unit_tests testing with linear fn'
 
@@ -368,6 +372,10 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%real_arr(5, um, (/0.,3.,3.,3.,0./), 'dfdx in center')
   call test%real_arr(5, ur, (/0.,3.,3.,3.,0./), 'dfdx on right edge')
 
+  call test%real_scalar( this%x(2,1.), 0., 'f-1(2,1)=0')
+  call test%real_scalar( this%x(2,4.), 0.5, 'f-1(2,4)=0.5')
+  call test%real_scalar( this%x(2,5.5), 1., 'f-1(2,5.5)=1')
+
   do k = 1, 5
     um(k) = this%average(k, 0.5, 0.75) ! Average from x=0.25 to 0.75 in each cell
   enddo
@@ -393,6 +401,10 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%real_arr(5, ul, (/1.,3.,12.,27.,61./), 'Return left edge')
   call test%real_arr(5, um, (/1.,6.75,18.75,36.75,61./), 'Return center')
   call test%real_arr(5, ur, (/1.,12.,27.,48.,61./), 'Return right edge')
+
+  call test%real_scalar( this%x(3,12.), 0., 'f-1(3,12)=0')
+  call test%real_scalar( this%x(3,18.75), 0.5, 'f-1(3,18.75)=0.5', robits=1)
+  call test%real_scalar( this%x(3,27.), 1., 'f-1(3,27)=1')
 
   ! x = 3 i   i=0 at origin
   ! f(x) = x^2 / 3   = 3 i^2

--- a/src/ALE/Recon1d_PPM_CWK.F90
+++ b/src/ALE/Recon1d_PPM_CWK.F90
@@ -29,6 +29,7 @@ public PPM_CWK, testing
 !! - average()                 *locally defined
 !! - f()                       *locally defined
 !! - dfdx()                    *locally defined
+!! - x()                       *locally defined
 !! - check_reconstruction()    *locally defined
 !! - unit_tests()              *locally defined
 !! - destroy()                 *locally defined
@@ -52,6 +53,8 @@ contains
   procedure :: f => f
   !> Implementation of the derivative of the PPM_CWK reconstruction at a point [A]
   procedure :: dfdx => dfdx
+  !> Implementation of solver for x: f(x)=t
+  procedure :: x => x
   !> Implementation of deallocation for PPM_CWK
   procedure :: destroy => destroy
   !> Implementation of check reconstruction for the PPM_CWK reconstruction
@@ -139,7 +142,7 @@ subroutine reconstruct(this, h, u)
   this%ur(n) = u(n) ! PCM
   this%ul(n) = u(n) ! PCM
 
-  do K = 2, n ! K=2 is interface between cells 1 and 2
+  do K = 2, n-1 ! K=2 is interface between cells 1 and 2
     u0 = u(k-1)
     u1 = u(k)
     u2 = u(k+1)
@@ -216,6 +219,62 @@ real function dfdx(this, k, x)
   dfdx = du + a6 * ( 2.0 * xc - 1.0 )
 
 end function dfdx
+
+!> Solver for x: f(x)=t
+real function x(this, k, t)
+  class(PPM_CWK), intent(in) :: this !< This reconstruction
+  integer,        intent(in) :: k    !< Cell number
+  real,           intent(in) :: t    !< Value to solve for [A]
+  real :: slp  ! Difference in edge values, ur-ul [A]
+  real :: a6   ! Colella and Woodward curvature parameter [A]
+  real :: sD   ! Square root of the quadratic discriminant [A]
+  real :: b    ! The b in f(x) = a x^2 + b x + c [A]
+  real :: c    ! The c in f(x) = a x^2 + b x + c [A]
+
+  ! The PPM profile is the quadratic profile: f(x) = ul + (slp+a6)*x - a6*x^2.
+  ! Setting f(x)=t gives: -a6*x^2 + (slp+a6)*x + (ul-t) = 0.
+  ! In the common parlance of solving a*x^2 + b*x + c = 0, this means
+  !  a = -a6;  b = slp+a6; c = ul-t
+  ! The quadratic formula x = ( -b +/- sD ) / ( 2a ) with sD = sqrt(b^2-4*a*c)
+  ! can suffer from catastrophic cancellation in some scenarios.
+  ! A mathematically equivalent form of x = 2c / ( -b -/+ sD ) also can fail.
+  ! Usually, to avoid catastrophic cancellation, we use the rule
+  !   If b>0 then the two roots are
+  !     ra = -(b+sD)/(2a)
+  !     rc = -2c/(b+sD)
+  !   otherwise if b<0 then the two roots are
+  !     ra = (-b+sD)/(2a)
+  !     rc = 2c/(-b+sD)
+  ! In all expressions, sD and b do not have cancelling contributions due to the signs.
+  ! Note that here, if b>0 then c<0, and vice versa, because we are looking
+  ! for f(x)=t which shifts "c" by t so that the root we are interested in
+  ! falls in the range 0 <= x <= 1 (assuming t falls in ul...ur).
+  ! When b>0 and a>0 then -b/(2a)<0 and ra<0<rc, so we need rc
+  ! When b>0 and a<0 then -b/(2a)>0 and ra>rc, so we need rc
+  ! When b<0 and a>0 then -b/(2a)>0 and ra>rc, so we need rc
+  ! When b<0 and a<0 then -b/(2a)<0 and ra<0<rc, so we need rc
+  ! So a form that always gives us the root that we want is
+  !   x = -2c/(b+sgn(b)*sD)
+  slp = this%ur(k) - this%ul(k)
+  a6 = 3.0 * ((this%u_mean(k) - this%ul(k)) + (this%u_mean(k) - this%ur(k)))
+  b = slp + a6 ! to avoid repeated computation
+  c = this%ul(k) - t ! to avoid repeated computation
+  if (abs(slp) > 0.) then
+    ! The max(0,..a.) here is out of an abundance of caution, but if the PPM parameters
+    ! have been made monotonic then the max is not necessary.
+    sD = sqrt( max( 0., b**2 + 4. * a6 * c ) )
+    ! Calculate the reciprocal of the denominator. Note: even if b=0, sign(sD,b)=sD>0.
+    x = 1. / ( b + sign( sD, b ) )
+    ! The actual root is
+    x = -2. * c * x
+    x = max( 0., min( 1., x ) )
+  else
+    ! Constant (or inconsistent) profile (ul=ur, a6=?): infer position from adjacent cell slopes.
+    x = 0.5 ! fallback
+    slp = this%ul(min(k+1,this%n)) - this%ur(max(k-1,1))
+    if (abs(slp) > 0.) x = 0.5 + sign( 0.5, slp ) ! either 0 or 1
+  endif
+end function x
 
 !> Average between xa and xb for cell k of a 1D PPM reconstruction [A]
 real function average(this, k, xa, xb)
@@ -374,6 +433,17 @@ logical function unit_tests(this, verbose, stdout, stderr)
   call test%real_arr(5, ul, (/1.,3.,12.,27.,61./), 'Return left edge')
   call test%real_arr(5, um, (/1.,6.75,18.75,36.75,61./), 'Return center')
   call test%real_arr(5, ur, (/1.,12.,27.,48.,61./), 'Return right edge')
+
+  call test%real_scalar( this%x(3,12.), 0., 'f-1(3,12)=0')
+  call test%real_scalar( this%x(3,15.1875), 0.25, 'f-1(3,15.1875)=0.25')
+  call test%real_scalar( this%x(3,18.75), 0.5, 'f-1(3,18.75)=0.5')
+  call test%real_scalar( this%x(3,27.), 1., 'f-1(3,27)=1')
+
+  call this%reconstruct( (/2.,2.,2.,2.,2./), (/-1.,-7.,-19.,-37.,-61./) )
+  call test%real_scalar( this%x(3,-12.), 0., 'f-1(3,-12)=0')
+  call test%real_scalar( this%x(3,-15.1875), 0.25, 'f-1(3,-15.1875)=0.25')
+  call test%real_scalar( this%x(3,-18.75), 0.5, 'f-1(3,-18.75)=0.5')
+  call test%real_scalar( this%x(3,-27.), 1., 'f-1(3,-27)=1')
 
   ! x = 3 i   i=0 at origin
   ! f(x) = x^2 / 3   = 3 i^2

--- a/src/ALE/Recon1d_PPM_hybgen.F90
+++ b/src/ALE/Recon1d_PPM_hybgen.F90
@@ -129,7 +129,7 @@ subroutine reconstruct(this, h, u)
   this%ur(n) = u(n) ! PCM
   this%ul(n) = u(n) ! PCM
 
-  do K = 2, n ! K=2 is interface between cells 1 and 2
+  do K = 2, n-1 ! K=2 is interface between cells 1 and 2
     u0 = u(k-1)
     u1 = u(k)
     u2 = u(k+1)

--- a/src/ALE/Recon1d_type.F90
+++ b/src/ALE/Recon1d_type.F90
@@ -18,6 +18,7 @@ type, abstract :: Recon1d
   integer :: n = 0 !< Number of cells in column
   real, allocatable, dimension(:) :: u_mean !< Cell mean [A]
   real :: h_neglect = 0. !< A negligibly small width used in cell reconstructions in the same units as h [H]
+  real :: x_tolerance = 1. * epsilon(1.) !< Solver tolerance for x in element (0,1) [nondim]
   logical :: check = .false. !< If true, enable some consistency checking
 
   logical :: debug = .false. !< If true, dump info as calculations are made (do not enable)
@@ -52,6 +53,8 @@ contains
   ! The following functions/subroutines are shared across all reconstructions and provided by this module
   ! unless replaced for the purpose of optimization
 
+  !> Solves for x such that f(x)=t
+  procedure :: x => x
   !> Remaps the column to subgrid h_sub
   procedure :: remap_to_sub_grid => remap_to_sub_grid
   !> Set debugging
@@ -99,7 +102,7 @@ interface
 
   !> Point-wise value of reconstruction [A]
   !!
-  !! THe function is only valid for 0 <= x <= 1. x is effectively clipped to this range.
+  !! The function is only valid for 0 <= x <= 1. x is effectively clipped to this range.
   real function i_f(this, k, x)
     import :: Recon1d
     class(Recon1d), intent(in) :: this !< This reconstruction
@@ -109,13 +112,25 @@ interface
 
   !> Point-wise value of derivative reconstruction [A]
   !!
-  !! THe function is only valid for 0 <= x <= 1. x is effectively clipped to this range.
+  !! The function is only valid for 0 <= x <= 1. x is effectively clipped to this range.
   real function i_dfdx(this, k, x)
     import :: Recon1d
     class(Recon1d), intent(in) :: this !< This reconstruction
     integer,        intent(in) :: k    !< Cell number
     real,           intent(in) :: x    !< Non-dimensional position within element [nondim]
   end function i_dfdx
+
+  !> Point-wise solver for x: f(x)=t [nondim]
+  !!
+  !! The function solves for the non-dimensional position x within the cell where
+  !! the reconstruction f(x)=t. The solver returns x=0 or x=1 if the target, t,
+  !! is outside of the cell.
+  real function i_x(this, k, t)
+    import :: Recon1d
+    class(Recon1d), intent(in) :: this !< This reconstruction
+    integer,        intent(in) :: k    !< Cell number
+    real,           intent(in) :: t    !< Value to solve for [A]
+  end function i_x
 
   !> Returns true if some inconsistency is detected, false otherwise
   !!
@@ -165,6 +180,62 @@ interface
 end interface
 
 contains
+
+!> Solve for x such that f(x)=t
+!!
+!! This solver uses bounded Newton-Raphson method with a fixed
+!! number of iterations
+real function x(this, k, t)
+  class(Recon1d), intent(in) :: this !< This reconstruction
+  integer,        intent(in) :: k    !< Cell number
+  real,           intent(in) :: t    !< Value to solve for [A]
+  real :: xl, xr, xo ! Left/right bounds and guess [nondim]
+  real :: fl, fr ! Left right values [A]
+  real :: slp ! Difference across cell or derivative wrt nondim x [A]
+  real :: f_at_x ! Value at current x [A]
+  integer :: iter
+
+  x = 0.5 ! Fall back for special conditions
+  fl = this%f(k, 0.)
+  fr = this%f(k, 1.)
+  slp = fr - fl
+  if ( ( fl - t ) * ( t - fr ) > 0. ) then
+    ! t is inside the range fl..fr
+    xl = 0.
+    xr = 1.
+    xo = ( t - this%f(k, 0.) ) / slp ! First guess by regula falsi
+    f_at_x = this%f(k, xo)
+    do iter = 1,10
+      slp = this%dfdx(k, xo)
+      x = xo - ( f_at_x - t ) / slp ! Newton-Raphson step
+      if ( x < xl ) x = 0.5 * ( xl + xo ) ! Replace with bi-section
+      if ( x > xr ) x = 0.5 * ( xr + xo ) ! Replace with bi-section
+      f_at_x = this%f(k, x)
+      if ( abs(f_at_x - t) <= 0. .or. abs(x - xo) < this%x_tolerance ) return
+      if ( f_at_x < t ) xl = x ! Replace left bound
+      if ( f_at_x > t ) xr = x ! Replace right bound
+      xo = x
+    enddo
+  elseif ( abs(slp) > 0. ) then
+    slp = sign(1., slp)
+    ! if t>u_mean & slp=1 then x=1
+    ! if t<u_mean & slp=1 then x=0
+    ! if t>u_mean & slp=-1 then x=0
+    ! if t<u_mean & slp=-1 then x=1
+    x = 0.5 + slp * sign(0.5, t - this%u_mean(k))
+  else
+    ! slp=0 so estimate "direction" from neighbors
+    slp = this%f(min(k+1,this%n), 0.) - this%f(max(k-1,1), 1.)
+    if ( abs(slp) > 0. ) slp = sign(1., slp)
+    ! if t>u_mean & slp=1 then x=1
+    ! if t<u_mean & slp=1 then x=0
+    ! if t>u_mean & slp=-1 then x=0
+    ! if t<u_mean & slp=-1 then x=1
+    ! if t=u_mean then x=0.5
+    ! if slp=0 then x=0.5
+    if ( abs(t - this%u_mean(k)) > 0. ) x = 0.5 + slp * sign(0.5, t - this%u_mean(k))
+  endif
+end function x
 
 !> Remaps the column to subgrid h_sub
 !!

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -22,7 +22,6 @@ use MOM_diag_mediator,     only : diag_save_grids, diag_restore_grids, diag_copy
 use MOM_domains,           only : create_group_pass, do_group_pass, group_pass_type
 use MOM_domains,           only : To_North, To_East
 use MOM_EOS,               only : calculate_density, calculate_density_derivs, EOS_domain
-use MOM_EOS,               only : calculate_spec_vol
 use MOM_EOS,               only : cons_temp_to_pot_temp, pot_temp_to_cons_temp
 use MOM_EOS,               only : prac_saln_to_abs_saln, abs_saln_to_prac_saln
 use MOM_error_handler,     only : MOM_error, FATAL, WARNING
@@ -37,6 +36,7 @@ use MOM_variables,         only : thermo_var_ptrs, ocean_internal_state, p3d
 use MOM_variables,         only : accel_diag_ptrs, cont_diag_ptrs, surface
 use MOM_verticalGrid,      only : verticalGrid_type, get_thickness_units, get_flux_units
 use MOM_wave_speed,        only : wave_speed, wave_speed_CS, wave_speed_init
+use Recon1d_EPPM_CWK,      only : EPPM_CWK
 
 implicit none ; private
 
@@ -121,6 +121,7 @@ type, public :: diagnostics_CS ; private
   integer :: id_drho_dT        = -1, id_drho_dS        = -1
   integer :: id_h_pre_sync     = -1
   integer :: id_tosq           = -1, id_sosq           = -1
+  integer :: id_t20d           = -1, id_t17d           = -1
 
   !>@}
   type(wave_speed_CS) :: wave_speed  !< Wave speed control struct
@@ -897,7 +898,7 @@ subroutine calculate_vertical_integrals(h, tv, p_surf, G, GV, US, CS)
                                                  !! as setting the surface pressure to 0.
   type(diagnostics_CS),    intent(inout) :: CS   !< Control structure returned by a
                                                  !! previous call to diagnostics_init.
-
+  ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     z_top, &  ! Height of the top of a layer or the ocean [Z ~> m].
     z_bot, &  ! Height of the bottom of a layer (for id_mass) or the
@@ -909,9 +910,16 @@ subroutine calculate_vertical_integrals(h, tv, p_surf, G, GV, US, CS)
     btm_pres,&! The pressure at the ocean bottom, or CMIP variable 'pbo'.
               ! This is the column mass multiplied by gravity plus the pressure
               ! at the ocean surface [R L2 T-2 ~> Pa].
-    tr_int    ! vertical integral of a tracer times density,
+    tr_int,&  ! vertical integral of a tracer times density,
               ! (Rho_0 in a Boussinesq model) [Conc R Z ~> Conc kg m-2].
+    d17,&     ! Depth of 17 degC isotherm [Z ~> m]
+    d20       ! Depth of 20 degC isotherm [Z ~> m]
   real :: tmp(SZI_(G),SZJ_(G),SZK_(GV)) ! Temporary array [defined at each usage]
+  real :: IG_Earth  ! Inverse of gravitational acceleration [T2 Z L-2 ~> s2 m-1].
+  real :: Ttop, Tbot ! Temperature at top/bottom of cell [C ~> degC]
+  type(EPPM_CWK) :: PPM ! Class for reconstruction
+  real :: d_from_ssh(0:GV%ke) ! eta-z (Distance from surface) [Z ~> m]
+  real :: dz ! Layer thickness in Z [Z ~> m]
 
   integer :: i, j, k, is, ie, js, je, nz
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
@@ -957,6 +965,53 @@ subroutine calculate_vertical_integrals(h, tv, p_surf, G, GV, US, CS)
       call find_col_mass(h, tv, G, GV, US, mass)
     endif
     if (CS%id_col_mass > 0) call post_data(CS%id_col_mass, mass, CS%diag)
+  endif
+  if (CS%id_t20d > 0 .or. CS%id_t17d > 0) then
+    call PPM%init(GV%ke, h_neglect=0.)
+    do j=js,je ; do i=is,ie
+      ! Pre-calculate the interface depths relative to the surface
+      if (GV%Boussinesq) then
+        d_from_ssh(0) = 0.
+        do k=1,nz
+          d_from_ssh(k) = d_from_ssh(k-1) + h(i,j,k) * GV%H_to_Z
+        enddo
+      else
+        ! Non-Boussinesq: use pre-computed layer-average specific volumes from tv%SpV_avg,
+        ! which are more accurate than cell-center specific volumes and correctly account
+        ! for surface pressure (including under ice-shelves).
+        d_from_ssh(0) = 0.
+        do k=1,nz
+          d_from_ssh(k) = d_from_ssh(k-1) + ( h(i,j,k) * GV%H_to_RZ ) * tv%SpV_avg(i,j,k)
+        enddo
+      endif
+      call PPM%reconstruct(h(i,j,:), tv%T(i,j,:))
+      d17(i,j) = d_from_ssh(nz)
+      d20(i,j) = d_from_ssh(nz)
+      do k=nz,1,-1
+        Ttop = PPM%f(k, 0.)
+        Tbot = PPM%f(k, 1.)
+        if ( Tbot>Ttop ) cycle ! The cell is inverted, skip to next
+        if ( 20.<Tbot .and. Tbot<Ttop ) exit ! The whole remaining column is warmer than 20
+        dz = d_from_ssh(k) - d_from_ssh(k-1) ! >=0
+        if ( Tbot<=17. .and. 17.<=Ttop ) then
+          ! The 17 degC isotherm is within the cell which is non-negatively stratified
+          d17(i,j) = d_from_ssh(k-1) + dz * PPM%x(k, 17.)
+        elseif ( Ttop<17. ) then
+          ! The 17 degC isotherm is above the top of the cell
+          d17(i,j) = d_from_ssh(k-1)
+        endif
+        if ( Tbot<=20. .and. 20.<=Ttop ) then
+          ! The 20 degC isotherm is within the cell which is non-negatively stratified
+          d20(i,j) = d_from_ssh(k-1) + dz * PPM%x(k, 20.)
+        elseif ( Ttop<20. ) then
+          ! The 20 degC isotherm is above the top of the cell
+          d20(i,j) = d_from_ssh(k-1)
+        endif
+      enddo
+    enddo ; enddo
+    call PPM%destroy()
+    if (CS%id_t17d > 0) call post_data(CS%id_t17d, d17, CS%diag)
+    if (CS%id_t20d > 0) call post_data(CS%id_t20d, d20, CS%diag)
   endif
 
   ! Practical salinity expressed as salt mass content
@@ -2014,6 +2069,14 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
         units='J m-2', conversion=US%Q_to_J_kg*US%RZ_to_kg_m2, v_extensive=.true., &
         standard_name='integral_wrt_depth_of_sea_water_potential_temperature_expressed_as_heat_content')
 
+    CS%id_t20d = register_diag_field('ocean_model', 't20d', diag%axesT1, Time, &
+        'Depth of 20 degree Celsius Isotherm', &
+        units='m', conversion=US%Z_to_m, &
+        standard_name='depth_of_isosurface_of_sea_water_potential_temperature')
+    CS%id_t17d = register_diag_field('ocean_model', 't17d', diag%axesT1, Time, &
+        'Depth of 17 degree Celsius Isotherm', &
+        units='m', conversion=US%Z_to_m, &
+        standard_name='depth_of_isosurface_of_sea_water_potential_temperature')
   endif
 
   CS%id_u = register_diag_field('ocean_model', 'u', diag%axesCuL, Time, &


### PR DESCRIPTION
Adds CMIP diagnostics t17d and t20d.

t17d is depth of the 17 degC isotherm. 0m where the ocean is everywhere cooler that 17 degC, and sea-floor when everywhere warmer. Simialrly, t20d is the depth of the 20 degC. "depth" here is defined as distance from the sea-surface.

Result from ocean_only/gloal_ALE/z initial conditions:
<img width="584" height="652" alt="image" src="https://github.com/user-attachments/assets/2c0d6978-c428-4175-934c-97aacf2ec1d5" />

Meta-data in output looks like:
```
        float t17d(Time, yh, xh) ;
                t17d:long_name = "Depth of 17 degree Celsius Isotherm" ;
                t17d:units = "m" ;
                t17d:missing_value = 1.e+20f ;
                t17d:_FillValue = 1.e+20f ;
                t17d:cell_methods = "area:mean yh:mean xh:mean time: point" ;
                t17d:cell_measures = "area: area_t" ;
                t17d:standard_name = "depth_of_isosurface_of_sea_water_potential_temperature" ;
        float t20d(Time, yh, xh) ;
                t20d:long_name = "Depth of 20 degree Celsius Isotherm" ;
                t20d:units = "m" ;
                t20d:missing_value = 1.e+20f ;
                t20d:_FillValue = 1.e+20f ;
                t20d:cell_methods = "area:mean yh:mean xh:mean time: point" ;
                t20d:cell_measures = "area: area_t" ;
                t20d:standard_name = "depth_of_isosurface_of_sea_water_potential_temperature" ;
```

Closes #992 