### PR TITLE
+Change some MOM_IS axis units to CMIP standards

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1677,7 +1677,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   call MOM_IS_diag_mediator_init(G, CS%US, param_file, CS%diag, component='MOM_IceShelf')
   ! This call sets up the diagnostic axes. These are needed,
   ! e.g. to generate the target grids below.
-  call set_IS_axes_info(G, param_file, CS%diag)
+  call set_IS_axes_info(G, CS%diag)
 
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec

--- a/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
+++ b/src/ice_shelf/MOM_ice_shelf_diag_mediator.F90
@@ -20,7 +20,7 @@ use MOM_diag_manager_infra, only : get_MOM_diag_field_id, DIAG_FIELD_NOT_FOUND
 use MOM_diag_manager_infra, only : diag_send_complete_infra
 use MOM_error_handler,      only : MOM_error, FATAL, is_root_pe, assert, callTree_showQuery
 use MOM_error_handler,      only : callTree_enter, callTree_leave, callTree_waypoint
-use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
+use MOM_file_parser,        only : get_param, log_version, param_file_type
 use MOM_grid,               only : ocean_grid_type
 use MOM_io,                 only : get_filename_appendix
 use MOM_safe_alloc,         only : safe_alloc_ptr, safe_alloc_alloc
@@ -159,9 +159,8 @@ integer :: id_clock_diag_mediator
 contains
 
 !> Set up the grid and axis information for use by the ice shelf model.
-subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
-  type(ocean_grid_type), intent(inout) :: G   !< The horizontal grid type
-  type(param_file_type), intent(in)    :: param_file !< Parameter file structure
+subroutine set_IS_axes_info(G, diag_cs, axes_set_name)
+  type(ocean_grid_type), intent(in)    :: G   !< The horizontal grid type
   type(diag_ctrl),       intent(inout) :: diag_cs !< A structure that is used to regulate diagnostic output
   character(len=*), optional, intent(in) :: axes_set_name !<  A name to use for this set of axes.
                                                 !! The default is "ice".
@@ -170,84 +169,49 @@ subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
   ! Local variables
   integer :: id_xq, id_yq, id_xh, id_yh, id_null
   integer :: i, j
-  character(len=80) :: grid_config, units_temp, set_name
-  ! This include declares and sets the variable "version".
-# include "version_variable.h"
-  character(len=40)  :: mdl = "MOM_IS_diag_mediator" ! This module's name.
+  character(len=80) :: set_name
   real, allocatable, dimension(:) :: IaxB, iax ! Index-based integer and half-integer i-axis labels [nondim]
   real, allocatable, dimension(:) :: JaxB, jax ! Index-based integer and half-integer j-axis labels [nondim]
 
   set_name = "ice_shelf" ; if (present(axes_set_name)) set_name = trim(axes_set_name)
 
-  ! This is inconsistent with the labeling of axis units from MOM_diag_manager, and it will be
-  ! corrected in a subsequent commit.
-
-  ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version)
-  call get_param(param_file, mdl, "GRID_CONFIG", grid_config, &
-                 "The method for defining the horizontal grid.  Valid "//&
-                 "entries include:\n"//&
-                 "\t file - read the grid from GRID_FILE \n"//&
-                 "\t mosaic - read the grid from a mosaic grid file \n"//&
-                 "\t cartesian - a Cartesian grid \n"//&
-                 "\t spherical - a spherical grid \n"//&
-                 "\t mercator  - a Mercator grid", fail_if_missing=.true.)
-
-  G%x_axis_units = "degrees_E"
-  G%y_axis_units = "degrees_N"
-  G%x_ax_unit_short = "degrees_E" ; G%y_ax_unit_short = "degrees_N"
-  G%grid_unit_to_L = 0.0
-
-  if (index(lowercase(trim(grid_config)),"cartesian") > 0) then
-    ! This is a Cartesian grid, and may have different axis units.
-    call get_param(param_file, mdl, "AXIS_UNITS", units_temp, &
-                 "The units for the x- and y- axis labels.  AXIS_UNITS "//&
-                 "should be defined as 'k' for km, 'm' for m, or 'd' "//&
-                 "for degrees of latitude and longitude (the default). "//&
-                 "Except on a Cartesian grid, only degrees are currently "//&
-                 "implemented.", default='degrees')
-    if (units_temp(1:1) == 'k') then
-      G%x_axis_units = "kilometers" ; G%y_axis_units = "kilometers"
-      G%x_ax_unit_short = "km" ; G%y_ax_unit_short = "km"
-      G%grid_unit_to_L = 1000.0*diag_cs%US%m_to_L
-    elseif (units_temp(1:1) == 'm') then
-      G%x_axis_units = "meters" ; G%y_axis_units = "meters"
-      G%x_ax_unit_short = "m" ; G%y_ax_unit_short = "m"
-      G%grid_unit_to_L = diag_cs%US%m_to_L
-    endif
-    call log_param(param_file, mdl, "explicit AXIS_UNITS", G%x_axis_units)
-  endif
-
   if (diag_cs%index_space_axes) then
     allocate(IaxB(G%IsgB:G%IegB))
