### PR TITLE
Add optional rescaling to time type conversion functions

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -47,7 +47,7 @@ use MOM_surface_forcing_gfdl, only : forcing_save_restart
 use MOM_time_manager, only : time_type, operator(>), operator(+), operator(-)
 use MOM_time_manager, only : operator(*), operator(/), operator(/=)
 use MOM_time_manager, only : operator(<=), operator(>=), operator(<)
-use MOM_time_manager, only : real_to_time, time_type_to_real
+use MOM_time_manager, only : real_to_time, time_to_real
 use MOM_tracer_flow_control, only : call_tracer_register, tracer_flow_control_init
 use MOM_tracer_flow_control, only : call_tracer_flux_init
 use MOM_unit_scaling, only : unit_scale_type
@@ -497,7 +497,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
   integer :: is, ie, js, je
 
   call callTree_enter("update_ocean_model(), ocean_model_MOM.F90")
-  dt_coupling = OS%US%s_to_T*time_type_to_real(Ocean_coupling_time_step)
+  dt_coupling = time_to_real(Ocean_coupling_time_step, scale=OS%US%s_to_T)
 
   if (.not.associated(OS)) then
     call MOM_error(FATAL, "update_ocean_model called with an unassociated "// &
@@ -659,7 +659,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
 
         if (step_thermo) then
           ! Back up Time1 to the start of the thermodynamic segment.
-          Time1 = Time1 - real_to_time(OS%US%T_to_s*(dtdia - dt_dyn))
+          Time1 = Time1 - real_to_time(dtdia - dt_dyn, unscale=OS%US%T_to_s)
           call step_MOM(OS%forces, OS%fluxes, OS%sfc_state, Time1, dtdia, OS%MOM_CSp, &
                         Waves=OS%Waves, do_dynamics=.false., do_thermodynamics=.true., &
                         start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_coupling)
@@ -667,7 +667,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, time_start_upda
       endif
 
       t_elapsed_seg = t_elapsed_seg + dt_dyn
-      Time1 = Time_seg_start + real_to_time(OS%US%T_to_s*t_elapsed_seg)
+      Time1 = Time_seg_start + real_to_time(t_elapsed_seg, unscale=OS%US%T_to_s)
     enddo
   endif
 

--- a/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
@@ -48,7 +48,7 @@ program Shelf_main
   use MOM_shared_initialization, only : write_ocean_geometry_file
   use MOM_string_functions,only : uppercase
   use MOM_time_manager,    only : time_type, set_date, get_date
-  use MOM_time_manager,    only : real_to_time, time_type_to_real
+  use MOM_time_manager,    only : real_to_time, time_to_real
   use MOM_time_manager,    only : operator(+), operator(-), operator(*), operator(/)
   use MOM_time_manager,    only : operator(>), operator(<), operator(>=)
   use MOM_time_manager,    only : increment_date, set_calendar_type, month_name
@@ -303,8 +303,8 @@ program Shelf_main
   segment_start_time = Time
   elapsed_time = 0.0
 
-  Time_step_shelf = real_to_time(US%T_to_s*time_step)
-  elapsed_time_master = (abs(time_step - US%s_to_T*time_type_to_real(Time_step_shelf)) > 1.0e-12*time_step)
+  Time_step_shelf = real_to_time(time_step, unscale=US%T_to_s)
+  elapsed_time_master = (abs(time_step - time_to_real(Time_step_shelf, scale=US%s_to_T)) > 1.0e-12*time_step)
   if (elapsed_time_master) &
     call MOM_mesg("Using real elapsed time for the master clock.", 2)
 
@@ -413,12 +413,12 @@ program Shelf_main
       ! does not lose resolution of order the timetype's resolution, provided that the timestep and
       ! tick are larger than 10-5 seconds.  If a clock with a finer resolution is used, a smaller
       ! value would be required.
-      time_chg = real_to_time(US%T_to_s*elapsed_time)
+      time_chg = real_to_time(elapsed_time, unscale=US%T_to_s)
       segment_start_time = segment_start_time + time_chg
-      elapsed_time = elapsed_time - US%s_to_T*time_type_to_real(time_chg)
+      elapsed_time = elapsed_time - time_to_real(time_chg, scale=US%s_to_T)
     endif
     if (elapsed_time_master) then
-      Master_Time = segment_start_time + real_to_time(US%T_to_s*elapsed_time)
+      Master_Time = segment_start_time + real_to_time(elapsed_time, unscale=US%T_to_s)
     else
       Master_Time = Master_Time + Time_step_shelf
     endif

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -60,7 +60,7 @@ program MOM6
   use MOM_string_functions,only : uppercase
   use MOM_surface_forcing, only : set_forcing, forcing_save_restart
   use MOM_surface_forcing, only : surface_forcing_init, surface_forcing_CS
-  use MOM_time_manager,    only : time_type, set_date, get_date, real_to_time, time_type_to_real
+  use MOM_time_manager,    only : time_type, set_date, get_date, real_to_time, time_to_real
   use MOM_time_manager,    only : operator(+), operator(-), operator(*), operator(/)
   use MOM_time_manager,    only : operator(>), operator(<), operator(>=)
   use MOM_time_manager,    only : increment_date, set_calendar_type, month_name
@@ -350,8 +350,8 @@ program MOM6
   endif
   ntstep = MAX(1,ceiling(dt_forcing/dt - 0.001))
 
-  Time_step_ocean = real_to_time(US%T_to_s*dt_forcing)
-  elapsed_time_master = (abs(dt_forcing - US%s_to_T*time_type_to_real(Time_step_ocean)) > 1.0e-12*dt_forcing)
+  Time_step_ocean = real_to_time(dt_forcing, unscale=US%T_to_s)
+  elapsed_time_master = (abs(dt_forcing - time_to_real(Time_step_ocean, scale=US%s_to_T)) > 1.0e-12*dt_forcing)
   if (elapsed_time_master) &
     call MOM_mesg("Using real elapsed time for the master clock.", 2)
 
@@ -520,7 +520,7 @@ program MOM6
             dtdia = dt_dyn*(n - n_last_thermo)
             ! Back up Time2 to the start of the thermodynamic segment.
             if (n > n_last_thermo+1) &
-              Time2 = Time2 - real_to_time(US%T_to_s*(dtdia - dt_dyn))
+              Time2 = Time2 - real_to_time((dtdia - dt_dyn), unscale=US%T_to_s)
             call step_MOM(forces, fluxes, sfc_state, Time2, dtdia, MOM_CSp, &
                           do_dynamics=.false., do_thermodynamics=.true., &
                           start_cycle=.false., end_cycle=(n==n_max), cycle_length=dt_forcing)
@@ -529,7 +529,7 @@ program MOM6
         endif
 
         t_elapsed_seg = t_elapsed_seg + dt_dyn
-        Time2 = Time1 + real_to_time(US%T_to_s*t_elapsed_seg)
+        Time2 = Time1 + real_to_time(t_elapsed_seg, unscale=US%T_to_s)
       enddo
     endif
 
@@ -542,12 +542,12 @@ program MOM6
       ! does not lose resolution of order the timetype's resolution, provided that the timestep and
       ! tick are larger than 10-5 seconds.  If a clock with a finer resolution is used, a smaller
       ! value would be required.
-      time_chg = real_to_time(US%T_to_s*elapsed_time)
+      time_chg = real_to_time(elapsed_time, unscale=US%T_to_s)
       segment_start_time = segment_start_time + time_chg
-      elapsed_time = elapsed_time - US%s_to_T*time_type_to_real(time_chg)
+      elapsed_time = elapsed_time - time_to_real(time_chg, scale=US%s_to_T)
     endif
     if (elapsed_time_master) then
-      Master_Time = segment_start_time + real_to_time(US%T_to_s*elapsed_time)
+      Master_Time = segment_start_time + real_to_time(elapsed_time, unscale=US%T_to_s)
     else
       Master_Time = Master_Time + Time_step_ocean
     endif

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -36,7 +36,7 @@ use MOM_io,                  only : read_netCDF_data, EAST_FACE, NORTH_FACE, num
 use MOM_restart,             only : register_restart_field, restart_init, MOM_restart_CS
 use MOM_restart,             only : restart_init_end, save_restart, restore_state
 use MOM_time_manager,        only : time_type, operator(+), operator(/), operator(*)
-use MOM_time_manager,        only : set_time, get_time, get_date, time_type_to_real
+use MOM_time_manager,        only : set_time, get_time, get_date, time_to_real
 use MOM_tracer_flow_control, only : call_tracer_set_forcing, tracer_flow_control_CS
 use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : surface
@@ -283,7 +283,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
   call callTree_enter("set_forcing, MOM_surface_forcing.F90")
 
   day_center = day_start + day_interval/2
-  dt = US%s_to_T * time_type_to_real(day_interval)
+  dt = time_to_real(day_interval, scale=US%s_to_T)
 
   if (CS%first_call_set_forcing) then
     ! Allocate memory for the mechanical and thermodynamic forcing fields.

--- a/config_src/infra/FMS1/MOM_time_manager.F90
+++ b/config_src/infra/FMS1/MOM_time_manager.F90
@@ -30,7 +30,7 @@ public :: get_date, set_date, increment_date, month_name, days_in_month
 public :: JULIAN, NOLEAP, THIRTY_DAY_MONTHS, GREGORIAN, NO_CALENDAR
 public :: set_calendar_type, get_calendar_type
 ! Module functions
-public :: real_to_time, time_minus_signed
+public :: real_to_time, time_minus_signed, time_to_real
 
 contains
 
@@ -39,14 +39,19 @@ contains
 !! signed integers, this version should work over the entire valid range (2^31 days or ~5.8835
 !! million years) of time_types, whereas the standard version in the FMS time_manager stops working
 !! for conversions of times greater than 2^31 seconds, or ~68.1 years.
-type(time_type) function real_to_time(x, err_msg)
+type(time_type) function real_to_time(time_in, err_msg, unscale)
 !  type(time_type)  :: real_to_time !< The output time as a time_type
-  real,                       intent(in)  :: x       !< The input time in real seconds.
+  real,                       intent(in)  :: time_in !< The input time in [s] or [T ~> s]
   character(len=*), optional, intent(out) :: err_msg !< An optional returned error message.
+  real,             optional, intent(in)  :: unscale !< A scaling factor that the input time is
+                                                     !! multiplied by, often in [s T-1 ~> nondim]
 
   ! Local variables
+  real             :: x  ! The time in real seconds [s]
+  real             :: real_subsecond_remainder ! The fractional seconds from time_in [s]
   integer          :: seconds, days, ticks
-  real             :: real_subsecond_remainder
+
+  x = time_in ; if (present(unscale)) x = unscale*time_in
 
   days = floor(x/86400.)
   seconds = floor(x - 86400.*days)
@@ -54,25 +59,41 @@ type(time_type) function real_to_time(x, err_msg)
   ticks = nint(real_subsecond_remainder * get_ticks_per_second())
 
   real_to_time = set_time(seconds=seconds, days=days, ticks=ticks, err_msg=err_msg)
+
 end function real_to_time
 
-!> Returns a real number representing time_a - time_b.
+!> Returns the real number of seconds encoded in the time type [s] or the rescaled
+!! amount of time in other units, often [T ~> s]
+real function time_to_real(time, scale)
+  type(time_type), intent(in) :: time   !< The time to be converted.
+  real, optional,  intent(in) :: scale  !< A scaling factor that returned the time is
+                                        !! multiplied by, often in [T s-1 ~> nondim]
+
+  time_to_real = time_type_to_real(time)
+  if (present(scale)) time_to_real = scale * time_to_real
+
+end function time_to_real
+
+!> Returns a real number representing time_a - time_b in [s] or [T ~> s] if scale is present.
 !! The FMS - operator for time types returns a new time type representing
 !! a difference that is always >= 0.
 !! In contrast, this function returns a negative real number if time_b > time_a,
 !! and a positive real otherwise, as would be expected for subtraction.
-real function time_minus_signed(time_a, time_b)
+real function time_minus_signed(time_a, time_b, scale)
   type(time_type), intent(in) :: time_a, time_b !< Two times for calculating time_a - time_b
+  real, optional,  intent(in) :: scale          !< A scaling factor that returned the time is
+                                                !! multiplied by, often in [T s-1 ~> nondim]
 
   ! Local variables
-  real :: abs_diff
+  real :: abs_diff ! The absolute value of the difference in times [s] or [T ~> s]
 
   ! Do FMS time subtraction, which will always be >= 0,
   ! and convert to a real number.
-  abs_diff = time_type_to_real(time_a - time_b)
+  abs_diff = time_to_real(time_a - time_b, scale)
 
   ! Add the sign back by comparing time_a and time_b
   time_minus_signed = merge(abs_diff, -abs_diff, time_a >= time_b)
+
 end function time_minus_signed
 
 end module MOM_time_manager

--- a/config_src/infra/FMS2/MOM_time_manager.F90
+++ b/config_src/infra/FMS2/MOM_time_manager.F90
@@ -30,7 +30,7 @@ public :: get_date, set_date, increment_date, month_name, days_in_month
 public :: JULIAN, NOLEAP, THIRTY_DAY_MONTHS, GREGORIAN, NO_CALENDAR
 public :: set_calendar_type, get_calendar_type
 ! Module functions
-public :: real_to_time, time_minus_signed
+public :: real_to_time, time_minus_signed, time_to_real
 
 contains
 
@@ -39,14 +39,19 @@ contains
 !! signed integers, this version should work over the entire valid range (2^31 days or ~5.8835
 !! million years) of time_types, whereas the standard version in the FMS time_manager stops working
 !! for conversions of times greater than 2^31 seconds, or ~68.1 years.
-type(time_type) function real_to_time(x, err_msg)
+type(time_type) function real_to_time(time_in, err_msg, unscale)
 !  type(time_type)  :: real_to_time !< The output time as a time_type
-  real,                       intent(in)  :: x       !< The input time in real seconds.
+  real,                       intent(in)  :: time_in !< The input time in [s] or [T ~> s]
   character(len=*), optional, intent(out) :: err_msg !< An optional returned error message.
+  real,             optional, intent(in)  :: unscale !< A scaling factor that the input time is
+                                                     !! multiplied by, often in [s T-1 ~> nondim]
 
   ! Local variables
+  real             :: x  ! The time in real seconds [s]
+  real             :: real_subsecond_remainder ! The fractional seconds from time_in [s]
   integer          :: seconds, days, ticks
-  real             :: real_subsecond_remainder
+
+  x = time_in ; if (present(unscale)) x = unscale*time_in
 
   days = floor(x/86400.)
   seconds = floor(x - 86400.*days)
@@ -54,25 +59,41 @@ type(time_type) function real_to_time(x, err_msg)
   ticks = nint(real_subsecond_remainder * get_ticks_per_second())
 
   real_to_time = set_time(seconds=seconds, days=days, ticks=ticks, err_msg=err_msg)
+
 end function real_to_time
 
-!> Returns a real number representing time_a - time_b.
+!> Returns the real number of seconds encoded in the time type [s] or the rescaled
+!! amount of time in other units, often [T ~> s]
+real function time_to_real(time, scale)
+  type(time_type), intent(in) :: time   !< The time to be converted.
+  real, optional,  intent(in) :: scale  !< A scaling factor that returned the time is
+                                        !! multiplied by, often in [T s-1 ~> nondim]
+
+  time_to_real = time_type_to_real(time)
+  if (present(scale)) time_to_real = scale * time_to_real
+
+end function time_to_real
+
+!> Returns a real number representing time_a - time_b in [s] or [T ~> s] if scale is present.
 !! The FMS - operator for time types returns a new time type representing
 !! a difference that is always >= 0.
 !! In contrast, this function returns a negative real number if time_b > time_a,
 !! and a positive real otherwise, as would be expected for subtraction.
-real function time_minus_signed(time_a, time_b)
+real function time_minus_signed(time_a, time_b, scale)
   type(time_type), intent(in) :: time_a, time_b !< Two times for calculating time_a - time_b
+  real, optional,  intent(in) :: scale          !< A scaling factor that returned the time is
+                                                !! multiplied by, often in [T s-1 ~> nondim]
 
   ! Local variables
-  real :: abs_diff
+  real :: abs_diff ! The absolute value of the difference in times [s] or [T ~> s]
 
   ! Do FMS time subtraction, which will always be >= 0,
   ! and convert to a real number.
-  abs_diff = time_type_to_real(time_a - time_b)
+  abs_diff = time_to_real(time_a - time_b, scale)
 
   ! Add the sign back by comparing time_a and time_b
   time_minus_signed = merge(abs_diff, -abs_diff, time_a >= time_b)
+
 end function time_minus_signed
 
 end module MOM_time_manager

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -46,7 +46,7 @@ use MOM_restart,              only : register_restart_field, register_restart_pa
 use MOM_restart,              only : query_initialized, set_initialized, restart_registry_lock
 use MOM_restart,              only : restart_init, is_new_run, determine_is_new_run, MOM_restart_CS
 use MOM_spatial_means,        only : global_mass_integral
-use MOM_time_manager,         only : time_type, real_to_time, time_type_to_real, operator(+)
+use MOM_time_manager,         only : time_type, real_to_time, operator(+)
 use MOM_time_manager,         only : operator(-), operator(>), operator(*), operator(/)
 use MOM_time_manager,         only : operator(>=), operator(==), increment_date
 use MOM_unit_tests,           only : unit_tests
@@ -607,6 +607,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   real :: I_wt_ssh  ! The inverse of the time weights [T-1 ~> s-1]
 
   type(time_type) :: Time_local, end_time_thermo
+  type(time_type) :: Time_end_diag ! End time of a diagnostic segment, as a time type
+
   type(group_pass_type) :: pass_tau_ustar_psurf
   logical :: showCallTree
 
@@ -791,7 +793,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     do j=js,je ; do i=is,ie ; CS%ssh_rint(i,j) = 0.0 ; enddo ; enddo
 
     if (CS%VarMix%use_variable_mixing) then
-      call enable_averages(cycle_time, Time_start + real_to_time(US%T_to_s*cycle_time), CS%diag)
+      Time_end_diag = Time_start + real_to_time(cycle_time, unscale=US%T_to_s)
+      call enable_averages(cycle_time, Time_end_diag, CS%diag)
       call calc_resoln_function(h, CS%tv, G, GV, US, CS%VarMix, CS%MEKE, CS%OBC, dt)
       call calc_depth_function(G, CS%VarMix)
       call disable_averaging(CS%diag)
@@ -819,7 +822,8 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     endif
     if (CS%UseWaves) then
       ! Update wave information, which is presently kept static over each call to step_mom
-      call enable_averages(time_interval, Time_start + real_to_time(US%T_to_s*time_interval), CS%diag)
+      Time_end_diag = Time_start + real_to_time(time_interval, unscale=US%T_to_s)
+      call enable_averages(time_interval, Time_end_diag, CS%diag)
       call find_ustar(forces, CS%tv, U_star, G, GV, US, halo=1)
       call thickness_to_dz(h, CS%tv, dz, G, GV, US, halo_size=1)
       call Update_Stokes_Drift(G, GV, US, Waves, dz, U_star, time_interval, do_dyn)
@@ -849,9 +853,9 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   do n=1,n_max
     rel_time = rel_time + dt ! The relative time at the end of the step.
     ! Set the universally visible time to the middle of the time step.
-    CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
+    CS%Time = Time_start + real_to_time(rel_time - 0.5*dt, unscale=US%T_to_s)
     ! Set the local time to the end of the time step.
-    Time_local = Time_start + real_to_time(US%T_to_s*rel_time)
+    Time_local = Time_start + real_to_time(rel_time, unscale=US%T_to_s)
 
     if (showCallTree) call callTree_enter("DT cycles (step_MOM) n=",n)
 
@@ -882,10 +886,10 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       if (dtdia > dt) then
         ! If necessary, temporarily reset CS%Time to the center of the period covered
         ! by the call to step_MOM_thermo, noting that they begin at the same time.
-        CS%Time = CS%Time + real_to_time(0.5*US%T_to_s*(dtdia-dt))
+        CS%Time = CS%Time + real_to_time(0.5*(dtdia-dt), unscale=US%T_to_s)
         ! The end-time of the diagnostic interval needs to be set ahead if there
         ! are multiple dynamic time steps worth of thermodynamics applied here.
-        end_time_thermo = Time_local + real_to_time(US%T_to_s*(dtdia-dt))
+        end_time_thermo = Time_local + real_to_time(dtdia-dt, unscale=US%T_to_s)
       endif
 
       ! Apply diabatic forcing, do mixing, and regrid.
@@ -901,7 +905,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       if (showCallTree) call callTree_waypoint("finished diabatic_first (step_MOM)")
 
       if (dtdia > dt) & ! Reset CS%Time to its previous value.
-        CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
+        CS%Time = Time_start + real_to_time(rel_time - 0.5*dt, unscale=US%T_to_s)
     endif ! end of block "(CS%diabatic_first .and. (CS%t_dyn_rel_adv==0.0))"
 
     if (do_dyn) then
@@ -999,7 +1003,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       ! If necessary, temporarily reset CS%Time to the center of the period covered
       ! by the call to step_MOM_thermo, noting that they end at the same time.
       if (dtdia > dt) &
-        CS%Time = CS%Time - real_to_time(0.5*US%T_to_s*(dtdia-dt))
+        CS%Time = CS%Time - real_to_time(0.5*(dtdia-dt), unscale=US%T_to_s)
 
       ! Apply diabatic forcing, do mixing, and regrid.
       call step_MOM_thermo(CS, G, GV, US, u, v, h, CS%tv, fluxes, dtdia, &
@@ -1018,7 +1022,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
       ! Reset CS%Time to its previous value.
       if (dtdia > dt) &
-        CS%Time = Time_start + real_to_time(US%T_to_s*(rel_time - 0.5*dt))
+        CS%Time = Time_start + real_to_time(rel_time - 0.5*dt, unscale=US%T_to_s)
     endif
 
     if (do_dyn) then
@@ -1136,7 +1140,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
   if (MOM_state_is_synchronized(CS)) &
     call write_energy(CS%u, CS%v, CS%h, CS%tv, Time_local, CS%nstep_tot, &
                       G, GV, US, CS%sum_output_CSp, CS%tracer_flow_CSp, &
-                      dt_forcing=real_to_time(US%T_to_s*time_interval) )
+                      dt_forcing=real_to_time(time_interval, unscale=US%T_to_s) )
 
   call cpu_clock_end(id_clock_other)
 
@@ -1189,6 +1193,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
     v => NULL(), & ! v : meridional velocity component [L T-1 ~> m s-1]
     h => NULL()    ! h : layer thickness [H ~> m or kg m-2]
 
+  type(time_type) :: Time_end_diag ! End time of a diagnostic segment, as a time type
   logical :: calc_dtbt  ! Indicates whether the dynamically adjusted
                         ! barotropic time step needs to be updated.
   logical :: showCallTree
@@ -1218,7 +1223,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
   if ((CS%t_dyn_rel_adv == 0.0) .and. CS%thickness_diffuse_first .and. &
       (CS%thickness_diffuse .or. CS%interface_filter)) then
 
-    call enable_averages(dt_tr_adv, Time_local+real_to_time(US%T_to_s*(dt_tr_adv-dt)), CS%diag)
+    Time_end_diag = Time_local + real_to_time(dt_tr_adv - dt, unscale=US%T_to_s)
+    call enable_averages(dt_tr_adv, Time_end_diag, CS%diag)
     if (CS%thickness_diffuse) then
       call cpu_clock_begin(id_clock_thick_diff)
       if (CS%VarMix%use_variable_mixing) &
@@ -1259,8 +1265,8 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_tr_adv, &
 
   ! The bottom boundary layer properties need to be recalculated.
   if (bbl_time_int > 0.0) then
-    call enable_averages(bbl_time_int, &
-              Time_local + real_to_time(US%T_to_s*(bbl_time_int-dt)), CS%diag)
+    Time_end_diag = Time_local + real_to_time(bbl_time_int - dt, unscale=US%T_to_s)
+    call enable_averages(bbl_time_int, Time_end_diag, CS%diag)
     ! Calculate the BBL properties and store them inside visc (u,h).
     call cpu_clock_begin(id_clock_BBL_visc)
     call set_viscous_BBL(CS%u, CS%v, CS%h, CS%tv, CS%visc, G, GV, US, CS%set_visc_CSp, CS%pbv)
@@ -2026,12 +2032,12 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
 
   ! Check to see if vertical tracer functions should be done
   do_vertical = (first_iter .or. (accumulated_time >= vertical_time))
-  if (do_vertical) vertical_time = accumulated_time + real_to_time(US%T_to_s*dt_offline_vertical)
+  if (do_vertical) vertical_time = accumulated_time + real_to_time(dt_offline_vertical, unscale=US%T_to_s)
 
   ! Increment the amount of time elapsed since last read and check if it's time to roll around
-  accumulated_time = accumulated_time + real_to_time(US%T_to_s*time_interval)
+  accumulated_time = accumulated_time + real_to_time(time_interval, unscale=US%T_to_s)
 
-  last_iter = (accumulated_time >= real_to_time(US%T_to_s*dt_offline))
+  last_iter = (accumulated_time >= real_to_time(dt_offline, unscale=US%T_to_s))
 
   if (CS%use_ALE_algorithm) then
     ! If this is the first iteration in the offline timestep, then we need to read in fields and
@@ -3520,7 +3526,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
               cont_stencil=CS%cont_stencil, dyn_h_stencil=CS%dyn_h_stencil)
     endif
     if (CS%dtbt_reset_period > 0.0) then
