### PR TITLE
MOM_interpolate: use get_axis_size()

### DIFF
--- a/config_src/infra/FMS1/MOM_io_infra.F90
+++ b/config_src/infra/FMS1/MOM_io_infra.F90
@@ -14,6 +14,7 @@ use mpp_io_mod,           only : mpp_open, mpp_close, mpp_flush
 use mpp_io_mod,           only : mpp_write_meta, mpp_write, mpp_read
 use mpp_io_mod,           only : mpp_get_atts, mpp_attribute_exist
 use mpp_io_mod,           only : mpp_get_axes, axistype, mpp_get_axis_data
+use mpp_io_mod,           only : mpp_get_axis_length
 use mpp_io_mod,           only : mpp_get_fields, fieldtype
 use mpp_io_mod,           only : mpp_get_info, mpp_get_times
 use mpp_io_mod,           only : mpp_io_init
@@ -33,7 +34,7 @@ public :: open_file, open_ASCII_file, file_is_open, close_file, flush_file, file
 public :: get_file_info, get_file_fields, get_file_times, get_filename_suffix
 public :: read_field, read_vector, write_metadata, write_field
 public :: field_exists, get_field_atts, get_field_size, read_field_chksum
-public :: get_axis_data, set_axis_data
+public :: get_axis_size, get_axis_data, set_axis_data
 public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
 public :: stdout_if_root
 ! These types are inherited from underlying infrastructure code, to act as containers for
@@ -403,6 +404,18 @@ subroutine get_field_size(filename, fieldname, sizes, field_found, no_domain)
   call field_size(filename, fieldname, sizes, field_found=field_found, no_domain=no_domain)
 
 end subroutine get_field_size
+
+
+!> Get the size of the axis
+function get_axis_size(axis) result(axis_size)
+  type(axistype), intent(in) :: axis
+    !< Infra axis
+  integer :: axis_size
+    !< Axis size
+
+  axis_size = mpp_get_axis_length(axis)
+end function get_axis_size
+
 
 !> Extracts and returns the axis data stored in an axistype.
 subroutine get_axis_data(axis, axis_name, axis_data)

--- a/config_src/infra/FMS2/MOM_io_infra.F90
+++ b/config_src/infra/FMS2/MOM_io_infra.F90
@@ -45,7 +45,7 @@ public :: open_file, open_ASCII_file, file_is_open, close_file, flush_file, file
 public :: get_file_info, get_file_fields, get_file_times, get_filename_suffix
 public :: read_field, read_vector, write_metadata, write_field
 public :: field_exists, get_field_atts, get_field_size, read_field_chksum
-public :: get_axis_data, set_axis_data
+public :: get_axis_size, get_axis_data, set_axis_data
 public :: io_infra_init, io_infra_end, MOM_namelist_file, check_namelist_error, write_version
 public :: stdout_if_root
 ! These types act as containers for information about files, fields and axes, respectively,
@@ -712,6 +712,17 @@ function find_index(vec) result(loc)
     endif
   enddo
 end function find_index
+
+
+!> Get the axis size from an axistype
+function get_axis_size(axis) result(axis_size)
+  type(axistype), intent(in) :: axis
+    !< Infra axis
+  integer :: axis_size
+    !< Axis size
+
+  axis_size = size(axis%ax_data)
+end function get_axis_size
 
 
 !> Extracts and returns the axis data stored in an axistype.

--- a/src/framework/MOM_interpolate.F90
+++ b/src/framework/MOM_interpolate.F90
@@ -12,7 +12,7 @@ use MOM_interp_infra,    only : get_external_field_info_infra => get_external_fi
 use MOM_interp_infra,    only : run_horiz_interp, build_horiz_interp_weights
 use MOM_interp_infra,    only : external_field
 use MOM_io_infra,        only : axistype
-use MOM_io_infra,        only : get_axis_data
+use MOM_io_infra,        only : get_axis_size, get_axis_data
 use MOM_io,              only : axis_info, set_axis_info
 use MOM_time_manager, only : time_type, set_date, operator(+), operator(<), operator(>)
 
@@ -303,16 +303,17 @@ subroutine get_external_field_info(field, size, axes, missing)
 
   integer :: n
     ! Axis index
+  integer :: ax_size
+    ! Axis size
 
   if (present(axes)) then
     call get_external_field_info_infra(field, size=size, axes=axes_infra, &
         missing=missing)
     ! TODO: Most of these methods were written to expect four dimensions.
-    ! I would not expect a generic field to be well-behaved, but I am unsure
-    ! how to validate such a field.
     do n=1,4
       ! Convert axistype to axis_info
-      allocate(ax_data(size(n)))
+      ax_size = get_axis_size(axes_infra(n))
+      allocate(ax_data(ax_size))
       call get_axis_data(axes_infra(n), axis_name, ax_data)
       call set_axis_info(axes(n), trim(axis_name), ax_data=ax_data)
       deallocate(ax_data)


### PR DESCRIPTION
The prior version of `get_external_field_info` incorrectly relied on the `size` output of `get_external_field_info_infra` to determine the size of an external field's axes, since all external fields are assumed to be domain-decomposed.

Since axis metadata is generally opaque, we have introduced a new infra function, `get_axis_data`, which returns the size of an axis.