### PR TITLE
Refactor OBC segment init/update (Part 4)

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -116,6 +116,7 @@ use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
 use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
 use MOM_open_boundary,         only : ocean_OBC_type, open_boundary_end
 use MOM_open_boundary,         only : register_temp_salt_segments, update_segment_tracer_reservoirs
+use MOM_open_boundary,         only : read_OBC_segment_data
 use MOM_open_boundary,         only : setup_OBC_tracer_reservoirs
 use MOM_open_boundary,         only : setup_OBC_thickness_reservoirs
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
@@ -3302,7 +3303,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     call calc_derived_thermo(CS%tv, CS%h, G, GV, US)
 
     ! Call this during initialization to fill boundary arrays from fixed values
-    call update_OBC_segment_data(G, GV, US, CS%OBC, CS%tv, CS%h, Time)
+    call read_OBC_segment_data(G, GV, US, CS%OBC, CS%tv, CS%h, Time)
+    call update_OBC_segment_data(G, GV, US, CS%OBC, CS%h, Time)
   endif
 
   if (use_ice_shelf .and. CS%debug) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -116,7 +116,7 @@ use MOM_mixed_layer_restrat,   only : mixedlayer_restrat_register_restarts
 use MOM_obsolete_diagnostics,  only : register_obsolete_diagnostics
 use MOM_open_boundary,         only : ocean_OBC_type, open_boundary_end
 use MOM_open_boundary,         only : register_temp_salt_segments, update_segment_tracer_reservoirs
-use MOM_open_boundary,         only : read_OBC_segment_data
+use MOM_open_boundary,         only : read_OBC_segment_data, initialize_OBC_segment_reservoirs
 use MOM_open_boundary,         only : setup_OBC_tracer_reservoirs
 use MOM_open_boundary,         only : setup_OBC_thickness_reservoirs
 use MOM_open_boundary,         only : open_boundary_register_restarts, remap_OBC_fields
@@ -3305,6 +3305,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     ! Call this during initialization to fill boundary arrays from fixed values
     call read_OBC_segment_data(G, GV, US, CS%OBC, CS%tv, CS%h, Time)
     call update_OBC_segment_data(G, GV, US, CS%OBC, CS%h, Time)
+    call initialize_OBC_segment_reservoirs(GV, CS%OBC)
   endif
 
   if (use_ice_shelf .and. CS%debug) then

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -12,6 +12,7 @@ use MOM_file_parser,           only : get_param, log_version, param_file_type, l
 use MOM_grid,                  only : ocean_grid_type
 use MOM_dyn_horgrid,           only : dyn_horgrid_type
 use MOM_open_boundary,         only : ocean_obc_type, update_OBC_segment_data, chksum_OBC_segments
+use MOM_open_boundary,         only : read_OBC_segment_data
 use MOM_open_boundary,         only : OBC_registry_type, file_OBC_CS
 use MOM_open_boundary,         only : register_file_OBC, file_OBC_end
 use MOM_unit_scaling,          only : unit_scale_type
@@ -168,8 +169,10 @@ subroutine update_OBC_data(OBC, G, GV, US, tv, h, CS, Time)
       call shelfwave_set_OBC_data(OBC, CS%shelfwave_OBC_CSp, G, GV, US, h, Time)
   if (CS%use_dyed_channel) &
       call dyed_channel_update_flow(OBC, CS%dyed_channel_OBC_CSp, G, GV, US, h, Time)
-  if (OBC%any_needs_IO_for_data .or. OBC%add_tide_constituents)  &
-      call update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
+  if (OBC%any_needs_IO_for_data .or. OBC%add_tide_constituents) then
+    call read_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
+    call update_OBC_segment_data(G, GV, US, OBC, h, Time)
+  endif
   if (CS%debug_OBCs) call chksum_OBC_segments(OBC, G, GV, US, CS%nk_OBC_debug)
 
 end subroutine update_OBC_data

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -50,6 +50,7 @@ public open_boundary_impose_land_mask
 public radiation_open_bdry_conds
 public read_OBC_segment_data
 public update_OBC_segment_data
