### PR TITLE
Ice-shelf latent heat fix

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1342,8 +1342,6 @@ subroutine add_shelf_flux(G, US, CS, sfc_state, fluxes, time_step)
     ! The salt flux should be mostly from sea ice, so perhaps none should be intercepted and this should be changed.
     if (associated(fluxes%salt_flux)) &
       fluxes%salt_flux(i,j) = frac_shelf * ISS%salt_flux(i,j)*CS%flux_factor + frac_open * fluxes%salt_flux(i,j)
-    if (associated(fluxes%latent)) &
-      fluxes%latent(i,j) = fluxes%latent(i,j) - frac_shelf * ISS%water_flux(i,j) * CS%Lat_Fusion
   endif ; enddo ; enddo
 
   if (CS%debug) then


### PR DESCRIPTION
Remove ice-shelf melting/freezing contribution to `fluxes%latent` because it is already accounted for in `fluxes%sens`