### PR TITLE
+Add and use trim_trailing_commas() and ints_to_string()

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -29,7 +29,7 @@ use MOM_interface_heights, only : thickness_to_dz
 use MOM_io,               only : slasher, vardesc, query_vardesc, MOM_read_data
 use MOM_io,               only : get_filename_appendix
 use MOM_safe_alloc,       only : safe_alloc_ptr, safe_alloc_alloc
-use MOM_string_functions, only : lowercase
+use MOM_string_functions, only : lowercase, ints_to_string, trim_trailing_commas
 use MOM_time_manager,     only : time_type
 use MOM_time_manager,     only : get_time
 use MOM_unit_scaling,     only : unit_scale_type
@@ -1056,7 +1056,7 @@ subroutine define_axes_group(diag_cs, handles, axes, nz, vertical_coordinate_num
   n = size(handles)
   if (n<1 .or. n>3) call MOM_error(FATAL, "define_axes_group: wrong size for list of handles!")
   allocate( axes%handles(n) )
-  axes%id = i2s(handles, n) ! Identifying string
+  axes%id = ints_to_string(handles, max(n,3)) ! Identifying string
   axes%rank = n
   axes%handles(:) = handles(:)
   axes%diag_cs => diag_cs ! A [circular] link back to the diag_cs structure
@@ -1169,7 +1169,7 @@ subroutine define_axes_group_dsamp(diag_cs, handles, axes, dl, nz, vertical_coor
   n = size(handles)
   if (n<1 .or. n>3) call MOM_error(FATAL, "define_axes_group: wrong size for list of handles!")
   allocate( axes%handles(n) )
-  axes%id = i2s(handles, n) ! Identifying string
+  axes%id = ints_to_string(handles, max(n,3)) ! Identifying string
   axes%rank = n
   axes%handles(:) = handles(:)
   axes%diag_cs => diag_cs ! A [circular] link back to the diag_cs structure
@@ -2437,14 +2437,7 @@ integer function register_diag_field(module_name, field_name, axes_in, init_time
   if (axes_in%is_v_point)   dimensions = trim(dimensions)//" xh, yq,"
   if (axes_in%is_layer)     dimensions = trim(dimensions)//" zl,"
   if (axes_in%is_interface) dimensions = trim(dimensions)//" zi,"
-
-  if (len_trim(dimensions) > 0) then
-    dimensions = trim(adjustl(dimensions))
-    if (dimensions(len_trim(dimensions):len_trim(dimensions)) == ",") then
-        dimensions = dimensions(1:len_trim(dimensions) - 1)
-    endif
-    dimensions = trim(dimensions)
-  endif
+  if (len_trim(dimensions) > 0) dimensions = trim_trailing_commas(dimensions)
 
   if (is_root_pe() .and. (diag_CS%available_diag_doc_unit > 0)) then
     msg = ''
@@ -3181,14 +3174,7 @@ function register_static_field(module_name, field_name, axes, &
   if (axes%is_v_point)   dimensions = trim(dimensions)//" xh, yq,"
   if (axes%is_layer)     dimensions = trim(dimensions)//" zl,"
   if (axes%is_interface) dimensions = trim(dimensions)//" zi,"
-
-  if (len_trim(dimensions) > 0) then
-    dimensions = trim(adjustl(dimensions))
-    if (dimensions(len_trim(dimensions):len_trim(dimensions)) == ",") then
-        dimensions = dimensions(1:len_trim(dimensions) - 1)
-    endif
-    dimensions = trim(dimensions)
-  endif
+  if (len_trim(dimensions) > 0) dimensions = trim_trailing_commas(dimensions)
 
   ! Document diagnostics in list of available diagnostics
   if (is_root_pe() .and. diag_CS%available_diag_doc_unit > 0) then
@@ -3859,28 +3845,6 @@ subroutine diag_mediator_end(time, diag_CS, end_diag_manager)
   endif
 
 end subroutine diag_mediator_end
-
-!> Convert the first n elements (up to 3) of an integer array to an underscore delimited string.
-function i2s(a,n_in)
-  ! "Convert the first n elements of an integer array to a string."
-  ! Perhaps this belongs elsewhere in the MOM6 code?
-  integer, dimension(:), intent(in) :: a    !< The array of integers to translate
-  integer, optional    , intent(in) :: n_in !< The number of elements to translate, by default all
-  character(len=15) :: i2s !< The returned string
-
-  character(len=15) :: i2s_temp
-  integer :: i,n
-
-  n=size(a)
-  if (present(n_in)) n = n_in
-
-  i2s = ''
-  do i=1,min(n,3)
-    write (i2s_temp, '(I4.4)') a(i)
-    i2s = trim(i2s) //'_'// trim(i2s_temp)
-  enddo
-  i2s = adjustl(i2s)
-end function i2s
 
 !> Returns a new diagnostic id, it may be necessary to expand the diagnostics array.
 integer function get_new_diag_id(diag_cs)

--- a/src/framework/MOM_string_functions.F90
+++ b/src/framework/MOM_string_functions.F90
@@ -17,6 +17,8 @@ public extract_integer
 public extract_real
 public remove_spaces
 public slasher
+public trim_trailing_commas
+public ints_to_string
 
 contains
 
@@ -326,6 +328,10 @@ logical function string_functions_unit_tests(verbose)
   fail = fail .or. localTestS(v,left_reals(r(:)),'0.0, 1.0, -2.0, 1.3, 3*3.0E-11, -5.1E+12')
   fail = fail .or. localTestS(v,left_reals(r(:),sep=' '),'0.0 1.0 -2.0 1.3 3*3.0E-11 -5.1E+12')
   fail = fail .or. localTestS(v,left_reals(r(:),sep=','),'0.0,1.0,-2.0,1.3,3*3.0E-11,-5.1E+12')
+  fail = fail .or. localTestS(v,ints_to_string(i(:),5),'_-0001_0001_0003_0003_0000')
+  fail = fail .or. localTestS(v,ints_to_string(i(2:),2),'_0001_0003')
+  fail = fail .or. localTestS(v,ints_to_string(i(:)),'_-0001_0001_0003')
+  fail = fail .or. localTestS(v,trim_trailing_commas("One, Two, Three, "), "One, Two, Three")
   fail = fail .or. localTestS(v,extractWord("One Two,Three",1),"One")
   fail = fail .or. localTestS(v,extractWord("One Two,Three",2),"Two")
   fail = fail .or. localTestS(v,extractWord("One Two,Three",3),"Three")
@@ -416,6 +422,49 @@ function slasher(dir)
     slasher = trim(dir)//"/"
   endif
 end function slasher
+
+!> Returns a left-adjusted string with trailing blanks and commas removed.
+function trim_trailing_commas(in_str) result(out_str)
+  character(len=*), intent(in) :: in_str  !< A string that is to be left adjusted and have
+                                          !! its trailing commas and white space removed.
+  character(len=len(in_str))   :: out_str !< A left-adjusted version of in_str with
+                                          !! trailing commas and white space removed
+
+  out_str = trim(adjustl(in_str))
+  if (len_trim(out_str) > 0) then
+    if (out_str(len_trim(out_str):len_trim(out_str)) == ",") then
+      out_str = out_str(1:len_trim(out_str) - 1)
+    endif
+    out_str = trim(out_str)
+  endif
+
+end function trim_trailing_commas
+
+!> Convert the first n elements (3 by default) of an integer array into an underscore delimited string.
+function ints_to_string(a, n) result(i2s)
+  integer, dimension(:), intent(in) :: a !< The array of integers to translate
+  integer, optional    , intent(in) :: n !< The number of elements to translate, by default the lesser
+                                         !! of 3 or all of the integers
+  character(len=5*size(a)+1) :: i2s !< The returned underscore delimited string of integers
+
+  character(len=8) :: i2s_temp
+  integer :: i, n_max
+
+  n_max = 3
+  if (present(n)) n_max = n
+
+  i2s = ''
+  do i=1,min(size(a), n_max)
+    if (a(i) < 0) then
+      write (i2s_temp, '(I5.4)') a(i)
+    else
+      write (i2s_temp, '(I4.4)') a(i)
+    endif
+    i2s = trim(i2s) //'_'// trim(i2s_temp)
+  enddo
+  i2s = adjustl(i2s)
+end function ints_to_string
+
 
 !> \namespace mom_string_functions
 !!


### PR DESCRIPTION
  This set of two commits first adds the new functions `ints_to_string()` and `trim_trailing_commas()` to MOM_string_functions, based on code that previously been in MOM_diag_mediator, and then in a second commit calls these functions from appropriate points in MOM_diag_mediator and eliminates the redundant code.  All answers and output are bitwise identical, apart from three new tests reported on by `string_functions_unit_tests()`.