+public initialize_OBC_segment_reservoirs
 public open_boundary_test_extern_uv
 public open_boundary_test_extern_h
 public open_boundary_zero_normal_flow
@@ -4870,15 +4871,8 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, h, Time)
     ! Set the thickness reservoir data.
     if (OBC%thickness_x_reservoirs_used .or. OBC%thickness_y_reservoirs_used) then
       do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
-        segment%h_Reg%h(i,j,k) = segment%h(i,j,k)
+        segment%h_Reg%h(i,j,k) = h(i+i_offset_in,j+j_offset_in,k)
       enddo ; enddo ; enddo
-      if (.not. segment%h_Reg%is_initialized) then
-        ! If the thickness reservoir has not yet been initialized, then set to external value.
-        do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
-          segment%h_Reg%h_res(i,j,k) = segment%h_Reg%h(i,j,k)
-        enddo ; enddo ; enddo
-        segment%h_Reg%is_initialized = .true.
-      endif
     endif
 
     do m = NUM_PHYS_FIELDS-1, segment%num_fields ! F_T = NUM_PHYS_FIELDS-1 and F_S = NUM_PHYS_FIELDS
@@ -4886,12 +4880,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, h, Time)
           (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data))) then
         cycle
       endif
-
       nt = segment%field(m)%tr_index
-      if (nt < 0) &
-        call MOM_error(FATAL, "update_OBC_segment_data: Did not find tracer " // &
-                       trim(segment%field(m)%name))
-
       ! Note the following unnecessary IF-branch is kept from the old code (as recent as Jan 2026).
       ! In the old code segment%field(m)%buffer_dst is always allocated at this point, and therefore
       ! the "else" section is unreachable. This will be fixed when OBC_inflow_conc is reworked.
