### PR TITLE
Brine plume updates for new vertical scale options, improving salt conservation, and adding time integration

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -294,6 +294,8 @@ type, public :: vertvisc_type
   ! The following elements are pointers so they can be used as targets for pointers in the restart registry.
   real, pointer, dimension(:,:) :: MLD => NULL()  !< Instantaneous active mixing layer depth [Z ~> m].
   real, pointer, dimension(:,:) :: h_ML => NULL() !< Instantaneous active mixing layer thickness [H ~> m or kg m-2].
+  real, pointer, dimension(:,:) :: MLD_param => NULL()  !< Instantaneous mixed layer depth [Z ~> m].
+  real, pointer, dimension(:,:) :: h_ML_param => NULL() !< Instantaneous mixed layer thickness [H ~> m or kg m-2].
   real, pointer, dimension(:,:) :: sfc_buoy_flx => NULL() !< Surface buoyancy flux (derived) [Z2 T-3 ~> m2 s-3].
   real, pointer, dimension(:,:,:) :: Kd_shear => NULL()
                 !< The shear-driven turbulent diapycnal diffusivity at the interfaces between layers

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -292,10 +292,19 @@ type, public :: vertvisc_type
     Ray_v       !< The Rayleigh drag velocity to be applied to each layer at v-points [H T-1 ~> m s-1 or Pa s m-1].
 
   ! The following elements are pointers so they can be used as targets for pointers in the restart registry.
-  real, pointer, dimension(:,:) :: MLD => NULL()  !< Instantaneous active mixing layer depth [Z ~> m].
-  real, pointer, dimension(:,:) :: h_ML => NULL() !< Instantaneous active mixing layer thickness [H ~> m or kg m-2].
-  real, pointer, dimension(:,:) :: MLD_param => NULL()  !< Instantaneous mixed layer depth [Z ~> m].
-  real, pointer, dimension(:,:) :: h_ML_param => NULL() !< Instantaneous mixed layer thickness [H ~> m or kg m-2].
+  real, pointer, dimension(:,:) :: MLD => NULL()
+                !< Instantaneous active mixing layer depth as used by the mixed layer restratification
+                !! parameterization [Z ~> m].
+  real, pointer, dimension(:,:) :: h_ML => NULL()
+                !< Instantaneous active mixing layer thickness as used by the mixed layer restratification
+                !! parameterization [H ~> m or kg m-2]
+  real, pointer, dimension(:,:) :: MLD_param => NULL()
+                !< Instantaneous active mixed or mixing layer depth as used by the brine plume parameterization.
+                !! It could be coordinated with MLD above but we may want the ability to use different scales
+                !! in different parameterizations [Z ~> m].
+  real, pointer, dimension(:,:) :: h_ML_param => NULL()
+                !< Instantaneous active mixed or mixing layer thickness as used by the brine plume
+                !! parameterization [H ~> m or kg m-2].
   real, pointer, dimension(:,:) :: sfc_buoy_flx => NULL() !< Surface buoyancy flux (derived) [Z2 T-3 ~> m2 s-3].
   real, pointer, dimension(:,:,:) :: Kd_shear => NULL()
                 !< The shear-driven turbulent diapycnal diffusivity at the interfaces between layers

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -12,7 +12,7 @@ use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, time_type
 use MOM_EOS,           only : calculate_density, calculate_TFreeze, EOS_domain
 use MOM_EOS,           only : calculate_specific_vol_derivs, calculate_density_derivs
-use MOM_error_handler, only : MOM_error, FATAL, WARNING, callTree_showQuery
+use MOM_error_handler, only : MOM_error, FATAL, WARNING, NOTE, callTree_showQuery
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,  only : forcing, extractFluxes1d, forcing_SinglePointPrint
@@ -73,7 +73,8 @@ type, public :: diabatic_aux_CS ; private
   logical :: do_brine_plume  !< If true, insert salt flux below the surface according to
                              !! a parameterization by \cite Nguyen2009.
   logical :: check_salt_bp   !< A logical to check for salt conservation in the brine plume scheme
-  logical :: check_salt_verbose !< A logical to be verbose when checking salt conservation
+  !TODO: Delete DEBUG lines after brine plume is proven to be conservative to numerical precision.
+  !DEBUG logical :: check_salt_verbose !< A logical to be verbose when checking salt conservation
   integer :: brine_plume_n   !< The exponent in the brine plume parameterization.
   real :: plume_strength     !< Fraction of the available brine to take to the bottom of the mixed
                              !! layer [nondim].
@@ -808,10 +809,12 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
                                    ! [S H ~> ppt m or ppt kg m-2]
   real :: top, bottom ! The thickness (positive) of the top and bottom of the cell [H ~> m or kg m-2]
   real :: np1, inp1   ! Brine plume exponent plus 1 and its inverse for integrals [nondim]
+  real :: top_np1, bottom_np1 ! top/bottom raised to power np1 [H^(n+1) ~> m^(n+1) or (kg m-2)^(n+1)]
   integer :: nz_finite! the index of the last (deepest) finite thickness layer
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
-  integer :: i, j, is, ie, js, je, k, nz, nb
+  integer :: i, j, is, ie, js, je, k, nz, nb, ne
   character(len=45) :: mesg
+  character(len=80), dimension(10) :: salt_error_mesg
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -839,7 +842,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
   if (CS%do_brine_plume .and. .not.present(MLD_h)) then
     call MOM_error(FATAL, "MOM_diabatic_aux.F90, applyBoundaryFluxesInOut(): "//&
-                   "Brine plume parameterization requires a mixed-layer depth argument,\n"//&
+                   "Brine plume parameterization requires a mixed-layer depth argument, "//&
                    "currently coming from the energetic PBL scheme.")
   endif
   if (CS%do_brine_plume .and. .not.associated(MLD_h)) then
@@ -848,7 +851,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   endif
   if (CS%do_brine_plume .and. .not. associated(fluxes%salt_left_behind)) then
     call MOM_error(FATAL, "MOM_diabatic_aux.F90, applyBoundaryFluxesInOut(): "//&
-                   "Brine plume parameterization requires DO_BRINE_PLUME\n"//&
+                   "Brine plume parameterization requires DO_BRINE_PLUME "//&
                    "to be turned on in SIS2 as well as MOM6.")
   endif
 
@@ -1149,6 +1152,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
             tv%S(i,j,k) = (hOld*tv%S(i,j,k) + dSalt)*Ithickness
           elseif (h2d(i,k) < 0.0) then ! h2d==0 is a special limit that needs no extra handling
             call forcing_SinglePointPrint(fluxes,G,i,j,'applyBoundaryFluxesInOut (h<0)')
+            !TODO: remove write statements
             write(0,*) 'applyBoundaryFluxesInOut(): lon,lat=',G%geoLonT(i,j),G%geoLatT(i,j)
             write(0,*) 'applyBoundaryFluxesInOut(): netT,netS,netH=', &
                 US%C_to_degC*netHeat(i), US%S_to_ppt*netSalt(i), netMassInOut(i)
@@ -1182,7 +1186,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
               do k=1,nz
                 salt_before = salt_before + h2d(i,k)*tv%S(i,j,k)
               enddo
-              if (CS%check_salt_verbose) write(0,*)'Salt before brine plume: ',salt_before
+              !DEBUG if (CS%check_salt_verbose) call MOM_error(NOTE,'Salt before brine plume: ',salt_before)
             endif
 
             ! Set the plume strength based on the salt rejected
@@ -1194,14 +1198,17 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
             ! Add salt back to any level (starting at top)
             bottom = 0.0
+            bottom_np1 = 0.0
             do k=1,nz ; if (salt_removed > salt_added) then
               top = bottom
               bottom = top+h2d(i,k)
 
               if (bottom <= mixing_depth .and. k<nz_finite) then
                 !Flux convergence integrated over layer
+                top_np1 = bottom_np1
+                bottom_np1 = bottom**np1
                 plume_flux = min(salt_removed-salt_added, dt * ( (plume_source * A_brine) &
-                                                     * ( (bottom**np1-top**np1) * inp1)))
+                                                     * ( (bottom_np1 - top_np1) * inp1)))
               elseif (h2d(i,k)>GV%H_subroundoff) then
                 ! if the bottom of the cell is > MLD or we are in the last
                 ! finite thickness cell, we put all the remaining salt in the level
@@ -1214,11 +1221,14 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
               ! Track salt added
               salt_added = salt_added + plume_flux
