### PR TITLE
+Add option for rotationally symmetric downsampling

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -6,6 +6,7 @@
 !! interfaces with additional diagnostic capabilities.
 module MOM_diag_mediator
 
+use MOM_array_transform,  only : symmetric_sum
 use MOM_checksums,        only : chksum0, zchksum, hchksum, uchksum, vchksum, Bchksum
 use MOM_coms,             only : PE_here
 use MOM_cpu_clock,        only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
@@ -258,6 +259,7 @@ type, public :: diag_ctrl
   logical :: diag_as_chksum  !< If true, log chksums in a text file instead of posting diagnostics
   logical :: show_call_tree  !< Display the call tree while running. Set by VERBOSITY level.
   logical :: index_space_axes !< If true, diagnostic horizontal coordinates axes are in index space.
+  logical :: symmetric_downsample_sums !< If true, use rotationally symmetric sums when downsampling diagnostics.
 
   ! The following fields are used for the output of the data.
   ! These give the computational-domain sizes, and are relative to a start value
@@ -2821,7 +2823,7 @@ subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_metho
 
   mstr = diag%axes%v_cell_method
   if (present(v_extensive)) then
-    if (present(v_cell_method)) call MOM_error(FATAL, "attach_cell_methods: " // &
+    if (present(v_cell_method)) call MOM_error(FATAL, "add_xyz_method: " // &
        'Vertical cell method was specified along with the vertically extensive flag.')
     if (v_extensive) then
       mstr='sum'
@@ -3467,8 +3469,12 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) remap_answer_date = max(remap_answer_date, 20230701)
   call get_param(param_file, mdl, 'USE_INDEX_DIAGNOSTIC_AXES', diag_cs%index_space_axes, &
-                 'If true, use a grid index coordinate convention for diagnostic axes. ',&
+                 'If true, use a grid index coordinate convention for diagnostic axes. ', &
                  default=.false.)
+  call get_param(param_file, mdl, 'SYMMETRIC_DOWNSAMPLE_SUMS', diag_cs%symmetric_downsample_sums, &
+                 'If true, use rotationally symmetric sums when downsampling diagnostics.', &
+                 default=.false.)
+
 
   dz_diag_needed = .false.
   if (diag_cs%num_diag_coords>0) then
