### PR TITLE
Autoconf: Build dependencies as libraries

### DIFF
--- a/.github/workflows/verify-linux.yml
+++ b/.github/workflows/verify-linux.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Check white space (non-blocking)
       run: |
@@ -50,13 +48,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with symmetric indexing
         run: make -C .testing -j build/symmetric/MOM6
@@ -75,13 +74,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with asymmetric indexing
         run: make -C .testing -j build/asymmetric/MOM6
@@ -100,13 +100,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with bit-reproducible optimization
         run: make -C .testing -j build/repro/MOM6
@@ -125,13 +126,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 supporting OpenMP
         run: make -C .testing -j build/openmp/MOM6
@@ -151,12 +153,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile target FMS
+      - name: Compile target depedencies
         run: |
           make -C .testing \
           DO_REGRESSION_TESTS=1 \
@@ -184,13 +184,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with aggressive optimization
         run: make -C .testing -j build/opt/MOM6
@@ -217,12 +218,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile target FMS
+      - name: Compile target dependencies
         run: |
           make -C .testing \
           DO_REGRESSION_TESTS=1 \
@@ -260,13 +259,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with code coverage
         run: make -C .testing -j build/cov/MOM6
@@ -296,13 +296,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 for the GFDL coupled driver
         run: make -C .testing -j check_mom6_api_coupled
@@ -317,8 +318,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -350,8 +349,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -375,8 +372,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -400,8 +395,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -425,8 +418,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -460,8 +451,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -487,8 +476,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -522,8 +509,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -558,8 +543,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -592,8 +575,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -638,8 +619,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -670,8 +649,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/ubuntu-setup
 

--- a/.github/workflows/verify-linux.yml
+++ b/.github/workflows/verify-linux.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with symmetric indexing
         run: make -C .testing -j build/symmetric/MOM6
@@ -80,8 +80,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with asymmetric indexing
         run: make -C .testing -j build/asymmetric/MOM6
@@ -106,8 +106,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with bit-reproducible optimization
         run: make -C .testing -j build/repro/MOM6
@@ -132,8 +132,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 supporting OpenMP
         run: make -C .testing -j build/openmp/MOM6
@@ -190,8 +190,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with aggressive optimization
         run: make -C .testing -j build/opt/MOM6
@@ -265,8 +265,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with code coverage
         run: make -C .testing -j build/cov/MOM6
@@ -302,8 +302,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 for the GFDL coupled driver
         run: make -C .testing -j check_mom6_api_coupled

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -16,13 +16,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with symmetric indexing
         run: make -C .testing -j build/symmetric/MOM6
@@ -41,13 +42,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with asymmetric indexing
         run: make -C .testing -j build/asymmetric/MOM6
@@ -66,13 +68,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with bit-reproducible optimization
         run: make -C .testing -j build/repro/MOM6
@@ -91,13 +94,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup/
 
-      - name: Compile FMS
-        run: make -C .testing -j build/deps/lib/libFMS.a
+      - name: Compile dependencies
+        run: |
+          make -C .testing -j build/deps/lib/libFMS.a
+          make -C .testing -j build/deps/lib/libgsw.a
+          make -C .testing -j build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 supporting OpenMP
         run: make -C .testing -j build/openmp/MOM6
@@ -117,12 +121,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup/
 
-      - name: Compile target FMS
+      - name: Compile target dependencies
         run: |
           make -C .testing \
           DO_REGRESSION_TESTS=1 \
@@ -155,8 +157,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -188,8 +188,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -213,8 +211,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -238,8 +234,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -263,8 +257,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -298,8 +290,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -325,8 +315,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -360,8 +348,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 
@@ -396,8 +382,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/macos-setup
 

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with symmetric indexing
         run: make -C .testing -j build/symmetric/MOM6
@@ -48,8 +48,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with asymmetric indexing
         run: make -C .testing -j build/asymmetric/MOM6
@@ -74,8 +74,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 with bit-reproducible optimization
         run: make -C .testing -j build/repro/MOM6
@@ -100,8 +100,8 @@ jobs:
       - name: Compile dependencies
         run: |
           make -C .testing -j build/deps/lib/libFMS.a
-          make -C .testing -j build/deps/lib/libgsw.a
-          make -C .testing -j build/deps/lib/libcvmix.a
+          make -C .testing -j PKG= build/deps/lib/libgsw.a
+          make -C .testing -j PKG= build/deps/lib/libcvmix.a
 
       - name: Compile MOM6 supporting OpenMP
         run: make -C .testing -j build/openmp/MOM6

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,2 @@
-# Ignore vim and emacs files
-*.swp
-*~
-html
-
-
 # Build output
-*.o
-*.mod
-MOM6
 build/
-deps/
-pkg/MARBL
-
-
-# Autoconf output
-aclocal.m4
-autom4te.cache/
-config.log
-config.status
-configure
-/Makefile
-Makefile.mkmf

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -71,7 +71,8 @@ MAKEFLAGS += --no-builtin-variables
 .SUFFIXES:
 
 # Determine the MOM6 autoconf srcdir
-AC_SRCDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../ac
+CODEBASE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))..
+AC_SRCDIR := $(CODEBASE)/ac
 
 # User-defined configuration
 -include config.mk
@@ -143,6 +144,10 @@ WORKSPACE ?= .
 BUILD ?= $(WORKSPACE)/build
 DEPS ?= $(BUILD)/deps
 WORK ?= $(WORKSPACE)/work
+
+# External tools
+MAKEDEP ?= $(abspath $(AC_SRCDIR)/makedep)
+PKG ?= $(abspath $(CODEBASE)/pkg)
 
 # Experiment configuration
 EXECS ?= symmetric/MOM6 asymmetric/MOM6 openmp/MOM6
@@ -344,8 +349,8 @@ endif
 
 # Set up the FMS build environment variables
 DEPS_ENV = \