@@ -4899,21 +4888,70 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, h, Time)
         do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
           segment%tr_Reg%Tr(nt)%t(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
         enddo ; enddo ; enddo
-        if (.not. segment%tr_Reg%Tr(nt)%is_initialized) then
-          ! If the tracer reservoir has not yet been initialized, then set to external value.
-          do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
-            segment%tr_Reg%Tr(nt)%tres(i,j,k) = segment%tr_Reg%Tr(nt)%t(i,j,k)
-          enddo ; enddo ; enddo
-          segment%tr_Reg%Tr(nt)%is_initialized = .true.
-        endif
       else
         segment%tr_Reg%Tr(nt)%OBC_inflow_conc = segment%field(m)%value
       endif
     enddo ! end tracer field loop
-
   enddo ! end segment loop
-
 end subroutine update_OBC_segment_data
+
+!> Initialize thickness and tracer reservoirs to external value.
+subroutine initialize_OBC_segment_reservoirs(GV, OBC)
+  type(verticalGrid_type), intent(in) :: GV  !< Ocean vertical grid structure
+  type(ocean_OBC_type),    pointer    :: OBC !< Open boundary structure
+
+  ! Local variables
+  type(OBC_segment_type), pointer :: segment => NULL()
+  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+  integer :: is_seg, ie_seg, js_seg, je_seg, nz
+  integer :: n, m, nt, i, j, k
+  character(len=256) :: msg ! Error message
+
+  if (.not. associated(OBC)) return
+
+  nz = GV%ke
+
+  do n=1,OBC%number_of_segments
+    segment => OBC%segment(n)
+
+    if (.not. segment%on_pe) cycle
+
+    isd = segment%HI%isd ; ied = segment%HI%ied ; IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
+    jsd = segment%HI%jsd ; jed = segment%HI%jed ; JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
+
+    if (segment%is_E_or_W) then
+      is_seg = IsdB ; ie_seg = IedB ! = is_seg
+      js_seg = jsd ; je_seg = jed
+    else
+      is_seg = isd ; ie_seg = ied
+      js_seg = JsdB ; je_seg = JedB ! = js_seg
+    endif
+
+    ! Thickness
+    ! If the thickness reservoir has not yet been initialized, then set to external value.
+    if (OBC%thickness_x_reservoirs_used .or. OBC%thickness_y_reservoirs_used) then
+      if (.not. segment%h_Reg%is_initialized) then ! h_Reg may be initialized by fill_thickness_segments
+        do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
+          segment%h_Reg%h_res(i,j,k) = segment%h_Reg%h(i,j,k)
+        enddo ; enddo ; enddo
+        segment%h_Reg%is_initialized = .true.
+      endif
+    endif
+
+    ! Tracers
+    ! If the tracer reservoir has not yet been initialized, then set to external value.
+    do m=NUM_PHYS_FIELDS-1, segment%num_fields ! F_T = NUM_PHYS_FIELDS-1 and F_S = NUM_PHYS_FIELDS
+      if (.not. allocated(segment%field(m)%buffer_dst)) cycle
+      nt = segment%field(m)%tr_index
+      if (.not. segment%tr_Reg%Tr(nt)%is_initialized) then ! T/S may be initialized by fill_temp_salt_segments
+        do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
+          segment%tr_Reg%Tr(nt)%tres(i,j,k) = segment%tr_Reg%Tr(nt)%t(i,j,k)
+        enddo ; enddo ; enddo
+        segment%tr_Reg%Tr(nt)%is_initialized = .true.
+      endif
+    enddo ! end tracer field loop
+  enddo ! end segment loop
+end subroutine initialize_OBC_segment_reservoirs
 
 !> Update the OBC ramp value as a function of time.
 !! If called with the optional argument activate=.true., record the

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -48,6 +48,7 @@ public open_boundary_end
 public open_boundary_impose_normal_slope
 public open_boundary_impose_land_mask
 public radiation_open_bdry_conds
+public read_OBC_segment_data
 public update_OBC_segment_data
 public open_boundary_test_extern_uv
 public open_boundary_test_extern_h
@@ -4136,8 +4137,6 @@ subroutine allocate_OBC_segment_data(OBC, segment)
 
   if (segment%is_E_or_W) then
     ! If these are just Flather, change update_OBC_segment_data accordingly
-    !   segment%Cg is never used. A version of Cg is calculated in MOM_barotropic.
-    allocate(segment%Cg(IsdB:IedB, jsd:jed), source=0.0)
     allocate(segment%Htot(IsdB:IedB,jsd:jed), source=0.0)
     ! Allocate dZtot with extra values at the end to avoid segmentation faults in cases where
     ! it is interpolated to OBC vorticity points.
@@ -4183,7 +4182,6 @@ subroutine allocate_OBC_segment_data(OBC, segment)
 
   if (segment%is_N_or_S) then
     ! If these are just Flather, change update_OBC_segment_data accordingly
-    allocate(segment%Cg(isd:ied,JsdB:JedB), source=0.0)
     allocate(segment%Htot(isd:ied,JsdB:JedB), source=0.0)
     ! Allocate dZtot with extra values at the end to avoid segmentation faults in cases where
     ! it is interpolated to OBC vorticity points.
@@ -4235,7 +4233,6 @@ subroutine deallocate_OBC_segment_data(segment)
 
   if (.not. segment%on_pe) return
 
-  if (allocated(segment%Cg)) deallocate(segment%Cg)
   if (allocated(segment%Htot)) deallocate(segment%Htot)
   if (allocated(segment%dZtot)) deallocate(segment%dZtot)
   if (allocated(segment%h)) deallocate(segment%h)
@@ -4356,18 +4353,18 @@ subroutine open_boundary_test_extern_h(G, GV, OBC, h)
 
 end subroutine open_boundary_test_extern_h
 
-!> Update the OBC values on the segments.
-subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
-  type(ocean_grid_type),                     intent(in)    :: G    !< Ocean grid structure
-  type(verticalGrid_type),                   intent(in)    :: GV   !<  Ocean vertical grid structure
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(ocean_OBC_type),                      pointer       :: OBC  !< Open boundary structure
-  type(thermo_var_ptrs),                     intent(in)    :: tv   !< Thermodynamics structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h    !< Thickness [H ~> m or kg m-2]
-  type(time_type),                           intent(in)    :: Time !< Model time
+!> Read OBC values on the segments from files
+subroutine read_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
+  type(ocean_grid_type),                     intent(in) :: G    !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in) :: GV   !< Ocean vertical grid structure
+  type(unit_scale_type),                     intent(in) :: US   !< A dimensional unit scaling type
+  type(ocean_OBC_type),                      pointer    :: OBC  !< Open boundary structure
+  type(thermo_var_ptrs),                     intent(in) :: tv   !< Thermodynamics structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h    !< Thickness [H ~> m or kg m-2]
+  type(time_type),                           intent(in) :: Time !< Model time
 
   ! Local variables