-              if (CS%check_salt_verbose) write(0,*)'Salt to layer k and remaining deficit:',&
-                                                   k,salt_added,salt_removed-salt_added
+              !DEBUG if (CS%check_salt_verbose) then
+              !DEBUG   write(mesg, '(A, I0, A, ES24.16, A, ES24.16)') &
+              !DEBUG        'Salt to layer ', k, ' and remaining deficit: ', salt_added, ', ', salt_removed-salt_added
+              !DEBUG   call MOM_error(NOTE,trim(mesg))
+              !DEBUG endif
 
               if (CS%id_brine_input > 0.) then
-                CS%brine_input(i,j,k) = plume_flux/dt
+                CS%brine_input(i,j,k) = plume_flux*Idt
               endif
 
             endif ; enddo
@@ -1229,21 +1239,44 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
                 salt_after = salt_after + h2d(i,k)*tv%S(i,j,k)
               enddo
               if (abs((salt_after-salt_before-salt_removed)/salt_after)>CS%check_salt_threshold) then
-                write(0,*)'Net plume strength    ',fluxes%salt_left_behind(i,j)
-                write(0,*)' H/BP dpt (h-unit)',total_h,mixing_depth
-                write(0,*)' H/BP dpt (m)     ',total_h*GV%H_to_Z,mixing_depth*GV%H_to_Z
-                write(0,*)' Salt before/after BP ',salt_before,salt_after
-                write(0,*)' Salt change BP       ',salt_after-salt_before,(salt_after-salt_before)/salt_after
-                write(0,*)' Salt removed by BP   ',salt_removed,salt_removed/salt_after
-                write(0,*)' Salt added by BP     ',salt_added,salt_added/salt_after
-                write(0,*)' Scheme error         ',(salt_added-salt_removed)/salt_after
-                write(0,*)' Diagnosed salt error ',(salt_after-salt_before-salt_removed)/salt_after
-                write(0,*)' Threshold            ',CS%check_salt_threshold
-                !write(0,*),'------'
-                !write(0,*),'h',h2d(i,:)
-                !write(0,*),'z',h2d(i,:)*GV%H_to_Z
-                !write(0,*),'S',tv%S(i,j,:)
-                call MOM_error(FATAL,'Salt change in brine plume scheme exceeds CHECK_SALT_BRINE_PLUME_THRESHOLD')
+                write(salt_error_mesg(1), '(A, ES24.16)')  &
+                      'Net plume strength:    ', fluxes%salt_left_behind(i,j)
+                write(salt_error_mesg(2), '(A, 2ES24.16)') &
+                     ' H/Plume dpt (h-unit): ', total_h, mixing_depth
+                write(salt_error_mesg(3), '(A, 2ES24.16)') &
+                     ' H/Plume dpt (m):      ', total_h*GV%H_to_Z, mixing_depth*GV%H_to_Z
+                write(salt_error_mesg(4), '(A, 2ES24.16)') &
+                     ' Salt before/after BP: ', salt_before, salt_after
+                write(salt_error_mesg(5), '(A, 2ES24.16)') &
+                     ' Salt change, abs/rel: ', salt_after-salt_before, (salt_after-salt_before)/salt_after
+                write(salt_error_mesg(6), '(A, 2ES24.16)') &
+                     ' Salt removed, abs/rel:', salt_removed, salt_removed/salt_after
+                write(salt_error_mesg(7), '(A, 2ES24.16)') &
+                     ' Salt added, abs/rel:  ', salt_added, salt_added/salt_after
+                write(salt_error_mesg(8), '(A, ES24.16)')  &
+                     ' Scheme relative error:', (salt_added-salt_removed)/salt_after
+                write(salt_error_mesg(9), '(A, ES24.16)')  &
+                     ' Diagnosed salt error: ', (salt_after-salt_before-salt_removed)/salt_after
+                write(salt_error_mesg(10),'(A, ES24.16)')  &
+                     ' Allowed error:        ', CS%check_salt_threshold
+
+                !DEBUG write(0,*),'h',h2d(i,:)
+                !DEBUG write(0,*),'z',h2d(i,:)*GV%H_to_Z
+                !DEBUG write(0,*),'S',tv%S(i,j,:)
+
+                ! Ideally this would be written to a single fatal error call,
+                !  but the long message seems to hit an FMS character limit?
+                call MOM_error(WARNING,'Salt change in brine plume scheme exceeds CHECK_SALT_BRINE_PLUME_THRESHOLD ')
+                do ne=1,10
+                  call MOM_error(WARNING,salt_error_mesg(ne),all_print=.true.)
+                enddo
+                call MOM_error(FATAL,'Salt conservation failed check in brine plume parameterization')
+                !call MOM_error(FATAL,'Salt conservation failed check in brine plume parameterization'//&
+                !               NEW_LINE('a')//salt_error_mesg(1)//NEW_LINE('a')//salt_error_mesg(2)//&
+                !               NEW_LINE('a')//salt_error_mesg(3)//NEW_LINE('a')//salt_error_mesg(4)//&
+                !               NEW_LINE('a')//salt_error_mesg(5)//NEW_LINE('a')//salt_error_mesg(6)//&
+                !               NEW_LINE('a')//salt_error_mesg(7)//NEW_LINE('a')//salt_error_mesg(8)//&
+                !               NEW_LINE('a')//salt_error_mesg(9)//NEW_LINE('a')//salt_error_mesg(10))
               endif
             endif
 
@@ -1256,6 +1289,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
         if (.not. CS%ignore_fluxes_over_land) then
            call forcing_SinglePointPrint(fluxes,G,i,j,'applyBoundaryFluxesInOut (land)')
+           !TODO: Remove write statements
            write(0,*) 'applyBoundaryFluxesInOut(): lon,lat=',G%geoLonT(i,j),G%geoLatT(i,j)
            write(0,*) 'applyBoundaryFluxesInOut(): netHeat,netSalt,netMassIn,netMassOut=',&
                US%C_to_degC*netHeat(i), US%S_to_ppt*netSalt(i), netMassIn(i), netMassOut(i)
@@ -1533,13 +1567,14 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
                  units="nondim", default=1.0, do_not_log=.not.CS%do_brine_plume)
   if (CS%plume_mld_fac<0.0) call MOM_error(FATAL,"BRINE_PLUME_MLD_FAC shouldn't be negative!")
   call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME", CS%check_salt_bp, &
-                 "If true, check for conservation in the brine plume scheme.", default=.false.)
+                 "If true, check for conservation in the brine plume scheme.", default=.false., debuggingParam=.true.)
   if (CS%check_salt_bp) then
     call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME_THRESHOLD", CS%check_salt_threshold, &
                    "Maximum allowed relative salt change in brine plume scheme.", &
-                   units="nondim", default=1.0e-14)
-    call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME_VERBOSE", CS%check_salt_verbose, &
-                 "Add output tracking salt conservation with brine plume scheme enabled.", default=.false.)
+                   units="nondim", default=1.0e-14, debuggingParam=.true.)
+    !DEBUG call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME_VERBOSE", CS%check_salt_verbose, &
+    !DEBUG                "Add output tracking salt conservation with brine plume scheme enabled.", default=.false., &
+    !DEBUG                debuggingParam=.true.)
   endif
 
 

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -883,7 +883,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst,        &
   !$OMP                                  A_brine,plume_flux,mixing_depth,total_h,          &
   !$OMP                                  plume_source,salt_added, salt_removed,salt_before,&
-  !$OMP                                  salt_after,top,bottom, nz_finite)                 &
+  !$OMP                                  salt_after,top,bottom, nz_finite, bottom_np1,     &
+  !$OMP                                  top_np1, salt_error_mesg)
   !$OMP                     firstprivate(SurfPressure)
   do j=js,je
   ! Work in vertical slices for efficiency

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -802,7 +802,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   real :: total_h     ! Total thickness of the water column [H ~> m or kg m-2]
   real :: plume_source! The rate of salt removal by the brine plume scheme
                       ! [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1]
-  real :: salt_added, salt_removed ! Helpers to keep stock of salt being moved by brine flux
+  real :: salt_added, salt_removed ! Trackers to keep stock of salt being moved by brine flux
                                    ! [S H ~> ppt m or ppt kg m-2]
   real :: salt_before, salt_after  ! Helpers to keep stock of salt before and after the brine plume scheme
                                    ! [S H ~> ppt m or ppt kg m-2]
