### PR TITLE
Change "end if" to endif and "end do" to enddo

### DIFF
--- a/config_src/drivers/STALE_mct_cap/mom_ocean_model_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_ocean_model_mct.F90
@@ -585,7 +585,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   call disable_averaging(OS%diag)
   Master_time = OS%Time ; Time1 = OS%Time
 
-  if(OS%offline_tracer_mode) then
+  if (OS%offline_tracer_mode) then
     call step_offline(OS%forces, OS%fluxes, OS%sfc_state, Time1, dt_coupling, OS%MOM_CSp)
 
   elseif ((.not.do_thermo) .or. (.not.do_dyn)) then
@@ -808,7 +808,7 @@ subroutine initialize_ocean_public_type(input_domain, Ocean_sfc, diag, maskmap, 
 
   call mpp_get_layout(input_domain,layout)
   call mpp_get_global_domain(input_domain, xsize=xsz, ysize=ysz)
-  if(PRESENT(maskmap)) then
+  if (PRESENT(maskmap)) then
     call mpp_define_domains((/1,xsz,1,ysz/),layout,Ocean_sfc%Domain, maskmap=maskmap)
   else
     call mpp_define_domains((/1,xsz,1,ysz/),layout,Ocean_sfc%Domain)

--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -439,14 +439,14 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       fluxes%lrunoff(i,j) = kg_m2_s_conversion * IOB%rofl_flux(i-i0,j-j0) * G%mask2dT(i,j)
     else if (associated(IOB%runoff)) then
       fluxes%lrunoff(i,j) = kg_m2_s_conversion * IOB%runoff(i-i0,j-j0) * G%mask2dT(i,j)
-    end if
+    endif
 
     ! ice runoff flux
     if (associated(IOB%rofi_flux)) then
       fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%rofi_flux(i-i0,j-j0) * G%mask2dT(i,j)
     else if (associated(IOB%calving)) then
       fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%calving(i-i0,j-j0) * G%mask2dT(i,j)
-    end if
+    endif
 
     if (associated(IOB%ustar_berg)) &
       fluxes%ustar_berg(i,j) = US%m_to_Z*US%T_to_s * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)

--- a/config_src/drivers/STALE_mct_cap/ocn_comp_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/ocn_comp_mct.F90
@@ -201,7 +201,7 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
 
     !  set the shr log io unit number
     call shr_file_setLogUnit(stdout)
-  end if
+  endif
 
   call set_calendar_type(NOLEAP)  !TODO: confirm this
 
@@ -316,13 +316,13 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
     close(nu)
     if (is_root_pe()) then
       write(stdout,*) 'Reading restart file(s): ',trim(restartfiles)
-    end if
+    endif
     call shr_file_freeUnit(nu)
     call ocean_model_init(glb%ocn_public, glb%ocn_state, time0, time_start, input_restart_file=trim(restartfiles))
   endif
   if (is_root_pe()) then
     write(stdout,'(/12x,a/)') '======== COMPLETED MOM INITIALIZATION ========'
-  end if
+  endif
 
   ! Initialize ocn_state%sfc_state out of sight
   call ocean_model_init_sfc(glb%ocn_state, glb%ocn_public)
@@ -384,14 +384,14 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
   if (mom_cpl_dt /= ocn_cpl_dt) then
     write(stdout,*) 'ERROR mom_cpl_dt and ocn_cpl_dt must be identical'
     call exit(0)
-  end if
+  endif
 
   ! send initial state to driver
 
   !TODO:
   ! if ( lsend_precip_fact )  then
   !    call seq_infodata_PutData( infodata, precip_fact=precip_fact)
-  ! end if
+  ! endif
 
   if (debug .and. root_pe().eq.pe_here()) print *, "calling ocn_export"
   call ocn_export(glb%ind, glb%ocn_public, glb%grid, o2x_o%rattr, mom_cpl_dt, ncouple_per_day)