-  PATH="${PATH}:$(realpath ../ac)" \
   FCFLAGS="$(FCFLAGS_FMS)" \
+  MAKEDEP=$(MAKEDEP) \
   REPORT_ERROR_LOGS="$(REPORT_ERROR_LOGS)"
 
 # FMS
@@ -362,7 +367,7 @@ $(DEPS)/configure.fms.ac: ../ac/deps/configure.fms.ac | $(DEPS)
 # GSW
 
 $(DEPS)/lib/libgsw.a: $(DEPS)/Makefile $(DEPS)/Makefile.gsw.in $(DEPS)/configure.gsw.ac $(DEPS)/m4
-	$(DEPS_ENV) $(MAKE) -C $(DEPS) lib/libgsw.a
+	$(DEPS_ENV) PKG=$(PKG) $(MAKE) -C $(DEPS) lib/libgsw.a
 
 $(DEPS)/Makefile.gsw.in: ../ac/deps/Makefile.gsw.in | $(DEPS)
 	cp ../ac/deps/Makefile.gsw.in $(DEPS)/Makefile.gsw.in
@@ -373,7 +378,7 @@ $(DEPS)/configure.gsw.ac: ../ac/deps/configure.gsw.ac | $(DEPS)
 # CVMix
 
 $(DEPS)/lib/libcvmix.a: $(DEPS)/Makefile $(DEPS)/Makefile.cvmix.in $(DEPS)/configure.cvmix.ac $(DEPS)/m4
-	$(DEPS_ENV) $(MAKE) -C $(DEPS) lib/libcvmix.a
+	$(DEPS_ENV) PKG=$(PKG) $(MAKE) -C $(DEPS) lib/libcvmix.a
 
 $(DEPS)/Makefile.cvmix.in: ../ac/deps/Makefile.cvmix.in | $(DEPS)
 	cp ../ac/deps/Makefile.cvmix.in $(DEPS)/Makefile.cvmix.in

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -311,7 +311,7 @@ $(BUILD)/opt_target: | $(TARGET_CODEBASE)
 $(BUILD)/%/Makefile: $(BUILD)/%/Makefile.in $(BUILD)/%/config.status
 	cd $(@D) && ./config.status
 
-$(BUILD)/%/config.status: $(BUILD)/%/configure $(DEPS)/lib/libFMS.a
+$(BUILD)/%/config.status: $(BUILD)/%/configure $(DEPS)/lib/libFMS.a $(DEPS)/lib/libgsw.a $(DEPS)/lib/libcvmix.a
 	cd $(@D) && $(MOM_ENV) ./configure -n --srcdir=$(AC_SRCDIR) $(MOM_ACFLAGS) \
 	 || (cat config.log && false)
 
@@ -340,25 +340,51 @@ $(TARGET_CODEBASE):
 endif
 
 
-## FMS
+## Dependencies
 
 # Set up the FMS build environment variables
-FMS_ENV = \
+DEPS_ENV = \
   PATH="${PATH}:$(realpath ../ac)" \
   FCFLAGS="$(FCFLAGS_FMS)" \
   REPORT_ERROR_LOGS="$(REPORT_ERROR_LOGS)"
 
-$(DEPS)/lib/libFMS.a: $(DEPS)/Makefile $(DEPS)/Makefile.fms.in $(DEPS)/configure.fms.ac $(DEPS)/m4
-	$(FMS_ENV) $(MAKE) -C $(DEPS) lib/libFMS.a
+# FMS
 
-$(DEPS)/Makefile: ../ac/deps/Makefile | $(DEPS)
-	cp ../ac/deps/Makefile $(DEPS)/Makefile
+$(DEPS)/lib/libFMS.a: $(DEPS)/Makefile $(DEPS)/Makefile.fms.in $(DEPS)/configure.fms.ac $(DEPS)/m4
+	$(DEPS_ENV) $(MAKE) -C $(DEPS) lib/libFMS.a
 
 $(DEPS)/Makefile.fms.in: ../ac/deps/Makefile.fms.in | $(DEPS)
 	cp ../ac/deps/Makefile.fms.in $(DEPS)/Makefile.fms.in
 
 $(DEPS)/configure.fms.ac: ../ac/deps/configure.fms.ac | $(DEPS)
 	cp ../ac/deps/configure.fms.ac $(DEPS)/configure.fms.ac
+
+# GSW
+
+$(DEPS)/lib/libgsw.a: $(DEPS)/Makefile $(DEPS)/Makefile.gsw.in $(DEPS)/configure.gsw.ac $(DEPS)/m4
+	$(DEPS_ENV) $(MAKE) -C $(DEPS) lib/libgsw.a
+
+$(DEPS)/Makefile.gsw.in: ../ac/deps/Makefile.gsw.in | $(DEPS)
+	cp ../ac/deps/Makefile.gsw.in $(DEPS)/Makefile.gsw.in
+
+$(DEPS)/configure.gsw.ac: ../ac/deps/configure.gsw.ac | $(DEPS)
+	cp ../ac/deps/configure.gsw.ac $(DEPS)/configure.gsw.ac
+
+# CVMix
+
+$(DEPS)/lib/libcvmix.a: $(DEPS)/Makefile $(DEPS)/Makefile.cvmix.in $(DEPS)/configure.cvmix.ac $(DEPS)/m4
+	$(DEPS_ENV) $(MAKE) -C $(DEPS) lib/libcvmix.a
+
+$(DEPS)/Makefile.cvmix.in: ../ac/deps/Makefile.cvmix.in | $(DEPS)
+	cp ../ac/deps/Makefile.cvmix.in $(DEPS)/Makefile.cvmix.in
+
+$(DEPS)/configure.cvmix.ac: ../ac/deps/configure.cvmix.ac | $(DEPS)
+	cp ../ac/deps/configure.cvmix.ac $(DEPS)/configure.cvmix.ac
+
+# Generic dependency content
+
+$(DEPS)/Makefile: ../ac/deps/Makefile | $(DEPS)
+	cp ../ac/deps/Makefile $(DEPS)/Makefile
 
 $(DEPS)/m4: ../ac/deps/m4 | $(DEPS)
 	cp -r ../ac/deps/m4 $(DEPS)/

