### PR TITLE
Add missing spaces in 53 strings

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -240,7 +240,7 @@ subroutine ALE_init( param_file, G, GV, US, max_depth, CS)
                  "extrapolated instead of piecewise constant", default=.false.)
   call get_param(param_file, mdl, "INIT_BOUNDARY_EXTRAP", init_boundary_extrap, &
                  "If true, values at the interfaces of boundary cells are "//&
-                 "extrapolated instead of piecewise constant during initialization."//&
+                 "extrapolated instead of piecewise constant during initialization.  "//&
                  "Defaults to REMAP_BOUNDARY_EXTRAP.", default=remap_boundary_extrap)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
@@ -415,14 +415,14 @@ subroutine ALE_register_diags(Time, G, GV, US, diag, CS)
       'Layer thicknesses tendency due to ALE regridding and remapping', &
       trim(thickness_units)//" s-1", conversion=GV%H_to_MKS*US%s_to_T, v_extensive=.true.)
   CS%id_remap_delta_integ_u2 = register_diag_field('ocean_model', 'ale_u2', diag%axesCu1, Time, &
-      'Rate of change in half rho0 times depth integral of squared zonal'//&
-      ' velocity by remapping. If REMAP_VEL_CONSERVE_KE is .true. then '//&
-      ' this measures the change before the KE-conserving correction is applied.', &
+      'Rate of change in half rho0 times depth integral of squared zonal '//&
+      'velocity by remapping. If REMAP_VEL_CONSERVE_KE is .true. then '//&
+      'this measures the change before the KE-conserving correction is applied.', &
       'W m-2', conversion=GV%H_to_kg_m2 * US%L_T_to_m_s**2 * US%s_to_T)
   CS%id_remap_delta_integ_v2 = register_diag_field('ocean_model', 'ale_v2', diag%axesCv1, Time, &
-      'Rate of change in half rho0 times depth integral of squared meridional'//&
-      ' velocity by remapping. If REMAP_VEL_CONSERVE_KE is .true. then '//&
-      ' this measures the change before the KE-conserving correction is applied.', &
+      'Rate of change in half rho0 times depth integral of squared meridional '//&
+      'velocity by remapping. If REMAP_VEL_CONSERVE_KE is .true. then '//&
+      'this measures the change before the KE-conserving correction is applied.', &
       'W m-2', conversion=GV%H_to_kg_m2 * US%L_T_to_m_s**2 * US%s_to_T)
 
 end subroutine ALE_register_diags

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2452,7 +2452,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       call get_param(param_file, "MOM", "ADVECT_TS", advect_TS, &
                    "If True, advect temperature and salinity horizontally "//&
                    "If False, T/S are registered for advection. "//&
-                   "This is intended only to be used in offline tracer mode."//&
+                   "This is intended only to be used in offline tracer mode, "//&
                    "and is by default false in that case", &
                    default=.false. )
     endif

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -275,7 +275,7 @@ subroutine PressureForce_FV_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, AD
        "MOM_PressureForce_FV_nonBouss: Module must be initialized before it is used.")
 
   if (CS%use_stanley_pgf) call MOM_error(FATAL, &
-       "MOM_PressureForce_FV_nonBouss: The Stanley parameterization is not yet"//&
+       "MOM_PressureForce_FV_nonBouss: The Stanley parameterization is not yet "//&
        "implemented in non-Boussinesq mode.")
 
   use_p_atm = associated(p_atm)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -160,8 +160,8 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   x_first = (MOD(G%first_direction,2) == 0)
 
   if (present(visc_rem_u) .neqv. present(visc_rem_v)) call MOM_error(FATAL, &
-      "MOM_continuity_PPM: Either both visc_rem_u and visc_rem_v or neither"// &
-      " one must be present in call to continuity_PPM.")
+      "MOM_continuity_PPM: Either both visc_rem_u and visc_rem_v or neither "// &
+      "one must be present in call to continuity_PPM.")
 
   if (x_first) then
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1392,7 +1392,7 @@ subroutine MOM_forcing_chksum(mesg, fluxes, G, US, haloshift)
     call hchksum(fluxes%heat_content_frunoff_glc, mesg//" fluxes%heat_content_frunoff_glc", G%HI, &
                  haloshift=hshift, unscale=US%QRZ_T_to_W_m2)
   if (associated(fluxes%heat_content_lprec)) &
