### PR TITLE
Fixes for layout and restart reproducing with REMAP_AUXILIARY_VARS

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1862,11 +1862,13 @@ subroutine ALE_regridding_and_remapping(CS, G, GV, US, u, v, h, tv, dtdia, Time_
       call remap_dyn_split_RK2_aux_vars(G, GV, CS%dyn_split_RK2_CSp, h_old_u, h_old_v, h_new_u, h_new_v, CS%ALE_CSp)
     endif
 
-    if (associated(CS%OBC)) then
+    if (associated(CS%OBC) .or. associated(CS%visc%Kv_shear_Bu)) then
       call pass_var(h, G%Domain, complete=.false.)
       call pass_var(h_new, G%Domain, complete=.true.)
-      call remap_OBC_fields(G, GV, h, h_new, CS%OBC, PCM_cell=PCM_cell)
     endif
+
+    if (associated(CS%OBC)) &
+      call remap_OBC_fields(G, GV, h, h_new, CS%OBC, PCM_cell=PCM_cell)
 
     call remap_vertvisc_aux_vars(G, GV, CS%visc, h, h_new, CS%ALE_CSp, CS%OBC)
     if (associated(CS%visc%Kv_shear)) &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1338,10 +1338,11 @@ subroutine remap_dyn_split_RK2_aux_vars(G, GV, CS, h_old_u, h_old_v, h_new_u, h_
     call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%u_av, CS%v_av)
     call pass_vector(CS%u_av, CS%v_av, G%Domain, complete=.false.)
     call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%CAu_pred, CS%CAv_pred)
-    call pass_vector(CS%CAu_pred, CS%CAv_pred, G%Domain, complete=.true.)
+    call pass_vector(CS%CAu_pred, CS%CAv_pred, G%Domain, complete=.false.)
   endif
 
   call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%diffu, CS%diffv)
+  call pass_vector(CS%diffu, CS%diffv, G%Domain, complete=.true.)
 
 end subroutine remap_dyn_split_RK2_aux_vars
 


### PR DESCRIPTION
This PR includes two updates related to reproducibility with REMAP_AUXILIARY_VARS = True:

- To reproduce across restart files requires an additional halo update on diffu and diffv in MOM_dynamics_split_RK2.F90 after applying remapping.
- To reproduce across layouts with vertex shear option requires a halo update on thickness before remapping the viscosities on the vertex points in MOM.F90.
- A note:  Unlike CS%visc%Kv_shear, CS%visc%Kv_shear_Bu does not appear to need to be passed to the halo points in MOM.F90. This is because computing it on the vertices ensures its interpolation to U & V points works properly over the full computational domain.  It was implemented correctly and is thus not touched in this PR.