-  integer :: c, i, j, k, n, m, nz, nt !, nk_dst
+  integer :: i, j, k, n, m
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   type(OBC_segment_type), pointer :: segment => NULL()
   real, dimension(:,:,:), pointer :: tmp_buffer_in => NULL()  ! Unrotated input [various units]
@@ -4377,26 +4374,16 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
   real, dimension(:,:,:), allocatable, target :: tmp_buffer ! A buffer for input data [various units]
   real :: dz_stack(SZK_(GV)) ! Distance between the interfaces at corner points [Z ~> m]
   integer :: i_seg_offset, j_seg_offset, bug_offset
-  integer :: is_seg, ie_seg, js_seg, je_seg
   real :: net_dz_src  ! Total vertical extent of the incoming flow in the source field [Z ~> m]
   real :: net_dz_int  ! Total vertical extent of the incoming flow in the model [Z ~> m]
   real :: scl_fac     ! A scaling factor to compensate for differences in total thicknesses [nondim]
-  real :: ramp_value  ! If OBC%ramp is True, where we are on the ramp from 0 to 1, or 1 otherwise [nondim].
   integer :: turns    ! Number of index quarter turns
-  real :: time_delta  ! Time since tidal reference date [T ~> s]
   logical :: flip_buffer ! If true, the input buffer needs to be transposed
-  real :: tidal_amp, tidal_phase
-  integer :: F_G, F_VT, F_VTAMP, F_VTPHASE
 
   if (.not. associated(OBC)) return
   if (OBC%user_BCs_set_globally) return
 
-  nz = GV%ke
-
   turns = modulo(G%HI%turns, 4)
-
-  if (OBC%add_tide_constituents) time_delta = time_minus_signed(Time, OBC%time_ref, scale=US%s_to_T)
-
   dz(:,:,:) = 0.0
   call thickness_to_dz(h, tv, dz, G, GV, US)
   call pass_var(dz, G%Domain)
@@ -4414,25 +4401,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
     i_seg_offset = G%idg_offset - segment%HI%IsgB
     j_seg_offset = G%jdg_offset - segment%HI%JsgB
 
-    if (segment%is_E_or_W) then
-      is_seg = IsdB ; ie_seg = is_seg
-      js_seg = jsd ; je_seg = jed
-    else
-      is_seg = isd ; ie_seg = ied
-      js_seg = JsdB ; je_seg = js_seg
-    endif
-
-    ! Calculate auxiliary fields at staggered locations.
-    ! Segment indices are on q points:
-    !
-    !       |-----------|------------|-----------|-----------|  J_obc
-    !     Is_obc                                          Ie_obc
-    !
-    ! i2 has to start at Is_obc+1 and end at Ie_obc.
-    ! j2 is J_obc and jshift has to be +1 at both the north and south.
-
     ! Calculate auxiliary fields at staggered locations
-    segment%Htot(:,:) = 0.0
     segment%dZtot(:,:) = 0.0
     if (segment%is_E_or_W) then
       I = IsdB
@@ -4440,38 +4409,26 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
       do k = 1, GV%ke ; do j = max(jsd-1, G%jsd), min(jed+1, G%jed)
         segment%dZtot(I,j) = segment%dZtot(I,j) + dz(isd,j,k)
       enddo ; enddo
