### PR TITLE
Regroup MOM_initialize_fixed parameters in MOM_parameter_doc

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -506,6 +506,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   type(ocean_OBC_type),    pointer       :: OBC !< Open boundary control structure
 
   ! Local variables
+  integer :: num_of_segs ! Number of open boundary segments
   integer :: n, n_seg ! For looping over segments
   logical :: debug, mask_outside, reentrant_x, reentrant_y
   character(len=15) :: segment_param_str ! The run-time parameter name for each segment
@@ -522,17 +523,17 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
 
-  allocate(OBC)
-
-  call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
-                 default=0, do_not_log=.true.)
   call log_version(param_file, mdl, version, &
                  "Controls where open boundaries are located, what kind of boundary condition "//&
-                 "to impose, and what data to apply, if any.", &
-                 all_default=(OBC%number_of_segments<=0))
-  call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", OBC%number_of_segments, &
-                 "The number of open boundary segments.", &
-                 default=0)
+                 "to impose, and what data to apply, if any.", all_default=.false.)
+  ! Parameter OBC_NUMBER_OF_SEGMENTS is always logged.
+  call get_param(param_file, mdl, "OBC_NUMBER_OF_SEGMENTS", num_of_segs, &
+                 "The number of open boundary segments.", default=0)
+  if (num_of_segs <= 0) & ! Do nothing if there is no OBC segments
+    return
+
+  allocate(OBC)
+  OBC%number_of_segments = num_of_segs
   call get_param(param_file, mdl, "OBC_USER_CONFIG", config1, &
                  "A string that sets how the open boundary conditions are "//&
                  " configured: \n", default="none", do_not_log=.true.)
@@ -606,12 +607,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
     call get_param(param_file, mdl, "OBC_TIDE_N_CONSTITUENTS", OBC%n_tide_constituents, &
          "Number of tidal constituents being added to the open boundary.", &
          default=0)
-
-    if (OBC%n_tide_constituents > 0) then
-      OBC%add_tide_constituents = .true.
-    else
-      OBC%add_tide_constituents = .false.
-    endif
+    OBC%add_tide_constituents = (OBC%n_tide_constituents > 0)
 
     call get_param(param_file, mdl, "DEBUG", debug, default=.false.)
     call get_param(param_file, mdl, "DEBUG_OBCS", OBC%debug, &
@@ -634,7 +630,6 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "for dependencies on the order with which the OBC segments are applied.", &
                  default=.false., debuggingParam=.true., do_not_log=(OBC%number_of_segments<2))
 
-
     call get_param(param_file, mdl, "OBC_SILLY_THICK", OBC%silly_h, &
                  "A silly value of thicknesses used outside of open boundary "//&
                  "conditions for debugging.", units="m", default=0.0, scale=US%m_to_Z, &
@@ -656,9 +651,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "If true, set the OBC tracer reservoirs at the startup of a new run from the "//&
                  "interior tracer concentrations regardless of properties that may be explicitly "//&
                  "specified for the reservoir concentrations.", default=enable_bugs, do_not_log=.true.)
-    reentrant_x = .false.
     call get_param(param_file, mdl, "REENTRANT_X", reentrant_x, default=.true.)
-    reentrant_y = .false.
     call get_param(param_file, mdl, "REENTRANT_Y", reentrant_y, default=.false.)
 
     ! Allocate everything
@@ -732,8 +725,8 @@ subroutine open_boundary_config(G, US, param_file, OBC)
       ! Need this for ocean_only mode boundary interpolation.
       call time_interp_external_init()
     endif
