### PR TITLE
Unified OBC Vorticity/Strain Configuration

### DIFF
--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -14,6 +14,8 @@ use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
 use MOM_open_boundary, only : ocean_OBC_type, OBC_DIRECTION_E, OBC_DIRECTION_W
 use MOM_open_boundary, only : OBC_DIRECTION_N, OBC_DIRECTION_S
+use MOM_open_boundary, only : OBC_VORTICITY_ZERO, OBC_VORTICITY_FREESLIP
+use MOM_open_boundary, only : OBC_VORTICITY_COMPUTED, OBC_VORTICITY_SPECIFIED
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : accel_diag_ptrs, porous_barrier_type
@@ -375,26 +377,32 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
       if (.not. OBC%segment(n)%on_pe) cycle
       I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
       if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
-        if (OBC%zero_vorticity) then ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-          dvdx(I,J) = 0. ; dudy(I,J) = 0.
-        enddo ; endif
-        if (OBC%freeslip_vorticity) then ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-          dudy(I,J) = 0.
-        enddo ; endif
-        if (OBC%computed_vorticity) then ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-          if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-            dudy(I,J) = 2.0*(OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%dxCu(I,j)
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-            dudy(I,J) = 2.0*(u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%dxCu(I,j+1)
-          endif
-        enddo ; endif
-        if (OBC%specified_vorticity) then ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-          if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-            dudy(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dxCu(I,j)*G%dyBu(I,J)
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-            dudy(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dxCu(I,j+1)*G%dyBu(I,J)
-          endif
-        enddo ; endif
+        select case (OBC%vorticity_config)
+          case (OBC_VORTICITY_ZERO)
+            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+              dvdx(I,J) = 0. ; dudy(I,J) = 0.
+            enddo
+          case (OBC_VORTICITY_FREESLIP)
+            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+              dudy(I,J) = 0.
+            enddo
+          case (OBC_VORTICITY_COMPUTED)
+            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+              if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                dudy(I,J) = 2.0*(OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%dxCu(I,j)
+              else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+                dudy(I,J) = 2.0*(u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%dxCu(I,j+1)
+              endif
+            enddo
+          case (OBC_VORTICITY_SPECIFIED)
+            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+              if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                dudy(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dxCu(I,j)*G%dyBu(I,J)
+              else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+                dudy(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dxCu(I,j+1)*G%dyBu(I,J)
+              endif
+            enddo
+        end select
 
         ! Project thicknesses across OBC points with a no-gradient condition.
         do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
@@ -415,26 +423,32 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
           enddo
         endif
       elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
-        if (OBC%zero_vorticity) then ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-          dvdx(I,J) = 0. ; dudy(I,J) = 0.
-        enddo ; endif
-        if (OBC%freeslip_vorticity) then ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-          dvdx(I,J) = 0.
-        enddo ; endif
-        if (OBC%computed_vorticity) then ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-          if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-            dvdx(I,J) = 2.0*(OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%dyCv(i,J)
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-            dvdx(I,J) = 2.0*(v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%dyCv(i+1,J)
-          endif
-        enddo ; endif
-        if (OBC%specified_vorticity) then ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-          if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-            dvdx(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dyCv(i,J)*G%dxBu(I,J)
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-            dvdx(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dyCv(i+1,J)*G%dxBu(I,J)
-          endif
-        enddo ; endif
+        select case (OBC%vorticity_config)
+          case (OBC_VORTICITY_ZERO)
+            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+              dvdx(I,J) = 0. ; dudy(I,J) = 0.
+            enddo
+          case (OBC_VORTICITY_FREESLIP)
+            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+              dvdx(I,J) = 0.
+            enddo
+          case (OBC_VORTICITY_COMPUTED)
+            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+              if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                dvdx(I,J) = 2.0*(OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%dyCv(i,J)
+              else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+                dvdx(I,J) = 2.0*(v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%dyCv(i+1,J)
+              endif
+            enddo
+          case (OBC_VORTICITY_SPECIFIED)
+            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+              if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                dvdx(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dyCv(i,J)*G%dxBu(I,J)
+              else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+                dvdx(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dyCv(i+1,J)*G%dxBu(I,J)
+              endif
+            enddo
+        end select
 
         ! Project thicknesses across OBC points with a no-gradient condition.
         do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -13,14 +13,13 @@ use MOM_domains,              only : create_group_pass, do_group_pass, group_pas
 use MOM_domains,              only : To_All, EAST_FACE, NORTH_FACE, SCALAR_PAIR, CGRID_NE, CORNER
 use MOM_dyn_horgrid,          only : dyn_horgrid_type
 use MOM_error_handler,        only : MOM_mesg, MOM_error, FATAL, WARNING, NOTE, is_root_pe
-use MOM_file_parser,          only : get_param, log_version, param_file_type, log_param
+use MOM_file_parser,          only : get_param, log_version, param_file_type, read_param
 use MOM_grid,                 only : ocean_grid_type, hor_index_type
 use MOM_interface_heights,    only : thickness_to_dz
 use MOM_interpolate,          only : init_external_field, time_interp_external, time_interp_external_init
 use MOM_interpolate,          only : external_field
 use MOM_io,                   only : slasher, field_size, file_exists, stderr, SINGLE_FILE
 use MOM_io,                   only : vardesc, query_vardesc, var_desc
-use MOM_obsolete_params,      only : obsolete_logical, obsolete_int, obsolete_real, obsolete_char
 use MOM_regridding,           only : regridding_CS
 use MOM_remapping,            only : remappingSchemesDoc, remappingDefaultScheme, remapping_CS
 use MOM_remapping,            only : initialize_remapping, remapping_core_h, end_remapping
@@ -87,6 +86,20 @@ integer, parameter, public :: OBC_DIRECTION_N = 100 !< Indicates the boundary is
 integer, parameter, public :: OBC_DIRECTION_S = 200 !< Indicates the boundary is an effective southern boundary
 integer, parameter, public :: OBC_DIRECTION_E = 300 !< Indicates the boundary is an effective eastern boundary
 integer, parameter, public :: OBC_DIRECTION_W = 400 !< Indicates the boundary is an effective western boundary
+!>@{ Enumeration values for OBC relative vorticity configurations
+integer, parameter, public :: OBC_VORTICITY_NONE = 0
+integer, parameter, public :: OBC_VORTICITY_ZERO = 1
+integer, parameter, public :: OBC_VORTICITY_FREESLIP = 2
+integer, parameter, public :: OBC_VORTICITY_COMPUTED = 3
+integer, parameter, public :: OBC_VORTICITY_SPECIFIED = 4
+!>@}
+!>@{ Enumeration values for OBC strain configurations
+integer, parameter, public :: OBC_STRAIN_NONE = 0
+integer, parameter, public :: OBC_STRAIN_ZERO = 1
+integer, parameter, public :: OBC_STRAIN_FREESLIP = 2
+integer, parameter, public :: OBC_STRAIN_COMPUTED = 3
+integer, parameter, public :: OBC_STRAIN_SPECIFIED = 4
+!>@}
 integer, parameter         :: MAX_OBC_FIELDS = 100  !< Maximum number of data fields needed for OBC segments
 
 !> Open boundary segment data from files (mostly).
@@ -325,20 +338,8 @@ type, public :: ocean_OBC_type
                                                       !! require less frequent update
   logical :: needs_IO_for_data = .false.              !< Is any i/o needed for OBCs on the current PE
   logical :: any_needs_IO_for_data = .false.          !< Is any i/o needed for OBCs globally
-  logical :: zero_vorticity = .false.                 !< If True, sets relative vorticity to zero on open boundaries.
-  logical :: freeslip_vorticity = .false.             !< If True, sets normal gradient of tangential velocity to zero
-                                                      !! in the relative vorticity on open boundaries.
-  logical :: computed_vorticity = .false.             !< If True, uses external data for tangential velocity
-                                                      !! in the relative vorticity on open boundaries.
-  logical :: specified_vorticity = .false.            !< If True, uses external data for tangential velocity
-                                                      !! gradients in the relative vorticity on open boundaries.
-  logical :: zero_strain = .false.                    !< If True, sets strain to zero on open boundaries.
-  logical :: freeslip_strain = .false.                !< If True, sets normal gradient of tangential velocity to zero
-                                                      !! in the strain on open boundaries.
-  logical :: computed_strain = .false.                !< If True, uses external data for tangential velocity to compute
-                                                      !! normal gradient in the strain on open boundaries.
-  logical :: specified_strain = .false.               !< If True, uses external data for tangential velocity gradients
-                                                      !! to compute strain on open boundaries.
+  integer :: vorticity_config                         !< An integer indicating OBC relative vorticity configuration
+  integer :: strain_config                            !< An integer indicating OBC strain configuration
   logical :: zero_biharmonic = .false.                !< If True, zeros the Laplacian of flow on open boundaries for
                                                       !! use in the biharmonic viscosity term.
   logical :: brushcutter_mode = .false.               !< If True, read data on supergrid.
@@ -511,13 +512,16 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   logical :: debug, mask_outside, reentrant_x, reentrant_y
   character(len=15) :: segment_param_str ! The run-time parameter name for each segment
   character(len=1024) :: segment_str      ! The contents (rhs) for parameter "segment_param_str"
-  character(len=200) :: config1          ! String for OBC_USER_CONFIG
+  character(len=200) :: config ! A string to temporarily store a few runtime parameters
   real               :: Lscale_in, Lscale_out ! parameters controlling tracer values at the boundaries [L ~> m]
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   logical :: enable_bugs     ! If true, the defaults for recently added bug-fix flags are set to
                              ! recreate the bugs, or if false bugs are only used if actively selected.
   logical :: debugging_tests ! If true, do additional calls resetting values to help debug the performance
                              ! of the open boundary condition code.
+  logical :: obsolete_param_set, param_set
+  logical :: zero_vorticity, freeslip_vorticity, computed_vorticity, specified_vorticity
+  logical :: zero_strain, freeslip_strain, computed_strain, specified_strain
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
 
@@ -532,62 +536,142 @@ subroutine open_boundary_config(G, US, param_file, OBC)
 
   allocate(OBC)
   OBC%number_of_segments = num_of_segs
-  call get_param(param_file, mdl, "OBC_USER_CONFIG", config1, &
+  call get_param(param_file, mdl, "OBC_USER_CONFIG", config, &
                  "A string that sets how the open boundary conditions are "//&
                  " configured: \n", default="none", do_not_log=.true.)
   call get_param(param_file, mdl, "NK", OBC%ke, &
                  "The number of model layers", default=0, do_not_log=.true.)
 
-  if (config1 /= "none" .and. config1 /= "dyed_obcs") OBC%user_BCs_set_globally = .true.
+  if (config /= "none" .and. config /= "dyed_obcs") OBC%user_BCs_set_globally = .true.
 
-  call get_param(param_file, mdl, "OBC_ZERO_VORTICITY", OBC%zero_vorticity, &
-       "If true, sets relative vorticity to zero on open boundaries.", &
-       default=.false.)
-  call get_param(param_file, mdl, "OBC_FREESLIP_VORTICITY", OBC%freeslip_vorticity, &
-       "If true, sets the normal gradient of tangential velocity to "//&
-       "zero in the relative vorticity on open boundaries. This cannot "//&
-       "be true if another OBC_XXX_VORTICITY option is True.", default=.true.)
-  call get_param(param_file, mdl, "OBC_COMPUTED_VORTICITY", OBC%computed_vorticity, &
-       "If true, uses the external values of tangential velocity "//&
-       "in the relative vorticity on open boundaries. This cannot "//&
-       "be true if another OBC_XXX_VORTICITY option is True.", default=.false.)
-  call get_param(param_file, mdl, "OBC_SPECIFIED_VORTICITY", OBC%specified_vorticity, &
-       "If true, uses the external values of tangential velocity "//&
-       "in the relative vorticity on open boundaries. This cannot "//&
-       "be true if another OBC_XXX_VORTICITY option is True.", default=.false.)
-  if ((OBC%zero_vorticity .and. OBC%freeslip_vorticity) .or.  &
-      (OBC%zero_vorticity .and. OBC%computed_vorticity) .or.  &
-      (OBC%zero_vorticity .and. OBC%specified_vorticity) .or.  &
-      (OBC%freeslip_vorticity .and. OBC%computed_vorticity) .or.  &
-      (OBC%freeslip_vorticity .and. OBC%specified_vorticity) .or.  &
-      (OBC%computed_vorticity .and. OBC%specified_vorticity))  &
-    call MOM_error(FATAL, "MOM_open_boundary.F90, open_boundary_config:\n"//&
-    "Only one of OBC_ZERO_VORTICITY, OBC_FREESLIP_VORTICITY, OBC_COMPUTED_VORTICITY\n"//&
-    "and OBC_IMPORTED_VORTICITY can be True at once.")
-  call get_param(param_file, mdl, "OBC_ZERO_STRAIN", OBC%zero_strain, &
-       "If true, sets the strain used in the stress tensor to zero on open boundaries.", &
-       default=.false.)
-  call get_param(param_file, mdl, "OBC_FREESLIP_STRAIN", OBC%freeslip_strain, &
-       "If true, sets the normal gradient of tangential velocity to "//&
-       "zero in the strain use in the stress tensor on open boundaries. This cannot "//&
-       "be true if another OBC_XXX_STRAIN option is True.", default=.true.)
-  call get_param(param_file, mdl, "OBC_COMPUTED_STRAIN", OBC%computed_strain, &
-       "If true, sets the normal gradient of tangential velocity to "//&
-       "zero in the strain use in the stress tensor on open boundaries. This cannot "//&
-       "be true if another OBC_XXX_STRAIN option is True.", default=.false.)
-  call get_param(param_file, mdl, "OBC_SPECIFIED_STRAIN", OBC%specified_strain, &
-       "If true, sets the normal gradient of tangential velocity to "//&
-       "zero in the strain use in the stress tensor on open boundaries. This cannot "//&
-       "be true if another OBC_XXX_STRAIN option is True.", default=.false.)
-  if ((OBC%zero_strain .and. OBC%freeslip_strain) .or.  &
-      (OBC%zero_strain .and. OBC%computed_strain) .or.  &
-      (OBC%zero_strain .and. OBC%specified_strain) .or.  &
-      (OBC%freeslip_strain .and. OBC%computed_strain) .or.  &
-      (OBC%freeslip_strain .and. OBC%specified_strain) .or.  &
-      (OBC%computed_strain .and. OBC%specified_strain))  &
-    call MOM_error(FATAL, "MOM_open_boundary.F90, open_boundary_config: \n"//&
-    "Only one of OBC_ZERO_STRAIN, OBC_FREESLIP_STRAIN, OBC_COMPUTED_STRAIN \n"//&
-    "and OBC_IMPORTED_STRAIN can be True at once.")
+  ! Configuration for OBC relative vorticity.
+  !   Old setup method
+  obsolete_param_set = .false.
+  zero_vorticity = .false.
+  call read_param(param_file, "OBC_ZERO_VORTICITY", zero_vorticity, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  freeslip_vorticity = .true.
+  call read_param(param_file, "OBC_FREESLIP_VORTICITY", freeslip_vorticity, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  computed_vorticity = .false.
+  call read_param(param_file, "OBC_COMPUTED_VORTICITY", computed_vorticity, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  specified_vorticity = .false.
+  call read_param(param_file, "OBC_SPECIFIED_VORTICITY", specified_vorticity, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  if (obsolete_param_set) then
+    call MOM_error(WARNING, 'OBC_ZERO_VORTICITY, OBC_FREESLIP_VORTICITY, OBC_COMPUTED_VORTICITY'//&
+                   ' and OBC_SPECIFIED_VORTICITY are obsolete, use OBC_VORTICITY_CONFIG instead.')
+    if ((zero_vorticity .and. freeslip_vorticity) .or.  &
+        (zero_vorticity .and. computed_vorticity) .or.  &
+        (zero_vorticity .and. specified_vorticity) .or.  &
+        (freeslip_vorticity .and. computed_vorticity) .or.  &
+        (freeslip_vorticity .and. specified_vorticity) .or.  &
+        (computed_vorticity .and. specified_vorticity))  &
+      call MOM_error(FATAL, "MOM_open_boundary.F90, open_boundary_config:\n"//&
+      "Only one of OBC_ZERO_VORTICITY, OBC_FREESLIP_VORTICITY, OBC_COMPUTED_VORTICITY\n"//&
+      "and OBC_IMPORTED_VORTICITY can be True at once.")
+    ! "config" is set from OBC_XXX_VORTICITY if they are used.
+    if (zero_vorticity) then
+      config = 'zero'
+    elseif (freeslip_vorticity) then
+      config = 'freeslip'
+    elseif (computed_vorticity) then
+      config = 'computed'
+    elseif (specified_vorticity) then
+      config = 'specified'
+    else
+      config = 'none'
+    endif
+  else
+    config = 'freeslip' ! Default
+  endif
+  !   New setup method (overrides old method if specified)
+  call read_param(param_file, "OBC_VORTICITY_CONFIG", config)
+  call get_param(param_file, mdl, "OBC_VORTICITY_CONFIG", config, &
+                 "Configuration for relative vorticity in momentum advection at open "//&
+                 "boundaries.  Options are: \n"// &
+                 " \t none      - No adjustment.\n"//&
+                 " \t zero      - Sets relative vorticity to zero.\n"//&
+                 " \t freeslip  - Sets the normal gradient of tangential velocity to zero.\n"//&
+                 " \t computed  - Computes the normal gradient of tangential velocity using\n"//&
+                 " \t             external values of tangential velocity.\n"//&
+                 " \t specified - Uses the external values of the normal gradient of\n"//&
+                 " \t             tangential velocity.", default="freeslip", do_not_read=.true.)
+  select case (trim(config))
+    case ("none")      ; OBC%vorticity_config = OBC_VORTICITY_NONE
+    case ("zero")      ; OBC%vorticity_config = OBC_VORTICITY_ZERO
+    case ("freeslip")  ; OBC%vorticity_config = OBC_VORTICITY_FREESLIP
+    case ("computed")  ; OBC%vorticity_config = OBC_VORTICITY_COMPUTED
+    case ("specified") ; OBC%vorticity_config = OBC_VORTICITY_SPECIFIED
+    case default
+      call MOM_error(FATAL, "MOM_open_boundary: Unrecognized OBC_VORTICITY_CONFIG: "//trim(config))
+  end select
+
+  ! Configuration for OBC strain.
+  !   Old setup method
+  obsolete_param_set = .false.
+  zero_strain = .false.
+  call read_param(param_file, "OBC_ZERO_STRAIN", zero_strain, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  freeslip_strain = .true.
+  call read_param(param_file, "OBC_FREESLIP_STRAIN", freeslip_strain, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  computed_strain = .false.
+  call read_param(param_file, "OBC_COMPUTED_STRAIN", computed_strain, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  specified_strain = .false.
+  call read_param(param_file, "OBC_SPECIFIED_STRAIN", specified_strain, set=param_set)
+  obsolete_param_set = obsolete_param_set .or. param_set
+  if (obsolete_param_set) then
+    call MOM_error(WARNING, 'OBC_ZERO_STRAIN, OBC_FREESLIP_STRAIN, OBC_COMPUTED_STRAIN'//&
+                   ' and OBC_SPECIFIED_STRAIN are obsolete, use OBC_STRAIN_CONFIG instead.')
+    if ((zero_strain .and. freeslip_strain) .or.  &
+        (zero_strain .and. computed_strain) .or.  &
+        (zero_strain .and. specified_strain) .or.  &
+        (freeslip_strain .and. computed_strain) .or.  &
+        (freeslip_strain .and. specified_strain) .or.  &
+        (computed_strain .and. specified_strain))  &
+      call MOM_error(FATAL, "MOM_open_boundary.F90, open_boundary_config: \n"//&
+      "Only one of OBC_ZERO_STRAIN, OBC_FREESLIP_STRAIN, OBC_COMPUTED_STRAIN \n"//&
+      "and OBC_IMPORTED_STRAIN can be True at once.")
+    ! "config" is set from OBC_XXX_STRAIN if they are used.
+    if (zero_strain) then
+      config = 'zero'
+    elseif (freeslip_strain) then
+      config = 'freeslip'
+    elseif (computed_strain) then
+      config = 'computed'
+    elseif (specified_strain) then
+      config = 'specified'
+    else
+      config = 'none'
+    endif
+  else
+    config = 'freeslip' ! Default
+  endif
+  !   New setup method (overrides old method if specified)
+  call read_param(param_file, "OBC_STRAIN_CONFIG", config)
+  call get_param(param_file, mdl, "OBC_STRAIN_CONFIG", config, &
+                 "Configuration for strain in horizontal viscosity at open boundaries.  "//&
+                 "Options are: \n"// &
+                 " \t none      - No adjustment.\n"//&
+                 " \t zero      - Sets strain to zero.\n"//&
+                 " \t freeslip  - Sets the normal gradient of tangential velocity to zero.\n"//&
+                 " \t computed  - Computes the normal gradient of tangential velocity using\n"//&
+                 " \t             external values of tangential velocity.\n"//&
+                 " \t specified - Uses the external values of the normal gradient of\n"//&
+                 " \t             tangential velocity.", default="freeslip", do_not_read=.true.)
+  select case (trim(config))
+    case ("none")      ; OBC%strain_config = OBC_STRAIN_NONE
+    case ("zero")      ; OBC%strain_config = OBC_STRAIN_ZERO
+    case ("freeslip")  ; OBC%strain_config = OBC_STRAIN_FREESLIP
+    case ("computed")  ; OBC%strain_config = OBC_STRAIN_COMPUTED
+    case ("specified") ; OBC%strain_config = OBC_STRAIN_SPECIFIED
+    case default
+      call MOM_error(FATAL, "MOM_open_boundary: Unrecognized OBC_STRAIN_CONFIG: "//trim(config))
+  end select
+
   call get_param(param_file, mdl, "OBC_ZERO_BIHARMONIC", OBC%zero_biharmonic, &
        "If true, zeros the Laplacian of flow on open boundaries in the biharmonic "//&
        "viscosity term.", default=.false.)
@@ -3963,15 +4047,18 @@ subroutine allocate_OBC_segment_data(OBC, segment)
     allocate(segment%normal_trans(IsdB:IedB,jsd:jed,OBC%ke), source=0.0)
     if (segment%nudged) &
       allocate(segment%nudged_normal_vel(IsdB:IedB,jsd:jed,OBC%ke), source=0.0)
-    if (segment%radiation_tan .or. segment%nudged_tan .or. segment%specified_tan .or. &
-        segment%oblique_tan .or. OBC%computed_vorticity .or. OBC%computed_strain) &
+    if (segment%radiation_tan .or. segment%nudged_tan .or. &
+        segment%specified_tan .or. segment%oblique_tan .or. &
+        (OBC%vorticity_config == OBC_VORTICITY_COMPUTED) .or. &
+        (OBC%strain_config == OBC_STRAIN_COMPUTED)) &
       allocate(segment%tangential_vel(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%nudged_tan) &
       allocate(segment%nudged_tangential_vel(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%nudged_grad) &
       allocate(segment%nudged_tangential_grad(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
-    if (OBC%specified_vorticity .or. OBC%specified_strain .or. segment%radiation_grad .or. &
-              segment%oblique_grad .or. segment%specified_grad) &
+    if (segment%radiation_grad .or. segment%oblique_grad .or. segment%specified_grad .or. &
+        (OBC%vorticity_config == OBC_VORTICITY_SPECIFIED) .or. &
+        (OBC%strain_config == OBC_STRAIN_SPECIFIED)) &
       allocate(segment%tangential_grad(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%oblique) then
       allocate(segment%grad_normal(JsdB:JedB,2,OBC%ke), source=0.0)
@@ -4001,15 +4088,18 @@ subroutine allocate_OBC_segment_data(OBC, segment)
     allocate(segment%normal_trans(isd:ied,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%nudged) &
       allocate(segment%nudged_normal_vel(isd:ied,JsdB:JedB,OBC%ke), source=0.0)
-    if (segment%radiation_tan .or. segment%nudged_tan .or. segment%specified_tan .or. &
-        segment%oblique_tan .or. OBC%computed_vorticity .or. OBC%computed_strain) &
+    if (segment%radiation_tan .or. segment%nudged_tan .or. &
+        segment%specified_tan .or. segment%oblique_tan .or. &
+        (OBC%vorticity_config == OBC_VORTICITY_COMPUTED) .or. &
+        (OBC%strain_config == OBC_STRAIN_COMPUTED)) &
       allocate(segment%tangential_vel(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%nudged_tan) &
       allocate(segment%nudged_tangential_vel(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%nudged_grad) &
       allocate(segment%nudged_tangential_grad(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
-    if (OBC%specified_vorticity .or. OBC%specified_strain .or. segment%radiation_grad .or. &
-              segment%oblique_grad .or. segment%specified_grad) &
+    if (segment%radiation_grad .or. segment%oblique_grad .or. segment%specified_grad .or. &
+        (OBC%vorticity_config == OBC_VORTICITY_SPECIFIED) .or. &
+        (OBC%strain_config == OBC_STRAIN_SPECIFIED)) &
       allocate(segment%tangential_grad(IsdB:IedB,JsdB:JedB,OBC%ke), source=0.0)
     if (segment%oblique) then
       allocate(segment%grad_normal(IsdB:IedB,2,OBC%ke), source=0.0)
@@ -6418,14 +6508,8 @@ subroutine rotate_OBC_config(OBC_in, G_in, OBC, G, turns)
   OBC%user_BCs_set_globally = OBC_in%user_BCs_set_globally
 
   ! These are conditionally read and set if number_of_segments > 0
-  OBC%zero_vorticity = OBC_in%zero_vorticity
-  OBC%freeslip_vorticity = OBC_in%freeslip_vorticity
-  OBC%computed_vorticity = OBC_in%computed_vorticity
-  OBC%specified_vorticity = OBC_in%specified_vorticity
-  OBC%zero_strain = OBC_in%zero_strain
-  OBC%freeslip_strain = OBC_in%freeslip_strain
-  OBC%computed_strain = OBC_in%computed_strain
-  OBC%specified_strain = OBC_in%specified_strain
+  OBC%vorticity_config = OBC_in%vorticity_config
+  OBC%strain_config = OBC_in%strain_config
   OBC%zero_biharmonic = OBC_in%zero_biharmonic
   OBC%silly_h = OBC_in%silly_h
   OBC%silly_u = OBC_in%silly_u
@@ -6860,14 +6944,6 @@ subroutine write_OBC_info(OBC, G, GV, US)
   if (OBC%update_OBC_seg_data) call MOM_mesg("update_OBC_seg_data", verb=1)
   if (OBC%needs_IO_for_data) call MOM_mesg("needs_IO_for_data", verb=1)
   if (OBC%any_needs_IO_for_data) call MOM_mesg("any_needs_IO_for_data", verb=1)
-  if (OBC%zero_vorticity) call MOM_mesg("zero_vorticity", verb=1)
-  if (OBC%freeslip_vorticity) call MOM_mesg("freeslip_vorticity", verb=1)
-  if (OBC%computed_vorticity) call MOM_mesg("computed_vorticity", verb=1)
-  if (OBC%specified_vorticity) call MOM_mesg("specified_vorticity", verb=1)
-  if (OBC%zero_strain) call MOM_mesg("zero_strain", verb=1)
-  if (OBC%freeslip_strain) call MOM_mesg("freeslip_strain", verb=1)
-  if (OBC%computed_strain) call MOM_mesg("computed_strain", verb=1)
-  if (OBC%specified_strain) call MOM_mesg("specified_strain", verb=1)
   if (OBC%zero_biharmonic) call MOM_mesg("zero_biharmonic", verb=1)
   if (OBC%brushcutter_mode) call MOM_mesg("brushcutter_mode", verb=1)
   if (OBC%check_reconstruction) call MOM_mesg("check_reconstruction", verb=1)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -97,8 +97,10 @@ type, public :: hor_visc_CS ; private
                              !! in setting the corner-point viscosities when USE_KH_BG_2D=True.
   real    :: Kh_bg_min       !< The minimum value allowed for Laplacian horizontal
                              !! viscosity [L2 T-1 ~> m2 s-1]. The default is 0.0.
-  logical :: FrictWork_bug    !< If true, retain an answer-changing bug in calculating FrictWork,
+  logical :: FrictWork_bug   !< If true, retain an answer-changing bug in calculating FrictWork,
                              !! which cancels the h in thickness flux and the h at velocity point.
+  logical :: OBC_strain_bug  !< If true, recover a bug that specified shear strain option at open
+                             !! boundaries cannot be applied.
   logical :: use_land_mask   !< Use the land mask for the computation of thicknesses
                              !! at velocity locations. This eliminates the dependence on
                              !! arbitrary values over land or outside of the domain.
@@ -441,6 +443,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   logical :: rescale_Kh
   logical :: find_FrictWork
   logical :: apply_OBC = .false.
+  logical :: apply_OBC_strain
   logical :: use_MEKE_Ku
   logical :: use_MEKE_Au
   logical :: skeb_use_frict
@@ -497,6 +500,12 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     apply_OBC = OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally
     apply_OBC = .true.
   endif ; endif ; endif
+
+  apply_OBC_strain = .false.
+  if (present(OBC)) then ; if (associated(OBC)) then
+    apply_OBC_strain = (OBC%zero_strain .or. OBC%freeslip_strain .or. OBC%computed_strain) &
+                       .or. ((.not. CS%OBC_strain_bug) .and. OBC%specified_strain)
+  endif ; endif
 
   if (.not.CS%initialized) call MOM_error(FATAL, &
          "MOM_hor_visc: Module must be initialized before it is used.")
@@ -666,7 +675,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
   !$OMP   is_vort, ie_vort, js_vort, je_vort, &
   !$OMP   is_Kh, ie_Kh, js_Kh, je_Kh, &
-  !$OMP   apply_OBC, rescale_Kh, find_FrictWork, use_kh_struct, skeb_use_frict, &
+  !$OMP   apply_OBC, apply_OBC_strain, rescale_Kh, find_FrictWork, use_kh_struct, skeb_use_frict, &
   !$OMP   use_MEKE_Ku, use_MEKE_Au, u_smooth, v_smooth, use_cont_huv, slope_x, slope_y, dz, &
   !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
   !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
@@ -782,7 +791,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! thicknesses on open boundaries.
     if (apply_OBC) then ; do n=1,OBC%number_of_segments
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
-      if (OBC%zero_strain .or. OBC%freeslip_strain .or. OBC%computed_strain) then
+      if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
           do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
             if (OBC%zero_strain) then
@@ -2642,7 +2651,9 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "If true, retain an answer-changing bug in calculating the FrictWork, "//&
                  "which cancels the h in thickness flux and the h at velocity point. This is"//&
                  "not recommended.", default=.false.)
-
+  call get_param(param_file, mdl, "OBC_SPECIFIED_STRAIN_BUG", CS%OBC_strain_bug, &
+                 "If true, recover a bug that specified shear strain option at open boundaries "//&
+                 "cannot be applied.", default=.true.)
   call get_param(param_file, mdl, "USE_GME", CS%use_GME, &
                  "If true, use the GM+E backscatter scheme in association \n"//&
                  "with the Gent and McWilliams parameterization.", default=.false.)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -20,7 +20,9 @@ use MOM_thickness_diffuse,     only : thickness_diffuse_CS, thickness_diffuse_ge
 use MOM_io,                    only : MOM_read_data, slasher
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, OBC_DIRECTION_E, OBC_DIRECTION_W
-use MOM_open_boundary,         only : OBC_DIRECTION_N, OBC_DIRECTION_S, OBC_NONE
+use MOM_open_boundary,         only : OBC_DIRECTION_N, OBC_DIRECTION_S
+use MOM_open_boundary,         only : OBC_STRAIN_NONE, OBC_STRAIN_ZERO, OBC_STRAIN_FREESLIP
+use MOM_open_boundary,         only : OBC_STRAIN_COMPUTED, OBC_STRAIN_SPECIFIED
 use MOM_stochastics,           only : stochastic_CS
 use MOM_unit_scaling,          only : unit_scale_type
 use MOM_verticalGrid,          only : verticalGrid_type
@@ -503,8 +505,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   apply_OBC_strain = .false.
   if (present(OBC)) then ; if (associated(OBC)) then
-    apply_OBC_strain = (OBC%zero_strain .or. OBC%freeslip_strain .or. OBC%computed_strain) &
-                       .or. ((.not. CS%OBC_strain_bug) .and. OBC%specified_strain)
+    apply_OBC_strain = (OBC%strain_config /= OBC_STRAIN_NONE) &
+      .and. ((.not. CS%OBC_strain_bug) .or. (OBC%strain_config /= OBC_STRAIN_SPECIFIED))
   endif ; endif
 
   if (.not.CS%initialized) call MOM_error(FATAL, &
@@ -794,25 +796,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
           do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
-            if (OBC%zero_strain) then
-              dvdx(I,J) = 0. ; dudy(I,J) = 0.
-            elseif (OBC%freeslip_strain) then
-              dudy(I,J) = 0.
-            elseif (OBC%computed_strain) then
-              if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
-                            (OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%IdxCu(I,j)
-              else
-                dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
-                            (u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdxCu(I,j+1)
-              endif
-            elseif (OBC%specified_strain) then
-              if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
-              else
-                dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
-              endif
-            endif
+            select case (OBC%strain_config)
+              case (OBC_STRAIN_ZERO)
+                dvdx(I,J) = 0. ; dudy(I,J) = 0.
+              case (OBC_STRAIN_FREESLIP)
+                dudy(I,J) = 0.
+              case (OBC_STRAIN_COMPUTED)
+                if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                  dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
+                              (OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%IdxCu(I,j)
+                else
+                  dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
+                              (u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdxCu(I,j+1)
+                endif
+              case (OBC_STRAIN_SPECIFIED)
+                if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                  dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
+                else
+                  dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
+                endif
+            end select
             if (CS%use_Leithy) then
               dvdx_smooth(I,J) = dvdx(I,J)
               dudy_smooth(I,J) = dudy(I,J)
@@ -820,25 +823,26 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           enddo
         elseif (OBC%segment(n)%is_E_or_W .and. (I >= is_vort) .and. (I <= ie_vort)) then
           do J = max(OBC%segment(n)%HI%JsdB,js_vort), min(OBC%segment(n)%HI%JedB,je_vort)
-            if (OBC%zero_strain) then
-              dvdx(I,J) = 0. ; dudy(I,J) = 0.
-            elseif (OBC%freeslip_strain) then
-              dvdx(I,J) = 0.
-            elseif (OBC%computed_strain) then
-              if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
-                            (OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%IdyCv(i,J)
-              else
-                dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
-                            (v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdyCv(i+1,J)
-              endif
-            elseif (OBC%specified_strain) then
-              if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
-              else
-                dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
-              endif
-            endif
+            select case (OBC%strain_config)
+              case (OBC_STRAIN_ZERO)
+                dvdx(I,J) = 0. ; dudy(I,J) = 0.
+              case (OBC_STRAIN_FREESLIP)
+                dvdx(I,J) = 0.
+              case (OBC_STRAIN_COMPUTED)
+                if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                  dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
+                              (OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%IdyCv(i,J)
+                else
+                  dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
+                              (v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdyCv(i+1,J)
+                endif
+              case (OBC_STRAIN_SPECIFIED)
+                if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                  dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
+                else
+                  dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
+                endif
+            end select
             if (CS%use_Leithy) then
               dvdx_smooth(I,J) = dvdx(I,J)
               dudy_smooth(I,J) = dudy(I,J)
@@ -1494,22 +1498,23 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1)*G%IdxCu(I,j+1)) - (Del2u(I,j)*G%IdxCu(I,j)))
       enddo ; enddo
       ! Adjust contributions to shearing strain on open boundaries.
-      if (apply_OBC) then ; if (OBC%zero_strain .or. OBC%freeslip_strain) then
+      if (apply_OBC) then ; if ((OBC%strain_config == OBC_STRAIN_ZERO) .or. &
+                                (OBC%strain_config == OBC_STRAIN_FREESLIP)) then
         do n=1,OBC%number_of_segments
           J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
             do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-              if (OBC%zero_strain) then
+              if (OBC%strain_config == OBC_STRAIN_ZERO) then
                 dDel2vdx(I,J) = 0. ; dDel2udy(I,J) = 0.
-              elseif (OBC%freeslip_strain) then
+              elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
                 dDel2udy(I,J) = 0.
               endif
             enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= Ieq)) then
             do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-              if (OBC%zero_strain) then
+              if (OBC%strain_config == OBC_STRAIN_ZERO) then
                 dDel2vdx(I,J) = 0. ; dDel2udy(I,J) = 0.
-              elseif (OBC%freeslip_strain) then
+              elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
                 dDel2vdx(I,J) = 0.
               endif
             enddo


### PR DESCRIPTION
This PR contains two changes to OBC configurations for relative vorticity and shear strain:

cc7d4f7b3eca7232c2cb1a7984753ff38d0699be fixes a bug that specified strain at OBCs is not properly applied in MOM_hor_visc, due to an incomplete if logic. A runtime flag `OBC_SPECIFIED_STRAIN_BUG` is added.

7a9ea9ee9b64af592d882cdc1bf85a86a42b0f34 uses a unified configuration to set up OBC vorticity and strain. 

Previously, vorticity and strain OBC behavior were controlled by two sets of four mutually exclusive logical parameters. The two new config parameters `OBC_VORTICITY_CONFIG` and  `OBC_STRAIN_CONFIG` are introduced to replace the legacy logicals. 

Old 
```
OBC_ZERO_VORTICITY = False      !   [Boolean] default = False
                                ! If true, sets relative vorticity to zero on open boundaries.
OBC_FREESLIP_VORTICITY = True   !   [Boolean] default = True 
                                ! If true, sets the normal gradient of tangential velocity to zero in the
                                ! relative vorticity on open boundaries. This cannot be true if another 
                                ! OBC_XXX_VORTICITY option is True.
OBC_COMPUTED_VORTICITY = False  !   [Boolean] default = False
                                ! If true, uses the external values of tangential velocity in the relative
                                ! vorticity on open boundaries. This cannot be true if another OBC_XXX_VORTICITY
                                ! option is True.
OBC_SPECIFIED_VORTICITY = False !   [Boolean] default = False
                                ! If true, uses the external values of tangential velocity in the relative
                                ! vorticity on open boundaries. This cannot be true if another OBC_XXX_VORTICITY
                                ! option is True.
OBC_ZERO_STRAIN = False         !   [Boolean] default = False
                                ! If true, sets the strain used in the stress tensor to zero on open boundaries.
OBC_FREESLIP_STRAIN = True      !   [Boolean] default = True
                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
                                ! use in the stress tensor on open boundaries. This cannot be true if another
                                ! OBC_XXX_STRAIN option is True.
OBC_COMPUTED_STRAIN = False     !   [Boolean] default = False
                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
                                ! use in the stress tensor on open boundaries. This cannot be true if another
                                ! OBC_XXX_STRAIN option is True.
OBC_SPECIFIED_STRAIN = False    !   [Boolean] default = False
                                ! If true, sets the normal gradient of tangential velocity to zero in the strain
                                ! use in the stress tensor on open boundaries. This cannot be true if another
                                ! OBC_XXX_STRAIN option is True.
```

New
```
OBC_VORTICITY_CONFIG = "freeslip" ! default = "freeslip"
                                ! Configuration for relative vorticity in momentum advection at open boundaries.
                                ! Options are:
                                !     none      - No adjustment.
                                !     zero      - Sets relative vorticity to zero.
                                !     freeslip  - Sets the normal gradient of tangential velocity to zero.
                                !     computed  - Computes the normal gradient of tangential velocity using
                                !                 external values of tangential velocity.
                                !     specified - Uses the external values of the normal gradient of
                                !                 tangential velocity.
OBC_STRAIN_CONFIG = "freeslip"  ! default = "freeslip"
                                ! Configuration for strain in horizontal viscosity at open boundaries.  Options
                                ! are:
                                !     none      - No adjustment.
                                !     zero      - Sets strain to zero.
                                !     freeslip  - Sets the normal gradient of tangential velocity to zero.
                                !     computed  - Computes the normal gradient of tangential velocity using
                                !                 external values of tangential velocity.
                                !     specified - Uses the external values of the normal gradient of
                                !                 tangential velocity.
```

Misc
* There is no answer change but there are runtime parameter changes.
* All old logical parameters are still accepted. And a runtime warning is issued if they are specified in MOM_input. 
* Only the new string parameters are documented in MOM_parameter_doc. 
* If both new and old parameters are specified, the new parameters take precedence. 
* The old parameters and corresponding code may be removed after a deprecation period.