-      CS%dtbt_reset_interval = real_to_time(US%T_to_s*CS%dtbt_reset_period)
+      CS%dtbt_reset_interval = real_to_time(CS%dtbt_reset_period, unscale=US%T_to_s)
       ! Set dtbt_reset_time to be the next even multiple of dtbt_reset_interval.
       CS%dtbt_reset_time = Time_init + CS%dtbt_reset_interval * &
                                  ((Time - Time_init) / CS%dtbt_reset_interval)
@@ -3548,7 +3554,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   !Set OBC segment data update period
   if (associated(CS%OBC) .and. CS%dt_obc_seg_period > 0.0) then
-    CS%dt_obc_seg_interval = real_to_time(US%T_to_s*CS%dt_obc_seg_period)
+    CS%dt_obc_seg_interval = real_to_time(CS%dt_obc_seg_period, unscale=US%T_to_s)
     CS%dt_obc_seg_time = Time + CS%dt_obc_seg_interval
   endif
 

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -2546,7 +2546,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
       (CS%id_uhbt_hifreq > 0) .or. (CS%id_vhbt_hifreq > 0)) &
     do_hifreq_output = query_averaging_enabled(CS%diag, time_int_in, time_end_in)
   if (do_hifreq_output) then
-    time_bt_start = time_end_in - real_to_time(US%T_to_s*dt)
+    time_bt_start = time_end_in - real_to_time(dt, unscale=US%T_to_s)
     dtbt_diag = dt/(nstep+nfilter) ! Note that this is not dtbt.
   endif
 