@@ -412,7 +412,7 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
   if (is_root_pe()) then
     call shr_file_setLogUnit (shrlogunit)
     call shr_file_setLogLevel(shrloglev)
-  end if
+  endif
 
 end subroutine ocn_init_mct
 
@@ -488,10 +488,10 @@ subroutine ocn_run_mct( EClock, cdata_o, x2o_o, o2x_o)
       time_start = time_start-coupling_timestep
       ! double the first coupling interval (to account for the missing coupling interval to due to lag)
       coupling_timestep = coupling_timestep*2
-    end if
+    endif
 
     firstCall = .false.
-  end if
+  endif
 
   ! Debugging clocks
   if (debug .and. is_root_pe()) then
@@ -526,7 +526,7 @@ subroutine ocn_run_mct( EClock, cdata_o, x2o_o, o2x_o)
           c1=glb%c1, c2=glb%c2, c3=glb%c3, c4=glb%c4)
   else
     call ocn_import(x2o_o%rattr, glb%ind,  glb%grid, Ice_ocean_boundary, glb%ocn_public, stdout, Eclock )
-  end if
+  endif
 
   ! Update internal ocean
   call update_ocean_model(ice_ocean_boundary, glb%ocn_state, glb%ocn_public, time_start, coupling_timestep)
@@ -760,7 +760,7 @@ character(32) function get_runtype()
   else
     write(stdout,*) 'ocn_comp_mct ERROR: unknown starttype'
     call exit(0)
-  end if
+  endif
   return
 
 end function

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -431,7 +431,7 @@ subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
   if (isPresent .and. isSet) then
      if (trim(value) .eq. '.true.') restart_eor = .true.
-  end if
+  endif
 
   if (localPet == 0) call cap_profiling("mom", "InitializeP0", "E")
 
@@ -506,7 +506,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
 
   if (localPet == 0) call cap_profiling("mom", "InitializeAdvertise", "B")
 
