### PR TITLE
+Improve the non-Boussinesq thkcello and volcello calculations

### DIFF
--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -19,7 +19,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public find_eta, dz_to_thickness, thickness_to_dz, dz_to_thickness_simple
+public find_eta, find_dz_for_eta, dz_to_thickness, thickness_to_dz, dz_to_thickness_simple
 public calc_derived_thermo
 public convert_MLD_to_ML_thickness
 public find_rho_bottom, find_col_avg_SpV, find_col_mass
@@ -42,6 +42,80 @@ interface thickness_to_dz
 end interface thickness_to_dz
 
 contains
+
+!> Calculates the change in height across layers, using the appropriate form for
+!! consistency with the calculation of the pressure gradient forces.
+subroutine find_dz_for_eta(h, tv, G, GV, US, dz_lay, halo_size)
+  type(ocean_grid_type),                      intent(in)  :: G   !< The ocean's grid structure.
+  type(verticalGrid_type),                    intent(in)  :: GV  !< The ocean's vertical grid structure.
+  type(unit_scale_type),                      intent(in)  :: US  !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h   !< Layer thicknesses [H ~> m or kg m-2]
+  type(thermo_var_ptrs),                      intent(in)  :: tv  !< A structure pointing to various
+                                                                 !! thermodynamic variables.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: dz_lay !< Height change across layers [Z ~> m]
+  integer,                          optional, intent(in)  :: halo_size !< width of halo points on
+                                                                 !! which to calculate eta.
+
+  ! Local variables
+  real :: p(SZI_(G),SZJ_(G),SZK_(GV)+1)   ! Hydrostatic pressure at each interface [R L2 T-2 ~> Pa]
+  real :: dz_geo(SZI_(G),SZJ_(G)) ! The change in geopotential height across a layer [L2 T-2 ~> m2 s-2]
+  real :: SpV_lay_conv(SZK_(GV))  ! The prescribed layer specific volume times a conversion factor from
+                                  ! the units of thickness to layer mass [Z H-1 ~> nondim or m3 kg-1]
+  real :: I_gEarth                ! The inverse of the gravitational acceleration times the
+                                  ! rescaling factor derived from eta_to_m [T2 Z L-2 ~> s2 m-1]
+  integer :: i, j, k, isv, iev, jsv, jev, nz, halo
+
+  halo = 0 ; if (present(halo_size)) halo = max(0,halo_size)
+
+  isv = G%isc-halo ; iev = G%iec+halo ; jsv = G%jsc-halo ; jev = G%jec+halo
+  nz = GV%ke
+
+  if ((isv<G%isd) .or. (iev>G%ied) .or. (jsv<G%jsd) .or. (jev>G%jed)) &
+    call MOM_error(FATAL,"find_dz_for_eta called with an overly large halo_size.")
+
+  if (GV%Boussinesq) then
+    do k=1,nz ; do j=jsv,jev ; do i=isv,iev
+      dz_lay(i,j,K) = h(i,j,k)*GV%H_to_Z
+    enddo ; enddo ; enddo
+  elseif (associated(tv%eqn_of_state)) then
+    I_gEarth = 1.0 / GV%g_Earth
+    !$OMP parallel do default(shared)
+    do j=jsv,jev
+      if (associated(tv%p_surf)) then
+        do i=isv,iev ; p(i,j,1) = tv%p_surf(i,j) ; enddo
+      else
+        do i=isv,iev ; p(i,j,1) = 0.0 ; enddo
+      endif
+      do k=1,nz ; do i=isv,iev
+        p(i,j,K+1) = p(i,j,K) + GV%g_Earth*GV%H_to_RZ*h(i,j,k)
+      enddo ; enddo
+    enddo
+    !$OMP parallel do default(shared) private(dz_geo)
+    do k=1,nz
+      call int_specific_vol_dp(tv%T(:,:,k), tv%S(:,:,k), p(:,:,K), p(:,:,K+1), &
+                               0.0, G%HI, tv%eqn_of_state, US, dz_geo, halo_size=halo)
+      do j=jsv,jev ; do i=isv,iev
+        dz_lay(i,j,K) = I_gEarth * dz_geo(i,j)
+      enddo ; enddo
+    enddo
+  else ! non-Boussinesq but with no equation of state
+    do k=1,nz ; do j=jsv,jev ; do i=isv,iev
+      dz_lay(i,j,K) = GV%H_to_RZ*h(i,j,k) / GV%Rlay(k)
+    enddo ; enddo ; enddo
+    ! This would be faster but could change answers.
+    ! do k=1,nz ; SpV_lay_conv(k) = GV%H_to_RZ / GV%Rlay(k) ; enddo
+    ! do k=1,nz ; do j=jsv,jev ; do i=isv,iev
+    !   dz_lay(i,j,K) = h(i,j,k) * SpV_lay_conv(k)
+    ! enddo ; enddo ; enddo
+  endif
+
+  ! To find eta, do the following:
+  ! do j=jsv,jev ; do i=isv,iev ; eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref) ; enddo ; enddo
+  ! do k=nz,1,-1 ; do j=jsv,jev ; do i=isv,iev
+  !   eta(i,j,K) = eta(i,j,K+1) + dz_lay(i,j,K)
+  ! enddo ; enddo ; enddo
+
+end subroutine find_dz_for_eta
 
 !> Calculates the heights of all interfaces between layers, using the appropriate
 !! form for consistency with the calculation of the pressure gradient forces.