@@ -4311,7 +4317,7 @@ subroutine downsample_diag_indices_get(fo1, fo2, dl, diag_cs, isv, iev, jsv, jev
     f2 = f2 + mod(fo2,dl)
   endif
 
-  ! Find the range of indices in the downscaled computational domain.
+  ! Find the range of indices in the downsampled computational domain.
   if ( f1 == dszi ) then
     isv = diag_cs%dsamp(dl)%isc ; iev = diag_cs%dsamp(dl)%iec   ! Field on Data domain, take compute domain indices
   elseif ( f1 == dszi + 1 ) then
@@ -4415,7 +4421,7 @@ subroutine downsample_diag_field_2d(locfield, locfield_dsamp, dl, diag_cs, diag,
     call MOM_error(FATAL, "downsample_diag_field_2d: Cannot downsample without a mask!!! ")
   endif
 
-  call downsample_field(locfield, locfield_dsamp, dl, diag%xyz_method, locmask, diag_cs,diag, &
+  call downsample_field(locfield, locfield_dsamp, dl, diag%xyz_method, locmask, diag_cs, diag, &
                         isv_o, jsv_o, isv, iev, jsv, jev)
 
 end subroutine downsample_diag_field_2d
@@ -4457,11 +4463,11 @@ end subroutine downsample_diag_field_2d
 !> This subroutine allocates and computes a down sampled 3d array given an input array
 !! The down sample method is based on the "cell_methods" for the diagnostics as explained
 !! in the above table
-subroutine downsample_field_3d(field_in, field_out, dl, method, mask, diag_cs, diag, &
+subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, diag, &
                                isv_o, jsv_o, isv_d, iev_d, jsv_d, jev_d)
   real, dimension(:,:,:), pointer :: field_in      !< Original field to be downsampled in arbitrary units [A ~> a]
   real, dimension(:,:,:), allocatable :: field_out !< Downsampled field in the same arbitrary units [A ~> a]
-  integer, intent(in) :: dl                !< Level of down sampling
+  integer, intent(in) :: dL                !< Level of down sampling
   integer,  intent(in) :: method           !< Sampling method
   real,  dimension(:,:,:), pointer :: mask !< Mask for field [nondim]
   type(diag_ctrl), intent(in) :: diag_CS   !< Structure used to regulate diagnostic output
@@ -4472,10 +4478,21 @@ subroutine downsample_field_3d(field_in, field_out, dl, method, mask, diag_cs, d
   integer, intent(in) :: iev_d             !< i-end index of down sampled data
   integer, intent(in) :: jsv_d             !< j-start index of down sampled data
   integer, intent(in) :: jev_d             !< j-end index of down sampled data
+
   ! Local variables
   character(len=240) :: mesg
-  integer :: i, j, ii, jj, i0, j0, f1, f2, f_in1, f_in2
-  integer :: k, ks, ke
+  integer :: i, j, k, i_dn, j_dn, ks, ke, i0, j0, f1, f2, f_in1, f_in2
+  integer :: ii, jj  ! The index locations on the full grid that contribute to the averages.
+  integer :: i0_off, j0_off  ! The starting point offsets between full array and reduced array
+                             ! indices when i or j is 0.
+  real :: wt(dL,dL) ! The nondimensional, area-, volume- or mass-based weight for an input
+                    ! value [nondim], [L2 ~> m2], [H L ~> m2 or kg m-1] or [H L2 ~> m3 or kg]
+  real :: wtd_field(dL,dL) ! The weighted field to sum, in [A ~> a], [A L2 ~> a m2],
+                    ! [A H L ~> a m2 or a kg m-1] or [A H L2 ~> a m3 or a kg]
+  real :: wt_1d(dL) ! The nondimensional, area-, volume- or mass-based weight for an input
+                    ! value [nondim], [L2 ~> m2], [H L ~> m2 or kg m-1] or [H L2 ~> m3 or kg]
+  real :: wtd_field_1d(dL) ! The weighted field to sum, in [A ~> a], [A L2 ~> a m2],
+                    ! [A H L ~> a m2 or a kg m-1] or [A H L2 ~> a m3 or a kg]
   real :: ave       ! The running sum of the average, in [A ~> a], [A L2 ~> a m2],
                     ! [A H L ~> a m2 or a kg m-1] or [A H L2 ~> a m3 or a kg]
   real :: weight    ! The nondimensional, area-, volume- or mass-based weight for an input
@@ -4485,128 +4502,117 @@ subroutine downsample_field_3d(field_in, field_out, dl, method, mask, diag_cs, d
   real :: eps_vol   ! A negligibly small volume or mass [H L2 ~> m3 or kg]
   real :: eps_area  ! A negligibly small area [L2 ~> m2]
   real :: eps_face  ! A negligibly small face area [H L ~> m2 or kg m-1]
+  logical :: naive  ! If true, use naive rotatially variant sums to reproduct previous answers.
 
   ks = 1 ; ke = size(field_in,3)
+
+  ! It would be better to use a max with eps_vol instead of adding it into the denominator.
   eps_face = 1.0e-20 * diag_cs%G%US%m_to_L * diag_cs%GV%m_to_H
   eps_area = 1.0e-20 * diag_cs%G%US%m_to_L**2
   eps_vol = 1.0e-20 * diag_cs%G%US%m_to_L**2 * diag_cs%GV%m_to_H
 
+  naive = .not.diag_CS%symmetric_downsample_sums
+
   ! Allocate the down sampled field on the down sampled data domain
 !  allocate(field_out(diag_cs%dsamp(dl)%isd:diag_cs%dsamp(dl)%ied,diag_cs%dsamp(dl)%jsd:diag_cs%dsamp(dl)%jed,ks:ke))
 !  allocate(field_out(1:size(field_in,1)/dl,1:size(field_in,2)/dl,ks:ke))
-  f_in1 = size(field_in,1)
-  f_in2 = size(field_in,2)
-  f1 = f_in1/dl
-  f2 = f_in2/dl
+  f_in1 = size(field_in, 1)
+  f_in2 = size(field_in, 2)
+  f1 = f_in1 / dL
+  f2 = f_in2 / dL
   ! Correction for the symmetric case
   if (diag_cs%G%symmetric) then
-    f1 = f1 + mod(f_in1,dl)
-    f2 = f2 + mod(f_in2,dl)
+    f1 = f1 + mod(f_in1, dL)
+    f2 = f2 + mod(f_in2, dL)
   endif
   allocate(field_out(1:f1,1:f2,ks:ke))
 
+  ! These are the starting point offsets between full array and reduced array indices when i or j is 0.
+  i0_off = (isv_o-1) - dL*isv_d
+  j0_off = (jsv_o-1) - dL*jsv_d
+
   ! Fill the down sampled field on the down sampled diagnostics (almost always compute) domain
-  !### The averaging used here is not rotationally invariant.
-  !  Also, it would be better to use a max with eps_vol instead of adding it in the denominator.
   if (method == MMM) then
     do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        weight = mask(ii,jj,k) * diag_cs%G%areaT(ii,jj) * diag_cs%h(ii,jj,k)
-        total_weight = total_weight + weight
-        ave = ave+field_in(ii,jj,k) * weight
+      do j_dn=1,dL ; do i_dn=1,dL
+        ! ii and jj are the index locations on the full grid that contribute to the averages.
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        wt(i_dn,j_dn) = mask(ii,jj,k) * diag_cs%G%areaT(ii,jj) * diag_cs%h(ii,jj,k)
+        wtd_field(i_dn,j_dn) = field_in(ii,jj,k) * wt(i_dn,j_dn)
       enddo ; enddo
-      field_out(i,j,k)  = ave / (total_weight + eps_vol)  ! Eps_vol avoids division by 0.
+      field_out(i,j,k) = square_sum(wtd_field(1:dL,1:dL), dL, naive) / &
+                        (square_sum(wt(1:dL,1:dL), dL, naive) + eps_vol) ! Eps_vol avoids division by 0.
     enddo ; enddo ; enddo
   elseif (method == SSS) then   ! e.g., volcello
     do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        weight = mask(ii,jj,k)
-        ave = ave+field_in(ii,jj,k)*weight
+      do j_dn=1,dL ; do i_dn=1,dL
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        wtd_field(i_dn,j_dn) = field_in(ii,jj,k) * mask(ii,jj,k)
       enddo ; enddo
-      field_out(i,j,k)  = ave ! This is a masked sum, and total_weight = 1.
+      field_out(i,j,k)  = square_sum(wtd_field(1:dL,1:dL), dL, naive) ! This is a masked sum.
     enddo ; enddo ; enddo
   elseif (method == MMP .or. method == MMS) then   ! e.g., T_advection_xy
     do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        weight = mask(ii,jj,k) * diag_cs%G%areaT(ii,jj)
-        total_weight = total_weight + weight
-        ave = ave+field_in(ii,jj,k) * weight
+      do j_dn=1,dL ; do i_dn=1,dL
+        ! ii and jj are the index locations on the full grid that contribute to the averages.
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        wt(i_dn,j_dn) = mask(ii,jj,k) * diag_cs%G%areaT(ii,jj)
+        wtd_field(i_dn,j_dn) = field_in(ii,jj,k) * wt(i_dn,j_dn)
       enddo ; enddo
-      field_out(i,j,k)  = ave / (total_weight + eps_area)  ! Eps_area avoids division by 0.
+      field_out(i,j,k) = square_sum(wtd_field(1:dL,1:dL), dL, naive) / &
+                        (square_sum(wt(1:dL,1:dL), dL, naive) + eps_area) ! Eps_area avoids division by 0.
     enddo ; enddo ; enddo
   elseif (method == PMM) then
     do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      ii=i0
-      do jj=j0,j0+dl-1
-        weight = mask(ii,jj,k) * diag_cs%G%dyCu(ii,jj) * diag_cs%h(ii,jj,k)
-        total_weight = total_weight + weight
-        ave = ave+field_in(ii,jj,k) * weight
+      II = dL*I + I0_off + (dL-1)
+      do j_dn=1,dL
+        jj = j_dn + (dL*j + j0_off)
+        !### The thickness here is offset by have a grid point from the rest of the expression.
+        wt_1d(j_dn) = mask(II,jj,k) * diag_cs%G%dyCu(II,jj) * diag_cs%h(ii,jj,k)
+        wtd_field_1d(j_dn) = field_in(II,jj,k) * wt_1d(j_dn)
       enddo
-      field_out(i,j,k)  = ave / (total_weight + eps_face)  ! Eps_face avoids division by 0.
+      field_out(I,j,k)  = sum_1d(wtd_field_1d(1:dL), dL) / &
+                         (sum_1d(wt_1d(1:dL), dL) + eps_face)  ! Eps_face avoids division by 0.
     enddo ; enddo ; enddo
   elseif (method == PSS) then    ! e.g. umo
     do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      ii=i0
-      do jj=j0,j0+dl-1
-        weight = mask(ii,jj,k)
-        ave = ave+field_in(ii,jj,k)*weight
+      II = dL*I + I0_off + (dL-1)
+      do j_dn=1,dL
+        jj = j_dn + (dL*j + j0_off)
+        wtd_field_1d(j_dn) = field_in(II,jj,k) * mask(II,jj,k)
       enddo
-      field_out(i,j,k)  = ave   ! This is a masked sum, and total_weight = 1.
+      field_out(I,j,k) = sum_1d(wtd_field_1d(1:dL), dL)   ! This is a masked sum.
     enddo ; enddo ; enddo
   elseif (method == SPS) then   ! e.g. vmo
-    do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      jj=j0
-      do ii=i0,i0+dl-1
-        weight = mask(ii,jj,k)
-        ave = ave+field_in(ii,jj,k)*weight
+    do k=ks,ke ; do J=jsv_d,jev_d ; do i=isv_d,iev_d
+      JJ = dL*J + J0_off + (dL-1)
+      do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        wtd_field_1d(i_dn) = field_in(ii,JJ,k) * mask(ii,JJ,k)
       enddo
-      field_out(i,j,k)  = ave  ! This is a masked sum, and total_weight = 1.
+      field_out(i,J,k) = sum_1d(wtd_field_1d(1:dL), dL)   ! This is a masked sum.
     enddo ; enddo ; enddo
   elseif (method == MPM) then
-    do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      jj=j0
-      do ii=i0,i0+dl-1
-        weight = mask(ii,jj,k) * diag_cs%G%dxCv(ii,jj) * diag_cs%h(ii,jj,k)
-        total_weight = total_weight + weight
-        ave = ave+field_in(ii,jj,k) * weight
+    do k=ks,ke ; do J=jsv_d,jev_d ; do i=isv_d,iev_d
+      JJ = dL*J + J0_off + (dL-1)
+      do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        !### The thickness here is offset by have a grid point from the rest of the expression.
+        wt_1d(i_dn) = mask(ii,JJ,k) * diag_cs%G%dxCv(ii,JJ) * diag_cs%h(ii,jj,k)
+        wtd_field_1d(i_dn) = field_in(ii,JJ,k) * wt_1d(i_dn)
       enddo
-      field_out(i,j,k)  = ave / (total_weight + eps_face)  ! Eps_face avoids division by 0.
+      field_out(i,J,k)  = sum_1d(wtd_field_1d(1:dL), dL) / &
+                         (sum_1d(wt_1d(1:dL), dL) + eps_face)  ! Eps_face avoids division by 0.
     enddo ; enddo ; enddo
   elseif (method == MSK) then ! The input field is a mask, so subsample it instead of averaging.
     field_out(:,:,:) = 0.0
     do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
       ave = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        ave = ave+field_in(ii,jj,k)
+      do j_dn=1,dL ; do i_dn=1,dL
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        ave = ave + field_in(ii,jj,k)
       enddo ; enddo
-      if (ave > 0.0) field_out(i,j,k)=1.0
+      if (ave > 0.0) field_out(i,j,k) = 1.0
     enddo ; enddo ; enddo
   else
     write (mesg,*) " unknown sampling method: ",method
@@ -4635,15 +4641,29 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   integer, intent(in) :: jev_d             !< j-end index of down sampled data
   ! Local variables
   character(len=240) :: mesg
-  integer :: i, j, ii, jj, i0, j0, f1, f2, f_in1, f_in2
+  integer :: i, j, i_dn, j_dn, i0, j0, f1, f2, f_in1, f_in2
+  integer :: ii, jj  ! The index locations on the full grid that contribute to the averages.
+  integer :: i0_off, j0_off  ! The starting point offsets between full array and reduced array
+                             ! indices when i or j is 0.
+  real :: wt(dL,dL) ! The nondimensional, area-, volume- or mass-based weight for an input
+                    ! value [nondim], [L2 ~> m2], [H L ~> m2 or kg m-1] or [H L2 ~> m3 or kg]
+  real :: wtd_field(dL,dL) ! The weighted field to sum, in [A ~> a], [A L2 ~> a m2],
+                    ! [A H L ~> a m2 or a kg m-1] or [A H L2 ~> a m3 or a kg]
+  real :: wt_1d(dL) ! The nondimensional, area-, volume- or mass-based weight for an input
+                    ! value [nondim], [L2 ~> m2], [H L ~> m2 or kg m-1] or [H L2 ~> m3 or kg]
+  real :: wtd_field_1d(dL) ! The weighted field to sum, in [A ~> a], [A L2 ~> a m2],
+                    ! [A H L ~> a m2 or a kg m-1] or [A H L2 ~> a m3 or a kg]
   real :: ave       ! The running sum of the average, in [A ~> a] or [A L2 ~> a m2]
   real :: weight    ! The nondimensional or area-weighted weight for an input value [nondim] or [L2 ~> m2]
   real :: total_weight ! The sum of weights contributing to a point [nondim] or [L2 ~> m2]
   real :: eps_area  ! A negligibly small area [L2 ~> m2]
   real :: eps_len   ! A negligibly small horizontal length [L ~> m]
+  logical :: naive  ! If true, use naive rotatially variant sums to reproduct previous answers.
 
   eps_len = 1.0e-20 * diag_cs%G%US%m_to_L
   eps_area = 1.0e-20 * diag_cs%G%US%m_to_L**2
+
+  naive = .not.diag_CS%symmetric_downsample_sums
 
   ! Allocate the down sampled field on the down sampled data domain
 !  allocate(field_out(diag_cs%dsamp(dl)%isd:diag_cs%dsamp(dl)%ied,diag_cs%dsamp(dl)%jsd:diag_cs%dsamp(dl)%jed))
@@ -4660,92 +4680,81 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   endif
   allocate(field_out(1:f1,1:f2))
 
+  ! These are the starting point offsets between full array and reduced array indices when i or j is 0.
+  i0_off = (isv_o-1) - dL*isv_d
+  j0_off = (jsv_o-1) - dL*jsv_d
+
   if (method == MMP) then
     do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        weight = mask(ii,jj)*diag_cs%G%areaT(ii,jj)
-        total_weight = total_weight + weight
-        ave = ave+field_in(ii,jj) * weight
+      do j_dn=1,dL ; do i_dn=1,dL
+        ! ii and jj are the index locations on the full grid that contribute to the averages.
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        wt(i_dn,j_dn) = mask(ii,jj) * diag_cs%G%areaT(ii,jj)
+        wtd_field(i_dn,j_dn) = field_in(ii,jj) * wt(i_dn,j_dn)
       enddo ; enddo
-      field_out(i,j) = ave / (total_weight + eps_area)  ! Eps_area avoids division by 0.
+      field_out(i,j) = square_sum(wtd_field(1:dL,1:dL), dL, naive) / &
+                      (square_sum(wt(1:dL,1:dL), dL, naive) + eps_area) ! Eps_area avoids division by 0.
     enddo ; enddo
   elseif (method == SSP) then    ! e.g., T_dfxy_cont_tendency_2d
     do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        weight = mask(ii,jj)
-        ave = ave+field_in(ii,jj)*weight
+      do j_dn=1,dL ; do i_dn=1,dL
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        wtd_field(i_dn,j_dn) = field_in(ii,jj) * mask(ii,jj)
       enddo ; enddo
-      field_out(i,j) = ave  ! This is a masked sum, and total_weight = 1.
+      field_out(i,j)  = square_sum(wtd_field(1:dL,1:dL), dL, naive) ! This is a masked sum.
     enddo ; enddo
   elseif (method == PSP) then   ! e.g., umo_2d
-    do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      ii=i0
-      do jj=j0,j0+dl-1
-        weight = mask(ii,jj)
-        ave = ave+field_in(ii,jj)*weight
+    do j=jsv_d,jev_d ; do I=isv_d,iev_d
+      II = dL*I + i0_off + (dL-1)
+      do j_dn=1,dL
+        jj = j_dn + (dL*j + j0_off)
+        wtd_field_1d(j_dn) = field_in(II,jj) * mask(II,jj)
       enddo
-      field_out(i,j) = ave  ! This is a masked sum, and total_weight = 1.
+      field_out(I,j) = sum_1d(wtd_field_1d(1:dL), dL)   ! This is a masked sum.
     enddo ; enddo
   elseif (method == SPP) then   ! e.g., vmo_2d
-    do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      jj=j0
-      do ii=i0,i0+dl-1
-        weight = mask(ii,jj)
-        ave = ave+field_in(ii,jj)*weight
+    do J=jsv_d,jev_d ; do i=isv_d,iev_d
+      JJ = dL*J + J0_off + (dL-1)
+      do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        wtd_field_1d(i_dn) = field_in(ii,JJ) * mask(ii,JJ)
       enddo
-      field_out(i,j) = ave  ! This is a masked sum, and total_weight = 1.
+      field_out(i,J) = sum_1d(wtd_field_1d(1:dL), dL)   ! This is a masked sum.
     enddo ; enddo
   elseif (method == PMP) then
-    do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      ii=i0
-      do jj=j0,j0+dl-1
-        weight = mask(ii,jj) * diag_cs%G%dyCu(ii,jj)!*diag_cs%h(ii,jj,1) !Niki?
-        total_weight = total_weight + weight
-        ave = ave+field_in(ii,jj) * weight
+    do j=jsv_d,jev_d ; do I=isv_d,iev_d
+      ! This expression for ii agrees with what was here before, but is it what we want?
+      II = dL*I + I0_off + (dL-1)
+      do j_dn=1,dL
+        jj = j_dn + (dL*j + j0_off)
+        ! Should this weight include the total thickness interpolated to velocity points?
+        wt_1d(j_dn) = mask(II,jj) * diag_cs%G%dyCu(II,jj)
+        wtd_field_1d(j_dn) = field_in(II,jj) * wt_1d(j_dn)
       enddo
-      field_out(i,j) = ave / (total_weight + eps_len)  ! Eps_len avoids division by 0.
+      field_out(I,j) = sum_1d(wtd_field_1d(1:dL), dL) / &
+                      (sum_1d(wt_1d(1:dL), dL) + eps_len)  ! Eps_len avoids division by 0.
     enddo ; enddo
   elseif (method == MPP) then
-    do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
-      ave = 0.0
-      total_weight = 0.0
-      jj=j0
-      do ii=i0,i0+dl-1
-        weight = mask(ii,jj)* diag_cs%G%dxCv(ii,jj)!*diag_cs%h(ii,jj,1) !Niki?
-        total_weight = total_weight +weight
-        ave = ave+field_in(ii,jj)*weight
+    do J=jsv_d,jev_d ; do i=isv_d,iev_d
+      JJ = dL*J + J0_off + (dL-1)
+      do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        ! Should this weight include the total thickness interpolated to velocity points?
+        wt_1d(i_dn) = mask(ii,JJ) * diag_cs%G%dxCv(ii,JJ)
+        wtd_field_1d(i_dn) = field_in(ii,JJ) * wt_1d(i_dn)
       enddo
-      field_out(i,j) = ave / (total_weight + eps_len)  ! Eps_len avoids division by 0.
+      field_out(i,J) = sum_1d(wtd_field_1d(1:dL), dL) / &
+                      (sum_1d(wt_1d(1:dL), dL) + Eps_len)  ! Eps_len avoids division by 0.
     enddo ; enddo
   elseif (method == MSK) then ! The input field is a mask, so subsample it instead of averaging.
     field_out(:,:) = 0.0
     do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      i0 = isv_o+dl*(i-isv_d)
-      j0 = jsv_o+dl*(j-jsv_d)
       ave = 0.0
-      do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-        ave = ave+field_in(ii,jj)
+      do j_dn=1,dL ; do i_dn=1,dL
+        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
+        ave = ave + field_in(ii,jj)
       enddo ; enddo
-      if (ave > 0.0) field_out(i,j)=1.0
+      if (ave > 0.0) field_out(i,j) = 1.0
     enddo ; enddo
   else
     write (mesg,*) " unknown sampling method: ",method
@@ -4753,6 +4762,65 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   endif
 
 end subroutine downsample_field_2d
+
+!> Do a rotationally symmetric sum of the elements of a 1-d array.
+function sum_1d(field, sz) result(sum)
+  integer, intent(in) :: sz        !<  The size of the array to sum
+  real,    intent(in) :: field(sz) !< The field to sum in arbitrary units [A ~> a]
+  real :: sum !< The rotationally symmetric sum of the entries in field [A ~> a]
+
+  ! Local variables
+  integer :: i, sz_2
+
+  if (sz == 2) then      ! The order of arithmetic does not matter.
+    sum = field(1) + field(2)
+  elseif (sz == 3) then  ! Use simpler code that has the same order of sums as the general case.
+    sum = field(2) + (field(1) + field(3))
+  else
+    ! This is a copy of the general code from symmetric_sum_1d in MOM_array_transform
+    sz_2 = sz / 2 ! Note that for an odd number sz_2 is rounded down.
+    sum = 0.0
+    if (2*sz_2 < sz) sum = field(sz_2+1)
+    ! Add pairs of values, working from the inside out.
+    do i=sz_2,1,-1
+      sum = sum + (field(i) + field(sz+1-i))
+    enddo
+  endif
+end function sum_1d
+
+!> Return the sum of the elements of a square 2-d array, perhaps using a rotationally symmetric sum.
+!! This could eventually wrap symmetric_sum, but for now it also can reproduce the previous answers.
+function square_sum(field, sz, naive_sum) result(sum)
+  integer,           intent(in) :: sz         !< The size of the array along each axis
+  real,              intent(in) :: field(sz, sz) !< The field to sum in arbitrary units [A ~> a]
+  logical, optional, intent(in) :: naive_sum !< If true, sum the elements in the order they appear in memory.
+  real :: sum !< The sum of the entries in field [A ~> a]
+
+  ! Local variables
+  integer :: i, j
+  logical :: simple_sum
+
+  simple_sum = .true. ; if (present(naive_sum)) simple_sum = naive_sum
+
+  if (sz == 1) then
+    sum = field(1,1)
+  elseif (simple_sum) then
+    ! This non-rotationally symmetric sum is here to reproduce previous results.
+    sum = 0.0
+    do j=1,sz ; do i=1,sz ; sum = sum + field(i,j) ; enddo ; enddo
+  elseif (sz == 2) then
+    ! This copy of code from symmetric_sum may facilitate inlining in a common case.
+    sum = (field(1,1) + field(2,2)) + (field(2,1) + field(1,2))
+  elseif (sz == 3) then
+    ! This copy of code from symmetric_sum may facilitate inlining in a common case.
+    sum = (field(2,2) + ((field(1,2) + field(3,2)) + (field(2,1) + field(2,3)))) + &
+          ((field(1,1) + field(3,3)) + (field(3,1) + field(1,3)))
+  else
+    sum = symmetric_sum(field(1:sz,1:sz))
+  endif
+
+end function square_sum
+
 
 !> Allocate and compute the 2d down sampled mask
 !! The masks are down sampled based on a minority rule, i.e., a coarse cell is open (1)


### PR DESCRIPTION
  Refactored `downsample_field_3d()` and `downsample_field_2d()` and added the option to use a rotationally symmetric sum when downsampling diagnostic output. The new runtime parameter `SYMMETRIC_DOWNSAMPLE_SUMS`, triggers the use of a symmetric order of the sums, either directly or for downsampling by a factor of 4 or more via a call to `symmetric_sum()`.  Internally the refactoring stores the values that are to be summed in a 2-d or 1-d array before calling the new internal routine `square_sum()` or `sum_1d()`.  There are also two comments added noting where thicknesses are used at velocity points without averaging to correct for the difference in their staggered locations.  By default, all solutions and diagnostics are identical, although there is annoying change in the locations of negative zeros for some diagnostics.  However, when `SYMMETRIC_DOWNSAMPLE_SUMS` is set to true, answers are mathematically equivalent but there are changes at roundoff in diagnostics that are written at 64-bit precision.