--- a/.testing/tc4/.gitignore
+++ b/.testing/tc4/.gitignore
@@ -3,7 +3,9 @@ aclocal.m4
 autom4te.cache/
 config.log
 config.status
+configure
 configure~
+Makefile
 
 # Output
 gen_grid

--- a/.testing/tc4/configure.ac
+++ b/.testing/tc4/configure.ac
@@ -47,24 +47,29 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 ])
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
-# NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
-#     not currently probe the Fortran 90 interfaces.
-#   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+# NOTE: nf-config does not have --libdir, so we parse the --flibs output.
+MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf90_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 AC_CONFIG_FILES([Makefile])

--- a/ac/Makefile.in
+++ b/ac/Makefile.in
@@ -14,8 +14,7 @@ CPPFLAGS = @CPPFLAGS@
 FCFLAGS = @FCFLAGS@
 LDFLAGS = @LDFLAGS@
 LIBS = @LIBS@
-SRC_DIRS = @SRC_DIRS@
-
+MAKEDEP_FLAGS = @MAKEDEP_FLAGS@
 
 -include Makefile.dep
 
@@ -31,8 +30,8 @@ rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(su
 # Generate dependencies
 .PHONY: depend
 depend: Makefile.dep
-Makefile.dep: $(MAKEDEP) $(call rwildcard,$(SRC_DIRS),*.h *.c *.inc *.F90)
-	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e $(SRC_DIRS)
+Makefile.dep: $(call rwildcard,$(SRC_DIRS),*.h *.c *.inc *.F90)
+	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep $(MAKEDEP_FLAGS)
 
 
 # Delete any files associated with configuration (including the Makefile).

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -51,7 +51,7 @@ AS_VAR_IF([MOM_MEMORY], [],
 )
 
 # Confirm that MOM_MEMORY is named 'MOM_memory.h'
-AS_IF([test $(basename "${MOM_MEMORY}") == "MOM_memory.h"], [],
+AS_IF([test $(basename "${MOM_MEMORY}") = "MOM_memory.h"], [],
  [AC_MSG_ERROR([MOM_MEMORY header ${MOM_MEMORY} must be named 'MOM_memory.h'])]
 )
 
@@ -138,31 +138,36 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 ])
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
-# NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
-#     not currently probe the Fortran 90 interfaces.
-#   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+# NOTE: nf-config does not have --libdir, so we parse the --flibs output.
+MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf90_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
 AX_FC_REAL8
-AS_IF(
-  [test "$enable_real8" != no],
-  [FCFLAGS="$FCFLAGS $REAL8_FCFLAGS"])
+AS_IF([test "$enable_real8" != no],
+  [FCFLAGS="$FCFLAGS $REAL8_FCFLAGS"]
+)
 
 
 # OpenMP configuration
@@ -177,8 +182,7 @@ m4_version_prereq([2.69], [AC_OPENMP], [
 ])
 
 # NOTE: Only apply OpenMP flags if explicitly enabled.