-  if(write_runtimelog) timeiads = MPI_Wtime()
+  if (write_runtimelog) timeiads = MPI_Wtime()
 
   call ESMF_LogWrite(subname//' enter', ESMF_LOGMSG_INFO)
 
@@ -571,7 +571,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
 
       if (cesm_coupled) then
         ! Multiinstance logfile name needs a correction
-        if(len_trim(inst_suffix) > 0) then
+        if (len_trim(inst_suffix) > 0) then
           n = index(logfile, '.')
           logfile = logfile(1:n-1)//trim(inst_suffix)//logfile(n:)
         endif
@@ -660,7 +660,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     if (is_root_pe()) then
         write(stdout,*) 'ice_ncat = ', Ice_ocean_boundary%ice_ncat
     endif
-  end if
+  endif
 
   if (is_root_pe()) then
     write(stdout,*) subname//'start time: y,m,d-',year,month,day,'h,m,s=',hour,minute,second
@@ -945,7 +945,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     call NUOPC_Advertise(exportState, standardName=fldsFrOcn(n)%stdname, name=fldsFrOcn(n)%shortname, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
   enddo
-  if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timeiads
+  if (write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timeiads
 
   if (localPet == 0) call cap_profiling("mom", "InitializeAdvertise", "E")
 
@@ -1044,7 +1044,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
 
   if (localPet == 0) call cap_profiling("mom", "InitializeRealize", "B")
 
-  if(write_runtimelog) timeirls = MPI_Wtime()
+  if (write_runtimelog) timeirls = MPI_Wtime()
 
   call shr_log_setLogUnit (stdout)
 
@@ -1253,7 +1253,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
     do n = 1,numOwnedElements
       lonMesh(n) = ownedElemCoords(2*n-1)
       latMesh(n) = ownedElemCoords(2*n)
-    end do
+    enddo
 
     elemMaskArray = ESMF_ArrayCreate(Distgrid, maskMesh, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -1270,8 +1270,8 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
         mask(n) = ocean_grid%mask2dT(ig,jg)
         lon(n)  = ocean_grid%geolonT(ig,jg)
         lat(n)  = ocean_grid%geolatT(ig,jg)
-      end do
-    end do
+      enddo
+    enddo
 
     eps_omesh = get_eps_omesh(ocean_state)
     do n = 1,lsize
@@ -1297,7 +1297,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
         write(err_msg, frmt)n,maskMesh(n),mask(n)
         call MOM_error(FATAL, err_msg)
       endif
-    end do
+    enddo
 
     ! realize the import and export fields using the mesh
     call MOM_RealizeFields(importState, fldsToOcn_num, fldsToOcn, "Ocn import", &
@@ -1342,8 +1342,8 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
           mod2med_areacor(k) = model_areas(k) / mesh_areas(k)
           med2mod_areacor(k) = mesh_areas(k) / model_areas(k)
         endif
-      end do
-    end do
+      enddo
+    enddo
     deallocate(mesh_areas)
     deallocate(model_areas)
 
@@ -1621,7 +1621,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
   if (use_cdeps_inline) then
      call mom_inline_init(gcomp, clock, eMesh, localPet, rc=rc)
      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !---------------------------------
   ! write out diagnostics
@@ -1632,7 +1632,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
   !if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   timere = 0.
-  if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timeirls
+  if (write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timeirls
 
   if (localPet == 0) call cap_profiling("mom", "InitializeRealize", "E")
 
@@ -1669,7 +1669,7 @@ subroutine DataInitialize(gcomp, rc)
 
   if (localPet == 0) call cap_profiling("mom", "DataInitialize", "B")
 
-  if(write_runtimelog) timedis = MPI_Wtime()
+  if (write_runtimelog) timedis = MPI_Wtime()
 
   ! query the Component for its clock, importState and exportState
   call ESMF_GridCompGet(gcomp, clock=clock, importState=importState, exportState=exportState, rc=rc)
@@ -1731,7 +1731,7 @@ subroutine DataInitialize(gcomp, rc)
     enddo
   endif
 
-  if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timedis
+  if (write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timedis
 
   if (localPet == 0) call cap_profiling("mom", "DataInitialize", "E")
 
@@ -1793,10 +1793,10 @@ subroutine ModelAdvance(gcomp, rc)
 
   if (localPet == 0) call cap_profiling("mom", "ModelAdvance", "B")
 
-  if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
-  if(write_runtimelog) then
+  if (profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
+  if (write_runtimelog) then
      timers = MPI_Wtime()
-     if(timere>0. .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time since last time step ',timers-timere
+     if (timere>0. .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time since last time step ',timers-timere
   endif
 
   call shr_log_setLogUnit (stdout)
@@ -1911,7 +1911,7 @@ subroutine ModelAdvance(gcomp, rc)
     if (use_cdeps_inline) then
       call mom_inline_run(clock, ocean_public, ocean_grid, ice_ocean_boundary, dbug, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    endif
 
     !---------------
     ! Update MOM6
@@ -1956,7 +1956,7 @@ subroutine ModelAdvance(gcomp, rc)
       ! turn off the alarm
       call ESMF_AlarmRingerOff(restart_alarm, rc=rc )
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    endif
 
     write_restart_eor = .false.
     if (restart_eor) then
@@ -1966,8 +1966,8 @@ subroutine ModelAdvance(gcomp, rc)
         ! turn off the alarm
         call ESMF_AlarmRingerOff(stop_alarm, rc=rc )
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      end if
-    end if
+      endif
+    endif
 
 #ifndef CESMCOUPLED
     call is_restart_fh(clock, restartfh_info, write_restartfh)
@@ -2071,12 +2071,12 @@ subroutine ModelAdvance(gcomp, rc)
     enddo
   endif
 
-  if(write_runtimelog) then
+  if (write_runtimelog) then
     timere = MPI_Wtime()
-    if(is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', timere-timers
+    if (is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', timere-timers
   endif
 
-  if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM Model_ADVANCE: ")
+  if (profile_memory) call ESMF_VMLogMemInfo("Leaving MOM Model_ADVANCE: ")
 
   if (localPet == 0) call cap_profiling("mom", "ModelAdvance", "E")
 
@@ -2299,7 +2299,7 @@ subroutine ocean_model_finalize(gcomp, rc)
     write(stdout,*) 'MOM: --- finalize called ---'
   endif
   rc = ESMF_SUCCESS
-  if(write_runtimelog) timefs = MPI_Wtime()
+  if (write_runtimelog) timefs = MPI_Wtime()
 
   call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -2334,7 +2334,7 @@ subroutine ocean_model_finalize(gcomp, rc)
   call outputlog_run(clock, .true., rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timefs
+  if (write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timefs
 
   if (localPet == 0) call cap_profiling("mom", "ocean_model_finalize", "E")
 

--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -249,7 +249,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hrain', isc, iec, jsc, jec, &
          ice_ocean_boundary%hrain, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !----
   ! enthalpy from frozen precipitation (hsnow)
@@ -258,7 +258,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hsnow', isc, iec, jsc, jec, &
          ice_ocean_boundary%hsnow, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !----
   ! enthalpy from liquid runoff (hrofl)
@@ -267,7 +267,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hrofl', isc, iec, jsc, jec, &
          ice_ocean_boundary%hrofl, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !----
   ! enthalpy from frozen runoff (hrofi)
@@ -276,7 +276,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hrofi', isc, iec, jsc, jec, &
          ice_ocean_boundary%hrofi, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !----
   ! enthalpy from liquid glc runoff (hrofl_glc)
@@ -285,7 +285,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hrofl_glc', isc, iec, jsc, jec, &
          ice_ocean_boundary%hrofl_glc, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !----
   ! enthalpy from frozen glc runoff (hrofi_glc)
@@ -294,7 +294,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hrofi_glc', isc, iec, jsc, jec, &
          ice_ocean_boundary%hrofi_glc, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
   !----
   ! enthalpy from evaporation (hevap)
   !----
@@ -302,7 +302,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     call state_getimport(importState, 'Foxx_hevap', isc, iec, jsc, jec, &
          ice_ocean_boundary%hevap, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  end if
+  endif
 
   !----
   ! enthalpy from condensation (hcond)
@@ -391,7 +391,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
           areacor=med2mod_areacor, do_sum=.true., esmf_ind=esmf_ind, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     enddo
-  end if
+  endif
 
   !----
   ! dust flux from sea ice
@@ -545,9 +545,9 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
         do i = isc, iec
           ig = i + ocean_grid%isc - isc
           !rotate
-          if(set_missing_stks_to_zero) then
+          if (set_missing_stks_to_zero) then
             do ib = 1, nsc
-              if((abs(stkx(i,j,ib)-9.99E20_ESMF_KIND_R8) <= 0.01_ESMF_KIND_R8)) then
+              if ((abs(stkx(i,j,ib)-9.99E20_ESMF_KIND_R8) <= 0.01_ESMF_KIND_R8)) then
                 ice_ocean_boundary%ustkb(i,j,ib) = 0.0
                 ice_ocean_boundary%vstkb(i,j,ib) = 0.0
               else

--- a/src/ALE/regrid_solvers.F90
+++ b/src/ALE/regrid_solvers.F90
@@ -166,7 +166,7 @@ subroutine linear_solver( N, A, R, X )
   if (A(N,N) == 0.0) then
     ! no pivot could be found, and the sytem is singular
     call MOM_error(FATAL, 'The final pivot in linear_solver is zero.')
-  end if
+  endif
 
   ! Solve the system by back substituting into what is now an upper-right matrix.
   X(N) = R(N) / A(N,N)  ! The last row is now trivially solved.

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -3746,7 +3746,7 @@ subroutine get_forcing_groups(fluxes, water, heat, ustar, tau_mag, press, shelf,
   iceberg = associated(fluxes%ustar_berg)
   heat_added = associated(fluxes%heat_added)
   buoy = associated(fluxes%buoy)
-  if(present(carbon)) carbon = associated(fluxes%carbon_content_lrunoff)
+  if (present(carbon)) carbon = associated(fluxes%carbon_content_lrunoff)
 end subroutine get_forcing_groups
 
 

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -232,7 +232,7 @@ function new_RandomNumberSequence(seed) result(twister)
     twister%state(i) = 1812433253 * ieor(twister%state(i-1), &
                                          ishft(twister%state(i-1), -30)) + i
     twister%state(i) = iand(twister%state(i), -1) ! for >32 bit machines
-  end do
+  enddo
   twister%currentElement = blockSize
 end function new_RandomNumberSequence
 
@@ -261,7 +261,7 @@ double precision function getRandomReal(twister)
     getRandomReal = dble(localInt + 2.0d0**32)/(2.0d0**32 - 1.0d0)
   else
     getRandomReal = dble(localInt            )/(2.0d0**32 - 1.0d0)
-  end if
+  endif
 end function getRandomReal
 
 !> Merge bits of u and v
@@ -292,11 +292,11 @@ subroutine nextState(twister)
   do k = 0, blockSize - M - 1
     twister%state(k) = ieor(twister%state(k + M), &
                             twist(twister%state(k), twister%state(k + 1)))
-  end do
+  enddo
   do k = blockSize - M, blockSize - 2
     twister%state(k) = ieor(twister%state(k + M - blockSize), &
                             twist(twister%state(k), twister%state(k + 1)))
-  end do
+  enddo
   twister%state(blockSize - 1) = ieor(twister%state(M - 1), &
                                       twist(twister%state(blockSize - 1), twister%state(0)))
   twister%currentElement = 0

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1440,7 +1440,7 @@ subroutine calc_sfc_displacement(PF, G, GV, US, mass_shelf, tv, h)
         enddo
         residual = mass_shelf(i,j) - mass_disp
         iter = iter+1
-      end do
+      enddo
       if (iter >= max_iter) call MOM_mesg("Warning: calc_sfc_displacement too many iterations.")
       z_top_shelf(i,j) = z_top
     endif

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -422,7 +422,7 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
 !  if (CS%write_obs) then
 !    temp_fid = open_profile_file("temp_"//trim(obs_file))
 !    salt_fid = open_profile_file("salt_"//trim(obs_file))
-!  end if
+!  endif
 
 end subroutine init_oda
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -1691,7 +1691,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do J=js-1,Jeq ; do I=is-1,Ieq
           Kh(I,J) = 0.25 * ((Kh_h(i,j,k) + Kh_h(i+1,j+1,k)) + (Kh_h(i,j+1,k) + Kh_h(i+1,j,k)))
         enddo ; enddo
-      end if
+      endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
         do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1810,7 +1810,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah(I,J) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
         enddo ; enddo
-      end if
+      endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
         do J=js-1,Jeq ; do I=is-1,Ieq

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -567,11 +567,11 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
         cmor_field_name='oml', cmor_long_name='ocean_mixed_layer_thickness_defined_by_mixing_scheme', &
         cmor_units='m', cmor_standard_name='Ocean Mixed Layer Thickness Defined by Mixing Scheme')
   endif
-  if( CS%StokesMOST ) then
-  CS%id_StokesXI = register_diag_field('ocean_model', 'StokesXI', diag%axesT1, Time, &
-      'Stokes Similarity Parameter', 'nondim')
-  CS%id_Lam2     = register_diag_field('ocean_model', 'Lam2',  diag%axesT1, Time, &
-      'Ustk0_ustar', 'nondim')
+  if ( CS%StokesMOST ) then
+    CS%id_StokesXI = register_diag_field('ocean_model', 'StokesXI', diag%axesT1, Time, &
+        'Stokes Similarity Parameter', 'nondim')
+    CS%id_Lam2     = register_diag_field('ocean_model', 'Lam2',  diag%axesT1, Time, &
+        'Ustk0_ustar', 'nondim')
   endif
   CS%id_BulkDrho = register_diag_field('ocean_model', 'KPP_BulkDrho', diag%axesTL, Time, &
       'Bulk difference in density used in Bulk Richardson number, as used by [CVMix] KPP', &

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -2797,7 +2797,7 @@ subroutine kappa_eqdisc(shape_func, CS, GV, dz, absf, B_flux, u_star, MLD_guess)
   hz(1) = 0.0
   do K=2,nz
     hz(K) = hz(K-1) + dz(K-1)
-  end do
+  enddo
   hbl = MLD_Guess ! hbl is boundary layer depth.
 
   u_star_I = 1.0/u_star
@@ -2866,7 +2866,7 @@ subroutine kappa_eqdisc(shape_func, CS, GV, dz, absf, B_flux, u_star, MLD_guess)
     elseif (hz(n) > hbl) then
       shape_func(n) = CS%shape_function_epsilon ! set an arbitrary low constant value below hbl, default 0.01
     endif
-  end do
+  enddo
 end subroutine kappa_eqdisc
 
 !> Gives velocity scale (v_0) using equations that approximate neural network of Sane et al. 2023

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -433,7 +433,7 @@ subroutine configure_MARBL_tracers(GV, US, param_file, CS)
       CS%sfo_cnt = CS%sfo_cnt + 1
     else if (trim(field_source) == "interior_tendency") then
       CS%ito_cnt = CS%ito_cnt + 1
-    end if
+    endif
 
     ! Total 3D Chlorophyll
     call MARBL_instances%add_output_for_GCM(num_elements=1, num_levels=nz, field_name="total_Chl", &
@@ -442,8 +442,8 @@ subroutine configure_MARBL_tracers(GV, US, param_file, CS)
       CS%sfo_cnt = CS%sfo_cnt + 1
     else if (trim(field_source) == "interior_tendency") then
       CS%ito_cnt = CS%ito_cnt + 1
-    end if
-  end if
+    endif
+  endif
 
   ! (5) Initialize forcing fields
   !     i. store all surface forcing indices

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -137,7 +137,7 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
   do m = 1,ntr
 
      local_advect_scheme(m) = Reg%Tr(m)%advect_scheme
-     if(local_advect_scheme(m) < 0) local_advect_scheme(m) = CS%default_advect_scheme
+     if (local_advect_scheme(m) < 0) local_advect_scheme(m) = CS%default_advect_scheme
 
      if (local_advect_scheme(m) == ADVECT_PLM) then
        stencil_local = 2

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -237,7 +237,7 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   if (present(diag_form)) Tr%diag_form = diag_form
 
   Tr%advect_scheme = -1
-  if(present(advect_scheme)) Tr%advect_scheme = advect_scheme
+  if (present(advect_scheme)) Tr%advect_scheme = advect_scheme
 
   Tr%t => tr_ptr
 

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -357,7 +357,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
     if (.not.use_waves) return
   else
     CS%WaveMethod = NULL_WaveMethod
-  end if
+  endif
 
   ! Wave modified physics
   !  Presently these are all in research mode


### PR DESCRIPTION
  Replaced "end if" with "endif" in 35 places in 10 files and "end do" with "enddo" in 12 places in 4 files to comply with the MOM6 style guide.  In addition, in 23 places in 7 files, code like `if(test)` were replaced with `if (test)`, also to align with the MOM6 style guide.  All answers are bitwise identical.