@@ -1176,8 +1176,6 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
             A_brine = (CS%brine_plume_n + 1) / (mixing_depth**(CS%brine_plume_n + 1))
 
             if (CS%check_salt_bp) then
-              !Helpers for debugging
-              salt_added = 0.0
               ! Record the total salt in the column before applying the plume scheme
               salt_before = 0.0
               do k=1,nz
@@ -1188,7 +1186,10 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
             ! Set the plume strength based on the salt rejected
             plume_source = ((1000.0*US%ppt_to_S) * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
-            if (CS%check_salt_bp) salt_removed = plume_source*dt
+            ! Note salt removed
+            salt_removed = plume_source*dt
+            ! Track salt added
+            salt_added = 0.0
 
             ! Add salt back to any level (starting at top)
             bottom = 0.0
@@ -1210,10 +1211,9 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
               Ithickness  = 1.0/h2d(i,k)
               tv%S(i,j,k) = tv%S(i,j,k) + plume_flux*Ithickness
 
-              if (CS%check_salt_bp) then
-                salt_added = salt_added + plume_flux
-                if (CS%check_salt_verbose) write(0,*)'Salt to layer k and remaining deficit:',k,salt_added,salt_removed-salt_added
-              endif
+              ! Track salt added
+              salt_added = salt_added + plume_flux
+              if (CS%check_salt_verbose) write(0,*)'Salt to layer k and remaining deficit:',k,salt_added,salt_removed-salt_added
 
               if (CS%id_brine_input > 0.) then
                 CS%brine_input(i,j,k) = plume_flux/dt

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -75,13 +75,15 @@ type, public :: diabatic_aux_CS ; private
   integer :: brine_plume_n   !< The exponent in the brine plume parameterization.
   real :: plume_strength     !< Fraction of the available brine to take to the bottom of the mixed
                              !! layer [nondim].
+  real :: plume_mld_fac      !< Proportionality factor between the mixed/mixing layer depth and the
+                             !! vertical scale used for the brine plume parameterization [nondim].
 
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag !< Structure used to regulate timing of diagnostic output
 
   ! Diagnostic handles
   integer :: id_createdH       = -1 !< Diagnostic ID of mass added to avoid grounding
-  integer :: id_brine_lay      = -1 !< Diagnostic ID of which layer receives the brine
+  integer :: id_brine_input    = -1 !< Diagnostic ID of which layer receives the brine salt flux
   integer :: id_penSW_diag     = -1 !< Diagnostic ID of Penetrative shortwave heating (flux convergence)
   integer :: id_penSWflux_diag = -1 !< Diagnostic ID of Penetrative shortwave flux
   integer :: id_nonpenSW_diag  = -1 !< Diagnostic ID of Non-penetrative shortwave heating
@@ -90,6 +92,8 @@ type, public :: diabatic_aux_CS ; private
   ! Optional diagnostic arrays
   real, allocatable, dimension(:,:)   :: createdH       !< The amount of volume added in order to
                                                         !! avoid grounding [H T-1 ~> m s-1]
+  real, allocatable, dimension(:,:,:) :: brine_input    !< Brine input diagnostic indicating
+                                                        !! the resulting salt tendency [S T-1 ~> ppt s-1]
   real, allocatable, dimension(:,:,:) :: penSW_diag     !< Heating in a layer from convergence of
                                                         !! penetrative SW [Q R Z T-1 ~> W m-2]
   real, allocatable, dimension(:,:,:) :: penSWflux_diag !< Penetrative SW flux at base of grid
@@ -795,7 +799,9 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   real :: A_brine(SZI_(G))  ! Constant [H-(n+1) ~> m-(n+1) or m(2n+2) kg-(n+1)].
   real :: fraction_left_brine ! Fraction of the brine that has not been applied yet [nondim]
   real :: plume_fraction ! Fraction of the brine that is applied to a layer [nondim]
-  real :: plume_flux  ! Brine flux to move downwards  [S H ~> ppt m or ppt kg m-2]
+  real :: plume_flux  ! Brine flux to move downwards  [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1]
+  real :: salt_added, salt_removed, net_flux ! Helpers to keep stock of salt being moved by brine flux
+                                             ! [S H ~> ppt m or ppt kg m-2]
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, is, ie, js, je, k, nz, nb
   character(len=45) :: mesg
@@ -803,7 +809,6 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   Idt = 1.0 / dt
-  plume_flux = 0.0
 
   calculate_energetics = (present(cTKE) .and. present(dSV_dT) .and. present(dSV_dS))
   calculate_buoyancy = present(SkinBuoyFlux)
@@ -989,16 +994,6 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
     !    ocean (and corresponding outward heat content), and ignoring penetrative SW.
     ! B/ update mass, salt, temp from mass leaving ocean.
     ! C/ update temp due to penetrative SW
-    if (CS%do_brine_plume) then
-      ! Find the plume mixing depth.
-      do i=is,ie ; total_h(i) = 0.0 ; enddo
-      do k=1,nz ; do i=is,ie ; total_h(i) = total_h(i) + h(i,j,k) ; enddo ; enddo
-      do i=is,ie
-        mixing_depth(i) = min( max(MLD_h(i,j) - minimum_forcing_depth, minimum_forcing_depth), &
-                               max(total_h(i), GV%angstrom_h) ) + GV%H_subroundoff
-        A_brine(i) = (CS%brine_plume_n + 1) / (mixing_depth(i) ** (CS%brine_plume_n + 1))
-      enddo
-    endif
 
     do i=is,ie
       if (G%mask2dT(i,j) > 0.) then
@@ -1075,7 +1070,6 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
         enddo ! k=1,1
 
         ! B/ Update mass, salt, temp from mass leaving ocean and other fluxes of heat and salt.
-        fraction_left_brine = 1.0
         do k=1,nz
           ! Place forcing into this layer if this layer has nontrivial thickness.
           ! For layers thin relative to 1/IforcingDepthScale, then distribute
@@ -1089,32 +1083,6 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
           ! be distributed downwards.
           if (-fractionOfForcing*netMassOut(i) > evap_CFL_limit*h2d(i,k)) then
             fractionOfForcing = -evap_CFL_limit*h2d(i,k)/netMassOut(i)
-          endif
-
-          if (CS%do_brine_plume .and. associated(fluxes%salt_left_behind)) then
-            if (fluxes%salt_left_behind(i,j) > 0 .and. fraction_left_brine > 0.0) then
-              ! Place forcing into this layer by depth for brine plume parameterization.
-              if (k == 1) then
-                dK(i) = 0.5 * h(i,j,k)         ! Depth of center of layer K
-                plume_flux = - (1000.0*US%ppt_to_S * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
-                plume_fraction = 1.0
-              else
-                dK(i) = dK(i) + 0.5 * ( h(i,j,k) + h(i,j,k-1) ) ! Depth of center of layer K
-                plume_flux = 0.0
-              endif
-              if (dK(i) <= mixing_depth(i) .and. fraction_left_brine > 0.0) then
-                plume_fraction = min(fraction_left_brine, (A_brine(i) * dK(i)**CS%brine_plume_n) * h(i,j,k))
-              else
-                IforcingDepthScale = 1. / max(GV%H_subroundoff, minimum_forcing_depth - netMassOut(i) )
-                ! plume_fraction = fraction_left_brine, unless h2d is less than IforcingDepthScale.
-                plume_fraction = min(fraction_left_brine, h2d(i,k)*IforcingDepthScale)
-              endif
-              fraction_left_brine = fraction_left_brine - plume_fraction
-              plume_flux = plume_flux + plume_fraction * (1000.0*US%ppt_to_S * (CS%plume_strength * &
-                           fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
-            else
-              plume_flux = 0.0
-            endif
           endif
 
           ! Change in state due to forcing
@@ -1161,7 +1129,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
             endif
             Ithickness  = 1.0/h2d(i,k) ! Inverse of new thickness
             T2d(i,k)    = (hOld*T2d(i,k) + dTemp)*Ithickness
-            tv%S(i,j,k) = (hOld*tv%S(i,j,k) + dSalt + plume_flux)*Ithickness
+            tv%S(i,j,k) = (hOld*tv%S(i,j,k) + dSalt)*Ithickness
           elseif (h2d(i,k) < 0.0) then ! h2d==0 is a special limit that needs no extra handling
             call forcing_SinglePointPrint(fluxes,G,i,j,'applyBoundaryFluxesInOut (h<0)')
             write(0,*) 'applyBoundaryFluxesInOut(): lon,lat=',G%geoLonT(i,j),G%geoLatT(i,j)
@@ -1175,6 +1143,66 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
           endif
 
         enddo ! k
+
+        if (CS%do_brine_plume .and. associated(fluxes%salt_left_behind)) then
+          ! Find the plume mixing depth.
+          total_h(i) = 0.5*h2d(i,1)
+          do k=2,nz ; total_h(i) = total_h(i) + 0.5*(h2d(i,k-1)+h2d(i,k)) ; enddo
+          mixing_depth(i) = min( max(CS%plume_mld_fac * MLD_h(i,j) - minimum_forcing_depth, minimum_forcing_depth), &
+                            max(total_h(i), GV%angstrom_h) ) + GV%H_subroundoff
+          A_brine(i) = (CS%brine_plume_n + 1) / (mixing_depth(i) ** (CS%brine_plume_n + 1))
+
+          !Helpers for debugging
+          salt_added = 0.0
+          salt_removed = 0.0
+          net_flux = 0.0
+
+          !Resetting fields used for prognostic salt calculation
+          fraction_left_brine = 1.0
+          plume_flux = 0.0
+          do k=1,nz
+            if (fluxes%salt_left_behind(i,j) > 0 .and. fraction_left_brine > 0.0) then
+              ! Place forcing into this layer by depth for brine plume parameterization.
+              if (k == 1) then
+                dK(i) = 0.5 * h2d(i,k)         ! Depth of center of layer K
+                ! salt_left_behind has units of R Z T-1, plume flux thus has units of S H T-1
+                plume_flux = - (1000.0*US%ppt_to_S * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
+                salt_removed = plume_flux*dt
+                plume_fraction = 1.0
+              else
+                dK(i) = dK(i) + 0.5 * ( h2d(i,k) + h2d(i,k-1) ) ! Depth of center of layer K
+                plume_flux = 0.0
+              endif
+              if (dK(i) <= mixing_depth(i) .and. fraction_left_brine > 0.0 .and. k<nz) then
+                plume_fraction = min(fraction_left_brine, (A_brine(i) * dK(i)**CS%brine_plume_n) * h2d(i,k))
+              else
+                IforcingDepthScale = 1. / GV%H_subroundoff
+                ! plume_fraction = fraction_left_brine, unless h2d is less than IforcingDepthScale.
+                plume_fraction = min(fraction_left_brine, h2d(i,k)*IforcingDepthScale)
+              endif
+              fraction_left_brine = fraction_left_brine - plume_fraction
+              plume_flux = plume_flux + plume_fraction * (1000.0*US%ppt_to_S * (CS%plume_strength * &
+                           fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
+              salt_added = salt_added + plume_fraction * (1000.0*US%ppt_to_S * (CS%plume_strength * &
+                           fluxes%salt_left_behind(i,j))) * GV%RZ_to_H*dt
+            else
+              plume_flux = 0.0
+            endif
+            net_flux = net_flux + plume_flux
+            Ithickness  = 1.0/h2d(i,k)
+            tv%S(i,j,k) = (h2d(i,k)*tv%S(i,j,k) + plume_flux*dt)*Ithickness
+            if (CS%id_brine_input > 0.) then
+               CS%brine_input(i,j,k) = plume_flux
+            endif
+          enddo
+          !if (fluxes%salt_left_behind(i,j) > 0 .and. abs(net_flux)>0.0) then
+          !  if (fraction_left_brine>0.0) then
+          !    print*,'Leftover brine?'
+          !    print*,total_h(i),mixing_depth(i),salt_removed
+          !    print*,salt_added+salt_removed,net_flux, fraction_left_brine
+          !  endif
+          !endif
+        endif
 
       ! Check if trying to apply fluxes over land points
       elseif ((abs(netHeat(i)) + abs(netSalt(i)) + abs(netMassIn(i)) + abs(netMassOut(i))) > 0.) then
@@ -1324,6 +1352,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
   ! Post the diagnostics
   if (CS%id_createdH       > 0) call post_data(CS%id_createdH      , CS%createdH      , CS%diag)
+  if (CS%id_brine_input    > 0) call post_data(CS%id_brine_input   , CS%brine_input   , CS%diag)
   if (CS%id_penSW_diag     > 0) call post_data(CS%id_penSW_diag    , CS%penSW_diag    , CS%diag)
   if (CS%id_penSWflux_diag > 0) call post_data(CS%id_penSWflux_diag, CS%penSWflux_diag, CS%diag)
   if (CS%id_nonpenSW_diag  > 0) call post_data(CS%id_nonpenSW_diag , CS%nonpenSW_diag , CS%diag)
@@ -1452,12 +1481,23 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
   call get_param(param_file, mdl, "BRINE_PLUME_FRACTION", CS%plume_strength, &
                  "Fraction of the available brine to mix down using the brine plume parameterization.", &
                  units="nondim", default=1.0, do_not_log=.not.CS%do_brine_plume)
+  call get_param(param_file, mdl, "BRINE_PLUME_MLD_FAC", CS%plume_mld_fac, &
+                 "Proportionality factor between plume scale and  MLD used in brine plume parameteterization.", &
+                 units="nondim", default=1.0, do_not_log=.not.CS%do_brine_plume)
+  if (CS%plume_mld_fac<0.0) call MOM_error(FATAL,"BRINE_PLUME_MLD_FAC shouldn't be negative!")
+
 
   if (useALEalgorithm) then
     CS%id_createdH = register_diag_field('ocean_model',"created_H",diag%axesT1, &
         Time, "The volume flux added to stop the ocean from drying out and becoming negative in depth", &
         "m s-1", conversion=GV%H_to_m*US%s_to_T)
     if (CS%id_createdH>0) allocate(CS%createdH(isd:ied,jsd:jed))
+
+    CS%id_brine_input = register_diag_field('ocean_model', 'Brine_Salt_Increment', &
+         diag%axesTL, Time, 'Salt rate of change due to brine plume','kg m-2 s-1', &
+         conversion=US%S_to_ppt*0.001*GV%H_to_RZ*US%RZ_T_to_kg_m2s, v_extensive=.true.)
+    if (CS%id_brine_input>0) allocate(CS%brine_input(isd:ied,jsd:jed,nz), source=0.0)
+
 
     ! diagnostic for heating of a grid cell from convergence of SW heat into the cell
     CS%id_penSW_diag = register_diag_field('ocean_model', 'rsdoabsorb',                     &

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -883,8 +883,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst,        &
   !$OMP                                  A_brine,plume_flux,mixing_depth,total_h,          &
   !$OMP                                  plume_source,salt_added, salt_removed,salt_before,&
-  !$OMP                                  salt_after,top,bottom, nz_finite, bottom_np1,     &
-  !$OMP                                  top_np1, salt_error_mesg)
+  !$OMP                                  salt_after,top,bottom,nz_finite,bottom_np1,       &
+  !$OMP                                  top_np1,salt_error_mesg,ne)                       &
   !$OMP                     firstprivate(SurfPressure)
   do j=js,je
   ! Work in vertical slices for efficiency

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -878,9 +878,9 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  netmassinout_rate,netheat_rate,netsalt_rate,      &
   !$OMP                                  drhodt,drhods,pen_sw_bnd_rate,                    &
   !$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst,        &
-  !$OMP                                  A_brine,plume_flux,mixing_depth,total_h, &
+  !$OMP                                  A_brine,plume_flux,mixing_depth,total_h,          &
   !$OMP                                  plume_source,salt_added, salt_removed,salt_before,&
-  !$OMP                                  salt_after,top,bottom)      &
+  !$OMP                                  salt_after,top,bottom, nz_finite)                 &
   !$OMP                     firstprivate(SurfPressure)
   do j=js,je
   ! Work in vertical slices for efficiency
@@ -1000,7 +1000,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
       if (CS%do_brine_plume .and. associated(fluxes%salt_left_behind)) then
         if (fluxes%salt_left_behind(i,j) > 0.0) then
           !Don't add in the salt that will later be distributed by the brine plume scheme
-          netSalt(i) = netSalt(i) - dt*((1000.0*US%ppt_to_S) * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
+          netSalt(i) = netSalt(i) - dt*((1000.0*US%ppt_to_S) * &
+                                        (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
         endif
       endif
     enddo
@@ -1213,7 +1214,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
 
               ! Track salt added
               salt_added = salt_added + plume_flux
-              if (CS%check_salt_verbose) write(0,*)'Salt to layer k and remaining deficit:',k,salt_added,salt_removed-salt_added
+              if (CS%check_salt_verbose) write(0,*)'Salt to layer k and remaining deficit:',&
+                                                   k,salt_added,salt_removed-salt_added
 
               if (CS%id_brine_input > 0.) then
                 CS%brine_input(i,j,k) = plume_flux/dt

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -72,11 +72,14 @@ type, public :: diabatic_aux_CS ; private
   logical :: chl_from_file   !< If true, chl_a is read from a file.
   logical :: do_brine_plume  !< If true, insert salt flux below the surface according to
                              !! a parameterization by \cite Nguyen2009.
+  logical :: check_salt_bp   !< A logical to check for salt conservation in the brine plume scheme
+  logical :: check_salt_verbose !< A logical to be verbose when checking salt conservation
   integer :: brine_plume_n   !< The exponent in the brine plume parameterization.
   real :: plume_strength     !< Fraction of the available brine to take to the bottom of the mixed
                              !! layer [nondim].
   real :: plume_mld_fac      !< Proportionality factor between the mixed/mixing layer depth and the
                              !! vertical scale used for the brine plume parameterization [nondim].
+  real :: check_salt_threshold!< The maximum relative salt change acceptable in a time step [nondim]
 
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(diag_ctrl), pointer :: diag !< Structure used to regulate timing of diagnostic output
@@ -760,9 +763,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
     netheat_rate, &  ! netheat but for dt=1 [C H T-1 ~> degC m s-1 or degC kg m-2 s-1]
     netsalt_rate, &  ! netsalt but for dt=1 (e.g. returns a rate)
                      ! [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1]
-    netMassInOut_rate, & ! netmassinout but for dt=1 [H T-1 ~> m s-1 or kg m-2 s-1]
-    mixing_depth, &  ! The mixing depth for brine plumes [H ~> m or kg m-2]
-    total_h          ! Total thickness of the water column [H ~> m or kg m-2]
+    netMassInOut_rate! netmassinout but for dt=1 [H T-1 ~> m s-1 or kg m-2 s-1]
   real, dimension(SZI_(G), SZK_(GV)) :: &
     h2d, &           ! A 2-d copy of the thicknesses [H ~> m or kg m-2]
     ! dz, &            ! Layer thicknesses in depth units [Z ~> m]
@@ -795,13 +796,19 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
                       ! and rejected brine are initially applied in vanishingly thin layers at the
                       ! top of the layer before being mixed throughout the layer.
   logical :: calculate_buoyancy ! If true, calculate the surface buoyancy flux.
-  real :: dK(SZI_(G))  ! Depth of the layer center in thickness units [H ~> m or kg m-2]
-  real :: A_brine(SZI_(G))  ! Constant [H-(n+1) ~> m-(n+1) or m(2n+2) kg-(n+1)].
-  real :: fraction_left_brine ! Fraction of the brine that has not been applied yet [nondim]
-  real :: plume_fraction ! Fraction of the brine that is applied to a layer [nondim]
+  real :: A_brine     ! Constant [H-(n+1) ~> m-(n+1) or m(2n+2) kg-(n+1)].
   real :: plume_flux  ! Brine flux to move downwards  [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1]
-  real :: salt_added, salt_removed, net_flux ! Helpers to keep stock of salt being moved by brine flux
-                                             ! [S H ~> ppt m or ppt kg m-2]
+  real :: mixing_depth! The mixing depth for brine plumes [H ~> m or kg m-2]
+  real :: total_h     ! Total thickness of the water column [H ~> m or kg m-2]
+  real :: plume_source! The rate of salt removal by the brine plume scheme
+                      ! [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1]
+  real :: salt_added, salt_removed ! Helpers to keep stock of salt being moved by brine flux
+                                   ! [S H ~> ppt m or ppt kg m-2]
+  real :: salt_before, salt_after  ! Helpers to keep stock of salt before and after the brine plume scheme
+                                   ! [S H ~> ppt m or ppt kg m-2]
+  real :: top, bottom ! The thickness (positive) of the top and bottom of the cell [H ~> m or kg m-2]
+  real :: np1, inp1   ! Brine plume exponent plus 1 and its inverse for integrals [nondim]
+  integer :: nz_finite! the index of the last (deepest) finite thickness layer
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, is, ie, js, je, k, nz, nb
   character(len=45) :: mesg
@@ -809,6 +816,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   Idt = 1.0 / dt
+  inp1 = 1./(CS%brine_plume_n+1)
+  np1 = CS%brine_plume_n+1
 
   calculate_energetics = (present(cTKE) .and. present(dSV_dT) .and. present(dSV_dS))
   calculate_buoyancy = present(SkinBuoyFlux)
@@ -860,7 +869,7 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  minimum_forcing_depth,evap_CFL_limit,dt,EOSdom,   &
   !$OMP                                  calculate_buoyancy,netPen_rate,SkinBuoyFlux,GoRho,&
   !$OMP                                  calculate_energetics,dSV_dT,dSV_dS,cTKE,g_Hconv2, &
-  !$OMP                                  EnthalpyConst,MLD_h)                              &
+  !$OMP                                  EnthalpyConst,MLD_h,np1,inp1)                     &
   !$OMP                          private(opacityBand,h2d,T2d,netMassInOut,netMassOut,      &
   !$OMP                                  netHeat,netSalt,Pen_SW_bnd,fractionOfForcing,     &
   !$OMP                                  IforcingDepthScale,g_conv,dSpV_dT,dSpV_dS,        &
@@ -869,10 +878,10 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  netmassinout_rate,netheat_rate,netsalt_rate,      &
   !$OMP                                  drhodt,drhods,pen_sw_bnd_rate,                    &
   !$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst,        &
-  !$OMP                                  mixing_depth,A_brine,fraction_left_brine,         &
-  !$OMP                                  plume_fraction,dK,total_h,salt_removed,           &
-  !$OMP                                  salt_added, net_flux)                             &
-  !$OMP                     firstprivate(SurfPressure,plume_flux)
+  !$OMP                                  A_brine,plume_flux,mixing_depth,total_h, &
+  !$OMP                                  plume_source,salt_added, salt_removed,salt_before,&
+  !$OMP                                  salt_after,top,bottom)      &
+  !$OMP                     firstprivate(SurfPressure)
   do j=js,je
   ! Work in vertical slices for efficiency
 
@@ -987,6 +996,12 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
       else
         fluxes%netMassOut(i,j) = 0.0
         fluxes%netMassIn(i,j) = 0.0
+      endif
+      if (CS%do_brine_plume .and. associated(fluxes%salt_left_behind)) then
+        if (fluxes%salt_left_behind(i,j) > 0.0) then
+          !Don't add in the salt that will later be distributed by the brine plume scheme
+          netSalt(i) = netSalt(i) - dt*((1000.0*US%ppt_to_S) * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
+        endif
       endif
     enddo
 
@@ -1146,64 +1161,93 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
         enddo ! k
 
         if (CS%do_brine_plume .and. associated(fluxes%salt_left_behind)) then
-          ! Find the plume mixing depth.
-          total_h(i) = 0.5*h2d(i,1)
-          do k=2,nz ; total_h(i) = total_h(i) + 0.5*(h2d(i,k-1)+h2d(i,k)) ; enddo
-          mixing_depth(i) = min( max(CS%plume_mld_fac * MLD_h(i,j) - minimum_forcing_depth, minimum_forcing_depth), &
-                            max(total_h(i), GV%angstrom_h) ) + GV%H_subroundoff
-          A_brine(i) = (CS%brine_plume_n + 1) / (mixing_depth(i) ** (CS%brine_plume_n + 1))
+          if (fluxes%salt_left_behind(i,j) > 0.0) then
 
-          !Helpers for debugging
-          salt_added = 0.0
-          salt_removed = 0.0
-          net_flux = 0.0
+            ! Find the plume mixing depth.
+            total_h = 0.0
+            do k=1,nz
+              total_h = total_h + h2d(i,k)
+              if (h2d(i,k)>GV%h_subroundoff) nz_finite = k
+            enddo
+            mixing_depth = min( max(CS%plume_mld_fac * MLD_h(i,j), minimum_forcing_depth), &
+                                max(total_h, GV%angstrom_h) )
 
-          !Resetting fields used for prognostic salt calculation
-          fraction_left_brine = 1.0
-          plume_flux = 0.0
-          do k=1,nz
-            if (fluxes%salt_left_behind(i,j) > 0 .and. fraction_left_brine > 0.0) then
-              ! Place forcing into this layer by depth for brine plume parameterization.
-              if (k == 1) then
-                dK(i) = 0.5 * h2d(i,k)         ! Depth of center of layer K
-                ! salt_left_behind has units of R Z T-1, plume flux thus has units of S H T-1
-                plume_flux = - (1000.0*US%ppt_to_S * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
-                salt_removed = plume_flux*dt
-                plume_fraction = 1.0
-              else
-                dK(i) = dK(i) + 0.5 * ( h2d(i,k) + h2d(i,k-1) ) ! Depth of center of layer K
-                plume_flux = 0.0
-              endif
-              if (dK(i) <= mixing_depth(i) .and. fraction_left_brine > 0.0 .and. k<nz) then
-                plume_fraction = min(fraction_left_brine, (A_brine(i) * dK(i)**CS%brine_plume_n) * h2d(i,k))
-              else
-                IforcingDepthScale = 1. / GV%H_subroundoff
-                ! plume_fraction = fraction_left_brine, unless h2d is less than IforcingDepthScale.
-                plume_fraction = min(fraction_left_brine, h2d(i,k)*IforcingDepthScale)
-              endif
-              fraction_left_brine = fraction_left_brine - plume_fraction
-              plume_flux = plume_flux + plume_fraction * (1000.0*US%ppt_to_S * (CS%plume_strength * &
-                           fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
-              salt_added = salt_added + plume_fraction * (1000.0*US%ppt_to_S * (CS%plume_strength * &
-                           fluxes%salt_left_behind(i,j))) * GV%RZ_to_H*dt
-            else
-              plume_flux = 0.0
+            ! Sets the brine plume coefficient based on integral constraint
+            A_brine = (CS%brine_plume_n + 1) / (mixing_depth**(CS%brine_plume_n + 1))
+
+            if (CS%check_salt_bp) then
+              !Helpers for debugging
+              salt_added = 0.0
+              ! Record the total salt in the column before applying the plume scheme
+              salt_before = 0.0
+              do k=1,nz
+                salt_before = salt_before + h2d(i,k)*tv%S(i,j,k)
+              enddo
+              if (CS%check_salt_verbose) write(0,*)'Salt before brine plume: ',salt_before
             endif
-            net_flux = net_flux + plume_flux
-            Ithickness  = 1.0/h2d(i,k)
-            tv%S(i,j,k) = (h2d(i,k)*tv%S(i,j,k) + plume_flux*dt)*Ithickness
-            if (CS%id_brine_input > 0.) then
-               CS%brine_input(i,j,k) = plume_flux
+
+            ! Set the plume strength based on the salt rejected
+            plume_source = ((1000.0*US%ppt_to_S) * (CS%plume_strength * fluxes%salt_left_behind(i,j))) * GV%RZ_to_H
+            if (CS%check_salt_bp) salt_removed = plume_source*dt
+
+            ! Add salt back to any level (starting at top)
+            bottom = 0.0
+            do k=1,nz ; if (salt_removed > salt_added) then
+              top = bottom
+              bottom = top+h2d(i,k)
+
+              if (bottom <= mixing_depth .and. k<nz_finite) then
+                !Flux convergence integrated over layer
+                plume_flux = min(salt_removed-salt_added, dt * ( (plume_source * A_brine) &
+                                                     * ( (bottom**np1-top**np1) * inp1)))
+              elseif (h2d(i,k)>GV%H_subroundoff) then
+                ! if the bottom of the cell is > MLD or we are in the last
+                ! finite thickness cell, we put all the remaining salt in the level
+                plume_flux = salt_removed-salt_added
+              endif
+
+              ! Update salinity
+              Ithickness  = 1.0/h2d(i,k)
+              tv%S(i,j,k) = tv%S(i,j,k) + plume_flux*Ithickness
+
+              if (CS%check_salt_bp) then
+                salt_added = salt_added + plume_flux
+                if (CS%check_salt_verbose) write(0,*)'Salt to layer k and remaining deficit:',k,salt_added,salt_removed-salt_added
+              endif
+
+              if (CS%id_brine_input > 0.) then
+                CS%brine_input(i,j,k) = plume_flux/dt
+              endif
+
+            endif ; enddo
+
+            if (CS%check_salt_bp) then
+              salt_after = 0.0
+              do k=1,nz
+                salt_after = salt_after + h2d(i,k)*tv%S(i,j,k)
+              enddo
+              if (abs((salt_after-salt_before-salt_removed)/salt_after)>CS%check_salt_threshold) then
+                write(0,*)'Net plume strength    ',fluxes%salt_left_behind(i,j)
+                write(0,*)' H/BP dpt (h-unit)',total_h,mixing_depth
+                write(0,*)' H/BP dpt (m)     ',total_h*GV%H_to_Z,mixing_depth*GV%H_to_Z
+                write(0,*)' Salt before/after BP ',salt_before,salt_after
+                write(0,*)' Salt change BP       ',salt_after-salt_before,(salt_after-salt_before)/salt_after
+                write(0,*)' Salt removed by BP   ',salt_removed,salt_removed/salt_after
+                write(0,*)' Salt added by BP     ',salt_added,salt_added/salt_after
+                write(0,*)' Scheme error         ',(salt_added-salt_removed)/salt_after
+                write(0,*)' Diagnosed salt error ',(salt_after-salt_before-salt_removed)/salt_after
+                write(0,*)' Threshold            ',CS%check_salt_threshold
+                !write(0,*),'------'
+                !write(0,*),'h',h2d(i,:)
+                !write(0,*),'z',h2d(i,:)*GV%H_to_Z
+                !write(0,*),'S',tv%S(i,j,:)
+                call MOM_error(FATAL,'Salt change in brine plume scheme exceeds CHECK_SALT_BRINE_PLUME_THRESHOLD')
+              endif
             endif
-          enddo
-          !if (fluxes%salt_left_behind(i,j) > 0 .and. abs(net_flux)>0.0) then
-          !  if (fraction_left_brine>0.0) then
-          !    print*,'Leftover brine?'
-          !    print*,total_h(i),mixing_depth(i),salt_removed
-          !    print*,salt_added+salt_removed,net_flux, fraction_left_brine
-          !  endif
-          !endif
-        endif
+
+          endif ! Salt was rejected
+
+        endif ! Do brine plume
 
       ! Check if trying to apply fluxes over land points
       elseif ((abs(netHeat(i)) + abs(netSalt(i)) + abs(netMassIn(i)) + abs(netMassOut(i))) > 0.) then
@@ -1486,6 +1530,15 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
                  "Proportionality factor between plume scale and  MLD used in brine plume parameteterization.", &
                  units="nondim", default=1.0, do_not_log=.not.CS%do_brine_plume)
   if (CS%plume_mld_fac<0.0) call MOM_error(FATAL,"BRINE_PLUME_MLD_FAC shouldn't be negative!")
+  call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME", CS%check_salt_bp, &
+                 "If true, check for conservation in the brine plume scheme.", default=.false.)
+  if (CS%check_salt_bp) then
+    call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME_THRESHOLD", CS%check_salt_threshold, &
+                   "Maximum allowed relative salt change in brine plume scheme.", &
+                   units="nondim", default=1.0e-14)
+    call get_param(param_file, mdl, "CHECK_SALT_BRINE_PLUME_VERBOSE", CS%check_salt_verbose, &
+                 "Add output tracking salt conservation with brine plume scheme enabled.", default=.false.)
+  endif
 
 
   if (useALEalgorithm) then

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -870,7 +870,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  drhodt,drhods,pen_sw_bnd_rate,                    &
   !$OMP                                  pen_TKE_2d,Temp_in,Salin_in,RivermixConst,        &
   !$OMP                                  mixing_depth,A_brine,fraction_left_brine,         &
-  !$OMP                                  plume_fraction,dK,total_h)                        &
+  !$OMP                                  plume_fraction,dK,total_h,salt_removed,           &
+  !$OMP                                  salt_added, net_flux)                             &
   !$OMP                     firstprivate(SurfPressure,plume_flux)
   do j=js,je
   ! Work in vertical slices for efficiency

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -187,6 +187,9 @@ type, public :: diabatic_CS ; private
                                      !! MLD calculation [Z ~> m].
   logical :: Use_KdWork_diag = .false.  !< Logical flag to indicate if any Kd_work diagnostics are on.
   logical :: Use_N2_diag = .false.   !< Logical flag to indicate if any N2 diagnostics are on.
+  logical :: MLD_param_003 = .false. !< Logical flag for if MLD in parameterizations uses the 0.03 MLD value
+  logical :: MLD_param_EN1 = .false. !< Logical flag for if MLD in parameterizations uses the EN1 MLD value
+  logical :: MLD_param_ePBL = .false.!< Logical flag for if MLD in parameterizations uses the ePBL h_ML value
 
   !>@{ Diagnostic IDs
   integer :: id_ea       = -1, id_eb       = -1 ! used by layer diabatic
@@ -494,10 +497,18 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   ! Diagnose mixed layer depths.
   call enable_averages(dt, Time_end, CS%diag)
-  if (CS%id_MLD_003 > 0 .or. CS%id_subMLN2 > 0 .or. CS%id_mlotstsq > 0) then
-    call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03*US%kg_m3_to_R, G, GV, US, CS%diag, &
-                                        CS%ref_h_mld, CS%id_MLD_003_zr, CS%id_MLD_003_rr, &
-                                        id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq, dz_subML=CS%dz_subML_N2)
+  if (CS%id_MLD_003 > 0 .or. CS%id_subMLN2 > 0 .or. CS%id_mlotstsq > 0 .or. CS%MLD_param_003 ) then
+    if (CS%MLD_param_003) then
+      call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03*US%kg_m3_to_R, G, GV, US, CS%diag, &
+                                          CS%ref_h_mld, CS%id_MLD_003_zr, CS%id_MLD_003_rr, &
+                                          id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq, dz_subML=CS%dz_subML_N2, &
+                                          MLD_out=visc%MLD_param)
+      call convert_MLD_to_ML_thickness(visc%MLD_param, h, visc%h_ML_param, tv, G, GV)
+    else
+      call diagnoseMLDbyDensityDifference(CS%id_MLD_003, h, tv, 0.03*US%kg_m3_to_R, G, GV, US, CS%diag, &
+                                          CS%ref_h_mld, CS%id_MLD_003_zr, CS%id_MLD_003_rr, &
+                                          id_N2subML=CS%id_subMLN2, id_MLDsq=CS%id_mlotstsq, dz_subML=CS%dz_subML_N2)
+    endif
   endif
   if (CS%id_MLD_0125 > 0) then
     call diagnoseMLDbyDensityDifference(CS%id_MLD_0125, h, tv, 0.125*US%kg_m3_to_R, G, GV, US, CS%diag, &
@@ -507,10 +518,16 @@ subroutine diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, &
     call diagnoseMLDbyDensityDifference(CS%id_MLD_user, h, tv, CS%MLDdensityDifference, G, GV, US, CS%diag, &
                                         ref_H_MLD=0.0, id_ref_z=-1, id_ref_rho=-1)
   endif
-  if ((CS%id_MLD_EN1 > 0) .or. (CS%id_MLD_EN2 > 0) .or. (CS%id_MLD_EN3 > 0)) then
+  if ((CS%id_MLD_EN1 > 0) .or. (CS%id_MLD_EN2 > 0) .or. (CS%id_MLD_EN3 > 0) .or. (CS%MLD_param_EN1)) then
     ! Surface Mixed Layer diagnostic
-    call diagnoseMLDbyEnergy((/CS%id_MLD_EN1, CS%id_MLD_EN2, CS%id_MLD_EN3/), h, tv, G, GV, US, CS%MLD_En_vals, &
-                             (/1,nz/), CS%diag, OM4_iteration=CS%use_OM4_MLD_En_iter)
+    if (CS%MLD_param_EN1) then
+      call diagnoseMLDbyEnergy((/CS%id_MLD_EN1, CS%id_MLD_EN2, CS%id_MLD_EN3/), h, tv, G, GV, US, CS%MLD_En_vals, &
+                               (/1,nz/), CS%diag, OM4_iteration=CS%use_OM4_MLD_En_iter,MLD_out=visc%MLD_param)
+      call convert_MLD_to_ML_thickness(visc%MLD_param, h, visc%h_ML_param, tv, G, GV)
+    else
+      call diagnoseMLDbyEnergy((/CS%id_MLD_EN1, CS%id_MLD_EN2, CS%id_MLD_EN3/), h, tv, G, GV, US, CS%MLD_En_vals, &
+                               (/1,nz/), CS%diag, OM4_iteration=CS%use_OM4_MLD_En_iter)
+    endif
   endif
   if ((CS%id_BMLD_EN1 > 0) .or. (CS%id_BMLD_EN2 > 0) .or. (CS%id_BMLD_EN3 > 0)) then
     ! Bottom Mixed Layer diagnostic
@@ -885,9 +902,10 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
   if (CS%use_energetic_PBL) then
 
     skinbuoyflux(:,:) = 0.0
+    ! pass the right MLD_h
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
             optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit, &
-            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML)
+            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML_param)
 
     if (CS%debug) then
       call hchksum(ent_t, "after applyBoundaryFluxes ent_t", G%HI, haloshift=0, unscale=GV%H_to_mks)
@@ -913,6 +931,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
     ! If visc%MLD or visc%h_ML exist, copy ePBL's BLD into them with appropriate conversions.
     if (associated(visc%h_ML)) call convert_MLD_to_ML_thickness(BLD, h, visc%h_ML, tv, G, GV)
     if (associated(visc%MLD)) visc%MLD(:,:) = BLD(:,:)
+    if (CS%MLD_PARAM_ePBL) visc%h_ML_param = visc%h_ML
     if (associated(visc%sfc_buoy_flx)) visc%sfc_buoy_flx(:,:) = SkinBuoyFlux(:,:)
 
     ! Find the vertical distances across layers, which may have been modified by the net surface flux
@@ -947,7 +966,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
   else
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
                                   optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, &
-                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD_h=visc%h_ML)
+                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD_h=visc%h_ML_param)
 
     ! Find the vertical distances across layers, which may have been modified by the net surface flux
     call thickness_to_dz(h, tv, dz, G, GV, US)
