### PR TITLE
ice-ocean-nolib: Fix SIS2 paths

### DIFF
--- a/.gitlab/pipeline-ci-tool.sh
+++ b/.gitlab/pipeline-ci-tool.sh
@@ -161,7 +161,14 @@ nolibs-ocean-ice-compile () {
     mkdir -p build-ocean-ice-nolibs-$1
     cd build-ocean-ice-nolibs-$1
     make -f ../tools/MRS/Makefile.build ./$1/env BUILD=. ENVIRON=../../environ -s
-    ../src/mkmf/bin/list_paths -l ../src/MOM6/config_src/{drivers/FMS_cap,memory/dynamic_symmetric,infra/FMS1,ext*} ../src/MOM6/src ../src/SIS2/*src ../src/icebergs/src ../src/{FMS1,coupler,ice_param,land_null,atmos_null}
+    ../src/mkmf/bin/list_paths -l \
+      ../src/MOM6/config_src/{drivers/FMS_cap,memory/dynamic_symmetric,infra/FMS1,ext*} \
+      ../src/MOM6/src \
+      ../src/SIS2/src \
+      ../src/SIS2/config_src/dynamic_symmetric \
+      ../src/SIS2/config_src/Icepack_interfaces \
+      ../src/icebergs/src \
+      ../src/{FMS1,coupler,ice_param,land_null,atmos_null}
     sed -i '/FMS1\/.*\/test_/d' path_names
     ../src/mkmf/bin/mkmf -t ../src/mkmf/templates/ncrc5-$1.mk -p MOM6 -c"-Duse_libMPI -Duse_netCDF -D_USE_LEGACY_LAND_ -Duse_AM3_physics" path_names
     (source $1/env ; make NETCDF=3 REPRO=1 MOM6 -s -j)


### PR DESCRIPTION
Patch to fix the SIS2 paths in the pipeline CI script.  Explicitly excludes the icebergs stub, since we are using the actual icebergs model.