### PR TITLE
Surface state diagnostic index bugfix

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -4117,7 +4117,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
       depth_ml = CS%Hmix_UV
       if (CS%answer_date < 20190101) depth_ml = GV%H_to_Z*CS%Hmix_UV
       !$OMP parallel do default(shared) private(depth,dh,hv)
-      do J=js-1,ie
+      do J=js-1,je
         do i=is,ie
           depth(i) = 0.0
           sfc_state%v(i,J) = 0.0


### PR DESCRIPTION
This fixes an error in the index bounds for v-velocity in the uppermost mixed layer.