@@ -1543,7 +1562,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
     skinbuoyflux(:,:) = 0.0
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
             optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit, &
-            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML)
+            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML_param)
 
     if (CS%debug) then
       call hchksum(ent_t, "after applyBoundaryFluxes ent_t", G%HI, haloshift=0, unscale=GV%H_to_MKS)
@@ -1564,6 +1583,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
     ! If visc%MLD or visc%h_ML exist, copy ePBL's BLD into them with appropriate conversions.
     if (associated(visc%h_ML)) call convert_MLD_to_ML_thickness(BLD, h, visc%h_ML, tv, G, GV)
     if (associated(visc%MLD)) visc%MLD(:,:) = BLD(:,:)
+    if (CS%MLD_PARAM_ePBL) visc%h_ML_param = visc%h_ML
     if (associated(visc%sfc_buoy_flx)) visc%sfc_buoy_flx(:,:) = SkinBuoyFlux(:,:)
 
     ! Augment the diffusivities and viscosity due to those diagnosed in energetic_PBL.
@@ -1589,7 +1609,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
   else
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
                                   optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, &
-                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD_h=visc%h_ML)
+                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD_h=visc%h_ML_param)
 
   endif   ! endif for CS%use_energetic_PBL
 
@@ -3241,7 +3261,8 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_diabatic_driver" ! This module's name.
   character(len=48)  :: thickness_units