-    call hchksum(fluxes%heat_content_lprec, mesg//" fluxes%heat_content_lprec", G%HI,  &
+    call hchksum(fluxes%heat_content_lprec, mesg//" fluxes%heat_content_lprec", G%HI, &
                  haloshift=hshift, unscale=US%QRZ_T_to_W_m2)
   if (associated(fluxes%heat_content_fprec)) &
     call hchksum(fluxes%heat_content_fprec, mesg//" fluxes%heat_content_fprec", G%HI, &

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -679,8 +679,8 @@ subroutine open_boundary_config(G, US, param_file, OBC)
        "If true, set the areas outside open boundaries to be land.", &
        default=.false.)
   call get_param(param_file, mdl, "RAMP_OBCS", OBC%ramp, &
-       "If true, ramps from zero to the external values over time, with"//&
-       "a ramping timescale given by RAMP_TIMESCALE. Ramping SSH only so far", &
+       "If true, ramps from zero to the external values over time, with "//&
+       "a ramping timescale given by RAMP_TIMESCALE. Ramping SSH only so far.", &
        default=.false.)
   call get_param(param_file, mdl, "OBC_RAMP_TIMESCALE", OBC%ramp_timescale, &
        "If RAMP_OBCS is true, this sets the ramping timescale.", &
@@ -1910,7 +1910,7 @@ subroutine parse_segment_str(ni_global, nj_global, segment_str, l, m, n, action_
     if (.not. (word2(1:2)=='I=')) call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str: "//&
                      "Second word of string '"//trim(segment_str)//"' must start with 'I='.")
   else
-    call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str"//&
+    call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str: "//&
                    "String '"//segment_str//"' must start with 'I=' or 'J='.")
   endif
 
@@ -1979,7 +1979,7 @@ subroutine parse_segment_str(ni_global, nj_global, segment_str, l, m, n, action_
     integer slen
 
     slen = len_trim(string)
-    if (slen==0) call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str"//&
+    if (slen==0) call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str: "//&
                                 "Parsed string was empty!")
     if (len_trim(string)==1 .and. string(1:1)=='N') then
       interpret_int_expr = imax
@@ -1995,7 +1995,7 @@ subroutine parse_segment_str(ni_global, nj_global, segment_str, l, m, n, action_
       read(string(1:slen),*,err=911) interpret_int_expr
     endif
     return
-    911 call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str"//&
+    911 call MOM_error(FATAL, "MOM_open_boundary.F90, parse_segment_str: "//&
                        "Problem reading value from string '"//trim(string)//"'.")
   end function interpret_int_expr
 end subroutine parse_segment_str

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -192,8 +192,8 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     u_nonsym(i,j) = u_comp(i,j) ; v_nonsym(i,j) = v_comp(i,j)
   enddo ; enddo
 
-  if (.not.associated(G%Domain_aux)) call MOM_error(FATAL," check_redundant"//&
-    " called with a non-associated auxiliary domain the grid type.")
+  if (.not.associated(G%Domain_aux)) call MOM_error(FATAL, &
+    " check_redundant called with a non-associated auxiliary domain the grid type.")
   call pass_vector(u_nonsym, v_nonsym, G%Domain_aux, direction)
 
   do I=IsdB,IedB ; do j=jsd,jed ; u_resym(I,j) = u_comp(I,j) ; enddo ; enddo
@@ -292,8 +292,8 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je, unscale)
     a_nonsym(i,j) = array(i,j)
   enddo ; enddo
 
-  if (.not.associated(G%Domain_aux)) call MOM_error(FATAL," check_redundant"//&
-    " called with a non-associated auxiliary domain the grid type.")
+  if (.not.associated(G%Domain_aux)) call MOM_error(FATAL, &
+    " check_redundant called with a non-associated auxiliary domain the grid type.")
   call pass_vector(a_nonsym, a_nonsym, G%Domain_aux, &
                    direction=To_All+Scalar_Pair, stagger=BGRID_NE)
 
@@ -397,8 +397,8 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     u_nonsym(i,j) = u_comp(i,j) ; v_nonsym(i,j) = v_comp(i,j)
   enddo ; enddo
 
-  if (.not.associated(G%Domain_aux)) call MOM_error(FATAL," check_redundant"//&
-    " called with a non-associated auxiliary domain the grid type.")
+  if (.not.associated(G%Domain_aux)) call MOM_error(FATAL, &
+    " check_redundant called with a non-associated auxiliary domain the grid type.")
   call pass_vector(u_nonsym, v_nonsym, G%Domain_aux, direction, stagger=BGRID_NE)
 
   do I=IsdB,IedB ; do J=JsdB,JedB

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -1400,9 +1400,9 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
                     !   function changes sign but has a local max/min in interval,
                     ! try subdividing interval as many times as necessary (or sub_it_max).
                     ! loop that increases number of subintervals:
-                    !call MOM_error(WARNING, "determinant changes sign"// &
-                    !            "but has a local max/min in interval;"//&
-                    !            " reduce increment in lam.")
+                    !call MOM_error(WARNING, "determinant changes sign "// &
+                    !            "but has a local max/min in interval; "//&
+                    !            "reduce increment in lam.")
                     ! begin subdivision loop -------------------------------------------
                     sub_rootfound = .false. ! initialize
                     do sub_it=1,sub_it_max
@@ -1427,8 +1427,8 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
                       ! sub intervals, try subdividing again unless sub_it_max has been reached.
                       if (sub_it == sub_it_max) then
                         call MOM_error(WARNING, "wave_speed: root not found "// &
-                                       " after sub_it_max subdivisions of original"// &
-                                       " interval.")
+                                       "after sub_it_max subdivisions of original "// &
+                                       "interval.")
                       endif ! sub_it == sub_it_max
                     enddo ! sub_it-loop-------------------------------------------------
                   endif ! det_l*ddet_l < 0.0

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -212,8 +212,8 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, acrit, num_pass, relc, debug,
       endif ; enddo ; enddo
     elseif (nfill == nfill_prev) then
       call MOM_error(WARNING, &
-           'Unable to fill missing points using either data at the same vertical level from a connected basin'//&
-           'or using a point from a previous vertical level.  Make sure that the original data has some valid'//&
+           'Unable to fill missing points using either data at the same vertical level from a connected basin '//&
+           'or using a point from a previous vertical level.  Make sure that the original data has some valid '//&
            'data in all basins.', .true.)
       write(mesg,*) 'nfill=',nfill
       call MOM_error(WARNING, mesg, .true.)

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -3037,8 +3037,8 @@ subroutine safe_string_copy(str1, str2, fieldnm, caller)
 
   if (len(trim(str1)) > len(str2)) then
     if (present(fieldnm) .and. present(caller)) then
-      call MOM_error(FATAL, trim(caller)//" attempted to copy the overly long"//&
-        " string "//trim(str1)//" into "//trim(fieldnm))
+      call MOM_error(FATAL, trim(caller)//" attempted to copy the overly long string "//&
+                     trim(str1)//" into "//trim(fieldnm))
     else
       call MOM_error(FATAL, "safe_string_copy: The string "//trim(str1)//&
                      " is longer than its intended target.")

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -577,8 +577,8 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
                  " If true, the domain is meridionally reentrant.", &
                  default=.false.)
     call get_param(param_file, mdl, "ICE_VISCOSITY_COMPUTE", CS%ice_viscosity_compute, &
-                 "If MODEL, compute ice viscosity internally using 1 or 4 quadrature points,"//&
-                 "if OBS read from a file,"//&
+                 "If MODEL, compute ice viscosity internally using 1 or 4 quadrature points, "//&
+                 "if OBS read from a file, "//&
                  "if CONSTANT a constant value (for debugging).", &
                  default="MODEL")
 

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -263,7 +263,7 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
   if (.not.GV%Boussinesq) CS%answer_date = max(CS%answer_date, 20230701)
 
   call get_param(PF, mdl, "REPRODUCE_2018_NMME_ANSWERS", CS%reproduce_2018_nmme, &
-               "Logical flag needed to reproduce older NMME forecast answers."//&
+               "Logical flag needed to reproduce older NMME forecast answers.  "//&
                "True gives old answers, the default of false gives different answers.", &
                default=.false.)
 

--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -223,8 +223,8 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
   endif
   write(mesg,'(i12)') CS%nstep_incupd
   if (is_root_pe()) &
-    call MOM_error(NOTE,"initialize_oda_incupd: Number of Timestep of inc. update:"//&
-                       trim(mesg))
+    call MOM_error(NOTE, "initialize_oda_incupd: Number of Timestep of inc. update: "//&
+                         trim(mesg))
 
   ! number of inc. update already done, CS%ncount, either from restart or set to 0.0
   if (query_initialized(CS%ncount, "oda_incupd_ncount", restart_CS) .and. &
@@ -235,8 +235,8 @@ subroutine initialize_oda_incupd( G, GV, US, param_file, CS, data_h, nz_data, re
   endif
   write(mesg,'(f4.1)') CS%ncount
   if (is_root_pe()) &
-    call MOM_error(NOTE,"initialize_oda_incupd: Inc. update already done:"//&
-                       trim(mesg))
+    call MOM_error(NOTE, "initialize_oda_incupd: Inc. update already done: "//&
+                         trim(mesg))
 
   ! get the vertical grid (h_obs) of the increments
   CS%nz_data = nz_data

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1364,7 +1364,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
   if (.not. MEKE_init) return
   CS%initialized = .true.
   call get_param(param_file, mdl, "MEKE_IN_DYNAMICS", meke_in_dynamics, &
-                 "If true, step MEKE forward with the dynamics"// &
+                 "If true, step MEKE forward with the dynamics "// &
                  "otherwise with the tracer timestep.", &
                  default=.true.)
 
@@ -1428,7 +1428,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
                    "The nondimensional coefficient governing the efficiency of the GEOMETRIC \n"//&
                    "thickness diffusion.", units="nondim", default=0.05)
     call get_param(param_file, mdl, "MEKE_EQUILIBRIUM_ALT", CS%MEKE_equilibrium_alt, &
-                   "If true, use an alternative formula for computing the (equilibrium)"//&
+                   "If true, use an alternative formula for computing the (equilibrium) "//&
                    "initial value of MEKE.", default=.false.)
     call get_param(param_file, mdl, "MEKE_EQUILIBRIUM_RESTORING", CS%MEKE_equilibrium_restoring, &
                    "If true, restore MEKE back to its equilibrium value, which is calculated at "//&
@@ -1522,15 +1522,15 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
                  "the deformation radius or grid-spacing. Only used if "//&
                  "MEKE_OLD_LSCALE=True", default=.false.)
   call get_param(param_file, mdl, "MEKE_VISCOSITY_COEFF_KU", CS%viscosity_coeff_Ku, &
-                 "If non-zero, is the scaling coefficient in the expression for"//&
-                 "viscosity used to parameterize harmonic lateral momentum mixing by"//&
-                 "unresolved eddies represented by MEKE. Can be negative to"//&
+                 "If non-zero, is the scaling coefficient in the expression for "//&
+                 "viscosity used to parameterize harmonic lateral momentum mixing by "//&
+                 "unresolved eddies represented by MEKE. Can be negative to "//&
                  "represent backscatter from the unresolved eddies.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_VISCOSITY_COEFF_AU", CS%viscosity_coeff_Au, &
-                 "If non-zero, is the scaling coefficient in the expression for"//&
-                 "viscosity used to parameterize biharmonic lateral momentum mixing by"//&
-                 "unresolved eddies represented by MEKE. Can be negative to"//&
+                 "If non-zero, is the scaling coefficient in the expression for "//&
+                 "viscosity used to parameterize biharmonic lateral momentum mixing by "//&
+                 "unresolved eddies represented by MEKE. Can be negative to "//&
                  "represent backscatter from the unresolved eddies.", &
                  units="nondim", default=0.0)
   call get_param(param_file, mdl, "MEKE_FIXED_MIXING_LENGTH", CS%Lfixed, &
@@ -1539,7 +1539,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
                  units="m", default=0.0, scale=US%m_to_L)
   call get_param(param_file, mdl, "MEKE_FIXED_TOTAL_DEPTH", CS%fixed_total_depth, &
                  "If true, use the nominal bathymetric depth as the estimate of the "//&
-                 "time-varying ocean depth.  Otherwise base the depth on the total ocean mass"//&
+                 "time-varying ocean depth.  Otherwise base the depth on the total ocean mass "//&
                  "per unit area.", default=.true.)
   call get_param(param_file, mdl, "MEKE_TOTAL_DEPTH_RHO", CS%rho_fixed_total_depth, &
                  "A density used to translate the nominal bathymetric depth into an estimate "//&

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2481,7 +2481,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "If true, the Laplacian coefficient is locally limited "//&
                  "to be stable.", default=.true., do_not_log=.not.CS%Laplacian)
   call get_param(param_file, mdl, "EY24_EBT_BS", CS%EY24_EBT_BS, &
-                 "If true, use the the backscatter scheme (EBT mode with kill switch)"//&
+                 "If true, use the the backscatter scheme (EBT mode with kill switch) "//&
                  "developed by Yankovsky et al. (2024). ", &
                  default=.false., do_not_log=.not.CS%Laplacian)
   if (.not.CS%Laplacian) CS%bound_Kh = .false.
@@ -2594,7 +2594,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
 !          "set or allocated.  See github.com/mom-ocean/MOM6/issues/1590 for a discussion.")
 !  endif
   if (CS%use_QG_Leith_visc .and. .not. (CS%Leith_Kh .or. CS%Leith_Ah) ) then
-    call MOM_error(FATAL, "MOM_hor_visc.F90, hor_visc_init:"//&
+    call MOM_error(FATAL, "MOM_hor_visc.F90, hor_visc_init: "//&
                  "LEITH_KH or LEITH_AH must be True when USE_QG_LEITH_VISC=True.")
   endif
 
@@ -2654,7 +2654,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(param_file, mdl, "FRICTWORK_BUG", CS%FrictWork_bug, &
                  "If true, retain an answer-changing bug in calculating the FrictWork, "//&
-                 "which cancels the h in thickness flux and the h at velocity point. This is"//&
+                 "which cancels the h in thickness flux and the h at velocity point. This is "//&
                  "not recommended.", default=.false.)
   call get_param(param_file, mdl, "OBC_SPECIFIED_STRAIN_BUG", CS%OBC_strain_bug, &
                  "If true, recover a bug that specified shear strain option at open boundaries "//&

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -3505,8 +3505,8 @@ subroutine internal_tides_init(Time, G, GV, US, param_file, diag, CS)
                  "The number of angular resolution bands for the internal "//&
                  "tide calculations.", default=24)
   call get_param(param_file, mdl, "DT_ITIDES", CS%dt_itides, &
-                 "The timestep for internal tides ray-tracing scheme"//&
-                 "If set to -1 (default), it uses the same value as DT_THERM", &
+                 "The timestep for internal tides ray-tracing scheme.  "//&
+                 "If set to -1 (default), it uses the same value as DT_THERM.", &
                  units="s", default=-1., scale=US%s_to_T)
 
   if (use_int_tides) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -855,9 +855,9 @@ subroutine calc_Visbeck_coeffs_old(h, slope_x, slope_y, N2_u, N2_v, G, GV, US, C
          "Module must be initialized before it is used.")
 
   if (.not. CS%calculate_Eady_growth_rate) return
-  if (.not. allocated(CS%SN_u)) call MOM_error(FATAL, "calc_slope_function:"// &
+  if (.not. allocated(CS%SN_u)) call MOM_error(FATAL, "calc_slope_function: "// &
          "%SN_u is not associated with use_variable_mixing.")
-  if (.not. allocated(CS%SN_v)) call MOM_error(FATAL, "calc_slope_function:R"// &
+  if (.not. allocated(CS%SN_v)) call MOM_error(FATAL, "calc_slope_function: "// &
          "%SN_v is not associated with use_variable_mixing.")
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -1217,9 +1217,9 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e)
          "Module must be initialized before it is used.")
 
   if (.not. CS%calculate_Eady_growth_rate) return
-  if (.not. allocated(CS%SN_u)) call MOM_error(FATAL, "calc_slope_function:"// &
+  if (.not. allocated(CS%SN_u)) call MOM_error(FATAL, "calc_slope_function: "// &
          "%SN_u is not associated with use_variable_mixing.")
-  if (.not. allocated(CS%SN_v)) call MOM_error(FATAL, "calc_slope_function:"// &
+  if (.not. allocated(CS%SN_v)) call MOM_error(FATAL, "calc_slope_function: "// &
          "%SN_v is not associated with use_variable_mixing.")
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -1597,7 +1597,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "when the first baroclinic deformation radius is well "//&
                  "resolved.", default=.false.)
   call get_param(param_file, mdl, "DEPTH_SCALED_KHTH", CS%Depth_scaled_KhTh, &
-                 "If true, KHTH is scaled away when the depth is shallower"//&
+                 "If true, KHTH is scaled away when the depth is shallower "//&
                  "than a reference depth: KHTH = MIN(1,H/H0)**N * KHTH, "//&
                  "where H0 is a reference depth, controlled via DEPTH_SCALED_KHTH_H0, "//&
                  "and the exponent (N) is controlled via DEPTH_SCALED_KHTH_EXP.",&
@@ -1795,7 +1795,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                    "that avoids division by layer thickness. Recommended.", default=.false.)
     if (CS%use_simpler_Eady_growth_rate) then
       if (.not. CS%use_stored_slopes) call MOM_error(FATAL, &
-           "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
+           "MOM_lateral_mixing_coeffs.F90, VarMix_init: "//&
            "When USE_SIMPLER_EADY_GROWTH_RATE=True, USE_STORED_SLOPES must also be True.")
       call get_param(param_file, mdl, "EADY_GROWTH_RATE_D_SCALE", CS%Eady_GR_D_scale, &
                      "The depth from surface over which to average SN when calculating "//&
@@ -1960,10 +1960,10 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "function independently at each point.", default=.false.)
     if (CS%interpolate_Res_fn) then
       if (CS%Res_coef_visc /= CS%Res_coef_khth) call MOM_error(FATAL, &
-           "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
+           "MOM_lateral_mixing_coeffs.F90, VarMix_init: "//&
            "When INTERPOLATE_RES_FN=True, VISC_RES_FN_POWER must equal KH_RES_SCALE_COEF.")
       if (CS%Res_fn_power_visc /= CS%Res_fn_power_khth) call MOM_error(FATAL, &
-           "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
+           "MOM_lateral_mixing_coeffs.F90, VarMix_init: "//&
            "When INTERPOLATE_RES_FN=True, VISC_RES_FN_POWER must equal KH_RES_FN_POWER.")
     endif
     call get_param(param_file, mdl, "GILL_EQUATORIAL_LD", Gill_equatorial_Ld, &
@@ -2120,7 +2120,7 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     enddo ; enddo
 
     if (.not. CS%use_stored_slopes) call MOM_error(FATAL, &
-           "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
+           "MOM_lateral_mixing_coeffs.F90, VarMix_init: "//&
            "USE_STORED_SLOPES must be True when using QG Leith.")
   endif
 

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -291,7 +291,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
     call MOM_error(FATAL, "mixedlayer_restrat_OM4: "// &
          "The resolution argument, Rd/dx, was not associated.")
   if (CS%use_Stanley_ML .and. .not.GV%Boussinesq) call MOM_error(FATAL, &
-       "MOM_mixedlayer_restrat: The Stanley parameterization is not"//&
+       "MOM_mixedlayer_restrat: The Stanley parameterization is not "//&
        "available without the Boussinesq approximation.")
 
   ! Extract the friction velocity from the forcing type.
@@ -1837,7 +1837,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
       endif
       if (CS%fl_from_file .and. CS%front_length>0.0) call MOM_error(FATAL, "mixedlayer_restrat_init: "// &
              "MLE_FRONT_LENGTH_FROM_FILE cannot be true when MLE_FRONT_LENGTH > 0.0. "// &
-             "If you want to use MLE_FRONT_LENGTH, set MLE_FRONT_LENGTH_FROM_FILE to false." // &
+             "If you want to use MLE_FRONT_LENGTH, set MLE_FRONT_LENGTH_FROM_FILE to false. " // &
              "If you want to use MLE_FRONT_LENGTH_FROM_FILE, set MLE_FRONT_LENGTH to 0.0.")
       call get_param(param_file, mdl, "MLE_USE_PBL_MLD", CS%MLE_use_PBL_MLD, &
              "If true, the MLE parameterization will use the mixed-layer "//&

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -419,10 +419,10 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
 !/BGR: New options for including Langmuir effects
 !/ 1. Options related to enhancing the mixing coefficient
   call get_param(paramFile, mdl, "USE_KPP_LT_K", CS%LT_K_Enhancement, &
-       'Flag for Langmuir turbulence enhancement of turbulent'//&
+       'Flag for Langmuir turbulence enhancement of turbulent '//&
        'mixing coefficient.', Default=.false.)
   call get_param(paramFile, mdl, "STOKES_MIXING", CS%Stokes_Mixing, &
-       'Flag for Langmuir turbulence enhancement of turbulent'//&
+       'Flag for Langmuir turbulence enhancement of turbulent '//&
        'mixing coefficient.', Default=.false.)
   if (CS%LT_K_Enhancement) then
     call get_param(paramFile, mdl, 'KPP_LT_K_SHAPE', string,                 &
@@ -469,7 +469,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
   endif
 !/ 2. Options related to enhancing the unresolved Vt2/entrainment in Rib
   call get_param(paramFile, mdl, "USE_KPP_LT_VT2", CS%LT_Vt2_Enhancement, &
-       'Flag for Langmuir turbulence enhancement of Vt2'//&
+       'Flag for Langmuir turbulence enhancement of Vt2 '//&
        'in Bulk Richardson Number.', Default=.false.)
   if (CS%LT_Vt2_Enhancement) then
     call get_param(paramFile, mdl, "KPP_LT_VT2_METHOD",string ,                  &
@@ -876,7 +876,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, tv, uStar, buoyFlux, Kt, Ks, Kv, &
 
           call MOM_error(FATAL,"KPP_calculate, after CVMix_coeffs_kpp: "// &
                    "Negative vertical viscosity or diffusivity has been detected. " // &
-                   "This is likely related to the choice of MATCH_TECHNIQUE and INTERP_TYPE2." //&
+                   "This is likely related to the choice of MATCH_TECHNIQUE and INTERP_TYPE2. " //&
                    "You might consider using the default options for these parameters." )
         endif
       enddo

--- a/src/parameterizations/vertical/MOM_CVMix_conv.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_conv.F90
@@ -85,7 +85,7 @@ logical function CVMix_conv_init(Time, G, GV, US, param_file, diag, CS)
   ! be aplied in the boundary layer
   if (useEPBL) then
     call MOM_error(WARNING, 'MOM_CVMix_conv_init: '// &
-           'CVMix convection may not be properly applied when ENERGETICS_SFC_PBL = True'//&
+           'CVMix convection may not be properly applied when ENERGETICS_SFC_PBL = True '//&
            'as convective mixing might occur in the boundary layer.')
   endif
 

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -264,8 +264,8 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
   ! Otherwise, warn user and kill job.
   if ((NumberTrue) > 1) then
     call MOM_error(FATAL, 'MOM_CVMix_shear_init: '// &
-           'Multiple shear driven internal mixing schemes selected,'//&
-           ' please disable all but one scheme to proceed.')
+           'Multiple shear driven internal mixing schemes selected, '//&
+           'please disable all but one scheme to proceed.')
   endif
 
   CVMix_shear_init = use_PP81 .or. use_LMD94

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -2654,7 +2654,7 @@ subroutine mixedlayer_detrain_2(h, T, S, R0, Spv0, Rcv, RcvTgt, dt, dt_diag, d_e
   dT_dS_gauge = CS%dT_dS_wt ; dS_dT_gauge = 1.0 / dT_dS_gauge
   num_events = 10.0
 
-  if (CS%nkbl /= 2) call MOM_error(FATAL, "MOM_mixed_layer"// &
+  if (CS%nkbl /= 2) call MOM_error(FATAL, "MOM_mixed_layer: "// &
                         "CS%nkbl must be 2 in mixedlayer_detrain_2.")
 
   if (dt < CS%BL_detrain_time) then ; dPE_time_ratio = CS%BL_detrain_time / (dt)

--- a/src/parameterizations/vertical/MOM_regularize_layers.F90
+++ b/src/parameterizations/vertical/MOM_regularize_layers.F90
@@ -572,21 +572,21 @@ subroutine regularize_surface(h, tv, dt, ea, eb, G, GV, US, CS)
         if (abs(h_tot1(i) - h_tot2(i)) > 1e-12*h_tot1(i)) then
           write(mesg,'(ES11.4," became ",ES11.4," diff ",ES11.4)') &
                 h_tot1(i), h_tot2(i), (h_tot1(i) - h_tot2(i))
-          call MOM_error(WARNING, "regularize_surface: Mass non-conservation."//&
+          call MOM_error(WARNING, "regularize_surface: Mass non-conservation.  "//&
                           trim(mesg), .true.)
           fatal_error = .true.
         endif
         if (abs(Th_tot1(i) - Th_tot2(i)) > 1e-12*abs(Th_tot1(i) + 10.0*US%degC_to_C*h_tot1(i))) then
           write(mesg,'(ES11.4," became ",ES11.4," diff ",ES11.4," int diff ",ES11.4)') &
                 Th_tot1(i), Th_tot2(i), (Th_tot1(i) - Th_tot2(i)), (Th_tot1(i) - Th_tot3(i))
-          call MOM_error(WARNING, "regularize_surface: Heat non-conservation."//&
+          call MOM_error(WARNING, "regularize_surface: Heat non-conservation.  "//&
                           trim(mesg), .true.)
           fatal_error = .true.
         endif
         if (abs(Sh_tot1(i) - Sh_tot2(i)) > 1e-12*abs(Sh_tot1(i) + 10.0*US%ppt_to_S*h_tot1(i))) then
           write(mesg,'(ES11.4," became ",ES11.4," diff ",ES11.4," int diff ",ES11.4)') &
                 Sh_tot1(i), Sh_tot2(i), (Sh_tot1(i) - Sh_tot2(i)), (Sh_tot1(i) - Sh_tot3(i))
-          call MOM_error(WARNING, "regularize_surface: Salinity non-conservation."//&
+          call MOM_error(WARNING, "regularize_surface: Salinity non-conservation.  "//&
                           trim(mesg), .true.)
           fatal_error = .true.
         endif

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2665,7 +2665,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
 
   if (CS%double_diffusion .and. CS%use_CVMix_ddiff) then
     call MOM_error(FATAL, 'set_diffusivity_init: '// &
-           'Multiple double-diffusion options selected (DOUBLE_DIFFUSION and'//&
+           'Multiple double-diffusion options selected (DOUBLE_DIFFUSION and '//&
            'USE_CVMIX_DDIFF), please disable all but one option to proceed.')
   endif
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -637,8 +637,7 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
   if (CS%StokesMixing) then
     if (present(Waves)) DoStokesMixing = associated(Waves)
     if (.not. DoStokesMixing) &
-      call MOM_error(FATAL,"Stokes Mixing called without allocated"//&
-                     "Waves Control Structure")
+      call MOM_error(FATAL, "Stokes Mixing called without associated Waves Control Structure")
   endif
   lfpmix = .false.
   if ( present(fpmix) ) lfpmix = fpmix
@@ -3231,8 +3230,7 @@ subroutine updateCFLtruncationValue(Time, CS, US, activate)
     CS%CFL_trunc = CS%CFL_truncS + wghtA * ( CS%CFL_truncE - CS%CFL_truncS )
   endif
   write(msg(1:12),'(es12.3)') CS%CFL_trunc
-  call MOM_error(NOTE, "MOM_vert_friction: updateCFLtruncationValue set CFL"// &
-                       " limit to "//trim(msg))
+  call MOM_error(NOTE, "MOM_vert_friction: updateCFLtruncationValue set CFL limit to "//trim(msg))
 end subroutine updateCFLtruncationValue
 
 !> Clean up and deallocate the vertical friction module

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -189,13 +189,13 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
                  "the equation of state. If negative (default), local pressure is used.", &
                  units="Pa", default=-1., scale=US%Pa_to_RL2_T2)
   call get_param(param_file, mdl, "NDIFF_INTERIOR_ONLY", CS%interior_only, &
-                 "If true, only applies neutral diffusion in the ocean interior."//&
-                 "That is, the algorithm will exclude the surface and bottom"//&
+                 "If true, only applies neutral diffusion in the ocean interior.  "//&
+                 "That is, the algorithm will exclude the surface and bottom "//&
                  "boundary layers.", default=.false.)
   if (CS%interior_only) then
     call get_param(param_file, mdl, "NDIFF_TAPERING", CS%tapering, &
                    "If true, neutral diffusion linearly decays to zero within "//&
-                   "a transition zone defined using boundary layer depths.    "//&
+                   "a transition zone defined using boundary layer depths.  "//&
                    "Only applicable when NDIFF_INTERIOR_ONLY=True", default=.false.)
   endif
   call get_param(param_file, mdl, "KHTR_USE_EBT_STRUCT", KhTh_use_ebt_struct, &

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -434,7 +434,7 @@ subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G
   type(tracer_flow_control_CS), pointer       :: CS        !< The control structure returned by a
                                                            !! previous call to call_tracer_register.
 
-  if (.not. associated(CS)) call MOM_error(FATAL, "call_tracer_set_forcing"// &
+  if (.not. associated(CS)) call MOM_error(FATAL, "call_tracer_set_forcing: "// &
          "Module must be initialized via call_tracer_register before it is used.")
 !  if (CS%use_ideal_age) &
 !    call ideal_age_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, &
@@ -851,12 +851,12 @@ subroutine store_stocks(pkg_name, ns, names, units, values, index, stock_values,
     write(ind_text,'(I0)') index
     if (ns > 1) then
       call MOM_error(FATAL,"Tracer package "//trim(pkg_name)//&
-          " is not permitted to return more than one value when queried"//&
-          " for specific stock index "//trim(ind_text)//".")
+          " is not permitted to return more than one value when queried "//&
+          "for specific stock index "//trim(ind_text)//".")
     elseif (ns+ns_tot > 1) then
       call MOM_error(FATAL,"Tracer packages "//trim(pkg_name)//" and "//&
-          trim(set_pkg_name)//" both attempted to set values for"//&
-          " specific stock index "//trim(ind_text)//".")
+          trim(set_pkg_name)//" both attempted to set values for "//&
+          "specific stock index "//trim(ind_text)//".")
     else
       set_pkg_name = pkg_name
     endif

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -92,7 +92,7 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "NUM_DYED_TRACERS", CS%ntr, &
                  "The number of dyed_obc tracers in this run. Each tracer "//&
-                 "should have a separate boundary segment."//&
+                 "should have a separate boundary segment.  "//&
                  "If not present, use NUM_DYE_TRACERS.", default=-1)
   if (CS%ntr == -1) then
     !for backward compatibility

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -259,8 +259,8 @@ subroutine DOME_initialize_sponges(G, GV, US, tv, depth_tot, PF, CSp)
   !  The remaining calls to set_up_sponge_field can be in any order.
   if ( associated(tv%T) ) then
     temp(:,:,:) = 0.0
-    call MOM_error(FATAL,"DOME_initialize_sponges is not set up for use with"//&
-                         " a temperatures defined.")
+    call MOM_error(FATAL, "DOME_initialize_sponges is not set up for use with "//&
+                          "temperatures defined.")
     ! This should use the target values of T in temp.
     call set_up_sponge_field(temp, tv%T, G, GV, nz, CSp)
     ! This should use the target values of S in temp.

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -226,7 +226,7 @@ subroutine idealized_hurricane_wind_init(Time, G, US, param_file, CS)
                  default=6.88, units="degrees")
   call get_param(param_file, mdl, "IDL_HURR_INFLOW_DANGLE_TR_SPEED", CS%P1_speed, &
                  "The translation speed dependence of the angle difference between the "//&
-                 "translation direction and the inflow direction"//&
+                 "translation direction and the inflow direction "//&
                  "for the parametric idealized hurricane.", &
                  default=-9.60, units="degrees s m-1", scale=US%L_T_to_m_s)
 

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -455,8 +455,8 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
                  " INPUT         - Testing with fixed values.", default=NULL_STRING)
     select case (TRIM(TMPSTRING2))
     case (NULL_STRING)! Default
-      call MOM_error(FATAL, "wave_interface_init called with SURFACE_BANDS"//&
-                           " but no SURFBAND_SOURCE.")
+      call MOM_error(FATAL, "wave_interface_init called with SURFACE_BANDS "//&
+                            "but no SURFBAND_SOURCE.")
     case (DATAOVR_STRING)! Using Data Override
       CS%DataSource = DATAOVR
       call get_param(param_file, mdl, "SURFBAND_FILENAME", CS%SurfBandFileName, &
@@ -511,8 +511,8 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
 
   case (DHH85_STRING) !Donelan et al., 1985 spectrum
     CS%WaveMethod = DHH85
-    call MOM_error(WARNING,"DHH85 only ever set-up for uniform cases w/"//&
-                           " Stokes drift in x-direction.")
+    call MOM_error(WARNING,"DHH85 only ever set-up for uniform cases w/ "//&
+                           "Stokes drift in x-direction.")
     call get_param(param_file, mdl, "DHH85_AGE_FP", CS%WaveAgePeakFreq, &
          "Choose true to use waveage in peak frequency.", default=.false.)
     call get_param(param_file, mdl, "DHH85_AGE", CS%WaveAge, &

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -55,7 +55,7 @@ subroutine dyed_obcs_set_OBC_data(OBC, G, GV, param_file, tr_Reg)
 
   call get_param(param_file, mdl, "NUM_DYED_TRACERS", ntr, &
                  "The number of dyed_obc tracers in this run. Each tracer "//&
-                 "should have a separate boundary segment."//&
+                 "should have a separate boundary segment.  "//&
                  "If not present, use NUM_DYE_TRACERS.", default=-1, do_not_log=.true.)
   if (ntr == -1) then
     !for backward compatibility


### PR DESCRIPTION
  Added missing spaces to strings that are concatenated across line breaks in 53 places, and rearranged strings in another 14 places that could appear to a grep as though they likely are missing spaces.  Many of the problematic instances were in error messages that are probably never called, but 35 occurred in the descriptions in MOM_parameter_doc files.  A total of 32 files were modified, and all solutions are bitwise identical.