### PR TITLE
Add vertical tracer flux diagnostic for dye tracers

### DIFF
--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -345,7 +345,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
     call initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag, OBC, CS%MARBL_tracers_CSp, &
                                 sponge_CSp)
   if (CS%use_regional_dyes) &
-    call initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%dye_tracer_CSp, sponge_CSp, tv)
+    call initialize_dye_tracer(restart, day, G, GV, US, h, diag, OBC, CS%dye_tracer_CSp, sponge_CSp, tv)
   if (CS%use_oil) &
     call initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS%oil_tracer_CSp, sponge_CSp)
   if (CS%use_advection_test_tracer) &

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -243,7 +243,7 @@ subroutine initialize_dye_tracer(restart, day, G, GV, US, h, diag, OBC, CS, spon
     write(var_name,'(A,I3.3,A)') "dye",m,"_dia_diff"
     write(longname,'(A,I3.3,A)') "Vertical diffusive flux of dye ",m," (positive up)"
     CS%id_tr_dia_diff(m) = register_diag_field('ocean_model', trim(var_name), &
-        diag%axesTL, day, trim(longname), 'conc H s-1', conversion=GV%H_to_MKS*US%s_to_T)
+        diag%axesTi, day, trim(longname), 'conc H s-1', conversion=GV%H_to_MKS*US%s_to_T)
   enddo
 
   ! Establish location of source
@@ -306,7 +306,7 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: vert_flux ! Vertical tracer flux positive upward
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: vert_flux ! Vertical tracer flux positive upward
                                               !! [conc H T-1 ~> conc m s-1]
   real    :: dz(SZI_(G),SZK_(GV)) ! Height change across layers [Z ~> m]
   real    :: z_bot    ! Height of the bottom of the layer relative to the sea surface [Z ~> m]
@@ -333,11 +333,12 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
       ! Calculate net vertical flux from entrainment
       ! Net flux = upward component - downward component
       ! Upward (from below): eb(k) * tr(k+1), Downward (from above): ea(k+1) * tr(k)
-      do k=1,nz ; do j=js,je ; do i=is,ie
-        vert_flux(i,j,k) = 0.0
-        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) + eb(i,j,k) * CS%tr(i,j,k+1,m) * Idt
-        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) - ea(i,j,k+1) * CS%tr(i,j,k,m) * Idt
+      do K=2,nz ; do j=js,je ; do i=is,ie
+        vert_flux(i,j,K) = 0.0
+        if (K < nz) vert_flux(i,j,K) = vert_flux(i,j,k) + (eb(i,j,k) * CS%tr(i,j,k+1,m)) * Idt
+        if (K < nz) vert_flux(i,j,K) = vert_flux(i,j,k) - (ea(i,j,k+1) * CS%tr(i,j,k,m)) * Idt
       enddo ; enddo ; enddo
+      do j=js,je ; do i=is,ie ; vert_flux(i,j,1) = 0.0 ; vert_flux(i,j,nz+1) = 0.0 ; enddo ; enddo
 
       ! Post diagnostic
       if (CS%id_tr_dia_diff(m) > 0) &
@@ -350,11 +351,12 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
       ! Calculate net vertical flux from entrainment
       ! Net flux = upward component - downward component
       ! Upward (from below): eb(k) * tr(k+1), Downward (from above): ea(k+1) * tr(k)
-      do k=1,nz ; do j=js,je ; do i=is,ie
-        vert_flux(i,j,k) = 0.0
-        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) + eb(i,j,k) * CS%tr(i,j,k+1,m) * Idt
-        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) - ea(i,j,k+1) * CS%tr(i,j,k,m) * Idt
+      do K=2,nz ; do j=js,je ; do i=is,ie
+        vert_flux(i,j,K) = 0.0
+        if (k < nz) vert_flux(i,j,K) = vert_flux(i,j,k) + (eb(i,j,k) * CS%tr(i,j,k+1,m)) * Idt
+        if (k < nz) vert_flux(i,j,K) = vert_flux(i,j,k) - (ea(i,j,k+1) * CS%tr(i,j,k,m)) * Idt
       enddo ; enddo ; enddo