@@ -66,13 +140,9 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
                     !! reference height between G%bathyT and eta [Z ~> m]. The default is 0.
 
   ! Local variables
-  real :: p(SZI_(G),SZJ_(G),SZK_(GV)+1)   ! Hydrostatic pressure at each interface [R L2 T-2 ~> Pa]
-  real :: dz_geo(SZI_(G),SZJ_(G),SZK_(GV)) ! The change in geopotential height
-                                           ! across a layer [L2 T-2 ~> m2 s-2].
+  real :: dz_lay(SZI_(G),SZJ_(G),SZK_(GV)) ! The change in height across a layer [Z ~> m]
   real :: dilate(SZI_(G))                 ! A non-dimensional dilation factor [nondim]
   real :: htot(SZI_(G))                   ! total thickness [H ~> m or kg m-2]
-  real :: I_gEarth          ! The inverse of the gravitational acceleration times the
-                            ! rescaling factor derived from eta_to_m [T2 Z L-2 ~> s2 m-1]
   real :: dZ_ref    ! The difference in the reference height between G%bathyT and eta [Z ~> m].
                     ! dZ_ref is 0 unless the optional argument dZref is present.
   integer :: i, j, k, isv, iev, jsv, jev, nz, halo
@@ -85,14 +155,12 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
   if ((isv<G%isd) .or. (iev>G%ied) .or. (jsv<G%jsd) .or. (jev>G%jed)) &
     call MOM_error(FATAL,"find_eta called with an overly large halo_size.")
 
-  I_gEarth = 1.0 / GV%g_Earth
   dZ_ref = 0.0 ; if (present(dZref)) dZ_ref = dZref
 
-  !$OMP parallel default(shared) private(dilate,htot)
-  !$OMP do
-  do j=jsv,jev ; do i=isv,iev ; eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref) ; enddo ; enddo
-
   if (GV%Boussinesq) then
+    !$OMP parallel default(shared) private(dilate,htot)
+    !$OMP do
+    do j=jsv,jev ; do i=isv,iev ; eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref) ; enddo ; enddo
     !$OMP do
     do j=jsv,jev ; do k=nz,1,-1 ; do i=isv,iev
       eta(i,j,K) = eta(i,j,K+1) + h(i,j,k)*GV%H_to_Z
@@ -101,7 +169,8 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
       ! Dilate the water column to agree with the free surface height
       ! that is used for the dynamics.
       !$OMP do
-      do j=jsv,jev
+      do j=jsv,jev    !$OMP parallel do default(shared)
+
         do i=isv,iev
           dilate(i) = (eta_bt(i,j)*GV%H_to_Z + G%bathyT(i,j)) / &
                       (eta(i,j,1) + (G%bathyT(i,j) + dZ_ref))
