### PR TITLE
Regrid optional adjustments

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -296,6 +296,13 @@ subroutine ALE_init( param_file, G, GV, US, max_depth, CS)
                  "legacy step and should not be needed if the initialization is "//&
                  "consistent with the coordinate mode.", default=.true.)
 
+  call get_param(param_file, mdl, "REGRID_USE_DEPTH_BASED_TIME_FILTER", local_logical, &
+                 "If true, always uses depth-based time filtering code that updates the "//&
+                 "generated grid using REGRID_TIME_SCALE, REGRID_FILTER_SHALLOW_DEPTH, "//&
+                 "REGRID_FILTER_DEEP_DEPTH parameters. Setting to True always uses "//&
+                 "filtering but setting to False bypasses calculations when filter times = 0.", &
+                 default=.true.)
+  call set_regrid_params(CS%regridCS, use_depth_based_time_filter=local_logical)
   call get_param(param_file, mdl, "REGRID_TIME_SCALE", CS%regrid_time_scale, &
                  "The time-scale used in blending between the current (old) grid "//&
                  "and the target (new) grid. A short time-scale favors the target "//&

--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -316,7 +316,7 @@ subroutine ALE_init( param_file, G, GV, US, max_depth, CS)
   call get_param(param_file, mdl, "REGRID_FILTER_DEEP_DEPTH", filter_deep_depth, &
                  "The depth below which full time-filtering is applied with time-scale "//&
                  "REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and "//&
-                 "REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.", &
+                 "REGRID_FILTER_DEEP_DEPTH the filter weights adopt a cubic profile.", &
                  units="m", default=0., scale=GV%m_to_H)
   call set_regrid_params(CS%regridCS, depth_of_time_filter_shallow=filter_shallow_depth, &
                          depth_of_time_filter_deep=filter_deep_depth)

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -108,6 +108,10 @@ type, public :: regridding_CS ; private
   !> Reference pressure for potential density calculations [R L2 T-2 ~> Pa]
   real :: ref_pressure = 2.e7
 
+  !> If true, always pass through the depth-based time filtering that uses CS%old_grid_weight
+  !! If false, allows bypassing of the call if CS%old_grid_weight==0
+  logical :: use_depth_based_time_filter
+
   !> Weight given to old coordinate when blending between new and old grids [nondim]
   !! Used only below depth_of_time_filter_shallow, with a cubic variation
   !! from zero to full effect between depth_of_time_filter_shallow and
@@ -1001,6 +1005,7 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
   else
     call set_regrid_params(CS, min_thickness=0.)
     call set_regrid_params(CS, use_adjust_interface_motion=.true.)
+    call set_regrid_params(CS, use_depth_based_time_filter=.true.)
   endif
 
   if (main_parameters .and. coordinateMode(coord_mode) == REGRIDDING_HYCOM1) then
@@ -1685,7 +1690,8 @@ subroutine build_zstar_grid( CS, G, GV, h, nom_depth_H, dzInterface, frac_shelf_
       endif
 
       ! Calculate the final change in grid position after blending new and old grids
-      call filtered_grid_motion( CS, nz, zOld, zNew, dzInterface(i,j,:) )
+      if (CS%use_depth_based_time_filter .or. CS%old_grid_weight>0.) &
+        call filtered_grid_motion(CS, nz, zOld, zNew, dzInterface(i,j,:))
 
 #ifdef __DO_SAFETY_CHECKS__
       dh = max(nominalDepth,totalThickness)
@@ -1784,7 +1790,8 @@ subroutine build_sigma_grid( CS, G, GV, h, nom_depth_H, dzInterface )
         zOld(k) = zOld(k+1) + h(i,j,k)
       enddo
 
-      call filtered_grid_motion( CS, nz, zOld, zNew, dzInterface(i,j,:) )
+      if (CS%use_depth_based_time_filter .or. CS%old_grid_weight>0.) &
+        call filtered_grid_motion(CS, nz, zOld, zNew, dzInterface(i,j,:))
 
 #ifdef __DO_SAFETY_CHECKS__
       dh = max(nominalDepth,totalThickness)
@@ -1931,7 +1938,8 @@ subroutine build_rho_grid( G, GV, US, h, nom_depth_H, tv, dzInterface, remapCS, 
       endif
 
       ! Calculate the final change in grid position after blending new and old grids
-      call filtered_grid_motion( CS, nz, zOld, zNew, dzInterface(i,j,:) )
+      if (CS%use_depth_based_time_filter .or. CS%old_grid_weight>0.) &
+        call filtered_grid_motion(CS, nz, zOld, zNew, dzInterface(i,j,:))
 
 #ifdef __DO_SAFETY_CHECKS__
       do k=2,CS%nk
@@ -2061,7 +2069,8 @@ subroutine build_grid_HyCOM1( G, GV, US, h, nom_depth_H, tv, h_new, dzInterface,
            h_neglect=h_neglect, h_neglect_edge=h_neglect_edge)
 
       ! Calculate the final change in grid position after blending new and old grids
-      call filtered_grid_motion( CS, GV%ke, z_col, z_col_new, dz_col )
+      if (CS%use_depth_based_time_filter .or. CS%old_grid_weight>0.) &
+        call filtered_grid_motion( CS, GV%ke, z_col, z_col_new, dz_col )
 
       ! This adjusts things robust to round-off errors
       dz_col(:) = -dz_col(:)
@@ -2140,7 +2149,8 @@ subroutine build_grid_adaptive(G, GV, US, h, nom_depth_H, tv, dzInterface, remap
     call build_adapt_column(CS%adapt_CS, G, GV, US, tv, i, j, zInt, tInt, sInt, h, &
                             nom_depth_H, zNext)
 
-    call filtered_grid_motion(CS, nz, zInt(i,j,:), zNext, dzInterface(i,j,:))
+    if (CS%use_depth_based_time_filter .or. CS%old_grid_weight>0.) &
+      call filtered_grid_motion(CS, nz, zInt(i,j,:), zNext, dzInterface(i,j,:))
     ! convert from depth to z
     do K = 1, nz+1 ; dzInterface(i,j,K) = -dzInterface(i,j,K) ; enddo
     if (CS%use_adjust_interface_motion) call adjust_interface_motion(CS, nz, h(i,j,:), dzInterface(i,j,:))
@@ -2774,8 +2784,8 @@ end function getCoordinateShortName
 
 !> Can be used to set any of the parameters for MOM_regridding.
 subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_grid_weight, &
-             interp_scheme, depth_of_time_filter_shallow, depth_of_time_filter_deep, &
-             use_adjust_interface_motion, compress_fraction, ref_pressure, &
+             use_depth_based_time_filter, depth_of_time_filter_shallow, depth_of_time_filter_deep, &
+             interp_scheme, use_adjust_interface_motion, compress_fraction, ref_pressure, &
              integrate_downward_for_e, remap_answers_2018, remap_answer_date, regrid_answer_date, &
              adaptTimeRatio, adaptZoom, adaptZoomCoeff, adaptBuoyCoeff, &
              adaptAlpha, adaptDoMin, adaptDrho0)
@@ -2784,9 +2794,10 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
   real,    optional, intent(in) :: min_thickness    !< Minimum thickness allowed when building the
                                                     !! new grid [H ~> m or kg m-2]
   real,    optional, intent(in) :: old_grid_weight  !< Weight given to old coordinate when time-filtering grid [nondim]
-  character(len=*), optional, intent(in) :: interp_scheme !< Interpolation method for state-dependent coordinates
+  logical, optional, intent(in) :: use_depth_based_time_filter !< Allow depth-based time filtering
   real,    optional, intent(in) :: depth_of_time_filter_shallow !< Depth to start cubic [H ~> m or kg m-2]
   real,    optional, intent(in) :: depth_of_time_filter_deep !< Depth to end cubic [H ~> m or kg m-2]
+  character(len=*), optional, intent(in) :: interp_scheme !< Interpolation method for state-dependent coordinates
   logical, optional, intent(in) :: use_adjust_interface_motion !< Call adjust_interface_motion()
   real,    optional, intent(in) :: compress_fraction !< Fraction of compressibility to add to potential density [nondim]
   real,    optional, intent(in) :: ref_pressure     !< The reference pressure for density-dependent
@@ -2818,6 +2829,8 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
       call MOM_error(FATAL,'MOM_regridding, set_regrid_params: Weight is out side the range 0..1!')
     CS%old_grid_weight = old_grid_weight
   endif
+  if (present(use_depth_based_time_filter)) CS%use_depth_based_time_filter = &
+                                                 use_depth_based_time_filter
   if (present(depth_of_time_filter_shallow)) CS%depth_of_time_filter_shallow = &
                                                 depth_of_time_filter_shallow
   if (present(depth_of_time_filter_deep)) CS%depth_of_time_filter_deep = &

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -102,6 +102,9 @@ type, public :: regridding_CS ; private
   !> Minimum thickness allowed when building the new grid through regridding [H ~> m or kg m-2].
   real :: min_thickness
 
+  !> If true, call adjust_interface_motion() after initial grid generation
+  logical :: use_adjust_interface_motion
+
   !> Reference pressure for potential density calculations [R L2 T-2 ~> Pa]
   real :: ref_pressure = 2.e7
 
@@ -991,8 +994,13 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
                  "thickness allowed.", units="m", scale=GV%m_to_H, &
                  default=regriddingDefaultMinThickness )
     call set_regrid_params(CS, min_thickness=tmpReal)
+    call get_param(param_file, mdl, "USE_ADJUST_INTERFACE_MOTION", tmpLogical, &
+              "When regridding, after the primary grid generation, call a function that ensures "//&
+              "positive layer thicknesses. Historically, this was required.", default=.true.)
+    call set_regrid_params(CS, use_adjust_interface_motion=tmpLogical)
   else
     call set_regrid_params(CS, min_thickness=0.)
+    call set_regrid_params(CS, use_adjust_interface_motion=.true.)
   endif
 
   if (main_parameters .and. coordinateMode(coord_mode) == REGRIDDING_HYCOM1) then
@@ -1702,7 +1710,7 @@ subroutine build_zstar_grid( CS, G, GV, h, nom_depth_H, dzInterface, frac_shelf_
       endif
 #endif
 
-      call adjust_interface_motion( CS, nz, h(i,j,:), dzInterface(i,j,:) )
+      if (CS%use_adjust_interface_motion) call adjust_interface_motion( CS, nz, h(i,j,:), dzInterface(i,j,:) )
 
     enddo
   enddo
@@ -2057,7 +2065,7 @@ subroutine build_grid_HyCOM1( G, GV, US, h, nom_depth_H, tv, h_new, dzInterface,
 
       ! This adjusts things robust to round-off errors
       dz_col(:) = -dz_col(:)
-      call adjust_interface_motion( CS, GV%ke, h(i,j,:), dz_col(:) )
+      if (CS%use_adjust_interface_motion) call adjust_interface_motion( CS, GV%ke, h(i,j,:), dz_col(:) )
 
       dzInterface(i,j,1:nki+1) = dz_col(1:nki+1)
       if (nki<CS%nk) dzInterface(i,j,nki+2:CS%nk+1) = 0.
@@ -2135,7 +2143,7 @@ subroutine build_grid_adaptive(G, GV, US, h, nom_depth_H, tv, dzInterface, remap
     call filtered_grid_motion(CS, nz, zInt(i,j,:), zNext, dzInterface(i,j,:))
     ! convert from depth to z
     do K = 1, nz+1 ; dzInterface(i,j,K) = -dzInterface(i,j,K) ; enddo
-    call adjust_interface_motion(CS, nz, h(i,j,:), dzInterface(i,j,:))
+    if (CS%use_adjust_interface_motion) call adjust_interface_motion(CS, nz, h(i,j,:), dzInterface(i,j,:))
   enddo ; enddo
 end subroutine build_grid_adaptive
 
@@ -2767,7 +2775,7 @@ end function getCoordinateShortName
 !> Can be used to set any of the parameters for MOM_regridding.
 subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_grid_weight, &
              interp_scheme, depth_of_time_filter_shallow, depth_of_time_filter_deep, &
-             compress_fraction, ref_pressure, &
+             use_adjust_interface_motion, compress_fraction, ref_pressure, &
              integrate_downward_for_e, remap_answers_2018, remap_answer_date, regrid_answer_date, &
              adaptTimeRatio, adaptZoom, adaptZoomCoeff, adaptBuoyCoeff, &
              adaptAlpha, adaptDoMin, adaptDrho0)
@@ -2779,6 +2787,7 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
   character(len=*), optional, intent(in) :: interp_scheme !< Interpolation method for state-dependent coordinates
   real,    optional, intent(in) :: depth_of_time_filter_shallow !< Depth to start cubic [H ~> m or kg m-2]
   real,    optional, intent(in) :: depth_of_time_filter_deep !< Depth to end cubic [H ~> m or kg m-2]
+  logical, optional, intent(in) :: use_adjust_interface_motion !< Call adjust_interface_motion()
   real,    optional, intent(in) :: compress_fraction !< Fraction of compressibility to add to potential density [nondim]
   real,    optional, intent(in) :: ref_pressure     !< The reference pressure for density-dependent
                                                     !! coordinates [R L2 T-2 ~> Pa]
@@ -2820,6 +2829,7 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
   endif
 
   if (present(min_thickness)) CS%min_thickness = min_thickness
+  if (present(use_adjust_interface_motion)) CS%use_adjust_interface_motion = use_adjust_interface_motion
   if (present(compress_fraction)) CS%compressibility_fraction = compress_fraction
   if (present(ref_pressure)) CS%ref_pressure = ref_pressure
   if (present(integrate_downward_for_e)) CS%integrate_downward_for_e = integrate_downward_for_e

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2646,7 +2646,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
   character(len=64) :: remappingScheme
   logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm (only used if useALEremapping)
   logical :: do_conv_adj, ignore
-  logical :: use_adjust_interface_motion
+  logical :: use_depth_based_time_fitler, use_adjust_interface_motion
   integer :: id_clock_routine, id_clock_ALE
 
   id_clock_routine = cpu_clock_id('(Initialize from Z)', grain=CLOCK_ROUTINE)
@@ -2801,6 +2801,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "from an input dataset using horiz_interp_and_extrap_tracer.  This routine "//&
                  "converges slowly, so an overly small tolerance can get expensive.", &
                  units="ppt", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
+  call get_param(PF, mdl, "REGRID_USE_DEPTH_BASED_TIME_FILTER", use_depth_based_time_fitler, &
+                 default=.true., do_not_log=.true.)
   call get_param(PF, mdl, "USE_ADJUST_INTERFACE_MOTION", use_adjust_interface_motion, &
                  default=.true., do_not_log=.true.)
 
@@ -2914,7 +2916,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
     ! Now remap from source grid to target grid, first setting reconstruction parameters
     if (remap_general) then
       call set_regrid_params( regridCS, min_thickness=0., &
-                              use_adjust_interface_motion=use_adjust_interface_motion)
+                              use_adjust_interface_motion=use_adjust_interface_motion, &
+                              use_depth_based_time_filter=use_depth_based_time_fitler)
       allocate( dz_interface(isd:ied,jsd:jed,nkd+1) ) ! Need for argument to regridding_main() but is not used
 
       call regridding_preadjust_reqs(regridCS, do_conv_adj, ignore)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2646,6 +2646,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
   character(len=64) :: remappingScheme
   logical :: om4_remap_via_sub_cells ! If true, use the OM4 remapping algorithm (only used if useALEremapping)
   logical :: do_conv_adj, ignore
+  logical :: use_adjust_interface_motion
   integer :: id_clock_routine, id_clock_ALE
 
   id_clock_routine = cpu_clock_id('(Initialize from Z)', grain=CLOCK_ROUTINE)
@@ -2800,6 +2801,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "from an input dataset using horiz_interp_and_extrap_tracer.  This routine "//&
                  "converges slowly, so an overly small tolerance can get expensive.", &
                  units="ppt", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
+  call get_param(PF, mdl, "USE_ADJUST_INTERFACE_MOTION", use_adjust_interface_motion, &
+                 default=.true., do_not_log=.true.)
 
   if (just_read) then
     if ((.not.useALEremapping) .and. adjust_temperature) &
@@ -2910,7 +2913,8 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
 
     ! Now remap from source grid to target grid, first setting reconstruction parameters
     if (remap_general) then
-      call set_regrid_params( regridCS, min_thickness=0. )
+      call set_regrid_params( regridCS, min_thickness=0., &
+                              use_adjust_interface_motion=use_adjust_interface_motion)
       allocate( dz_interface(isd:ied,jsd:jed,nkd+1) ) ! Need for argument to regridding_main() but is not used
 
       call regridding_preadjust_reqs(regridCS, do_conv_adj, ignore)


### PR DESCRIPTION
ALE: Add runtime flags for optional regridding adjustments

This PR adds two new runtime parameters to give finer control over ALE regridding behaviour, motivated by the need to configure an ice shelf cavity configuration more robustly.

`USE_ADJUST_INTERFACE_MOTION` (default true) Controls whether adjust_interface_motion() is called after the primary grid generation step. This post-processing step enforces positive layer thicknesses and was historically always applied. Setting it to false allows configurations
  where the primary coordinate generator is already well-behaved (e.g. z* in an ice shelf cavity) to skip this step.

`REGRID_USE_DEPTH_BASED_TIME_FILTER` (default true) Controls whether the depth-based time filtering of grid interfaces is always applied or only when old_grid_weight > 0. Previously, filtered_grid_motion() was called unconditionally in all coordinate builders (z*, sigma, rho, HyCOM1, adaptive), even when no filtering was needed. Setting this to false bypasses the call when the filter time-scale is zero, avoiding unnecessary computation.

Both flags are exposed via set_regrid_params() and are back-compatible by defaulting to true (preserving previous behaviour). The use_depth_based_time_filter flag is also correctly initialised in non-main-parameter code paths used by the diagnostic remapper and ODA driver.