-      do k = 1, GV%ke ; do j = jsd, jed
-        segment%h(I,j,k) = h(isd,j,k)
-        segment%Htot(I,j) = segment%Htot(I,j) + segment%h(I,j,k)
-      enddo ; enddo
-      do j = jsd, jed
-        segment%Cg(I,j) = sqrt(GV%g_prime(1) * max(0.0, segment%dZtot(I,j)))
-      enddo
     else ! (segment%direction == OBC_DIRECTION_N .or. segment%direction == OBC_DIRECTION_S)
       J = JsdB
       ! dZtot may extend one point past the end of the segment on the current PE for use at vorticity points
       do k = 1, GV%ke ; do i = max(isd-1, G%isd), min(ied+1, G%ied)
         segment%dZtot(i,J) = segment%dZtot(i,J) + dz(i,jsd,k)
       enddo ; enddo
-      do k = 1, GV%ke ; do i = isd, ied
-        segment%h(i,J,k) = h(i,jsd,k)
-        segment%Htot(i,J) = segment%Htot(i,J) + segment%h(i,J,k)
-      enddo ; enddo
-      do i = isd, ied
-        segment%Cg(i,J) = sqrt(GV%g_prime(1) * max(0.0, segment%dZtot(i,J)))
-      enddo
     endif
 
     ! Read data from files to buffer_src
-    do m = 1,segment%num_fields
+    do m=1,segment%num_fields
       if (segment%field(m)%required .and. (.not. allocated(segment%field(m)%buffer_dst))) &
         call MOM_error(FATAL, 'buffer_dst not allocated')
 
-      !This field may not require a high frequency OBC segment update and might be allowed
-      !a less frequent update as set by the parameter update_OBC_period_max in MOM.F90.
-      !Cycle if it is not the time to update OBC segment data for this field.
-      if (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data)) cycle
-      if (.not. segment%field(m)%use_IO) cycle
+      if ( (.not. segment%field(m)%use_IO) .or. & ! .and. (.not. segment%field(m)%required)
+           (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data)) ) &
+        !This field may not require a high frequency OBC segment update and might be allowed
+        !a less frequent update as set by the parameter update_OBC_period_max in MOM.F90.
+        !Cycle if it is not the time to update OBC segment data for this field.
+        cycle
+
       ! read source data interpolated to the current model time
       ! NOTE: buffer is sized for vertex points, but may be used for faces
       if (segment%is_E_or_W) then
@@ -4716,6 +4673,70 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
       deallocate(tmp_buffer)
       if (turns /= 0) deallocate(tmp_buffer_in)
     enddo ! end field loop