-  logical :: physical_OBL_scheme
+  character(len=20)  :: brine_plume_mld_def
+  logical :: physical_OBL_scheme, do_brine_plume
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, nbands
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -3381,6 +3402,27 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
                  "(e.g. evaporation, sea-ice formation) in one time-step. The unused "//&
                  "mass loss is passed down through the column.", &
                  units="nondim", default=0.8)
+
+  call get_param(param_file, mdl, "DO_BRINE_PLUME", do_brine_plume, &
+                 "If true, enables a brine plume parameterizations (not logged here)", &
+                 do_not_log=.true.,default=.false.)
+  if (do_brine_plume) then
+    call get_param(param_file, mdl, "BRINE_PLUME_MLD_DEF", brine_plume_mld_def, &
+                   "A string that determines which mixed/mixing depth is used in setting "//&
+                   "the brine plume depth", default='MLD_EN1')
+    select case (trim(brine_plume_mld_def))
+    case ('MLD_003')
+      CS%MLD_PARAM_003 = .true.
+    case ('MLD_EN1')
+      CS%MLD_PARAM_EN1 = .true.
+    case ('H_ePBL')
+      CS%MLD_PARAM_ePBL = .true.
+    case default
+      call MOM_error(FATAL,"Invalid choice for BRINE_PLUME_MLD_DEF.  Valid options are"//&
+                     "MLD_003, MLD_EN1, or H_ePBL.")
+    end select
+
+  endif
 
   if (CS%use_energetic_PBL .and. .not.CS%useALEalgorithm) &
     call MOM_error(FATAL, "diabatic_driver_init: "//&

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -187,9 +187,9 @@ type, public :: diabatic_CS ; private
                                      !! MLD calculation [Z ~> m].
   logical :: Use_KdWork_diag = .false.  !< Logical flag to indicate if any Kd_work diagnostics are on.
   logical :: Use_N2_diag = .false.   !< Logical flag to indicate if any N2 diagnostics are on.
-  logical :: MLD_param_003 = .false. !< Logical flag for if MLD in parameterizations uses the 0.03 MLD value
-  logical :: MLD_param_EN1 = .false. !< Logical flag for if MLD in parameterizations uses the EN1 MLD value
-  logical :: MLD_param_ePBL = .false.!< Logical flag for if MLD in parameterizations uses the ePBL h_ML value
+  logical :: MLD_param_003 = .false. !< Logical flag if MLD in brine plume should use the 0.03 mixed layer depth
+  logical :: MLD_param_EN1 = .false. !< Logical flag if MLD in brine plume should use the EN1 mixed layer depth
+  logical :: MLD_param_ePBL = .false.!< Logical flag if MLD in brine plume should use the ePBL boundary layer depth
 
   !>@{ Diagnostic IDs
   integer :: id_ea       = -1, id_eb       = -1 ! used by layer diabatic
@@ -902,7 +902,6 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
   if (CS%use_energetic_PBL) then
 
     skinbuoyflux(:,:) = 0.0
-    ! pass the right MLD_h
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
             optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit, &
             CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML_param)
@@ -931,7 +930,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
     ! If visc%MLD or visc%h_ML exist, copy ePBL's BLD into them with appropriate conversions.
     if (associated(visc%h_ML)) call convert_MLD_to_ML_thickness(BLD, h, visc%h_ML, tv, G, GV)
     if (associated(visc%MLD)) visc%MLD(:,:) = BLD(:,:)
-    if (CS%MLD_PARAM_ePBL) visc%h_ML_param = visc%h_ML
+    if (CS%MLD_param_ePBL) visc%h_ML_param = visc%h_ML
     if (associated(visc%sfc_buoy_flx)) visc%sfc_buoy_flx(:,:) = SkinBuoyFlux(:,:)
 
     ! Find the vertical distances across layers, which may have been modified by the net surface flux
@@ -1583,7 +1582,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
     ! If visc%MLD or visc%h_ML exist, copy ePBL's BLD into them with appropriate conversions.
     if (associated(visc%h_ML)) call convert_MLD_to_ML_thickness(BLD, h, visc%h_ML, tv, G, GV)
     if (associated(visc%MLD)) visc%MLD(:,:) = BLD(:,:)
-    if (CS%MLD_PARAM_ePBL) visc%h_ML_param = visc%h_ML
+    if (CS%MLD_param_ePBL) visc%h_ML_param = visc%h_ML
     if (associated(visc%sfc_buoy_flx)) visc%sfc_buoy_flx(:,:) = SkinBuoyFlux(:,:)
 
     ! Augment the diffusivities and viscosity due to those diagnosed in energetic_PBL.
@@ -3409,14 +3408,15 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   if (do_brine_plume) then
     call get_param(param_file, mdl, "BRINE_PLUME_MLD_DEF", brine_plume_mld_def, &
                    "A string that determines which mixed/mixing depth is used in setting "//&
-                   "the brine plume depth", default='MLD_EN1')
+                   "the brine plume depth, \n Valid options are MLD_003, MLD_EN1, and H_ePBL",&
+                   default='MLD_EN1')
     select case (trim(brine_plume_mld_def))
     case ('MLD_003')
