### PR TITLE
makedep: support empty macros and defines

### DIFF
--- a/ac/makedep
+++ b/ac/makedep
@@ -389,7 +389,9 @@ def scan_fortran_file(src_file, defines=None):
 
     cpp_defines = defines if defines is not None else []
 
-    cpp_macros = dict([t.split('=') for t in cpp_defines])
+    cpp_macros = dict(
+        [t.split('=') if '=' in t else (t, None) for t in cpp_defines]
+    )
     cpp_group_stack = []
 
     with io.open(src_file, 'r', errors='replace') as file:
@@ -454,13 +456,14 @@ def scan_fortran_file(src_file, defines=None):
             # Activate a new macro (ignoring the value)
             match = re_cpp_define.match(line)
             if match:
+                # TODO: Tokenize this, don't hunt for `(` in `macro`.
                 tokens = line.strip()[1:].split(maxsplit=2)
                 macro = tokens[1]
                 value = tokens[2] if tokens[2:] else None
                 if '(' in macro:
                     # TODO: Actual handling of function macros
                     macro, arg = macro.split('(', maxsplit=1)
-                    value = '(' + arg + value
+                    value = '(' + arg + value if value else '(' + arg
                 cpp_macros[macro] = value
 
             # Deactivate a macro


### PR DESCRIPTION
Makedep preprocessor parsing assumed define macros of the form `#define macro(X) some-macro` but did not support empty macros of the form `#define macro(X)`.

Preprocessor flag macros were assumed to be of the form `-DMACRO=VALUE`, and did not support empty macros `-DMACRO`.

This patch addresses both issues.