### PR TITLE
*Test before using frazil for ice-shelf water flux

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -871,7 +871,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     mass_flux(i,j) = ISS%water_flux(i,j) * ISS%area_shelf_h(i,j)
 
     !Add frazil formation
-    if (ISS%hmask(i,j) == 1 .or. ISS%hmask(i,j) == 2) &
+    if (allocated(sfc_state%frazil) .and. ((ISS%hmask(i,j) == 1.) .or. (ISS%hmask(i,j) == 2.))) &
       ISS%water_flux(i,j) = ISS%water_flux(i,j) - sfc_state%frazil(i,j) * I_dt_LHF
     fluxes%iceshelf_melt(i,j) = ISS%water_flux(i,j)
   enddo ; enddo ! i- and j-loops


### PR DESCRIPTION
  Added a test to only apply frazil at the base of an ice shelf if the `sfc_state%frazil` array is allocated, thereby avoiding a segmentation fault in cases that have and ice shelf but do not have the runtime parameter `FRAZIL` set to true.  This bug was causing the ocean_only/ISOMIP test cases to fail, and fixing it allows them to work again, providing the same answers as previously.

  This bug was introduced on Dec. 2, 2025 as a part of PR #985 to dev/gfdl.