-      CS%MLD_PARAM_003 = .true.
+      CS%MLD_param_003 = .true.
     case ('MLD_EN1')
-      CS%MLD_PARAM_EN1 = .true.
+      CS%MLD_param_EN1 = .true.
     case ('H_ePBL')
-      CS%MLD_PARAM_ePBL = .true.
+      CS%MLD_param_ePBL = .true.
     case default
       call MOM_error(FATAL,"Invalid choice for BRINE_PLUME_MLD_DEF.  Valid options are"//&
                      "MLD_003, MLD_EN1, or H_ePBL.")

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2869,19 +2869,27 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
   if (MLE_use_PBL_MLD .or. MLE_use_Bodner) then
     call safe_alloc_ptr(visc%MLD, isd, ied, jsd, jed)
   endif
-  if ((hfreeze >= 0.0) .or. MLE_use_PBL_MLD .or. do_brine_plume .or. use_fpmix .or. &
+  if ((hfreeze >= 0.0) .or. MLE_use_PBL_MLD .or. use_fpmix .or. &
       use_neutral_diffusion .or. use_hor_bnd_diff .or. use_ideal_age) then
     call safe_alloc_ptr(visc%h_ML, isd, ied, jsd, jed)
+  endif
+  if (do_brine_plume) then
+    call safe_alloc_ptr(visc%h_ML_param, isd, ied, jsd, jed)
+    call safe_alloc_ptr(visc%MLD_param, isd, ied, jsd, jed)
   endif
 
   if (MLE_use_PBL_MLD) then
     call register_restart_field(visc%MLD, "MLD", .false., restart_CS, &
                   "Instantaneous active mixing layer depth", units="m", conversion=US%Z_to_m)
   endif
-  if (MLE_use_PBL_MLD .or. do_brine_plume .or. use_fpmix .or. &
-      use_neutral_diffusion .or. use_hor_bnd_diff) then
+  if (MLE_use_PBL_MLD .or. use_fpmix .or. use_neutral_diffusion .or. use_hor_bnd_diff) then
     call register_restart_field(visc%h_ML, "h_ML", .false., restart_CS, &
                   "Instantaneous active mixing layer thickness", &
+                  units=get_thickness_units(GV), conversion=GV%H_to_mks)
+  endif
+  if (do_brine_plume) then
+    call register_restart_field(visc%h_ML_param, "h_ML_param", .false., restart_CS, &
+                  "Instantaneous active mixed layer thickness", &
                   units=get_thickness_units(GV), conversion=GV%H_to_mks)
   endif
 


### PR DESCRIPTION
- Codes in 3 options, MLD_003, MLD_EN1, and H_EPBL, all of which can be passed to brine plume param to set the plume depth
- Brine plume scheme failed dimensional consistency because it was not multiplied by the time step.  The units of plume_flux in the description are updated, which exposes why it failed the time dimension consistency test.
- The brine plume scheme was moved after the application of other fluxes that can add salt/heat/mass to the ocean in applyboundaryfluxesinout.  This change made it easier to track that it only moves salt in the vertical and doesn't create/destroy salt.
- The brine plume salt flux is now multipled by dt to convert from a rate to an amount.  This has a large impact on the behavior, but is approximately compensated by an unrealated bug in SIS2.
- The brine plume scheme did not conserve salt because it could neglect salt if the mixed layer depth wasn't deeper than the center of the bottom grid cell, possibly due to round off.  A new condition is added to insert salt into the bottom layer if it is thick enough to accept salt.  This significantly improves conservation, though round-off level errors are still possible.
- Complete a stub for a brine plume diagnostic, which can be used to verify how the brine plume scheme moves salt in the vertical.
- Adds an option to increase the vertical scale for brine plumes proportionally to the chosen mixed layer depth.
- Updated some parameter names and formatting related to the MLD used in the brine scheme.
- The brine plume salt flux contribution is no longer added to the top level and subtracted later in the brine plume part. Rather, the salt that is added in applyboundaryfluxes now has the brine plume salt flux removed.  The salt flux is then simply applied by adding it back in during the brine plume part.
- The code to handle flux deposition within the mixed layer was rewritten to ensure the salt flux is entirely used by the bottom-most finite thickness layer.
- The flux is now prescribed by analytical integral over the layer instead of midpoint quadrature.
- Debugging options are enhanced to better track and report on salt conservation.