### PR TITLE
Diagnostic output time scaling fix in HA_accum

### DIFF
--- a/src/diagnostics/MOM_harmonic_analysis.F90
+++ b/src/diagnostics/MOM_harmonic_analysis.F90
@@ -5,7 +5,7 @@
 !> Inline harmonic analysis (conventional)
 module MOM_harmonic_analysis
 
-use MOM_time_manager,  only : time_type, real_to_time, time_type_to_real, time_minus_signed
+use MOM_time_manager,  only : time_type, real_to_time, time_to_real, time_minus_signed
 use MOM_time_manager,  only : set_date, get_date, increment_date
 use MOM_time_manager,  only : operator(+), operator(-), operator(<), operator(>), operator(>=)
 use MOM_grid,          only : ocean_grid_type
@@ -239,8 +239,8 @@ subroutine HA_init(Time, US, param_file, nc, CS)
     if (HA_start_time <= 0.0) HA_start_time = 0.0
   endif
 
-  CS%time_start = Time + real_to_time(US%T_to_s * HA_start_time)
-  CS%time_end = Time + real_to_time(US%T_to_s * HA_end_time)
+  CS%time_start = Time + real_to_time(HA_start_time, unscale=US%T_to_s)
+  CS%time_end = Time + real_to_time(HA_end_time, unscale=US%T_to_s)
 
   call get_date(Time, year, month, day, hour, minute, second)
   write(mesg,*) "MOM_harmonic_analysis: run segment starts on ", year, month, day, hour, minute, second
@@ -337,7 +337,7 @@ subroutine HA_accum(key, data, Time, G, CS)
   enddo
 
   nc  = CS%nc
-  now = CS%US%s_to_T * time_minus_signed(Time, CS%time_ref)
+  now = time_minus_signed(Time, CS%time_ref, scale=CS%US%s_to_T)
 
   !!! Additional processing at the initial accumulating step !!!
   if (ha1%old_time < 0.0) then
@@ -412,7 +412,7 @@ subroutine HA_accum(key, data, Time, G, CS)
   !!! Compute harmonic constants and write output as Time approaches CS%time_end !!!
   ! This guarantees that HA_write will be called before Time becomes larger than CS%time_end.
   ! Result of subtracting time types is always >= 0, which is acceptable here.
-  if (time_type_to_real(CS%time_end - Time) <= dt) then
+  if (time_to_real(CS%time_end - Time, scale=CS%US%s_to_T) <= dt) then
     call HA_write(ha1, Time, G, CS)
 
     write(mesg,*) "MOM_harmonic_analysis: harmonic analysis done, key = ", trim(ha1%key)


### PR DESCRIPTION
  Added a missing dimensional scaling argument in the test for when to write harmonic analysis diagnostics in `HA_accum()`.  Also used the new `unscale` argument in 2 calls to `real_to_time()` in `HA_init()` and used the new `scale` argument in one call to `time_to_real()` in `HA_accum()`.  Answers and diagnostics are bitwise identical when scaling is not applied, but this does correct a problem where some diagnostics may have been written at the wrong time previously when dimensional rescaling of time is being used.