### PR TITLE
Two small fixes for building docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,3 +16,5 @@ sphinxcontrib_htmlhelp<2.0.5
 sphinxcontrib_qthelp<1.0.7
 sphinxcontrib_serializinghtml<1.0.7
 alabaster<0.7.14
+# setuptools 82.0.0 removed pkg_resources
+setuptools<82.0.0

--- a/src/framework/MOM_ANN.F90
+++ b/src/framework/MOM_ANN.F90
@@ -723,7 +723,7 @@ end function ANN_unit_tests
 !! y_{l,j} = f_l( b_{l,j} + A_{l,j,i} x_{l-1,i} )
 !! \f]
 !! where \f$ f(x) = max(0, x) \f$ is the ReLU activation function, \f$b_{l,j}\f$ is a bias for each neuron,
-!! $\f$A_{l,j,i}\f$ are a rectangular matrix of weights for each layer, and \f$x_{l-1,i}\f$ are the outputs
+!! \f$A_{l,j,i}\f$ are a rectangular matrix of weights for each layer, and \f$x_{l-1,i}\f$ are the outputs
 !! of the previous layer, \f$l-1\f$. The subscript on \f$ f_l() \f$ indicates the activation function is
 !! optional for each layer.
 !!


### PR DESCRIPTION
This will at least partially address #1039 by adding two fixes:
1. Removing an unnecessary $ before an equation
2. Adding setuptools<82.0.0 to the requirements to keep pkg_resources which is required by the old version of sphinx 

Per Alistair building the docs may still time out. 