### PR TITLE
Correct the path to the Icepack interfaces

### DIFF
--- a/.gitlab/pipeline-ci-tool.sh
+++ b/.gitlab/pipeline-ci-tool.sh
@@ -166,7 +166,7 @@ nolibs-ocean-ice-compile () {
       ../src/MOM6/src \
       ../src/SIS2/src \
       ../src/SIS2/config_src/dynamic_symmetric \
-      ../src/SIS2/config_src/Icepack_interfaces \
+      ../src/SIS2/config_src/external/Icepack_interfaces \
       ../src/icebergs/src \
       ../src/{FMS1,coupler,ice_param,land_null,atmos_null}
     sed -i '/FMS1\/.*\/test_/d' path_names


### PR DESCRIPTION
  The previous attempt to fix the automated no-library build of the ice-ocean model incorrectly specified the path to the Icepack_interfaces.  This has now been corrected from `src/SIS2/config_src/external/Icepack_interfaces` to `src/SIS2/config_src/external/Icepack_interfaces` in pipeline-ci-tool.sh.  The real mystery here is why the testing on the previous PR actually worked.