+  enddo ! endd segment loop
+end subroutine read_OBC_segment_data
+
+!> Update the OBC values on the segments.
+subroutine update_OBC_segment_data(G, GV, US, OBC, h, Time)
+  type(ocean_grid_type),                     intent(in) :: G    !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in) :: GV   !< Ocean vertical grid structure
+  type(unit_scale_type),                     intent(in) :: US   !< A dimensional unit scaling type
+  type(ocean_OBC_type),                      pointer    :: OBC  !< Open boundary structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h    !< Thickness [H ~> m or kg m-2]
+  type(time_type),                           intent(in) :: Time !< Model time
+
+  ! Local variables
+  type(OBC_segment_type), pointer :: segment => NULL()
+  integer :: c, i, j, k, n, m, nz, nt
+  integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+  integer :: is_seg, ie_seg, js_seg, je_seg ! Orientation-agnostic loop ranges
+  integer :: i_offset_in, j_offset_in ! Indexing offset for interior cells
+  real :: ramp_value  ! If OBC%ramp is True, where we are on the ramp from 0 to 1, or 1 otherwise [nondim].
+  real :: time_delta  ! Time since tidal reference date [T ~> s]
+  real :: tidal_amp, tidal_phase ! Tidal amplitude [Z ~> m] and phase [rad]
+  integer :: F_G, F_VT, F_VTAMP, F_VTPHASE
+
+  if (.not. associated(OBC)) return
+  if (OBC%user_BCs_set_globally) return
+
+  nz = GV%ke
+
+  if (OBC%add_tide_constituents) &
+    time_delta = time_minus_signed(Time, OBC%time_ref, scale=US%s_to_T)
+
+  do n=1,OBC%number_of_segments
+    segment => OBC%segment(n)
+
+    if (.not. segment%on_pe) cycle ! continue to next segment if not in data domain
+
+    isd = segment%HI%isd ; ied = segment%HI%ied ; IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
+    jsd = segment%HI%jsd ; jed = segment%HI%jed ; JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
+    i_offset_in = ied - IedB ! = 0 if East, South, North; = 1 if West
+    j_offset_in = jed - JedB ! = 0 if North, West, East ; = 1 if South
+
+    if (segment%is_E_or_W) then
+      is_seg = IsdB ; ie_seg = is_seg
+      js_seg = jsd ; je_seg = jed
+    else
+      is_seg = isd ; ie_seg = ied
+      js_seg = JsdB ; je_seg = js_seg
+    endif
+
+    ! Calculate auxiliary fields at staggered locations.
+    ! Segment indices are on q points:
+    !
+    !       |-----------|------------|-----------|-----------|  J_obc
+    !     Is_obc                                          Ie_obc
+    !
+    ! i2 has to start at Is_obc+1 and end at Ie_obc.
+    ! j2 is J_obc and jshift has to be +1 at both the north and south.
+
+    ! Calculate auxiliary fields at staggered locations
+    segment%Htot(:,:) = 0.0
+    do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
+      segment%h(i,j,k) = h(i+i_offset_in,j+j_offset_in,k)
+      segment%Htot(i,j) = segment%Htot(i,j) + segment%h(i,j,k)
+    enddo ; enddo ; enddo
 
     ! Update segment velocities, gradient, SSH and thickness/tracer reserviors
     if (segment%is_E_or_W .and. allocated(segment%field(F_U)%buffer_dst)) then
@@ -7078,7 +7099,6 @@ subroutine chksum_OBC_segment_data(segment, GV, US, nk, nseg_out)
       norm = -1.0 ; tang = 1.0
     endif
 
-    if (allocated(segment%Cg)) call write_2d_array_vals("Cg"//trim(sn), segment%Cg, dir, nk, unscale=US%L_T_to_m_s)
     if (allocated(segment%Htot)) call write_2d_array_vals("Htot"//trim(sn), segment%Htot, dir, nk, unscale=GV%H_to_mks)
     if (allocated(segment%dZtot)) call write_2d_array_vals("dZtot"//trim(sn), segment%dZtot, dir, nk, unscale=US%Z_to_m)
     if (allocated(segment%SSH)) call write_2d_array_vals("SSH"//trim(sn), segment%SSH, dir, nk, unscale=US%Z_to_m)


### PR DESCRIPTION
This PR follows https://github.com/NOAA-GFDL/MOM6/pull/1068 and splits subroutine `update_OBC_segment_data` into three parts.

1. `read_OBC_segment_data` reads data into each `OBC_segment_data_type`'s `buffer_dst`.
2. `update_OBC_segment_data` uses `buffer_dst` to update fields actually used by the rest of the model, i.e. `normal_vel`, `tangential_vel` etc and the external fields in thickness/tracer registry. Note that these fields also depend on the evolution of the interior, therefore this step always needs to be called, even if the external data is not updated (`VALUE` mode). A bug fix is included in a subsequent PR.
3. `initialize_OBC_segment_reservoirs` initializes thickness/tracer reservoir if they are not initialized by `fill_xxx_segments`.

232dc3e569eec8f44a79442a0db9a7171a197253 splits out read_OBC_segment_data
1af336e17eaa2c2b85d840187df883bd51d2c0d6 splits out initialize_OBC_segment_reservoirs

There are no answer or parameter changes. 

Edit: I should add that this PR was tested to reproduce NWA12 and ESMG test suites that do not need input files.