@@ -2975,7 +2975,7 @@ subroutine btstep_timeloop(eta, ubt, vbt, uhbt0, Datu, BTCL_u, vhbt0, Datv, BTCL
     if (do_hifreq_output) then
       ! Note that this compresses the time so that all of the timesteps, including those in the
       ! extra timesteps for filtering, fit within dt.
-      time_step_end = time_bt_start + real_to_time(n*US%T_to_s*dtbt_diag)
+      time_step_end = time_bt_start + real_to_time(n*dtbt_diag, unscale=US%T_to_s)
       call enable_averages(dtbt, time_step_end, CS%diag)
       if (CS%id_ubt_hifreq > 0) call post_data(CS%id_ubt_hifreq, ubt(IsdB:IedB,jsd:jed), CS%diag)
       if (CS%id_vbt_hifreq > 0) call post_data(CS%id_vbt_hifreq, vbt(isd:ied,JsdB:JedB), CS%diag)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -36,7 +36,7 @@ use MOM_restart,           only : register_restart_field, register_restart_pair
 use MOM_restart,           only : query_initialized, set_initialized, save_restart
 use MOM_restart,           only : only_read_from_restarts
 use MOM_restart,           only : restart_init, is_new_run, MOM_restart_CS
-use MOM_time_manager,      only : time_type, time_type_to_real, operator(+)
+use MOM_time_manager,      only : time_type, operator(+)
 use MOM_time_manager,      only : operator(-), operator(>), operator(*), operator(/)
 
 use MOM_ALE,                   only : ALE_CS, ALE_remap_velocities

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -37,7 +37,7 @@ use MOM_restart,           only : register_restart_field, register_restart_pair
 use MOM_restart,           only : query_initialized, set_initialized, save_restart
 use MOM_restart,           only : only_read_from_restarts
 use MOM_restart,           only : restart_init, is_new_run, MOM_restart_CS
-use MOM_time_manager,      only : time_type, time_type_to_real, operator(+)
+use MOM_time_manager,      only : time_type, operator(+)
 use MOM_time_manager,      only : operator(-), operator(>), operator(*), operator(/)
 
 use MOM_ALE,                   only : ALE_CS, ALE_remap_velocities

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -282,7 +282,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
   call pass_var(hp, G%Domain, clock=id_clock_pass)
   call pass_vector(uh, vh, G%Domain, clock=id_clock_pass)
 
-  call enable_averages(0.5*dt, Time_local-real_to_time(0.5*US%T_to_s*dt), CS%diag)
+  call enable_averages(0.5*dt, Time_local-real_to_time(0.5*dt, unscale=US%T_to_s), CS%diag)
 !   Here the first half of the thickness fluxes are offered for averaging.
   if (CS%id_uh > 0) call post_data(CS%id_uh, uh, CS%diag)
   if (CS%id_vh > 0) call post_data(CS%id_vh, vh, CS%diag)

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -68,7 +68,7 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : MOM_set_verbosity
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_get_input, only : directories
-use MOM_time_manager, only : time_type, time_type_to_real, operator(+)
+use MOM_time_manager, only : time_type, operator(+)
 use MOM_time_manager, only : operator(-), operator(>), operator(*), operator(/)
 
 use MOM_ALE, only : ALE_CS

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4371,7 +4371,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
 
   turns = modulo(G%HI%turns, 4)
 
-  if (OBC%add_tide_constituents) time_delta = US%s_to_T * time_minus_signed(Time, OBC%time_ref)
+  if (OBC%add_tide_constituents) time_delta = time_minus_signed(Time, OBC%time_ref, scale=US%s_to_T)
 
   dz(:,:,:) = 0.0
   call thickness_to_dz(h, tv, dz, G, GV, US)
@@ -4903,7 +4903,7 @@ subroutine update_OBC_ramp(Time, OBC, US, activate)
     endif
   endif
   if (.not.OBC%ramping_is_activated) return
-  deltaTime = max(0., US%s_to_T * time_minus_signed(Time, OBC%ramp_start_time))
+  deltaTime = max(0., time_minus_signed(Time, OBC%ramp_start_time, scale=US%s_to_T))
   if (deltaTime >= OBC%trunc_ramp_time) then
     OBC%ramp_value = 1.0
     OBC%ramp = .false. ! This turns off ramping after this call

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -42,7 +42,7 @@ use MOM_io, only : slasher, fieldtype, vardesc, var_desc
 use MOM_io, only : close_file, SINGLE_FILE, MULTIPLE
 use MOM_restart, only : register_restart_field, save_restart
 use MOM_restart, only : restart_init, restore_state, MOM_restart_CS, register_restart_pair
-use MOM_time_manager, only : time_type, time_type_to_real, real_to_time, operator(>), operator(-)
+use MOM_time_manager, only : time_type, time_to_real, real_to_time, operator(>), operator(-)
 use MOM_transcribe_grid, only : copy_dyngrid_to_MOM_grid, copy_MOM_grid_to_dyngrid
 use MOM_transcribe_grid, only : rotate_dyngrid
 use MOM_unit_scaling, only : unit_scale_type, unit_scaling_init, fix_restart_unit_scaling
@@ -948,7 +948,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
 
   if (CS%shelf_mass_is_dynamic) &
     call write_ice_shelf_energy(CS%dCS, G, US, ISS%mass_shelf, ISS%area_shelf_h, Time, &
-                                time_step=real_to_time(US%T_to_s*time_step) )
+                                time_step=real_to_time(time_step, unscale=US%T_to_s) )
 
   if (CS%debug) call MOM_forcing_chksum("Before add shelf flux", fluxes, G, CS%US, haloshift=0)
 
