### PR TITLE
Fix bug in registration of ALE sponge diagnostics for generic tracers

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3602,12 +3602,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   if (associated(CS%sponge_CSp)) &
     call init_sponge_diags(Time, G, GV, US, diag, CS%sponge_CSp)
 
-  if (associated(CS%ALE_sponge_CSp)) &
-    call init_ALE_sponge_diags(Time, G, diag, CS%ALE_sponge_CSp, US)
-
   if (associated(CS%oda_incupd_CSp)) &
     call init_oda_incupd_diags(Time, G, GV, diag, CS%oda_incupd_CSp, US)
-
 
   call tracer_advect_init(Time, G, US, param_file, diag, CS%tracer_adv_CSp)
   call tracer_hor_diff_init(Time, G, GV, US, param_file, diag, CS%tv%eqn_of_state, CS%diabatic_CSp, &
@@ -3641,6 +3637,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
              CS%diag, CS%OBC, CS%tracer_flow_CSp, CS%sponge_CSp, &
              CS%ALE_sponge_CSp, CS%tv)
   if (present(tracer_flow_CSp)) tracer_flow_CSp => CS%tracer_flow_CSp
+
+  if (associated(CS%ALE_sponge_CSp)) &
+    call init_ALE_sponge_diags(Time, G, diag, CS%ALE_sponge_CSp, US)
 
   ! If running in offline tracer mode, initialize the necessary control structure and
   ! parameters

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -672,7 +672,6 @@ subroutine init_ALE_sponge_diags(Time, G, diag, CS, US)
   CS%diag => diag
 
   do m=1,CS%fldno
-    CS%id_sp_tendency(m) = -1
     if ((trim(CS%Ref_val(m)%unit) == 'none') .or. (len_trim(CS%Ref_val(m)%unit) == 0)) then
       tend_unit = "s-1"
     else

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -142,8 +142,9 @@ type, public :: ALE_sponge_CS ; private
                                    !! It is not clear why this needs to be greater than 0.
 
   !>@{ Diagnostic IDs
-  integer, dimension(MAX_FIELDS_) :: id_sp_tendency  !< Diagnostic ids for tracer
-                                               !! tendencies due to sponges
+  integer, dimension(MAX_FIELDS_) :: id_sp_tendency = reshape([-1], [MAX_FIELDS_], [-1]) !< Diagnostic ids for tracer
+                                                                                         !! tendencies due to sponges.
+                                                                                         !! Init all to -1.
   integer :: id_sp_u_tendency                  !< Diagnostic id for zonal momentum tendency due to
                                                !! Rayleigh damping
   integer :: id_sp_v_tendency                  !< Diagnostic id for meridional momentum tendency due to


### PR DESCRIPTION
In NOAA-GFDL/CEFI-regional-MOM6#250, @CGjelstrup reported an issue where enabling the generic tracer sponge/nudging caused a crash due to an unregistered sponge tendency diagnostic. The issue was caused by the order in which the registration code for the sponge diagnostics and generic tracers is called--the sponge diags are registered before the generic tracers are set up, so the generic tracer sponge tendency diagnostics are never registered. 

This PR fixes the issue by relocating the call to `init_ALE_sponge_diags` so that it is after `tracer_flow_control_init`. It also makes sure that the array of sponge tendency diag ids, `id_sp_tendency`, is immediately initialized to -1s to help avoid any future bugs. 

For immediately initializing `id_sp_tendency` to -1s, I did 
```
integer, dimension(MAX_FIELDS_) :: id_sp_tendency = reshape([-1], [MAX_FIELDS_], [-1])
```
I don't think this hack with `reshape` is done anywhere else in MOM6, but it was the best/only way I could figure out to initialize within a `type` declaration. If there's any issues with this just let me know.

Also, I have this same PR open in the CEFI fork of MOM6---if you'd prefer it to go through CEFI first we could do that. 