+      do j=js,je ; do i=is,ie ; vert_flux(i,j,1) = 0.0 ; vert_flux(i,j,nz+1) = 0.0 ; enddo ; enddo
 
       ! Post diagnostic
       if (CS%id_tr_dia_diff(m) > 0) &

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -5,7 +5,7 @@ module regional_dyes
 
 use MOM_coms,               only : EFP_type
 use MOM_coupler_types,      only : set_coupler_type_data, atmos_ocn_coupler_flux
-use MOM_diag_mediator,      only : diag_ctrl
+use MOM_diag_mediator,      only : diag_ctrl, post_data, register_diag_field
 use MOM_error_handler,      only : MOM_error, FATAL, WARNING
 use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,       only : forcing
@@ -58,6 +58,8 @@ type, public :: dye_tracer_CS ; private
 
   integer, allocatable, dimension(:) :: ind_tr !< Indices returned by atmos_ocn_coupler_flux if it is used and the
                                                !! surface tracer concentrations are to be provided to the coupler.
+
+  integer, allocatable, dimension(:) :: id_tr_dia_diff !< Diagnostic IDs for vertical tracer fluxes (positive up)
 
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                    !! regulate the timing of diagnostic output.
@@ -116,6 +118,8 @@ function register_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
            CS%dye_source_maxdepth(CS%ntr))
   allocate(CS%ind_tr(CS%ntr))
   allocate(CS%tr_desc(CS%ntr))
+  allocate(CS%id_tr_dia_diff(CS%ntr))
+  CS%id_tr_dia_diff(:) = -1
 
   CS%dye_source_minlon(:) = -1.e30
   call get_param(param_file, mdl, "DYE_SOURCE_MINLON", CS%dye_source_minlon, &
@@ -204,12 +208,13 @@ end function register_dye_tracer
 
 !> This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
 !! and it sets up the tracer output.
-subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_CSp, tv)
+subroutine initialize_dye_tracer(restart, day, G, GV, US, h, diag, OBC, CS, sponge_CSp, tv)
   logical,                            intent(in) :: restart !< .true. if the fields have already been
                                                             !! read from a restart file.
   type(time_type), target,            intent(in) :: day  !< Time of the start of the run.
   type(ocean_grid_type),              intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type),            intent(in) :: GV   !< The ocean's vertical grid structure
+  type(unit_scale_type),              intent(in) :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thicknesses [H ~> m or kg m-2]
   type(diag_ctrl), target,            intent(in) :: diag !< Structure used to regulate diagnostic output.
   type(ocean_OBC_type),               pointer    :: OBC  !< This open boundary condition type specifies
@@ -222,6 +227,7 @@ subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_C
   type(thermo_var_ptrs),              intent(in) :: tv   !< A structure pointing to various thermodynamic variables
 
   ! Local variables
+  character(len=64)  :: var_name, longname
   real    :: dz(SZI_(G),SZK_(GV)) ! Height change across layers [Z ~> m]
   real    :: z_bot    ! Height of the bottom of the layer relative to the sea surface [Z ~> m]
   real    :: z_center ! Height of the center of the layer relative to the sea surface [Z ~> m]
@@ -231,6 +237,14 @@ subroutine initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_C
   if (CS%ntr < 1) return
 
   CS%diag => diag
+
+  ! Register vertical flux diagnostic
+  do m = 1, CS%ntr
+    write(var_name,'(A,I3.3,A)') "dye",m,"_dia_diff"
+    write(longname,'(A,I3.3,A)') "Vertical diffusive flux of dye ",m," (positive up)"
+    CS%id_tr_dia_diff(m) = register_diag_field('ocean_model', trim(var_name), &
+        diag%axesTL, day, trim(longname), 'conc H s-1', conversion=GV%H_to_MKS*US%s_to_T)
+  enddo
 
   ! Establish location of source
   do j=G%jsc,G%jec
@@ -292,15 +306,20 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: vert_flux ! Vertical tracer flux positive upward
+                                              !! [conc H T-1 ~> conc m s-1]
   real    :: dz(SZI_(G),SZK_(GV)) ! Height change across layers [Z ~> m]
   real    :: z_bot    ! Height of the bottom of the layer relative to the sea surface [Z ~> m]
   real    :: z_center ! Height of the center of the layer relative to the sea surface [Z ~> m]
+  real    :: Idt      ! Inverse of timestep [T-1 ~> s-1]
   integer :: i, j, k, is, ie, js, je, nz, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   if (.not.associated(CS)) return
   if (CS%ntr < 1) return
