### PR TITLE
Fixes wrong number of levels in z-coord diags

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -432,8 +432,16 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
                    trim(message), units=trim(coord_units))
   elseif (trim(string)=='PARAM') then
     ! Read coordinate resolution (main model = ALE_RESOLUTION)
-    ke = GV%ke ! Use model nk by default
-    allocate(dz(ke))
+    allocate(dz(1001))
+    dz(:) = -1. ! Setting to <0 allows detection of unset elements
+    call get_param(param_file, mdl, coord_res_param, dz, "Scan", units="", do_not_log=.true.)
+    if (dz(1001)>=0.) call MOM_error(FATAL,trim(mdl)//", initialize_regridding: "// &
+        "PARAM specification is limited to 1000 values. Hack the code to use more!")
+    do ke=1,1000 ! Find number of defined levels
+      if (dz(ke+1)<0.) exit
+    enddo
+    deallocate(dz)
+    allocate(dz(ke)) ! Allocate with the correct number of levels, and re-read thicknesses
     call get_param(param_file, mdl, coord_res_param, dz, &
                    trim(message), units=trim(coord_units), fail_if_missing=.true.)
   elseif (index(trim(string),'FILE:')==1) then


### PR DESCRIPTION
When a z-coordinate diagnostic grid is specified via the "PARAM" method of coordinate definition, then the number of levels was always the same as the main model. This commit fixes this by first allowing for upto a 1000 levels in the new grid, checking for the actual requested size, and then allocating to that size.

It appears we have no examples using this mode, which is probably how this bug has persisted so long. This "PARAM" method of specifying grids is being used in a range of new CMIP7 diagnostics in both MOM6 and COBALT.