@@ -112,36 +181,18 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
         enddo ; enddo
       enddo
     endif
+    !$OMP end parallel
   else
-    if (associated(tv%eqn_of_state)) then
-      !$OMP do
-      do j=jsv,jev
-        if (associated(tv%p_surf)) then
-          do i=isv,iev ; p(i,j,1) = tv%p_surf(i,j) ; enddo
-        else
-          do i=isv,iev ; p(i,j,1) = 0.0 ; enddo
-        endif
-        do k=1,nz ; do i=isv,iev
-          p(i,j,K+1) = p(i,j,K) + GV%g_Earth*GV%H_to_RZ*h(i,j,k)
-        enddo ; enddo
-      enddo
-      !$OMP do
-      do k=1,nz
-        call int_specific_vol_dp(tv%T(:,:,k), tv%S(:,:,k), p(:,:,K), p(:,:,K+1), &
-                                 0.0, G%HI, tv%eqn_of_state, US, dz_geo(:,:,k), halo_size=halo)
-      enddo
-      !$OMP do
-      do j=jsv,jev
-        do k=nz,1,-1 ; do i=isv,iev
-          eta(i,j,K) = eta(i,j,K+1) + I_gEarth * dz_geo(i,j,k)
-        enddo ; enddo
-      enddo
-    else
-      !$OMP do
-      do j=jsv,jev ;  do k=nz,1,-1 ; do i=isv,iev
-        eta(i,j,K) = eta(i,j,K+1) + GV%H_to_RZ*h(i,j,k) / GV%Rlay(k)
-      enddo ; enddo ; enddo
-    endif
+    call find_dz_for_eta(h, tv, G, GV, US, dz_lay, halo_size)
+    !$OMP parallel default(shared) private(dilate,htot)
+    !$OMP do
+    do j=jsv,jev
+      do i=isv,iev ; eta(i,j,nz+1) = -(G%bathyT(i,j) + dZ_ref) ; enddo
+      do k=nz,1,-1 ; do i=isv,iev
+        eta(i,j,K) = eta(i,j,K+1) + dz_lay(i,j,k)
+      enddo ; enddo
+    enddo
+
     if (present(eta_bt)) then
       ! Dilate the water column to agree with the free surface height
       ! from the time-averaged barotropic solution.
@@ -156,8 +207,8 @@ subroutine find_eta_3d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
         enddo ; enddo
       enddo
     endif
+    !$OMP end parallel
   endif
-  !$OMP end parallel
 
 end subroutine find_eta_3d
 
@@ -184,13 +235,8 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
                     !! reference height between G%bathyT and eta [Z ~> m]. The default is 0.
 
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1) :: &
-    p          ! Hydrostatic pressure at each interface [R L2 T-2 ~> Pa]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
-    dz_geo     ! The change in geopotential height across a layer [L2 T-2 ~> m2 s-2].
+  real :: dz_lay(SZI_(G),SZJ_(G),SZK_(GV)) ! The change in height across a layer [Z ~> m]
   real :: htot(SZI_(G))  ! The sum of all layers' thicknesses [H ~> m or kg m-2].
-  real :: I_gEarth          ! The inverse of the gravitational acceleration times the
-                            ! rescaling factor derived from eta_to_m [T2 Z L-2 ~> s2 m-1]
   real :: dZ_ref    ! The difference in the reference height between G%bathyT and eta [Z ~> m].
                     ! dZ_ref is 0 unless the optional argument dZref is present.
   integer :: i, j, k, is, ie, js, je, nz, halo
@@ -199,54 +245,33 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
   is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
   nz = GV%ke
 
-  I_gEarth = 1.0 / GV%g_Earth
   dZ_ref = 0.0 ; if (present(dZref)) dZ_ref = dZref
-
-  !$OMP parallel default(shared) private(htot)
-  !$OMP do
-  do j=js,je ; do i=is,ie ; eta(i,j) = -(G%bathyT(i,j) + dZ_ref) ; enddo ; enddo
 
   if (GV%Boussinesq) then
     if (present(eta_bt)) then