-    !    if (open_boundary_query(OBC, needs_ext_seg_data=.true.)) &
- !   call initialize_segment_data(G, OBC, param_file)
+    ! if (open_boundary_query(OBC, needs_ext_seg_data=.true.)) &
+    !   call initialize_segment_data(G, OBC, param_file)
 
     if (open_boundary_query(OBC, apply_open_OBC=.true.)) then
       call get_param(param_file, mdl, "OBC_RADIATION_MAX", OBC%rx_max, &
@@ -847,7 +840,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
 
   endif ! OBC%number_of_segments > 0
 
-    ! Safety check
+  ! Safety check
   if ((OBC%open_u_BCs_exist_globally .or. OBC%open_v_BCs_exist_globally) .and. &
        .not.G%symmetric ) call MOM_error(FATAL, &
        "MOM_open_boundary, open_boundary_config: "//&

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -90,39 +90,39 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
   ! To initialize masks, the bathymetry in halo regions must be filled in
   call pass_var(G%bathyT, G%Domain)
 
-  ! Determine the position of any open boundaries
+  ! Determine the position of any open boundaries and create OBC
   call open_boundary_config(G, US, PF, OBC)
 
-  ! Make bathymetry consistent with open boundaries
-  call get_param(PF, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
-                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
-  call get_param(PF, mdl, "OBC_PROJECTION_BUG", OBC_projection_bug, &
-                 "If false, use only interior ocean points at OBCs to specify several "//&
-                 "calculations at OBC points, and it avoids applying a land mask at the bay-like "//&
-                 "intersection of orthogonal OBC segments.  Otherwise the calculation of terms "//&
-                 "like the potential vorticity used in the barotropic solver relies on bathymetry "//&
-                 "or other fields being projected outward across OBCs.  This option changes "//&
-                 "answers for some configurations that use OBCs.", &
-                 default=enable_bugs, do_not_log=.not.associated(OBC))
-  open_corners = .not.OBC_projection_bug
-
-  if (associated(OBC) .and. OBC_projection_bug .and. read_meanSL_file) &
-    ! OBC_projection_bug modifies bathyT outside of the open boundaries, so meanSL would have to be
-    ! modified as well.
-    call MOM_error(FATAL, "MOM_initialize_fixed: To read mean sea level file, "//&
-                   "OBC_PROJECTION_BUG needs to be False.")
-
-  ! This call sets masks that prohibit flow over any point interpreted as land
+  ! Make bathymetry (if OBC_PROJECTION_BUG) and masks consistent with open boundaries.
   if (associated(OBC)) then
+    call get_param(PF, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
+                   default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
+    call get_param(PF, mdl, "OBC_PROJECTION_BUG", OBC_projection_bug, &
+                   "If false, use only interior ocean points at OBCs to specify several "//&
+                   "calculations at OBC points, and it avoids applying a land mask at the "//&
+                   "bay-like intersection of orthogonal OBC segments.  Otherwise the "//&
+                   "calculation of terms like the potential vorticity used in the barotropic "//&
+                   "solver relies on bathymetry or other fields being projected outward across "//&
+                   "OBCs.  This option changes answers for some configurations that use OBCs.", &
+                   default=enable_bugs)
+    open_corners = .not.OBC_projection_bug
+
+    if (OBC_projection_bug .and. read_meanSL_file) &
+      ! OBC_projection_bug modifies bathyT outside of the open boundaries, so meanSL would have to be
+      ! modified as well.
+      call MOM_error(FATAL, "MOM_initialize_fixed: To read mean sea level file, "//&
+                     "OBC_PROJECTION_BUG needs to be False.")
+
+    ! This call sets masks that prohibit flow over any point interpreted as land
     if (OBC_projection_bug) &
       call open_boundary_impose_normal_slope(OBC, G, G%bathyT)
-    call initialize_masks(G, PF, US, OBC_dir_u=OBC%segnum_u, OBC_dir_v=OBC%segnum_v, open_corner_OBCs=open_corners)
+    call initialize_masks(G, PF, US, OBC_dir_u=OBC%segnum_u, OBC_dir_v=OBC%segnum_v, &
+                          open_corner_OBCs=open_corners)
+    ! Make OBC mask consistent with land mask
+    call open_boundary_impose_land_mask(OBC, G, G%areaCu, G%areaCv, US)
   else
     call initialize_masks(G, PF, US)
   endif
-
-  ! Make OBC mask consistent with land mask
-  call open_boundary_impose_land_mask(OBC, G, G%areaCu, G%areaCv, US)
 
   if (debug) then
     call hchksum(G%bathyT, 'MOM_initialize_fixed: depth ', G%HI, haloshift=1, unscale=US%Z_to_m)

--- a/src/initialization/MOM_fixed_initialization.F90
+++ b/src/initialization/MOM_fixed_initialization.F90
@@ -60,7 +60,6 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
                                                  !! to parse for model parameter values.
 
   ! Local variables
-  character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
   logical            :: OBC_projection_bug, open_corners, enable_bugs
   logical            :: read_porous_file, read_meanSL_file
@@ -71,20 +70,15 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
 # include "version_variable.h"
 
   call callTree_enter("MOM_initialize_fixed(), MOM_fixed_initialization.F90")
-  call log_version(PF, mdl, version, "")
   call get_param(PF, mdl, "DEBUG", debug, default=.false.)
-
-  call get_param(PF, mdl, "INPUTDIR", inputdir, &
-         "The directory in which input files are found.", default=".")
-  inputdir = slasher(inputdir)
 
   ! Set up the parameters of the physical domain (i.e. the grid), G
   call set_grid_metrics(G, PF, US)
 
-  ! Calculate time mean ocean total thickness
+  ! Read time mean sea level from file
   call get_param(PF, mdl, "READ_MEAN_SEA_LEVEL", read_meanSL_file, &
-                "If true, use a 2D map for time mean sea level, which is used to calculate "// &
-                "time mean ocean total thickness.", default=.False.)
+                 "If true, use a 2D map for time mean sea level, which is used to calculate "// &
+                 "time mean ocean total thickness.", default=.False.)
   if (read_meanSL_file) &
     call set_meanSL_from_file(G%meanSL, G, PF, US)
 
@@ -138,6 +132,9 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
     call qchksum(G%mask2dBu, 'MOM_initialize_fixed: mask2dBu ', G%HI)
   endif
 
+  ! Set up other fixed quantities
+  ! Parameters below are logged under "module MOM_fixed_initialization".
+  call log_version(PF, mdl, version, "")
   ! Modulate geometric scales according to geography.
   call get_param(PF, mdl, "CHANNEL_CONFIG", config, &
                  "A parameter that determines which set of channels are \n"//&
@@ -182,12 +179,12 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
   if (read_porous_file) &
     call set_subgrid_topo_at_vel_from_file(G, PF, US)
 
-!    Calculate the value of the Coriolis parameter at the latitude   !
-!  of the q grid points [T-1 ~> s-1].
+  !    Calculate the value of the Coriolis parameter at the latitude   !
+  !  of the q grid points [T-1 ~> s-1].
   call MOM_initialize_rotation(G%CoriolisBu, G, PF, US=US)
-!   Calculate the components of grad f (beta)
+  !   Calculate the components of grad f (beta)
   call MOM_calculate_grad_Coriolis(G%dF_dx, G%dF_dy, G, US=US)
-!   Calculate the square of the Coriolis parameter
+  !   Calculate the square of the Coriolis parameter
   do I=G%IsdB,G%IedB ; do J=G%JsdB,G%JedB
     G%Coriolis2Bu(I,J) = G%CoriolisBu(I,J)**2
   enddo ; enddo
@@ -201,7 +198,7 @@ subroutine MOM_initialize_fixed(G, US, OBC, PF)
 
   call initialize_grid_rotation_angle(G, PF)
 
-! Compute global integrals of grid values for later use in scalar diagnostics !
+  ! Compute global integrals of grid values for later use in scalar diagnostics !
   call compute_global_grid_integrals(G, US=US)
 
   call callTree_leave('MOM_initialize_fixed()')

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -24,7 +24,6 @@ use MOM_open_boundary, only : ocean_OBC_type, open_boundary_test_extern_h
 use MOM_open_boundary, only : fill_temp_salt_segments, setup_OBC_tracer_reservoirs
 use MOM_open_boundary, only : fill_thickness_segments
 use MOM_open_boundary, only : set_initialized_OBC_tracer_reservoirs
-use MOM_grid_initialize, only : initialize_masks, set_grid_metrics
 use MOM_restart, only : restore_state, is_new_run, copy_restart_var, copy_restart_vector
 use MOM_restart, only : restart_registry_lock, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, set_up_sponge_ML_density


### PR DESCRIPTION
This PR has two commits

16ffe1803014b7847f865fed26e63fd3d2fe8934 is meant to fix the issue that all parameters in MOM_initialize_fixed after OBC are logged under module MOM_open_boundary in MOM_parameter_doc.

By moving `log_version` call after OBC, parameters from MOM_initialize_fixed are now logged under three "modules" in
MOM_parameter_doc:
1. module MOM_grid_init, parameters before OBC, which also (incorrectly) includes topography related parameters.
2. module MOM_open_boundary
3. module MOM_initialize_fixed, parameters after OBC

This is a hack rather than a fix.

83140ad5f3b050adacaefa815d2929e4536f8cf2 makes OBC related calls in `MOM_initialize_fixed` explicitly conditional for readability. ~It also removes `if (associated(OBC)` in `open_boundary_config` and reduces one level of indentation. 
(I realize that unlike VScode, github treats moving indentation as line change, which makes it difficult to review.)~
Edit: retain the `if (associated(OBC)` and indentation for now for easier review. 

There is no answer change, but MOM_parameter_doc would be modified.