+
+  Idt = 1.0 / dt
 
   if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
     do m=1,CS%ntr
@@ -310,10 +329,36 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
       call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
                                           evap_CFL_limit, minimum_forcing_depth)
       call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+
+      ! Calculate net vertical flux from entrainment
+      ! Net flux = upward component - downward component
+      ! Upward (from below): eb(k) * tr(k+1), Downward (from above): ea(k+1) * tr(k)
+      do k=1,nz ; do j=js,je ; do i=is,ie
+        vert_flux(i,j,k) = 0.0
+        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) + eb(i,j,k) * CS%tr(i,j,k+1,m) * Idt
+        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) - ea(i,j,k+1) * CS%tr(i,j,k,m) * Idt
+      enddo ; enddo ; enddo
+
+      ! Post diagnostic
+      if (CS%id_tr_dia_diff(m) > 0) &
+        call post_data(CS%id_tr_dia_diff(m), vert_flux, CS%diag)
     enddo
   else
     do m=1,CS%ntr
       call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+
+      ! Calculate net vertical flux from entrainment
+      ! Net flux = upward component - downward component
+      ! Upward (from below): eb(k) * tr(k+1), Downward (from above): ea(k+1) * tr(k)
+      do k=1,nz ; do j=js,je ; do i=is,ie
+        vert_flux(i,j,k) = 0.0
+        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) + eb(i,j,k) * CS%tr(i,j,k+1,m) * Idt
+        if (k < nz) vert_flux(i,j,k) = vert_flux(i,j,k) - ea(i,j,k+1) * CS%tr(i,j,k,m) * Idt
+      enddo ; enddo ; enddo
+
+      ! Post diagnostic
+      if (CS%id_tr_dia_diff(m) > 0) &
+        call post_data(CS%id_tr_dia_diff(m), vert_flux, CS%diag)
     enddo
   endif
 

--- a/src/tracer/dye_example.F90
+++ b/src/tracer/dye_example.F90
@@ -334,9 +334,7 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
       ! Net flux = upward component - downward component
       ! Upward (from below): eb(k) * tr(k+1), Downward (from above): ea(k+1) * tr(k)
       do K=2,nz ; do j=js,je ; do i=is,ie
-        vert_flux(i,j,K) = 0.0
-        if (K < nz) vert_flux(i,j,K) = vert_flux(i,j,k) + (eb(i,j,k) * CS%tr(i,j,k+1,m)) * Idt
-        if (K < nz) vert_flux(i,j,K) = vert_flux(i,j,k) - (ea(i,j,k+1) * CS%tr(i,j,k,m)) * Idt
+        vert_flux(i,j,K) = (eb(i,j,k-1) * CS%tr(i,j,k,m) - ea(i,j,k) * CS%tr(i,j,k-1,m)) * Idt
       enddo ; enddo ; enddo
       do j=js,je ; do i=is,ie ; vert_flux(i,j,1) = 0.0 ; vert_flux(i,j,nz+1) = 0.0 ; enddo ; enddo
 
@@ -352,9 +350,7 @@ subroutine dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
       ! Net flux = upward component - downward component
       ! Upward (from below): eb(k) * tr(k+1), Downward (from above): ea(k+1) * tr(k)
       do K=2,nz ; do j=js,je ; do i=is,ie
-        vert_flux(i,j,K) = 0.0
-        if (k < nz) vert_flux(i,j,K) = vert_flux(i,j,k) + (eb(i,j,k) * CS%tr(i,j,k+1,m)) * Idt
-        if (k < nz) vert_flux(i,j,K) = vert_flux(i,j,k) - (ea(i,j,k+1) * CS%tr(i,j,k,m)) * Idt
+        vert_flux(i,j,K) = (eb(i,j,k-1) * CS%tr(i,j,k,m) - ea(i,j,k) * CS%tr(i,j,k-1,m)) * Idt
       enddo ; enddo ; enddo
       do j=js,je ; do i=is,ie ; vert_flux(i,j,1) = 0.0 ; vert_flux(i,j,nz+1) = 0.0 ; enddo ; enddo
 


### PR DESCRIPTION
- Register vertical flux diagnostic in initialize_dye_tracer
- Calculate net vertical flux from entrainment (positive upward)
- Post flux diagnostic in dye_tracer_column_physics