### PR TITLE
Zero out allocated array in MOM_temp_salt_initialize_from_Z

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2918,7 +2918,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
       call set_regrid_params( regridCS, min_thickness=0., &
                               use_adjust_interface_motion=use_adjust_interface_motion, &
                               use_depth_based_time_filter=use_depth_based_time_fitler)
-      allocate( dz_interface(isd:ied,jsd:jed,nkd+1) ) ! Need for argument to regridding_main() but is not used
+      allocate( dz_interface(isd:ied,jsd:jed,nkd+1), source=0.) ! Need for argument to regridding_main() but is not used
 
       call regridding_preadjust_reqs(regridCS, do_conv_adj, ignore)
       if (do_conv_adj) call convective_adjustment(G, GV_loc, h1, tv_loc)
@@ -3002,7 +3002,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
     call find_interfaces(rho_z, z_in, kd, Rb, Z_bottom, zi, G, GV, US, nlevs, nkml, &
                          Hmix_depth, eps_z, eps_rho, density_extrap_bug)
 
-    deallocate(rho_z)
+    deallocate(rho_z, Rb)
 
     dz(:,:,:) = 0.0
     if (correct_thickness) then


### PR DESCRIPTION
We detected this uninitialized data via layout dependent behavior of the iOM5 configuration in which we had turned off the time-filtering of coordinates in ALE mode.  The locally allocated array was uninitialized and is harmless for most configurations that use time-filtering in the vertical grid generation. The time-filter uses land masks and sets things to zero on land.

I also de-allocated a local variable (Rb) used on another if-branch in the same routine.