### PR TITLE
Add missing comments to undocumented variables in the ice-shelf code

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -211,7 +211,7 @@ type, public :: ice_shelf_CS ; private
              id_tfreeze = -1, id_tfl_shelf = -1, &
              id_thermal_driving = -1, id_haline_driving = -1, &
              id_u_ml = -1, id_v_ml = -1, id_sbdry = -1, &
-             id_h_shelf = -1, id_dhdt_shelf, id_h_mask = -1, id_frazil = -1, &
+             id_h_shelf = -1, id_dhdt_shelf = -1, id_h_mask = -1, id_frazil = -1, &
              id_surf_elev = -1, id_bathym = -1, &
              id_area_shelf_h = -1, &
              id_ustar_shelf = -1, id_shelf_mass = -1, id_mass_flux = -1, &

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -133,8 +133,7 @@ type, public :: diag_ctrl
   real, dimension(:,:),   pointer :: mask2dBu  => null() !< 2D mask array for cell-corner points [nondim]
   real, dimension(:,:),   pointer :: mask2dCu  => null() !< 2D mask array for east-face points [nondim]
   real, dimension(:,:),   pointer :: mask2dCv  => null() !< 2D mask array for north-face points [nondim]
-  !> Computational domain mask arrays for 2D diagnostics [nondim]
-  real, dimension(:,:),   pointer :: mask2dT_comp => null()
+  real, dimension(:,:),   pointer :: mask2dT_comp => null() !< 2D cell-center mask on the computational domain [nondim]
 
 ! Space for diagnostics is dynamically allocated as it is needed.
 ! The chunk size is how much the array should grow on each new allocation.

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -255,9 +255,10 @@ end type ice_shelf_dyn_CS
 
 !> A container for loop bounds
 type :: loop_bounds_type ; private
-  !>@{ Loop bounds
-  integer :: ish, ieh, jsh, jeh
-  !>@}
+  integer :: ish !< Starting i-index of the computational domain [nondim]
+  integer :: ieh !< Ending i-index of the computational domain [nondim]
+  integer :: jsh !< Starting j-index of the computational domain [nondim]
+  integer :: jeh !< Ending j-index of the computational domain [nondim]
 end type loop_bounds_type
 
 contains


### PR DESCRIPTION
This PR adds comments to undocumented variables in the ice-shelf code. The following changes have been made

 1. MOM_ice_shelf_dynamics.F90 — `ish`,` ieh`, `jsh`, `jeh` split into individual declarations with !< doc comments.
 2. MOM_ice_shelf.F90 — `id_dhdt_shelf` now has = -1 initializer, consistent with all other diagnostic handles.
 3. MOM_ice_shelf_diag_mediator.F90 —` mask2dT_comp` now has an inline !< doc comment (the orphaned !> block comment   above it was also removed).

Disclosure: Copilot has been used to make these changes.