-      !$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je ; do i=is,ie
         eta(i,j) = GV%H_to_Z*eta_bt(i,j) - dZ_ref
       enddo ; enddo
     else
-      !$OMP do
-      do j=js,je ; do k=1,nz ; do i=is,ie
-        eta(i,j) = eta(i,j) + h(i,j,k)*GV%H_to_Z
-      enddo ; enddo ; enddo
-    endif
-  else
-    if (associated(tv%eqn_of_state)) then
-      !$OMP do
+      !$OMP parallel do default(shared)
       do j=js,je
-        if (associated(tv%p_surf)) then
-          do i=is,ie ; p(i,j,1) = tv%p_surf(i,j) ; enddo
-        else
-          do i=is,ie ; p(i,j,1) = 0.0 ; enddo
-        endif
-
+        do i=is,ie ; eta(i,j) = -(G%bathyT(i,j) + dZ_ref) ; enddo
         do k=1,nz ; do i=is,ie
-          p(i,j,k+1) = p(i,j,k) + GV%g_Earth*GV%H_to_RZ*h(i,j,k)
+          eta(i,j) = eta(i,j) + h(i,j,k)*GV%H_to_Z
         enddo ; enddo
       enddo
-      !$OMP do
-      do k = 1, nz
-        call int_specific_vol_dp(tv%T(:,:,k), tv%S(:,:,k), p(:,:,k), p(:,:,k+1), 0.0, &
-                                 G%HI, tv%eqn_of_state, US, dz_geo(:,:,k), halo_size=halo)
-      enddo
-      !$OMP do
-      do j=js,je ; do k=1,nz ; do i=is,ie
-          eta(i,j) = eta(i,j) + I_gEarth * dz_geo(i,j,k)
-      enddo ; enddo ; enddo
-    else
-      !$OMP do
-      do j=js,je ; do k=1,nz ; do i=is,ie
-        eta(i,j) = eta(i,j) + GV%H_to_RZ*h(i,j,k) / GV%Rlay(k)
-      enddo ; enddo ; enddo
     endif
+  else
+    call find_dz_for_eta(h, tv, G, GV, US, dz_lay, halo_size)
+    !$OMP parallel default(shared) private(htot)
+    !$OMP do
+    do j=js,je
+      do i=is,ie ; eta(i,j) = -(G%bathyT(i,j) + dZ_ref) ; enddo
+      do k=1,nz ; do i=is,ie
+        eta(i,j) = eta(i,j) + dz_lay(i,j,k)
+      enddo ; enddo
+    enddo
     if (present(eta_bt)) then
       !   Dilate the water column to agree with the time-averaged column
       ! mass from the barotropic solution.
@@ -260,8 +285,8 @@ subroutine find_eta_2d(h, tv, G, GV, US, eta, eta_bt, halo_size, dZref)
         enddo
       enddo
     endif
+    !$OMP end parallel
   endif
-  !$OMP end parallel
 
 end subroutine find_eta_2d
 

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -28,7 +28,7 @@ use MOM_EOS,               only : prac_saln_to_abs_saln, abs_saln_to_prac_saln
 use MOM_error_handler,     only : MOM_error, FATAL, WARNING
 use MOM_file_parser,       only : get_param, log_version, param_file_type
 use MOM_grid,              only : ocean_grid_type
-use MOM_interface_heights, only : find_eta, find_col_mass
+use MOM_interface_heights, only : find_eta, find_dz_for_eta, find_col_mass
 use MOM_spatial_means,     only : global_area_mean, global_layer_mean
 use MOM_spatial_means,     only : global_volume_mean, global_area_integral
 use MOM_tracer_registry,   only : tracer_registry_type, post_tracer_transport_diagnostics
@@ -60,6 +60,10 @@ type, public :: diagnostics_CS ; private
                                        !! barotropic wave speed [nondim].
   real :: mono_N2_depth = -1.          !< The depth below which N2 is limited as monotonic for the purposes of
                                        !! calculating the equivalent barotropic wave speed [H ~> m or kg m-2].