-    do i=G%IsgB, G%IegB
-      Iaxb(i)=real(i)
+    do I=G%IsgB,G%IegB
+      Iaxb(I) = real(I)
     enddo
     allocate(iax(G%isg:G%ieg))
-    do i=G%isg, G%ieg
-      iax(i)=real(i)-0.5
+    do i=G%isg,G%ieg
+      iax(i) = real(i)-0.5
     enddo
     allocate(JaxB(G%JsgB:G%JegB))
-    do j=G%JsgB, G%JegB
-      JaxB(j)=real(j)
+    do J=G%JsgB,G%JegB
+      JaxB(J) = real(J)
     enddo
     allocate(jax(G%jsg:G%jeg))
-    do j=G%jsg, G%jeg
-      jax(j)=real(j)-0.5
+    do j=G%jsg,G%jeg
+      jax(j) = real(j)-0.5
     enddo
   endif
 
   ! Horizontal axes for the native grids.
   if (diag_cs%index_space_axes) then
-    id_xq = MOM_diag_axis_init('xB', IaxB, 'none', 'x', &
-        'Boundary point grid-space longitude', G%Domain, position=EAST, set_name=set_name)
-    id_yq = MOM_diag_axis_init('yB', JaxB, 'none', 'y', &
-        'Boundary point grid-space latitude', G%Domain, position=NORTH, set_name=set_name)
+    if (G%symmetric) then
+      id_xq = MOM_diag_axis_init('Iq', IaxB(G%IsgB:G%IegB), 'none', 'x', &
+          'Boundary (q) point grid-space longitude', G%Domain, position=EAST, set_name=set_name)
+      id_yq = MOM_diag_axis_init('Jq', JaxB(G%JsgB:G%JegB), 'none', 'y', &
+          'Boundary (q) point grid-space latitude', G%Domain, position=NORTH, set_name=set_name)
+    else
+      id_xq = MOM_diag_axis_init('Iq', IaxB(G%isg:G%ieg), 'none', 'x', &
+          'Boundary (q) point grid-space longitude', G%Domain, position=EAST, set_name=set_name)
+      id_yq = MOM_diag_axis_init('Jq', JaxB(G%jsg:G%jeg), 'none', 'y', &
+          'Boundary (q) point grid-space latitude', G%Domain, position=NORTH, set_name=set_name)
+    endif
 
-    id_xh = MOM_diag_axis_init('xT', iax, 'none', 'x', &
-        'T point grid-space longitude', G%Domain, set_name=set_name)
-    id_yh = MOM_diag_axis_init('yT', jax, 'none', 'y', &
-        'T point grid-space latitude', G%Domain, set_name=set_name)
+    id_xh = MOM_diag_axis_init('ih', iax, 'none', 'x', &
+        'Tracer (h) point grid-space longitude', G%Domain, set_name=set_name)
+    id_yh = MOM_diag_axis_init('jh', jax, 'none', 'y', &
+        'Tracer (h) point grid-space latitude', G%Domain, set_name=set_name)
   else
     if (G%symmetric) then
       id_xq = MOM_diag_axis_init('xB', G%gridLonB(G%isgB:G%iegB), G%x_axis_units, 'x', &
@@ -263,9 +227,9 @@ subroutine set_IS_axes_info(G, param_file, diag_cs, axes_set_name)
 
     endif
     id_xh = MOM_diag_axis_init('xT', G%gridLonT(G%isg:G%ieg), G%x_axis_units, 'x', &
-        'T point nominal longitude', G%Domain, set_name=set_name)
+        'Tracer point nominal longitude', G%Domain, set_name=set_name)
     id_yh = MOM_diag_axis_init('yT', G%gridLatT(G%jsg:G%jeg), G%y_axis_units, 'y', &
-        'T point nominal latitude', G%Domain, set_name=set_name)
+        'Tracer point nominal latitude', G%Domain, set_name=set_name)
   endif
 
   ! Axis groupings for 2-D arrays


### PR DESCRIPTION
  Modified `set_IS_axes_info()` to follow the pattern from the rest of MOM6 and take the units for the horizontal axes from the grid type.  In most cases, this has the effect of changing the units from "degrees_E" and "degrees_N" to "degrees_east" and "degrees_north" to follow CMIP protocols, and to mirror changes that were made to the standard MOM6 framework code in 2017.  All solutions are bitwise identical, but there are changes to the metadata in some output files, and some runtime parameters that had been read from both `set_IS_axes_info()` and `set_grid_metrics()` in MOM_grid_initialize.F90 are now only read in the latter routine.  As a result of these changes, `set_IS_axes_info()` no longer takes a `param_file_type` argument and the grid argument is now `intent(in)`.

  The analogous SIS2 pull request can be found at https://github.com/NOAA-GFDL/SIS2/pull/237.