### PR TITLE
Fix bug in time differencing

### DIFF
--- a/config_src/infra/FMS1/MOM_time_manager.F90
+++ b/config_src/infra/FMS1/MOM_time_manager.F90
@@ -19,8 +19,9 @@ use time_manager_mod, only : NO_CALENDAR
 
 implicit none ; private
 
+! FMS re-exports
 public :: time_type, get_time, set_time
-public :: time_type_to_real, real_to_time_type, real_to_time
+public :: time_type_to_real, real_to_time_type
 public :: set_ticks_per_second, get_ticks_per_second
 public :: operator(+), operator(-), operator(*), operator(/)
 public :: operator(>), operator(<), operator(>=), operator(<=)
@@ -28,6 +29,8 @@ public :: operator(==), operator(/=), operator(//)
 public :: get_date, set_date, increment_date, month_name, days_in_month
 public :: JULIAN, NOLEAP, THIRTY_DAY_MONTHS, GREGORIAN, NO_CALENDAR
 public :: set_calendar_type, get_calendar_type
+! Module functions
+public :: real_to_time, time_minus_signed
 
 contains
 
@@ -52,5 +55,24 @@ type(time_type) function real_to_time(x, err_msg)
 
   real_to_time = set_time(seconds=seconds, days=days, ticks=ticks, err_msg=err_msg)
 end function real_to_time
+
+!> Returns a real number representing time_a - time_b.
+!! The FMS - operator for time types returns a new time type representing
+!! a difference that is always >= 0.
+!! In contrast, this function returns a negative real number if time_b > time_a,
+!! and a positive real otherwise, as would be expected for subtraction.
+real function time_minus_signed(time_a, time_b)
+  type(time_type), intent(in) :: time_a, time_b !< Two times for calculating time_a - time_b
+
+  ! Local variables
+  real :: abs_diff
+
+  ! Do FMS time subtraction, which will always be >= 0,
+  ! and convert to a real number.
+  abs_diff = time_type_to_real(time_a - time_b)
+
+  ! Add the sign back by comparing time_a and time_b
+  time_minus_signed = merge(abs_diff, -abs_diff, time_a >= time_b)
+end function time_minus_signed
 
 end module MOM_time_manager

--- a/config_src/infra/FMS2/MOM_time_manager.F90
+++ b/config_src/infra/FMS2/MOM_time_manager.F90
@@ -19,8 +19,9 @@ use time_manager_mod, only : NO_CALENDAR
 
 implicit none ; private
 
+! FMS re-exports
 public :: time_type, get_time, set_time
-public :: time_type_to_real, real_to_time_type, real_to_time
+public :: time_type_to_real, real_to_time_type
 public :: set_ticks_per_second, get_ticks_per_second
 public :: operator(+), operator(-), operator(*), operator(/)
 public :: operator(>), operator(<), operator(>=), operator(<=)
@@ -28,6 +29,8 @@ public :: operator(==), operator(/=), operator(//)
 public :: get_date, set_date, increment_date, month_name, days_in_month
 public :: JULIAN, NOLEAP, THIRTY_DAY_MONTHS, GREGORIAN, NO_CALENDAR
 public :: set_calendar_type, get_calendar_type
+! Module functions
+public :: real_to_time, time_minus_signed
 
 contains
 
@@ -52,5 +55,24 @@ type(time_type) function real_to_time(x, err_msg)
 
   real_to_time = set_time(seconds=seconds, days=days, ticks=ticks, err_msg=err_msg)
 end function real_to_time
+
+!> Returns a real number representing time_a - time_b.
+!! The FMS - operator for time types returns a new time type representing
+!! a difference that is always >= 0.
+!! In contrast, this function returns a negative real number if time_b > time_a,
+!! and a positive real otherwise, as would be expected for subtraction.
+real function time_minus_signed(time_a, time_b)
+  type(time_type), intent(in) :: time_a, time_b !< Two times for calculating time_a - time_b
+
+  ! Local variables
+  real :: abs_diff
+
+  ! Do FMS time subtraction, which will always be >= 0,
+  ! and convert to a real number.
+  abs_diff = time_type_to_real(time_a - time_b)
+
+  ! Add the sign back by comparing time_a and time_b
+  time_minus_signed = merge(abs_diff, -abs_diff, time_a >= time_b)
+end function time_minus_signed
 
 end module MOM_time_manager

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -29,7 +29,7 @@ use MOM_restart,              only : register_restart_field, register_restart_pa
 use MOM_restart,              only : query_initialized, set_initialized, MOM_restart_CS
 use MOM_string_functions,     only : extract_word, remove_spaces, uppercase, lowercase
 use MOM_tidal_forcing,        only : astro_longitudes, astro_longitudes_init, eq_phase, nodal_fu, tidal_frequency
-use MOM_time_manager,         only : set_date, time_type, time_type_to_real, operator(-)
+use MOM_time_manager,         only : set_date, time_type, time_minus_signed
 use MOM_tracer_registry,      only : tracer_type, tracer_registry_type, tracer_name_lookup
 use MOM_unit_scaling,         only : unit_scale_type
 use MOM_variables,            only : thermo_var_ptrs
@@ -4322,7 +4322,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
 
   if (.not. associated(OBC)) return
 
-  if (OBC%add_tide_constituents) time_delta = US%s_to_T * time_type_to_real(Time - OBC%time_ref)
+  if (OBC%add_tide_constituents) time_delta = US%s_to_T * time_minus_signed(Time, OBC%time_ref)
 
   if (OBC%number_of_segments >= 1) then
     dz(:,:,:) = 0.0
@@ -4924,7 +4924,7 @@ subroutine update_OBC_ramp(Time, OBC, US, activate)
     endif
   endif
   if (.not.OBC%ramping_is_activated) return
-  deltaTime = max( 0., US%s_to_T*time_type_to_real( Time - OBC%ramp_start_time ) )
+  deltaTime = max(0., US%s_to_T * time_minus_signed(Time, OBC%ramp_start_time))
   if (deltaTime >= OBC%trunc_ramp_time) then
     OBC%ramp_value = 1.0
     OBC%ramp = .false. ! This turns off ramping after this call

--- a/src/diagnostics/MOM_harmonic_analysis.F90
+++ b/src/diagnostics/MOM_harmonic_analysis.F90
@@ -5,7 +5,7 @@
 !> Inline harmonic analysis (conventional)
 module MOM_harmonic_analysis
 
-use MOM_time_manager,  only : time_type, real_to_time, time_type_to_real
+use MOM_time_manager,  only : time_type, real_to_time, time_type_to_real, time_minus_signed
 use MOM_time_manager,  only : set_date, get_date, increment_date
 use MOM_time_manager,  only : operator(+), operator(-), operator(<), operator(>), operator(>=)
 use MOM_grid,          only : ocean_grid_type
@@ -337,7 +337,7 @@ subroutine HA_accum(key, data, Time, G, CS)
   enddo
 
   nc  = CS%nc
-  now = CS%US%s_to_T * time_type_to_real(Time - CS%time_ref)
+  now = CS%US%s_to_T * time_minus_signed(Time, CS%time_ref)
 
   !!! Additional processing at the initial accumulating step !!!
   if (ha1%old_time < 0.0) then
@@ -410,7 +410,8 @@ subroutine HA_accum(key, data, Time, G, CS)
   enddo ! c=1,nc
 
   !!! Compute harmonic constants and write output as Time approaches CS%time_end !!!
-  ! This guarantees that HA_write will be called before Time becomes larger than CS%time_end
+  ! This guarantees that HA_write will be called before Time becomes larger than CS%time_end.
+  ! Result of subtracting time types is always >= 0, which is acceptable here.
   if (time_type_to_real(CS%time_end - Time) <= dt) then
     call HA_write(ha1, Time, G, CS)
 

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -12,7 +12,7 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING
 use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_grid,          only : ocean_grid_type
 use MOM_io,            only : field_exists, file_exists, MOM_read_data
-use MOM_time_manager,  only : set_date, time_type, time_type_to_real, operator(-)
+use MOM_time_manager,  only : set_date, time_type, time_minus_signed
 use MOM_unit_scaling,  only : unit_scale_type
 
 implicit none ; private
@@ -98,7 +98,7 @@ subroutine astro_longitudes_init(time_ref, longitudes)
   real, parameter :: PI = 4.0 * atan(1.0)            !> 3.14159... [nondim]
 
   ! Find date at time_ref in days since midnight at the start of 1900-01-01
-  D = time_type_to_real(time_ref - set_date(1900, 1, 1, 0, 0, 0)) / (24.0 * 3600.0)
+  D = time_minus_signed(time_ref, set_date(1900, 1, 1, 0, 0, 0)) / (24.0 * 3600.0)
   ! Time since 1900-01-01 in Julian centuries
   ! Kowalik and Luick use 36526, but Schureman uses 36525 which I think is correct.
   T = D / 36525.0
@@ -633,7 +633,7 @@ subroutine calc_tidal_forcing(Time, e_tide_eq, e_tide_sal, G, US, CS)
     return
   endif
 
-  now = US%s_to_T * time_type_to_real(Time - cs%time_ref)
+  now = US%s_to_T * time_minus_signed(Time, cs%time_ref)
 
   do c=1,CS%nc
     m = CS%struct(c)
@@ -707,7 +707,7 @@ subroutine calc_tidal_forcing_legacy(Time, e_sal, e_sal_tide, e_tide_eq, e_tide_
     return
   endif
 
-  now = US%s_to_T * time_type_to_real(Time - cs%time_ref)
+  now = US%s_to_T * time_minus_signed(Time, cs%time_ref)
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     e_sal_tide(i,j) = e_sal(i,j)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -24,7 +24,7 @@ use MOM_open_boundary, only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_E
 use MOM_open_boundary, only : OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_PointAccel,    only : write_u_accel, write_v_accel, PointAccel_init
 use MOM_PointAccel,    only : PointAccel_CS
-use MOM_time_manager,  only : time_type, time_type_to_real, operator(-)
+use MOM_time_manager,  only : time_type, time_minus_signed
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs, vertvisc_type
 use MOM_variables,     only : cont_diag_ptrs, accel_diag_ptrs
@@ -3221,7 +3221,7 @@ subroutine updateCFLtruncationValue(Time, CS, US, activate)
     endif
   endif
   if (.not.CS%CFLrampingIsActivated) return
-  deltaTime = max( 0., US%s_to_T*time_type_to_real( Time - CS%rampStartTime ) )
+  deltaTime = max(0., US%s_to_T * time_minus_signed(Time, CS%rampStartTime))
   if (deltaTime >= CS%truncRampTime) then
     CS%CFL_trunc = CS%CFL_truncE
     CS%truncRampTime = 0. ! This turns off ramping after this call


### PR DESCRIPTION
As described in #1052, when two FMS time types are subtracted, the resulting time type is always positive. For some calculations in MOM6 involving model time relative to a reference date, the time should actually be negative if the model time is before the reference date.

This PR adds a new function to MOM_time_manager that first does `abs_diff = time_type_to_real(time_a - time_b)` to get a real number representing the time difference in seconds. The number will always be >= 0, so `merge(abs_diff, -abs_diff, time_a >= time_b)` makes the result negative if `time_a < time_b`.

 Then, all of the places I could catch that calculate time in seconds relative to a reference date are fixed to use the new function. For example, in  MOM_tidal_forcing, `now = US%s_to_T * time_minus_signed(Time, cs%time_ref)`. This should result in correct tidal forcing even when `Time < cs%time_ref`. 

Fixes #1052 