-AS_IF(
-  [test "$enable_openmp" = yes], [
+AS_IF([test "$enable_openmp" = yes], [
   FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
   LDFLAGS="$LDFLAGS $OPENMP_FCFLAGS"
 ])
@@ -192,19 +196,22 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
   AX_FC_CHECK_MODULE([fms_mod],
     [AC_SUBST([FCFLAGS], ["-I${srcdir}/ac/deps/include $FCFLAGS"])],
     [AC_MSG_ERROR([Could not find fms_mod Fortran module.])],
-    [-I${srcdir}/ac/deps/include])
+    [-I${srcdir}/ac/deps/include]
+  )
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
 
@@ -231,7 +238,29 @@ AX_FC_CHECK_MODULE([fms2_io_mod], [
 ])
 
 
-# Python interpreter test
+# GSW configuration
+AX_FC_CHECK_MODULE([gsw_mod_toolbox], [], [
+  AC_MSG_ERROR([Could not find module gsw_mod_toolbox.])
+])
+MOM6_FC_CHECK_LIB([gsw], [gsw_rho], [gsw_mod_toolbox], [sa,ct,p], [rho], [],
+  [], [
+    AC_MSG_ERROR([Could not find gsw_rho in gsw_mod_toolbox.])
+  ]
+)
+
+
+# CVMix configuration
+AX_FC_CHECK_MODULE([cvmix_utils], [], [
+  AC_MSG_ERROR([Could not find module cvmix_utils.])
+])
+MOM6_FC_CHECK_LIB([cvmix], [cvmix_init_kpp], [cvmix_kpp], [], [], [],
+  [], [
+    AC_MSG_ERROR([Could not find cvmix_update_wrap in cvmix_utils.])
+  ]
+)
+
+
+## Python configuration
 
 # Declare the Python interpreter variable
 AC_ARG_VAR([PYTHON], [Python interpreter command])
@@ -255,14 +284,33 @@ AC_PATH_PROG([MAKEDEP], [makedep], [${srcdir}/ac/makedep])
 AC_SUBST([MAKEDEP])
 
 
-# Generate source list and configure dependency command
-AC_SUBST([SRC_DIRS], ["\\
+# Generate Makedep source list and configure dependency command
+MAKEDEP_FLAGS="-e"
+
+# NOTE: Some pattern rules for this multiline flag constructor.
+#   - Previous args have no line continuation, so the next arg leads with `\\`.
+#   - Flag lines precede with a space ` -s` for syntax clarity.
+EXCLUDE_DIRS="\\
+  -s ${srcdir}/src/equation_of_state/TEOS10 \\
+  -s ${srcdir}/src/parameterizations/CVmix"
+
+# TODO: This may be optional in the future, so we use AS_IF.
+AS_IF([test -n "${EXCLUDE_DIRS}"], [
+  MAKEDEP_FLAGS="${MAKEDEP_FLAGS} ${EXCLUDE_DIRS}"
+])
+
+SRC_DIRS="\\
   ${srcdir}/src \\
   ${MODEL_FRAMEWORK} \\
   ${srcdir}/config_src/external \\
   ${DRIVER_DIR} \\
-  ${MOM_MEMORY_DIR}"]
-)
+  ${MOM_MEMORY_DIR}"
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS} ${SRC_DIRS}"
+
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
+AC_SUBST([MAKEDEP_FLAGS])
+
+# Add makedep to config.status
 AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
 
 

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -250,8 +250,8 @@ MOM6_FC_CHECK_LIB([gsw], [gsw_rho], [gsw_mod_toolbox], [sa,ct,p], [rho], [],
 
 
 # CVMix configuration
-AX_FC_CHECK_MODULE([cvmix_utils], [], [
-  AC_MSG_ERROR([Could not find module cvmix_utils.])
+AX_FC_CHECK_MODULE([cvmix_kpp], [], [
+  AC_MSG_ERROR([Could not find module cvmix_kpp.])
 ])
 MOM6_FC_CHECK_LIB([cvmix], [cvmix_init_kpp], [cvmix_kpp], [], [], [],
   [], [

--- a/ac/deps/.gitignore
+++ b/ac/deps/.gitignore
@@ -1,5 +1,7 @@
 /bin/
 /fms/
+/gsw/
+/cvmix/
 /include/
 /lib/
 /mkmf/

--- a/ac/deps/Makefile
+++ b/ac/deps/Makefile
@@ -32,6 +32,10 @@ CVMIX_SOURCE = $(call SOURCE,CVMix-src/src/shared)
 REPORT_ERROR_LOGS ?=
 
 
+# If set, use the submodule repositories in pkg/
+PKG ?= $(abspath ../../pkg)
+MAKEDEP ?= $(abspath ../makedep)
+
 #---
 # Rules
 
@@ -46,8 +50,6 @@ all: lib/libcvmix.a
 # $(1): target library
 # $(2): dependency label
 # $(3): library source files
-# $(4): library source URL
-# $(5): library source commit
 
 define LIB_RULES
 lib/$(1): $(2)/build/$(1)
@@ -60,6 +62,7 @@ $(2)/build/$(1): $(2)/build/Makefile
 
 $(2)/build/Makefile: $(2)/build/Makefile.in $(2)/build/configure
 	cd $$(@D) && { \
+	  MAKEDEP=$$(MAKEDEP) \
 	  ./configure --srcdir=../src \
 	  || { \
 	    if [ "$${REPORT_ERROR_LOGS}" = true ]; then cat config.log ; fi ; \
@@ -79,16 +82,36 @@ $(2)/build/configure.ac: configure.$(2).ac m4 | $(2)/build
 
 $(2)/build:
 	mkdir -p $$@
-
-$(2)/src:
-	git clone $(4) $$@
-	git -C $$@ checkout $(5)
-
 endef
 
-$(eval $(call LIB_RULES,libFMS.a,fms,$(FMS_SOURCE),$(FMS_URL),$(FMS_COMMIT)))
-$(eval $(call LIB_RULES,libgsw.a,gsw,$(GSW_SOURCE),$(GSW_URL),$(GSW_COMMIT)))
-$(eval $(call LIB_RULES,libcvmix.a,cvmix,$(CVMIX_SOURCE),$(CVMIX_URL),$(CVMIX_COMMIT)))
+$(eval $(call LIB_RULES,libFMS.a,fms,$(FMS_SOURCE)))
+$(eval $(call LIB_RULES,libgsw.a,gsw,$(GSW_SOURCE)))
+$(eval $(call LIB_RULES,libcvmix.a,cvmix,$(CVMIX_SOURCE)))
+
+
+# Dependency source
+
+fms/src:
+	git clone $(FMS_URL) $@
+	git -C $@ checkout $(FMS_COMMIT)
+
+
+ifdef PKG
+gsw/src: | gsw/build
+	ln -s $(PKG)/GSW-Fortran gsw/src
+
+cvmix/src: | cvmix/build
+	ln -s $(PKG)/CVMix-src cvmix/src
+
+else
+gsw/src:
+	git clone $(GSW_URL) $@
+	git -C $@ checkout $(GSW_COMMIT)
+
+cvmix/src:
+	git clone $(CVMIX_URL) $@
+	git -C $@ checkout $(CVMIX_COMMIT)
+endif
 
 
 # Cleanup

--- a/ac/deps/Makefile
+++ b/ac/deps/Makefile
@@ -10,6 +10,12 @@ MAKEFLAGS += -R
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
 FMS_COMMIT ?= 2023.03
 
+GSW_URL ?= https://github.com/mom-ocean/GSW-Fortran.git
+GSW_COMMIT ?= 29e64d652786e1d076a05128c920f394202bfe10
+
+CVMIX_URL ?= https://github.com/mom-ocean/CVMix-src.git
+CVMIX_COMMIT ?= 65ef5c73bc7f5663d5688f75c3855d431da4baea
+
 
 # List of source files to link this Makefile's dependencies to model Makefiles
 # Assumes a depth of two, and the following extensions: F90 inc c h
@@ -18,6 +24,8 @@ SOURCE = \
   $(foreach ext,F90 inc c h,$(wildcard $(1)/*/*.$(ext) $(1)/*/*/*.$(ext)))
 
 FMS_SOURCE = $(call SOURCE,fms/src)
+GSW_SOURCE = $(call SOURCE,gsw/src)
+CVMIX_SOURCE = $(call SOURCE,CVMix-src/src/shared)
 
 
 # If `true`, print logs if an error is encountered.
@@ -29,53 +37,66 @@ REPORT_ERROR_LOGS ?=
 
 .PHONY: all
 all: lib/libFMS.a
+all: lib/libgsw.a
+all: lib/libcvmix.a
 
 
-#---
-# FMS build
+# Library build rules template
+#
+# $(1): target library
+# $(2): dependency label
+# $(3): library source files
+# $(4): library source URL
+# $(5): library source commit
 
-# NOTE: We emulate the automake `make install` stage by storing libFMS.a to
-#   ${srcdir}/deps/lib and copying module files to ${srcdir}/deps/include.
-lib/libFMS.a: fms/build/libFMS.a
-	mkdir -p lib include
-	cp fms/build/libFMS.a lib/libFMS.a
-	cp fms/build/*.mod include
+define LIB_RULES
+lib/$(1): $(2)/build/$(1)
+	mkdir -p $$(@D) include/
+	cp $$< $$@
+	cp $$(dir $$<)/*.mod include/
 
-fms/build/libFMS.a: fms/build/Makefile
-	$(MAKE) -C fms/build libFMS.a
+$(2)/build/$(1): $(2)/build/Makefile
+	$$(MAKE) -C $$(@D) $(1)
 
-fms/build/Makefile: fms/build/Makefile.in fms/build/configure
-	cd $(@D) && { \
+$(2)/build/Makefile: $(2)/build/Makefile.in $(2)/build/configure
+	cd $$(@D) && { \
 	  ./configure --srcdir=../src \
 	  || { \
-	    if [ "${REPORT_ERROR_LOGS}" = true ]; then cat config.log ; fi ; \
+	    if [ "$${REPORT_ERROR_LOGS}" = true ]; then cat config.log ; fi ; \
 	    false; \
 	  } \
 	}
 
-fms/build/Makefile.in: Makefile.fms.in | fms/build
-	cp Makefile.fms.in fms/build/Makefile.in
+$(2)/build/Makefile.in: Makefile.$(2).in | $(2)/build
+	cp $$< $$@
 
-fms/build/configure: fms/build/configure.ac $(FMS_SOURCE) | fms/src
-	autoreconf fms/build
+$(2)/build/configure: $(2)/build/configure.ac $(3) | $(2)/src
+	autoreconf $$(@D)
 
-fms/build/configure.ac: configure.fms.ac m4 | fms/build
-	cp configure.fms.ac fms/build/configure.ac
-	cp -r m4 fms/build
+$(2)/build/configure.ac: configure.$(2).ac m4 | $(2)/build
+	cp $$< $$@
+	cp -r m4 $$(@D)
 
-fms/build:
-	mkdir -p fms/build
+$(2)/build:
+	mkdir -p $$@
 
-fms/src:
-	git clone $(FMS_URL) $@
-	git -C $@ checkout $(FMS_COMMIT)
+$(2)/src:
+	git clone $(4) $$@
+	git -C $$@ checkout $(5)
+
+endef
+
+$(eval $(call LIB_RULES,libFMS.a,fms,$(FMS_SOURCE),$(FMS_URL),$(FMS_COMMIT)))
+$(eval $(call LIB_RULES,libgsw.a,gsw,$(GSW_SOURCE),$(GSW_URL),$(GSW_COMMIT)))
+$(eval $(call LIB_RULES,libcvmix.a,cvmix,$(CVMIX_SOURCE),$(CVMIX_URL),$(CVMIX_COMMIT)))
+
 
 # Cleanup
 
 .PHONY: clean
 clean:
-	rm -rf fms/build lib include
+	rm -rf fms/build gsw/build cvmix/build lib include
 
 .PHONY: distclean
 distclean: clean
-	rm -rf fms
+	rm -rf fms gsw cvmix

--- a/ac/deps/Makefile.cvmix.in
+++ b/ac/deps/Makefile.cvmix.in
@@ -1,0 +1,30 @@
+# Makefile template for CVMix
+#
+# Compiler flags are configured by autoconf's configure script.
+#
+# Source code dependencies are configured by makedep and saved to Makefile.dep.
+
+FC = @FC@
+LD = @FC@
+AR = @AR@
+PYTHON = @PYTHON@
+MAKEDEP = @MAKEDEP@
+
+DEFS = @DEFS@
+CPPFLAGS = @CPPFLAGS@
+FCFLAGS = @FCFLAGS@
+LDFLAGS = @LDFLAGS@
+LIBS = @LIBS@
+ARFLAGS = @ARFLAGS@
+
+-include Makefile.dep
+
+# Generate Makefile from template
+Makefile: Makefile.in config.status
+	./config.status
+
+
+.PHONY: depend
+depend: Makefile.dep
+Makefile.dep:
+	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e -x libcvmix.a @srcdir@/src/shared

--- a/ac/deps/Makefile.gsw.in
+++ b/ac/deps/Makefile.gsw.in
@@ -1,0 +1,30 @@
+# Makefile template for GSW
+#
+# Compiler flags are configured by autoconf's configure script.
+#
+# Source code dependencies are configured by makedep and saved to Makefile.dep.
+
+FC = @FC@
+LD = @FC@
+AR = @AR@
+PYTHON = @PYTHON@
+MAKEDEP = @MAKEDEP@
+
+DEFS = @DEFS@
+CPPFLAGS = @CPPFLAGS@
+FCFLAGS = @FCFLAGS@
+LDFLAGS = @LDFLAGS@
+LIBS = @LIBS@
+ARFLAGS = @ARFLAGS@
+
+-include Makefile.dep
+
+# Generate Makefile from template
+Makefile: Makefile.in config.status
+	./config.status
+
+
+.PHONY: depend
+depend: Makefile.dep
+Makefile.dep:
+	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e -x libgsw.a @srcdir@

--- a/ac/deps/configure.cvmix.ac
+++ b/ac/deps/configure.cvmix.ac
@@ -11,7 +11,12 @@ AC_CONFIG_SRCDIR([src/shared/cvmix_utils.F90])
 AC_CONFIG_MACRO_DIR([m4])
 
 
-# Standard Fortran configuration
+# Build dependencies
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+AC_ARG_VAR([MAKEDEP], [Makefile dependency generator])
+
+
+# Fortran configuration
 AC_LANG([Fortran])
 AC_FC_SRCEXT([f90])
 AC_PROG_FC
@@ -52,19 +57,23 @@ AX_FC_CHECK_MODULE([netcdf], [], [
 
 
 # Verify that Python is available
-AC_PATH_PROGS([PYTHON], [python python3 python2], [
+AS_IF([test -z "$PYTHON"], [
+  AC_PATH_PROGS([PYTHON], [python python3 python2])
+])
+AS_IF([test -z "$PYTHON"], [
   AC_MSG_ERROR([Could not find python.])
 ])
-AC_ARG_VAR([PYTHON], [Python interpreter command])
+AC_SUBST([PYTHON])
 
 
 # Verify that makedep is available
-AC_PATH_PROGS([MAKEDEP], [makedep], [], ["${PATH}:${srcdir}/../../.."])
-AS_IF([test -n "${MAKEDEP}"], [
-  AC_SUBST([MAKEDEP])
-], [
-  AC_MSG_ERROR(["Could not find makedep."])
+AS_IF([test -z "$MAKEDEP"], [
+  AC_PATH_PROG([MAKEDEP], [makedep])
 ])
+AS_IF([test -z "$MAKEDEP"], [
+  AC_MSG_ERROR([Could not find makedep.])
+])
+AC_SUBST([MAKEDEP])
 
 
 # Autoconf does not configure the archiver (ar), as it is handled by Automake.

--- a/ac/deps/configure.cvmix.ac
+++ b/ac/deps/configure.cvmix.ac
@@ -1,0 +1,82 @@
+# Autoconf configuration
+AC_PREREQ([2.63])
+
+AC_INIT(
+    [GSW],
+    [ ],
+    [https://github.com/TEOS-10/GSW-Fortran/issues])
+
+# Validate srdcir and configure input
+AC_CONFIG_SRCDIR([src/shared/cvmix_utils.F90])
+AC_CONFIG_MACRO_DIR([m4])
+
+
+# Standard Fortran configuration
+AC_LANG([Fortran])
+AC_FC_SRCEXT([f90])
+AC_PROG_FC
+
+
+# netCDF configuration
+
+# Check for netcdf.h header function declarations.
+# If unavailable, then try to invoke nc-create.
+AC_LANG_PUSH([C])
+AC_CHECK_HEADERS([netcdf.h], [], [
+  AS_UNSET([ac_cv_header_netcdf_h])
+  AC_PATH_PROG([NC_CONFIG], [nc-config])
+  AS_IF([test -n "$NC_CONFIG"], [
+      AC_SUBST([CPPFLAGS], ["$CPPFLAGS -I$($NC_CONFIG --includedir)"])
+    ],
+    [AC_MSG_ERROR([Could not find nc-config.])]
+  )
+  AC_CHECK_HEADERS([netcdf.h], [], [
+    AC_MSG_ERROR([Could not find netcdf.h])
+  ])
+])
+AC_LANG_POP([C])
+
+# Search for the Fortran netCDF module, fallback to nf-config.
+AX_FC_CHECK_MODULE([netcdf], [], [
+  AS_UNSET([ax_fc_cv_mod_netcdf])
+  AC_PATH_PROG([NF_CONFIG], [nf-config])
+  AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([FCFLAGS], ["$FCFLAGS -I$($NF_CONFIG --includedir)"])
+    ],
+    [AC_MSG_ERROR([Could not find nf-config.])]
+  )
+  AX_FC_CHECK_MODULE([netcdf], [], [
+    AC_MSG_ERROR([Could not find netcdf module.])
+  ])
+])
+
+
+# Verify that Python is available
+AC_PATH_PROGS([PYTHON], [python python3 python2], [
+  AC_MSG_ERROR([Could not find python.])
+])
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+
+
+# Verify that makedep is available
+AC_PATH_PROGS([MAKEDEP], [makedep], [], ["${PATH}:${srcdir}/../../.."])
+AS_IF([test -n "${MAKEDEP}"], [
+  AC_SUBST([MAKEDEP])
+], [
+  AC_MSG_ERROR(["Could not find makedep."])
+])
+
+
+# Autoconf does not configure the archiver (ar), as it is handled by Automake.
+AR=ar
+ARFLAGS=rv
+AC_SUBST([AR])
+AC_SUBST([ARFLAGS])
+
+AC_CONFIG_COMMANDS([Makefile.dep], [make depend])
+
+AC_SUBST([CPPFLAGS])
+
+# Prepare output
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/ac/deps/configure.fms.ac
+++ b/ac/deps/configure.fms.ac
@@ -11,6 +11,11 @@ AC_CONFIG_SRCDIR([fms/fms.F90])
 AC_CONFIG_MACRO_DIR([m4])
 
 
+# Build dependencies
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+AC_ARG_VAR([MAKEDEP], [Makefile dependency generator])
+
+
 # C configuration
 
 # Autoconf assumes that LDFLAGS can be passed to CFLAGS, even though this is
@@ -68,7 +73,7 @@ AC_CHECK_FUNCS([sched_getaffinity], [], [AC_DEFINE([__APPLE__])])
 LDFLAGS="$FC_LDFLAGS"
 
 
-# Standard Fortran configuration
+# Fortran configuration
 AC_LANG([Fortran])
 AC_FC_SRCEXT([f90])
 AC_PROG_FC
@@ -171,19 +176,23 @@ FCFLAGS="$FCFLAGS $ALLOW_ARG_MISMATCH_FCFLAGS"
 
 
 # Verify that Python is available
-AC_PATH_PROGS([PYTHON], [python python3 python2], [
+AS_IF([test -z "$PYTHON"], [
+  AC_PATH_PROGS([PYTHON], [python python3 python2])
+])
+AS_IF([test -z "$PYTHON"], [
   AC_MSG_ERROR([Could not find python.])
 ])
-AC_ARG_VAR([PYTHON], [Python interpreter command])
+AC_SUBST([PYTHON])
 
 
 # Verify that makedep is available
-AC_PATH_PROGS([MAKEDEP], [makedep], [], ["${PATH}:${srcdir}/../../.."])
-AS_IF([test -n "${MAKEDEP}"], [
-  AC_SUBST([MAKEDEP])
-], [
-  AC_MSG_ERROR(["Could not find makedep."])
+AS_IF([test -z "$MAKEDEP"], [
+  AC_PATH_PROG([MAKEDEP], [makedep])
 ])
+AS_IF([test -z "$MAKEDEP"], [
+  AC_MSG_ERROR([Could not find makedep.])
+])
+AC_SUBST([MAKEDEP])
 
 
 # Autoconf does not configure the archiver (ar), as it is handled by Automake.

--- a/ac/deps/configure.gsw.ac
+++ b/ac/deps/configure.gsw.ac
@@ -10,8 +10,12 @@ AC_INIT(
 AC_CONFIG_SRCDIR([modules/gsw_mod_toolbox.f90])
 AC_CONFIG_MACRO_DIR([m4])
 
+# Dependency configuration
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+AC_ARG_VAR([MAKEDEP], [Makefile dependency generator])
 
-# Standard Fortran configuration
+
+# Fortran compiler test
 AC_LANG([Fortran])
 AC_FC_SRCEXT([f90])
 AC_PROG_FC
@@ -52,19 +56,23 @@ AX_FC_CHECK_MODULE([netcdf], [], [
 
 
 # Verify that Python is available
-AC_PATH_PROGS([PYTHON], [python python3 python2], [
+AS_IF([test -z "$PYTHON"], [
+  AC_PATH_PROGS([PYTHON], [python python3 python2])
+])
+AS_IF([test -z "$PYTHON"], [
   AC_MSG_ERROR([Could not find python.])
 ])
-AC_ARG_VAR([PYTHON], [Python interpreter command])
+AC_SUBST([PYTHON])
 
 
 # Verify that makedep is available
-AC_PATH_PROGS([MAKEDEP], [makedep], [], ["${PATH}:${srcdir}/../../.."])
-AS_IF([test -n "${MAKEDEP}"], [
-  AC_SUBST([MAKEDEP])
-], [
-  AC_MSG_ERROR(["Could not find makedep."])
+AS_IF([test -z "$MAKEDEP"], [
+  AC_PATH_PROG([MAKEDEP], [makedep])
 ])
+AS_IF([test -z "$MAKEDEP"], [
+  AC_MSG_ERROR([Could not find makedep.])
+])
+AC_SUBST([MAKEDEP])
 
 
 # Autoconf does not configure the archiver (ar), as it is handled by Automake.

--- a/ac/deps/configure.gsw.ac
+++ b/ac/deps/configure.gsw.ac
@@ -1,0 +1,82 @@
+# Autoconf configuration
+AC_PREREQ([2.63])
+
+AC_INIT(
+    [GSW],
+    [ ],
+    [https://github.com/TEOS-10/GSW-Fortran/issues])
+
+# Validate srdcir and configure input
+AC_CONFIG_SRCDIR([modules/gsw_mod_toolbox.f90])
+AC_CONFIG_MACRO_DIR([m4])
+
+
+# Standard Fortran configuration
+AC_LANG([Fortran])
+AC_FC_SRCEXT([f90])
+AC_PROG_FC
+
+
+# netCDF configuration
+
+# Check for netcdf.h header function declarations.
+# If unavailable, then try to invoke nc-create.
+AC_LANG_PUSH([C])
+AC_CHECK_HEADERS([netcdf.h], [], [
+  AS_UNSET([ac_cv_header_netcdf_h])
+  AC_PATH_PROG([NC_CONFIG], [nc-config])
+  AS_IF([test -n "$NC_CONFIG"], [
+      AC_SUBST([CPPFLAGS], ["$CPPFLAGS -I$($NC_CONFIG --includedir)"])
+    ],
+    [AC_MSG_ERROR([Could not find nc-config.])]
+  )
+  AC_CHECK_HEADERS([netcdf.h], [], [
+    AC_MSG_ERROR([Could not find netcdf.h])
+  ])
+])
+AC_LANG_POP([C])
+
+# Search for the Fortran netCDF module, fallback to nf-config.
+AX_FC_CHECK_MODULE([netcdf], [], [
+  AS_UNSET([ax_fc_cv_mod_netcdf])
+  AC_PATH_PROG([NF_CONFIG], [nf-config])
+  AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([FCFLAGS], ["$FCFLAGS -I$($NF_CONFIG --includedir)"])
+    ],
+    [AC_MSG_ERROR([Could not find nf-config.])]
+  )
+  AX_FC_CHECK_MODULE([netcdf], [], [
+    AC_MSG_ERROR([Could not find netcdf module.])
+  ])
+])
+
+
+# Verify that Python is available
+AC_PATH_PROGS([PYTHON], [python python3 python2], [
+  AC_MSG_ERROR([Could not find python.])
+])
+AC_ARG_VAR([PYTHON], [Python interpreter command])
+
+
+# Verify that makedep is available
+AC_PATH_PROGS([MAKEDEP], [makedep], [], ["${PATH}:${srcdir}/../../.."])
+AS_IF([test -n "${MAKEDEP}"], [
+  AC_SUBST([MAKEDEP])
+], [
+  AC_MSG_ERROR(["Could not find makedep."])
+])
+
+
+# Autoconf does not configure the archiver (ar), as it is handled by Automake.
+AR=ar
+ARFLAGS=rv
+AC_SUBST([AR])
+AC_SUBST([ARFLAGS])
+
+AC_CONFIG_COMMANDS([Makefile.dep], [make depend])
+
+AC_SUBST([CPPFLAGS])
+
+# Prepare output
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/ac/m4/mom6_fc_check_lib.m4
+++ b/ac/m4/mom6_fc_check_lib.m4
@@ -1,0 +1,82 @@
+dnl MOM6_FC_CHECK_LIB(LIBRARY, PROCEDURE,
+dnl                   [MODULE], [ARGS], [FUNC-RESULT], [DECLS],
+dnl                   [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND],
+dnl                   [OTHER-LDFLAGS], [OTHER-LIBS])
+dnl
+dnl This macro checks if a Fortran library containing a designated function
+dnl is available to the compiler.  For the most part, this macro should behave
+dnl like the Autoconf AC_CHECK_LIB macro.
+dnl
+dnl This macro differs from AC_CHECK_LIB, since it includes several additional
+dnl arguments.  Although the next four arguments are optional, they are
+dnl required for many function tests.
+dnl
+dnl - MODULE specifies the Fortran module containing the procedure.
+dnl
+dnl - ARGS is used to specify any arguments of the procedure.
+dnl
+dnl - FUNC-RESULT, if set, identifies the procedure as a function rather than
+dnl   a subroutine, and specifies the function test result.
+dnl
+dnl - DECLS is used as a code block to explicitly declare variables, when
+dnl   implicit typing is not sufficient.
+dnl
+dnl The following argument has also been added.
+dnl
+dnl - OTHER-LDFLAGS allows specification of supplemental LDFLAGS arguments.
+dnl   This can be used, for example, to test for the library with different
+dnl   -L flags, or perhaps other ld configurations.
+dnl
+dnl Results are cached in the mom6_fc_cv_lib_LIBRARY_PROCEDURE variable.
+dnl
+AC_DEFUN([MOM6_FC_CHECK_LIB],[
+  AS_VAR_PUSHDEF([mom6_fc_Lib], [mom6_fc_cv_lib_$1_$2])
+  m4_ifval([$9],
+    [mom6_fc_lib_msg_LDFLAGS=" with $9"],
+    [mom6_fc_lib_msg_LDFLAGS=""]
+  )
+  AC_CACHE_CHECK(
+    [for $2 in -l$1$mom6_fc_lib_msg_LDFLAGS],
+    [mom6_fc_Lib],[
+      mom6_fc_check_lib_save_LDFLAGS=$LDFLAGS
+      LDFLAGS="$9 $LDFLAGS"
+      mom6_fc_check_lib_save_LIBS=$LIBS
+      LIBS="-l$1 $10 $LIBS"
+      AS_IF([test -n "$3"],
+        [mom6_fc_use_mod="use $3"],
+        [mom6_fc_use_mod=""]
+      )
+      AS_IF([test -n "$5"],
+        [mom6_fc_proc="$5 = $2"],
+        [mom6_fc_proc="call $2"]
+      )
+      AS_IF([test -n "$4"],
+        [mom6_fc_proc="${mom6_fc_proc}($4)"]
+      )
+      AS_IF([test -n "$6"],
+        [mom6_fc_decls="$6"],
+        [mom6_fc_decls=""]
+      )
+      AC_LANG_PUSH([Fortran])
+      AC_LINK_IFELSE([dnl
+dnl Begin 7-column code block
+AC_LANG_PROGRAM([], [dnl
+        $mom6_fc_use_mod
+        $mom6_fc_decls
+        $mom6_fc_proc])dnl
+dnl End code block
+        ],
+        [AS_VAR_SET([mom6_fc_Lib], [yes])],
+        [AS_VAR_SET([mom6_fc_Lib], [no])]
+      )
+      AC_LANG_POP([Fortran])
+      LIBS=$mom6_fc_check_lib_save_LIBS
+      LDFLAGS=$mom6_fc_check_lib_save_LDFLAGS
+    ]
+  )
+  AS_VAR_IF([mom6_fc_Lib], [yes],
+    [m4_default([$7], [LIBS="-l$1 $LIBS"])],
+    [$8]
+  )
+  AS_VAR_POPDEF([mom6_fc_Lib])
+])


### PR DESCRIPTION
This patch significantly modifies the Autoconf-based builds to separate external content in `pkg/` from the main MOM6 source code.

These changes are meant to address the challenges with analysis of source code which is outside of our control.  Such content is now built separately, isolating it from the usual MOM6 code requirements.

A secondary benefit is that a submodule checkout is no longer required for ocean-only builds.

The patch includes the following specific changes.

* Builds relying on `ac/deps/` now build libraries for GibbsSeaWater (`libgsw.a`) and CVMix (`libcvmix.a`) alongside `libFMS.a`.  This replaces any content placed externally into `pkg/`.

* A new macro, `MOM6_FC_CHECK_LIB`, improves library detection tests by including support for both subroutines and functions, as well as generic argument lists.

  It still relies on implicit typing, so only reals and integers are supported.  We can hopefully fix this in the future.

* Makefiles across the build system (`ac/deps/`, `.testing/`, etc.) have been updated to generate and use the new libraries.

These changes are not intended to break existing builds, as summarized below.

* `src/parameters/CVMix/` and `TEOS10/` are explicitly excluded from the makedep source trees, but the symbolic links to `pkg/` are retained, and existing builds which assume their presence should still work.

* The legacy `AX_FC_CHECK_LIB` macro has been retained, so that it remains available to any external MOM6-examples builds.

* The git submodules have not been removed, although the GitHub Actions no longer uses then in testing.

The patch also includes the following related minor modifications.

* The GitHub Actions FMS build stages now includes GSW and CVMix

* `.gitignore` files are modified to target files produced by the build system, rather than globbing of various incidental files.

* A non-POSIX shell operation `==` in `configure.ac` has been replaced.