+  logical :: accurate_thick_cello      !< If true, use the same careful integrals to find the diagnosed
+                                       !! non-Boussinesq layer thicknesses as are used to find the free
+                                       !! surface height, instead of using an approximate thickness
+                                       !! based on division by the mid-layer density.
 
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                        !! regulate the timing of diagnostic output.
@@ -215,6 +219,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   real :: Rcv(SZI_(G),SZJ_(G),SZK_(GV)) ! Coordinate variable potential density [R ~> kg m-3].
   real :: work_3d(SZI_(G),SZJ_(G),SZK_(GV)) ! A 3-d temporary work array in various units
                                             ! including [nondim] and [H ~> m or kg m-2].
+  real :: dz_lay(SZI_(G),SZJ_(G),SZK_(GV)) ! Height change across layers [Z ~> m]
   real :: uh_tmp(SZIB_(G),SZJ_(G),SZK_(GV)) ! A temporary zonal transport [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: vh_tmp(SZI_(G),SZJB_(G),SZK_(GV)) ! A temporary meridional transport [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: mass_cell(SZI_(G),SZJ_(G))       ! The vertically integrated mass in a grid cell [R Z L2 ~> kg]
@@ -223,7 +228,6 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
   real :: Rd1(SZI_(G),SZJ_(G))             ! First baroclinic deformation radius [L ~> m]
   real :: CFL_cg1(SZI_(G),SZJ_(G))         ! CFL for first baroclinic gravity wave speed, either based on the
                                            ! overall grid spacing or just one direction [nondim]
-
 
   ! tmp array for surface properties
   real :: pressure_1d(SZI_(G)) ! Temporary array for pressure when calling EOS [R L2 T-2 ~> Pa]
@@ -318,22 +322,31 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
     call post_data(CS%id_uv, uv, CS%diag)
   endif
 
-  ! Find the interface heights, relative either to a reference height or to the bottom [Z ~> m].
-  if (CS%id_e > 0) then
-    call find_eta(h, tv, G, GV, US, eta, dZref=G%Z_ref)
+  ! Find the layer thicknesses in [Z ~> m] that can be used to determine interface heights
+  if ((CS%id_e > 0) .or. (CS%id_e_D > 0) .or. &
+      ((CS%id_thkcello>0 .or. CS%id_volcello>0) .and. (CS%accurate_thick_cello))) &
+    call find_dz_for_eta(h, tv, G, GV, US, dz_lay)
+
+  if ((CS%id_e > 0) .or. (CS%id_e_D > 0)) then
+    ! Find the interface heights, relative a reference height or to the bottom [Z ~> m]
+    do j=js,je ; do i=is,ie ; eta(i,j,nz+1) = -(G%bathyT(i,j) + G%Z_ref) ; enddo ; enddo
+    do k=nz,1,-1 ; do j=js,je ; do i=is,ie
+      eta(i,j,K) = eta(i,j,K+1) + dz_lay(i,j,K)
+    enddo ; enddo ; enddo
     if (CS%id_e > 0) call post_data(CS%id_e, eta, CS%diag)
+
     if (CS%id_e_D > 0) then
+      ! Find the interface heights, relative to the bottom [Z ~> m]
       do k=1,nz+1 ; do j=js,je ; do i=is,ie
         eta(i,j,k) = eta(i,j,k) + (G%bathyT(i,j) + G%Z_ref)
       enddo ; enddo ; enddo
+      ! This is more accurate but changes answers in the e_D diagnostic:
+      ! do j=js,je ; do i=is,ie ; eta(i,j,nz+1) = 0.0 ; enddo ; enddo
+      ! do k=nz,1,-1 ; do j=js,je ; do i=is,ie
+      !   eta(i,j,K) = eta(i,j,K+1) + dz_lay(i,j,K)
+      ! enddo ; enddo ; enddo
       call post_data(CS%id_e_D, eta, CS%diag)
     endif
-  elseif (CS%id_e_D > 0) then
-    call find_eta(h, tv, G, GV, US, eta)
-    do k=1,nz+1 ; do j=js,je ; do i=is,ie
-      eta(i,j,k) = eta(i,j,k) + G%bathyT(i,j)
-    enddo ; enddo ; enddo
-    call post_data(CS%id_e_D, eta, CS%diag)
   endif
 
   ! mass per area of grid cell (for Boussinesq, use Rho0)
@@ -341,7 +354,7 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
     call post_data(CS%id_masscello, h, CS%diag)
   endif
 
-  ! mass of liquid ocean (for Bouss, use Rho0). The reproducing sum requires the use of MKS units.
+  ! mass of liquid ocean (for Bouss, use Rho0) [R Z L2 ~> kg]
   if (CS%id_masso > 0) then
     mass_cell(:,:) = 0.0
     do k=1,nz ; do j=js,je ; do i=is,ie
@@ -358,9 +371,9 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
         call post_data(CS%id_thkcello, h, CS%diag)
       else
         do k=1,nz ; do j=js,je ; do i=is,ie
-          work_3d(i,j,k) = GV%H_to_Z*h(i,j,k)
+          dz_lay(i,j,k) = GV%H_to_Z*h(i,j,k)
         enddo ; enddo ; enddo
-        call post_data(CS%id_thkcello, work_3d, CS%diag)
+        call post_data(CS%id_thkcello, dz_lay, CS%diag)
       endif ; endif
       if (CS%id_volcello > 0) then ! volcello = h*area for Boussinesq
         do k=1,nz ; do j=js,je ; do i=is,ie
@@ -368,37 +381,41 @@ subroutine calculate_diagnostic_fields(u, v, h, uh, vh, tv, ADp, CDp, p_surf, &
         enddo ; enddo ; enddo
         call post_data(CS%id_volcello, work_3d, CS%diag)
       endif
-    else ! thkcello = dp/(rho*g) for non-Boussinesq
-      EOSdom(:) = EOS_domain(G%HI)
-      do j=js,je
-        if (associated(p_surf)) then ! Pressure loading at top of surface layer [R L2 T-2 ~> Pa]
-          do i=is,ie
-            pressure_1d(i) = p_surf(i,j)
-          enddo
-        else
-          do i=is,ie
-            pressure_1d(i) = 0.0
-          enddo
-        endif
-        do k=1,nz ! Integrate vertically downward for pressure
-          do i=is,ie ! Pressure for EOS at the layer center [R L2 T-2 ~> Pa]
-            pressure_1d(i) = pressure_1d(i) + 0.5*(GV%H_to_RZ*GV%g_Earth)*h(i,j,k)
-          enddo
-          ! Store in-situ density [R ~> kg m-3] in work_3d
-          call calculate_density(tv%T(:,j,k), tv%S(:,j,k),  pressure_1d, rho_in_situ, &
-                                 tv%eqn_of_state, EOSdom)
-          do i=is,ie ! Cell thickness = dz = dp/(g*rho) (meter); store in work_3d
-            work_3d(i,j,k) = (GV%H_to_RZ*h(i,j,k)) / rho_in_situ(i)
-          enddo
-          do i=is,ie ! Pressure for EOS at the bottom interface [R L2 T-2 ~> Pa]
-            pressure_1d(i) = pressure_1d(i) + 0.5*(GV%H_to_RZ*GV%g_Earth)*h(i,j,k)
-          enddo
-        enddo ! k
-      enddo ! j
-      if (CS%id_thkcello > 0) call post_data(CS%id_thkcello, work_3d, CS%diag)
+    else ! thkcello is approximately dp/(rho*g) in non-Boussinesq mode.
+      if (.not.CS%accurate_thick_cello) then
+        ! This is only an approximate calculation of dz_lay that does not use the careful integrals
+        ! found in find_dz_for_eta that mirror what is done for the pressure gradient calculations.
+        EOSdom(:) = EOS_domain(G%HI)
+        do j=js,je
+          if (associated(p_surf)) then ! Pressure loading at top of surface layer [R L2 T-2 ~> Pa]
+            do i=is,ie
+              pressure_1d(i) = p_surf(i,j)
+            enddo
+          else
+            do i=is,ie
+              pressure_1d(i) = 0.0
+            enddo
+          endif
+          do k=1,nz ! Integrate vertically downward for pressure
+            do i=is,ie ! Pressure for EOS at the layer center [R L2 T-2 ~> Pa]
+              pressure_1d(i) = pressure_1d(i) + 0.5*(GV%H_to_RZ*GV%g_Earth)*h(i,j,k)
+            enddo
+            ! Store in-situ density [R ~> kg m-3] in work_3d
+            call calculate_density(tv%T(:,j,k), tv%S(:,j,k),  pressure_1d, rho_in_situ, &
+                                   tv%eqn_of_state, EOSdom)
+            do i=is,ie ! Cell thickness = dz = dp/(g*rho) (meter); store in work_3d
+              dz_lay(i,j,k) = (GV%H_to_RZ*h(i,j,k)) / rho_in_situ(i)
+            enddo
+            do i=is,ie ! Pressure for EOS at the bottom interface [R L2 T-2 ~> Pa]
+              pressure_1d(i) = pressure_1d(i) + 0.5*(GV%H_to_RZ*GV%g_Earth)*h(i,j,k)
+            enddo
+          enddo ! k
+        enddo ! j
+      endif ! Otherwise dz_lay is set in the call to find_dz_for_eta above.
+      if (CS%id_thkcello > 0) call post_data(CS%id_thkcello, dz_lay, CS%diag)
       if (CS%id_volcello > 0) then
         do k=1,nz ; do j=js,je ; do i=is,ie ! volcello = dp/(rho*g)*area for non-Boussinesq
-          work_3d(i,j,k) = US%Z_to_m*US%L_to_m**2*G%areaT(i,j) * work_3d(i,j,k)
+          work_3d(i,j,k) = US%Z_to_m*US%L_to_m**2*G%areaT(i,j) * dz_lay(i,j,k)
         enddo ; enddo ; enddo
         call post_data(CS%id_volcello, work_3d, CS%diag)
       endif
@@ -1872,6 +1889,12 @@ subroutine MOM_diagnostics_init(MIS, ADp, CDp, Time, G, GV, US, param_file, diag
                  "If true, use the OM4 remapping-via-subcells algorithm for calculating EBT structure. "//&
                  "See REMAPPING_USE_OM4_SUBCELLS for details. "//&
                  "We recommend setting this option to false.", default=om4_remap_via_sub_cells)
+  call get_param(param_file, mdl, "ACCURATE_NONBOUS_THICK_CELLO", CS%accurate_thick_cello, &
+                 "If true, use the same careful integrals to find the diagnosed non-Boussinesq "//&
+                 "layer thicknesses as are used to find the free surface height, instead of "//&
+                 "using an approximate thickness based on division by the mid-layer density.", &
+                 default=.false., do_not_log=GV%Boussinesq)
+  if (GV%Boussinesq) CS%accurate_thick_cello = .false.
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
                  default=99991231)


### PR DESCRIPTION
  This PR consists of two commits.  The first creates the new publicly visible subroutine `find_dz_for_eta()` that does the calculation of the integrals that convert the layer thicknesses into height changes across layers and used this in `find_eta_2d()` and `find_eta_3d()`.  As a part of these changes, `find_eta_2d()` and `find_eta_3d()` were refactored to call `find_dz_for_eta()` to reduce code duplication and to simplify the openMP directives.  All answers are bitwise identical, but there is a new publicly visible interface.

  The second commit adds the new runtime option `ACCURATE_NONBOUS_THICK_CELLO` to improve the calculation of the diagnosed layer thicknesses and volumes in non-Boussinesq mode by using the same code in `find_dz_for_eta()` as is used for
the free surface.  The code to calculate the diagnostics `e` and `e_D` were also refactored to use the same thicknesses from `find_dz_for_eta()`, thereby avoiding extra calls to the equation of state.  Depending on which diagnostics are used, this change may speed up the code in some non-Boussinesq cases.  By default, all diagnostics are bitwise identical.

  By default, all answers and diagnostics are bitwise identical with this PR, but there is a new publicly visible interface and a new runtime option in the MOM_parameter_doc files for non-Boussinesq runs.