@@ -1423,7 +1423,7 @@ subroutine add_shelf_flux(G, US, CS, sfc_state, fluxes, time_step)
 
     ! take into account changes in mass (or thickness) when imposing ice shelf mass
     if (CS%override_shelf_movement .and. CS%mass_from_file) then
-      dTime = real_to_time(US%T_to_s*CS%time_step)
+      dTime = real_to_time(CS%time_step, unscale=US%T_to_s)
 
       ! Compute changes in mass after at least one full time step
       if (CS%Time > dTime) then
@@ -2760,7 +2760,7 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
   ISS => CS%ISS
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
-  remaining_time = US%s_to_T*time_type_to_real(time_interval)
+  remaining_time = time_to_real(time_interval, scale=US%s_to_T)
   full_time_step = remaining_time
   Ifull_time_step = 1./full_time_step
 
@@ -2770,7 +2770,7 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
     min_time_step = 1000.0*US%s_to_T ! At 1 km resolution this would imply ice is moving at ~1 meter per second
   endif
 
-  write (mesg,*) "TIME in ice shelf call, yrs: ", time_type_to_real(Time)/(365. * 86400.)
+  write (mesg,*) "TIME in ice shelf call, yrs: ", time_to_real(Time)/(365. * 86400.)
   call MOM_mesg("solo_step_ice_shelf: "//mesg, 5)
 
   ISS%dhdt_shelf(:,:) = ISS%h_shelf(:,:)

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -669,7 +669,7 @@ subroutine set_analysis_time(Time,CS)
 
   if (Time >= CS%Time) then
     ! increment the analysis time to the next step
-    CS%Time = CS%Time + real_to_time(CS%US%T_to_s*(CS%assim_interval))
+    CS%Time = CS%Time + real_to_time(CS%assim_interval, unscale=CS%US%T_to_s)
 
     call get_date(Time, yr, mon, day, hr, min, sec)
     write(mesg,*) 'Model Time: ', yr, mon, day, hr, min, sec

--- a/src/parameterizations/lateral/MOM_streaming_filter.F90
+++ b/src/parameterizations/lateral/MOM_streaming_filter.F90
@@ -12,7 +12,7 @@ use MOM_hor_index,     only : hor_index_type
 use MOM_io,            only : axis_info, set_axis_info
 use MOM_restart,       only : register_restart_field, query_initialized, MOM_restart_CS
 use MOM_tidal_forcing, only : tidal_frequency
-use MOM_time_manager,  only : time_type, time_type_to_real
+use MOM_time_manager,  only : time_type, time_to_real
 use MOM_unit_scaling,  only : unit_scale_type
 
 implicit none ; private
@@ -161,7 +161,7 @@ subroutine Filt_accum(u, u1, Time, US, CS)
              c1, c2              !< Coefficients for the filter equations [nondim]
   integer :: i, j, k
 
-  now = US%s_to_T * time_type_to_real(Time)
+  now = time_to_real(Time, scale=US%s_to_T)
 
   ! Initialize CS%old_time at the first time step
   if (CS%old_time<0.0) CS%old_time = now

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -633,7 +633,7 @@ subroutine calc_tidal_forcing(Time, e_tide_eq, e_tide_sal, G, US, CS)
     return
   endif
 
-  now = US%s_to_T * time_minus_signed(Time, cs%time_ref)
+  now = time_minus_signed(Time, cs%time_ref, scale=US%s_to_T)
 
   do c=1,CS%nc
     m = CS%struct(c)
@@ -707,7 +707,7 @@ subroutine calc_tidal_forcing_legacy(Time, e_sal, e_sal_tide, e_tide_eq, e_tide_
     return
   endif
 
-  now = US%s_to_T * time_minus_signed(Time, cs%time_ref)
+  now = time_minus_signed(Time, cs%time_ref, scale=US%s_to_T)
 
   do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
     e_sal_tide(i,j) = e_sal(i,j)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -372,7 +372,7 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
   ! the end of the diabatic processes.
   if (associated(tv%T) .AND. associated(tv%frazil)) then
     ! For frazil diagnostic, the first call covers the first half of the time step
-    call enable_averages(0.5*dt, Time_end - real_to_time(0.5*US%T_to_s*dt), CS%diag)
+    call enable_averages(0.5*dt, Time_end - real_to_time(0.5*dt, unscale=US%T_to_s), CS%diag)
     if (CS%frazil_tendency_diag) then
       do k=1,nz ; do j=js,je ; do i=is,ie
         temp_diag(i,j,k) = tv%T(i,j,k)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -3227,7 +3227,7 @@ subroutine updateCFLtruncationValue(Time, CS, US, activate)
     endif
   endif
   if (.not.CS%CFLrampingIsActivated) return
-  deltaTime = max(0., US%s_to_T * time_minus_signed(Time, CS%rampStartTime))
+  deltaTime = max(0., time_minus_signed(Time, CS%rampStartTime, scale=US%s_to_T))
   if (deltaTime >= CS%truncRampTime) then
     CS%CFL_trunc = CS%CFL_truncE
     CS%truncRampTime = 0. ! This turns off ramping after this call

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -18,7 +18,7 @@ use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : query_initialized, set_initialized, MOM_restart_CS
 use MOM_spatial_means, only : global_mass_int_EFP
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
-use MOM_time_manager, only : time_type, time_type_to_real
+use MOM_time_manager, only : time_type, time_to_real
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
@@ -373,7 +373,7 @@ subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, 
   Isecs_per_year = 1.0 / (365.0*86400.0*US%s_to_T)
   !   Set the surface value of tracer 1 to increase exponentially
   ! with a 30 year time scale.
-  year = US%s_to_T*time_type_to_real(CS%Time) * Isecs_per_year
+  year = time_to_real(CS%Time, scale=US%s_to_T) * Isecs_per_year
 
   do m=1,CS%ntr
 

--- a/src/tracer/nw2_tracers.F90
+++ b/src/tracer/nw2_tracers.F90
@@ -14,7 +14,7 @@ use MOM_hor_index, only : hor_index_type
 use MOM_interface_heights, only : thickness_to_dz
 use MOM_io, only : file_exists, MOM_read_data, slasher, vardesc, var_desc
 use MOM_restart, only : query_initialized, set_initialized, MOM_restart_CS
-use MOM_time_manager, only : time_type, time_type_to_real
+use MOM_time_manager, only : time_type
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_unit_scaling, only : unit_scale_type

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -24,7 +24,7 @@ use MOM_forcing_type, only : forcing, mech_forcing
 use MOM_forcing_type, only : allocate_mech_forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_safe_alloc, only : safe_alloc_ptr
-use MOM_time_manager, only : time_type, operator(+), operator(/), time_type_to_real
+use MOM_time_manager, only : time_type, operator(+), operator(/), time_to_real
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables, only : thermo_var_ptrs, surface
 use MOM_verticalGrid, only : verticalGrid_type
@@ -373,9 +373,9 @@ subroutine idealized_hurricane_wind_forcing(sfc_state, forces, day, G, US, CS)
   endif
 
   !> Compute storm center location
-  XC = CS%Hurr_cen_X0 + (time_type_to_real(day)*US%s_to_T * CS%hurr_translation_spd * &
+  XC = CS%Hurr_cen_X0 + (time_to_real(day, scale=US%s_to_T) * CS%hurr_translation_spd * &
        cos(CS%hurr_translation_dir))
-  YC = CS%Hurr_cen_Y0 + (time_type_to_real(day)*US%s_to_T * CS%hurr_translation_spd * &
+  YC = CS%Hurr_cen_Y0 + (time_to_real(day, scale=US%s_to_T) * CS%hurr_translation_spd * &
        sin(CS%hurr_translation_dir))
 
   if (CS%BR_Bench) then

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -19,7 +19,7 @@ use MOM_open_boundary,  only : OBC_DIRECTION_N, OBC_DIRECTION_E, OBC_DIRECTION_S
 use MOM_open_boundary,  only : OBC_registry_type
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
-use MOM_time_manager,   only : time_type, time_type_to_real
+use MOM_time_manager,   only : time_type, time_to_real
 
 implicit none ; private
 
@@ -248,7 +248,7 @@ subroutine Kelvin_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   if (G%grid_unit_to_L <= 0.) call MOM_error(FATAL, 'Kelvin_initialization.F90: '// &
           "Kelvin_set_OBC_data() is only set to work with Cartesian axis units.")
 
-  time_sec = US%s_to_T*time_type_to_real(Time)
+  time_sec = time_to_real(Time, scale=US%s_to_T)
   PI = 4.0*atan(1.0)
 
   turns = modulo(G%HI%turns, 4)

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -14,7 +14,7 @@ use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,   only : OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S, OBC_DIRECTION_E
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
 use MOM_open_boundary,   only : OBC_registry_type, register_OBC
-use MOM_time_manager,    only : time_type, time_type_to_real
+use MOM_time_manager,    only : time_type, time_to_real
 use MOM_tracer_registry, only : tracer_registry_type, tracer_name_lookup
 use MOM_tracer_registry, only : tracer_type
 use MOM_unit_scaling,    only : unit_scale_type
@@ -171,7 +171,7 @@ subroutine dyed_channel_update_flow(OBC, CS, G, GV, US, h, Time)
   if (.not.associated(OBC)) call MOM_error(FATAL, 'dyed_channel_initialization.F90: '// &
         'dyed_channel_update_flow() was called but OBC type was not initialized!')
 
-  time_sec = US%s_to_T * time_type_to_real(Time)
+  time_sec = time_to_real(Time, scale=US%s_to_T)
   PI = 4.0*atan(1.0)
 
   turns = modulo(G%HI%turns, 4)

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -13,7 +13,7 @@ use MOM_grid,           only : ocean_grid_type
 use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_W
 use MOM_open_boundary,  only : OBC_segment_type, register_OBC
 use MOM_open_boundary,  only : OBC_registry_type, rotate_OBC_segment_direction
-use MOM_time_manager,   only : time_type, time_type_to_real
+use MOM_time_manager,   only : time_type, time_to_real
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
 
@@ -169,7 +169,7 @@ subroutine shelfwave_set_OBC_data(OBC, CS, G, GV, US, h, Time)
   turns = modulo(G%HI%turns, 4)
   my_amp = CS%my_amp ; if ((turns==2) .or. (turns==3)) my_amp = -CS%my_amp
 
-  time_sec = US%s_to_T*time_type_to_real(Time)
+  time_sec = time_to_real(Time, scale=US%s_to_T)
   if (CS%shelfwave_correct_amplitude) then
     ! This makes the units and edge value of normal_vel_bt the same as my_amp.
     I_yscale = 1.0 / CS%kk

--- a/src/user/supercritical_initialization.F90
+++ b/src/user/supercritical_initialization.F90
@@ -11,7 +11,7 @@ use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
 use MOM_open_boundary,  only : ocean_OBC_type, OBC_segment_type, rotate_OBC_segment_direction
 use MOM_open_boundary,  only : OBC_DIRECTION_E, OBC_DIRECTION_W
-use MOM_time_manager,   only : time_type, time_type_to_real
+use MOM_time_manager,   only : time_type
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
 

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -16,7 +16,7 @@ use MOM_open_boundary,  only : OBC_segment_type, register_OBC
 use MOM_open_boundary,  only : OBC_registry_type
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
-use MOM_time_manager,   only : time_type, time_type_to_real
+use MOM_time_manager,   only : time_type, time_to_real
 
 implicit none ; private
 
@@ -97,7 +97,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
 
   if (.not.associated(OBC)) return
 
-  time_sec = US%s_to_T*time_type_to_real(Time)
+  time_sec = time_to_real(Time, scale=US%s_to_T)
   cff_eta = CS%tide_ssh_amp * sin(2.0*PI*time_sec / CS%tide_period)
 
   segment => OBC%segment(1)


### PR DESCRIPTION
  This PR adds the ability to do dimensional rescaling in the conversion and from time types via optional arguments to the time type conversion functions.  The changes include adding the new function `time_to_real()` that wraps `time_type_to_real()` with the option to rescale the output time into different units than seconds, and added optional `unscale` and `scale` arguments to `real_to_time()` and `time_minus_signed()`, respectively.

  A second simple commit in this PR removes unused module use statements for `time_type_to_real` in 5 modules.

  The third commit refactors 34 calls to `real_to_time()` to use the new `unscale` argument and replaced 16 calls to `time_type_to_real()` with calls to the new routine `time_to_real()`, of which 15 use a `scale` argument.  It also uses the new scale argument in 5 calls to `time_minus_signed()`.

  Although these changes lead to some lines that are longer than before, the use of the `scale` and `unscale` arguments makes it much easier to detect incorrect rescaling factors.

  All answers are bitwise identical, but there is a new publicly visible interface and new optional arguments to two other publicly
visible interfaces
