### PR TITLE
Fix reference of unassociated pointer

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1495,12 +1495,12 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
 
   if (present(mask)) then
     locmask => mask
-  elseif (.NOT. is_stat) then
+  elseif (.NOT. is_stat .and. associated(diag%axes)) then
     if (associated(diag%axes%mask2d)) locmask => diag%axes%mask2d
   endif
 
   dl=1
-  if (.NOT. is_stat) dl = diag%axes%downsample_level !static field downsample i not supported yet
+  if (.NOT. is_stat .and. associated(diag%axes)) dl = diag%axes%downsample_level !static field downsample not supported
   !Downsample the diag field and mask (if present)
   if (dl > 1) then
     isv_o = isv ; jsv_o = jsv


### PR DESCRIPTION
There are two references to members of `diag%axes` that assume `diag%axes` are associated, but in the specific case I was debugging this was not the case. These references were trapped when debugging but they don't seem to be hit except under special circumstances.