### PR TITLE
(*)Correctly downsample masks

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -164,9 +164,10 @@ type, public :: diag_grid_storage
 end type diag_grid_storage
 
 ! Integers to encode the total cell methods
-!integer :: PPP=111  ! x:point,y:point,z:point, this kind of diagnostic is not currently present in diag_table.MOM6
-!integer :: PPS=112  ! x:point,y:point,z:sum  , this kind of diagnostic is not currently present in diag_table.MOM6
-!integer :: PPM=113  ! x:point,y:point,z:mean , this kind of diagnostic is not currently present in diag_table.MOM6
+! Note that vorticity points (the PPP and PPM methods) are not fully dealt with for downsampling.
+integer :: PPP=111  !< x:point,y:point,z:point
+!integer :: PPS=112 ! x:point,y:point,z:sum  , this kind of diagnostic is not currently present in diag_table.MOM6
+integer :: PPM=113  !< x:point,y:point,z:mean
 integer :: PSP=121  !< x:point,y:sum,z:point
 integer :: PSS=122  !< x:point,y:sum,z:point
 integer :: PSM=123  !< x:point,y:sum,z:mean
@@ -892,63 +893,62 @@ subroutine set_masks_for_axes_dsamp(G, diag_cs)
   type(diag_ctrl),               pointer    :: diag_cs !< A pointer to a type with many variables
                                                        !! used for diagnostics
   ! Local variables
-  integer :: c, dl
+  integer :: c, dL
   type(axes_grp), pointer :: axes => NULL() ! Current axes, for convenience
 
   ! Each downsampled axis needs both downsampled and non-downsampled masks.
   ! The downsampled mask is needed for sending out the diagnostics output via diag_manager.
   ! The non-downsampled mask is needed for downsampling the diagnostics field.
-  do dl=2,MAX_DSAMP_LEV
-    if (dl /= 2) call MOM_error(FATAL, "set_masks_for_axes_dsamp: Downsample level other than 2 is not supported!")
+  do dL=2,MAX_DSAMP_LEV
     do c=1, diag_cs%num_diag_coords
       ! Level/layer h-points in diagnostic coordinate
       axes => diag_cs%remap_axesTL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesTL(c)%dsamp(dl)%mask3d, &
-              dl, G%isc, G%jsc, G%isd, G%jsd, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesTL(c)%dsamp(dL)%mask3d, &
+              dL, xyz_method(axes), G%isc, G%jsc, G%isd, G%jsd, &
               G%HId2%isc, G%HId2%iec, G%HId2%jsc, G%HId2%jec, G%HId2%isd, G%HId2%ied, G%HId2%jsd, G%HId2%jed)
-      diag_cs%dsamp(dl)%remap_axesTL(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesTL(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Level/layer u-points in diagnostic coordinate
       axes => diag_cs%remap_axesCuL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCuL(c)%dsamp(dl)%mask3d, &
-              dl, G%IscB, G%jsc, G%IsdB, G%jsd, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesCuL(c)%dsamp(dL)%mask3d, &
+              dL, xyz_method(axes), G%IscB, G%jsc, G%IsdB, G%jsd, &
               G%HId2%IscB, G%HId2%IecB, G%HId2%jsc, G%HId2%jec, G%HId2%IsdB, G%HId2%IedB, G%HId2%jsd, G%HId2%jed)
-      diag_cs%dsamp(dl)%remap_axesCul(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesCul(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Level/layer v-points in diagnostic coordinate
       axes => diag_cs%remap_axesCvL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCvL(c)%dsamp(dl)%mask3d, &
-              dl, G%isc, G%JscB, G%isd, G%JsdB, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesCvL(c)%dsamp(dL)%mask3d, &
+              dL, xyz_method(axes), G%isc, G%JscB, G%isd, G%JsdB, &
               G%HId2%isc, G%HId2%iec, G%HId2%JscB, G%HId2%JecB, G%HId2%isd, G%HId2%ied, G%HId2%JsdB, G%HId2%JedB)
-      diag_cs%dsamp(dl)%remap_axesCvL(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesCvL(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Level/layer q-points in diagnostic coordinate
       axes => diag_cs%remap_axesBL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesBL(c)%dsamp(dl)%mask3d, &
-              dl, G%IscB, G%JscB, G%IsdB, G%JsdB, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesBL(c)%dsamp(dL)%mask3d, &
+              dL, xyz_method(axes), G%IscB, G%JscB, G%IsdB, G%JsdB, &
               G%HId2%IscB, G%HId2%IecB, G%HId2%JscB, G%HId2%JecB, G%HId2%IsdB, G%HId2%IedB, G%HId2%JsdB, G%HId2%JedB)
-      diag_cs%dsamp(dl)%remap_axesBL(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesBL(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Interface h-points in diagnostic coordinate (w-point)
       axes => diag_cs%remap_axesTi(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesTi(c)%dsamp(dl)%mask3d,  &
-              dl, G%isc, G%jsc, G%isd, G%jsd, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesTi(c)%dsamp(dL)%mask3d,  &
+              dL, xyz_method(axes), G%isc, G%jsc, G%isd, G%jsd, &
               G%HId2%isc, G%HId2%iec, G%HId2%jsc, G%HId2%jec, G%HId2%isd, G%HId2%ied, G%HId2%jsd, G%HId2%jed)
-      diag_cs%dsamp(dl)%remap_axesTi(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesTi(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Interface u-points in diagnostic coordinate
       axes => diag_cs%remap_axesCui(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCui(c)%dsamp(dl)%mask3d,  &
-              dl, G%IscB, G%jsc, G%IsdB, G%jsd, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesCui(c)%dsamp(dL)%mask3d,  &
+              dL, xyz_method(axes), G%IscB, G%jsc, G%IsdB, G%jsd, &
               G%HId2%IscB, G%HId2%IecB, G%HId2%jsc, G%HId2%jec, G%HId2%IsdB, G%HId2%IedB, G%HId2%jsd, G%HId2%jed)
-      diag_cs%dsamp(dl)%remap_axesCui(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesCui(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Interface v-points in diagnostic coordinate
       axes => diag_cs%remap_axesCvi(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCvi(c)%dsamp(dl)%mask3d,  &
-              dl, G%isc, G%JscB, G%isd, G%JsdB, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesCvi(c)%dsamp(dL)%mask3d,  &
+              dL, xyz_method(axes), G%isc, G%JscB, G%isd, G%JsdB, &
               G%HId2%isc, G%HId2%iec, G%HId2%JscB, G%HId2%JecB, G%HId2%isd, G%HId2%ied, G%HId2%JsdB, G%HId2%JedB)
-      diag_cs%dsamp(dl)%remap_axesCvi(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesCvi(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
       ! Interface q-points in diagnostic coordinate
       axes => diag_cs%remap_axesBi(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesBi(c)%dsamp(dl)%mask3d,  &
-              dl, G%IscB, G%JscB, G%IsdB, G%JsdB, &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dL)%remap_axesBi(c)%dsamp(dL)%mask3d,  &
+              dL, xyz_method(axes), G%IscB, G%JscB, G%IsdB, G%JsdB, &
               G%HId2%IscB, G%HId2%IecB, G%HId2%JscB, G%HId2%JecB, G%HId2%IsdB, G%HId2%IedB, G%HId2%JsdB, G%HId2%JedB)
-      diag_cs%dsamp(dl)%remap_axesBi(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
+      diag_cs%dsamp(dL)%remap_axesBi(c)%mask3d => axes%mask3d ! Set a pointer to the non-downsampled mask
     enddo
   enddo
 end subroutine set_masks_for_axes_dsamp
@@ -4221,7 +4221,7 @@ subroutine downsample_diag_masks_set(G, nz, diag_cs)
   type(diag_ctrl),               pointer    :: diag_cs !< A pointer to a type with many variables
                                                        !! used for diagnostics
   ! Local variables
-  integer :: k, dl
+  integer :: k, dL
 
 !print*,'original c extents ',G%isc,G%iec,G%jsc,G%jec
 !print*,'original c extents ',G%iscb,G%iecb,G%jscb,G%jecb
@@ -4237,16 +4237,17 @@ subroutine downsample_diag_masks_set(G, nz, diag_cs)
 ! original dB-sym extents       0          56           0          56
 ! coarse   d extents            1          28           1          28
 
-  do dl=2,MAX_DSAMP_LEV
-    ! 2d mask
-    call downsample_mask(G%mask2dT, diag_cs%dsamp(dl)%mask2dT,  dl, G%isc, G%jsc, G%isd, G%jsd, &
+  do dL=2,MAX_DSAMP_LEV
+    ! 2d masks
+    call downsample_mask(G%mask2dT, diag_cs%dsamp(dL)%mask2dT, dL, MMP, G%isc, G%jsc, G%isd, G%jsd, &
             G%HId2%isc, G%HId2%iec, G%HId2%jsc, G%HId2%jec, G%HId2%isd, G%HId2%ied, G%HId2%jsd, G%HId2%jed)
-    call downsample_mask(G%mask2dBu, diag_cs%dsamp(dl)%mask2dBu, dl,G%IscB, G%JscB, G%IsdB, G%JsdB, &
-            G%HId2%IscB,G%HId2%IecB, G%HId2%JscB,G%HId2%JecB,G%HId2%IsdB,G%HId2%IedB,G%HId2%JsdB,G%HId2%JedB)
-    call downsample_mask(G%mask2dCu, diag_cs%dsamp(dl)%mask2dCu, dl, G%IscB, G%jsc, G%IsdB, G%jsd, &
-            G%HId2%IscB,G%HId2%IecB, G%HId2%jsc, G%HId2%jec,G%HId2%IsdB,G%HId2%IedB,G%HId2%jsd, G%HId2%jed)
-    call downsample_mask(G%mask2dCv, diag_cs%dsamp(dl)%mask2dCv, dl,G %isc ,G%JscB, G%isd, G%JsdB, &
-            G%HId2%isc ,G%HId2%iec, G%HId2%JscB,G%HId2%JecB,G%HId2%isd ,G%HId2%ied, G%HId2%JsdB,G%HId2%JedB)
+    call downsample_mask(G%mask2dBu, diag_cs%dsamp(dL)%mask2dBu, dL, PPP, G%IscB, G%JscB, G%IsdB, G%JsdB, &
+            G%HId2%IscB, G%HId2%IecB, G%HId2%JscB, G%HId2%JecB, G%HId2%IsdB, G%HId2%IedB, G%HId2%JsdB, G%HId2%JedB)
+    call downsample_mask(G%mask2dCu, diag_cs%dsamp(dL)%mask2dCu, dL, PMP, G%IscB, G%jsc, G%IsdB, G%jsd, &
+            G%HId2%IscB, G%HId2%IecB, G%HId2%jsc, G%HId2%jec, G%HId2%IsdB, G%HId2%IedB, G%HId2%jsd, G%HId2%jed)
+    call downsample_mask(G%mask2dCv, diag_cs%dsamp(dL)%mask2dCv, dL, MPP, G%isc, G%JscB, G%isd, G%JsdB, &
+            G%HId2%isc, G%HId2%iec, G%HId2%JscB, G%HId2%JecB, G%HId2%isd, G%HId2%ied, G%HId2%JsdB, G%HId2%JedB)
+
     ! 3d native masks are needed by diag_manager but the native variables
     ! can only be masked 2d - for ocean points, all layers exists.
     allocate(diag_cs%dsamp(dl)%mask3dTL(G%HId2%isd:G%HId2%ied,G%HId2%jsd:G%HId2%jed,1:nz))
@@ -4820,16 +4821,18 @@ function square_sum(field, sz, naive_sum) result(sum)
 end function square_sum
 
 
-!> Allocate and compute the 2d down sampled mask
+!> Allocate and compute the 2d down sampled mask.
 !! The masks are down sampled based on a minority rule, i.e., a coarse cell is open (1)
-!! if at least one of the sub-cells are open, otherwise it's closed (0)
-subroutine downsample_mask_2d(field_in, field_out, dl, isc_o, jsc_o, isd_o, jsd_o, &
+!! if at least one of the sub-cells are open, otherwise it's closed (0), using the same points
+!! that would appear in the downsampled sum, average or down-selection.
+subroutine downsample_mask_2d(mask_in, mask_dsamp, dL, method, isc_o, jsc_o, isd_o, jsd_o, &
                               isc_d, iec_d, jsc_d, jec_d, isd_d, ied_d, jsd_d, jed_d)
   integer, intent(in) :: isd_o !< Original data domain i-start index
   integer, intent(in) :: jsd_o !< Original data domain j-start index
-  real, dimension(isd_o:,jsd_o:), intent(in) :: field_in !< Original field to be down sampled in arbitrary units [A]
-  real, dimension(:,:), pointer :: field_out   !< Down sampled field mask [nondim]
-  integer, intent(in) :: dl    !< Level of down sampling
+  real, dimension(isd_o:,jsd_o:), intent(in) :: mask_in !< Original mask to be down sampled [nondim]
+  real, dimension(:,:), pointer :: mask_dsamp   !< Down-sampled mask [nondim]
+  integer, intent(in) :: method !< Sampling method
+  integer, intent(in) :: dL    !< Level of down sampling
   integer, intent(in) :: isc_o !< Original i-start index
   integer, intent(in) :: jsc_o !< Original j-start index
   integer, intent(in) :: isc_d !< Computational i-start index of down sampled data
@@ -4840,34 +4843,80 @@ subroutine downsample_mask_2d(field_in, field_out, dl, isc_o, jsc_o, isd_o, jsd_
   integer, intent(in) :: ied_d !< Data domain i-end index of down sampled data
   integer, intent(in) :: jsd_d !< Data domain j-start index of down sampled data
   integer, intent(in) :: jed_d !< Data domain j-end index of down sampled data
+
   ! Local variables
-  integer :: i, j, ii, jj, i0, j0
-  real    :: tot_non_zero  ! The sum of values in the down-scaled cell [A]
+  real    :: tot_non_zero    ! The sum of mask values in the down-scaled cell or face [nondim]
+  character(len=8) :: method_str
+  integer :: i, j, i_dn, j_dn
+  integer :: ii, jj  ! The index locations on the full grid that contribute to the averages.
+  integer :: i0_off, j0_off  ! The starting point offsets between full array and reduced array
+                             ! indices when i or j is 0.
 
   ! down sampled mask = 0 unless the mask value of one of the down sampling cells is 1
-  allocate(field_out(isd_d:ied_d,jsd_d:jed_d))
-  field_out(:,:) = 0.0
-  do j=jsc_d,jec_d ; do i=isc_d,iec_d
-    i0 = isc_o+dl*(i-isc_d)
-    j0 = jsc_o+dl*(j-jsc_d)
-    tot_non_zero = 0.0
-    do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-      tot_non_zero = tot_non_zero + field_in(ii,jj)
+  allocate(mask_dsamp(isd_d:ied_d, jsd_d:jed_d), source=0.0)
+
+  i0_off = ((isc_o-1) - dL*isc_d)
+  j0_off = ((jsc_o-1) - dL*jsc_d)
+  if ((method == MMM) .or. (method == MMP) .or. (method == MMS) .or. (method == SSS)) then
+    ! This applies at tracer points.
+    do j=jsc_d,jec_d ; do i=isc_d,iec_d
+      tot_non_zero = 0.0
+      do j_dn=1,dL ; do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        jj = j_dn + (dL*j + j0_off)
+        tot_non_zero = tot_non_zero + abs(mask_in(ii,jj))
+      enddo ; enddo
+      if (tot_non_zero > 0.0) mask_dsamp(i,j) = 1.0
     enddo ; enddo
-    if (tot_non_zero > 0.0) field_out(i,j)=1.0
-  enddo ; enddo
+  elseif ((method == PMM) .or. (method == PSP) .or. (method == PMP) .or. (method == PSS)) then
+    ! This applies at u-velocity points.
+    do j=jsc_d,jec_d ; do I=isc_d,iec_d
+      tot_non_zero = 0.0
+      II = (dL*I + I0_off) + (dL-1)
+      do j_dn=1,dL
+        jj = j_dn + (dL*j + j0_off)
+        tot_non_zero = tot_non_zero + abs(mask_in(II,jj))
+      enddo
+      if (tot_non_zero > 0.0) mask_dsamp(I,j) = 1.0
+    enddo ; enddo
+  elseif ((method == MPM) .or. (method == SPP) .or. (method == MPP) .or. (method == SPS)) then
+    ! This applies at v-velocity points.
+    do J=jsc_d,jec_d ; do i=isc_d,iec_d
+      tot_non_zero = 0.0
+      JJ = (dL*J + J0_off) + (dL-1)
+      do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        tot_non_zero = tot_non_zero + abs(mask_in(ii,JJ))
+      enddo
+      if (tot_non_zero > 0.0) mask_dsamp(i,J) = 1.0
+    enddo ; enddo
+  elseif ((method == PPP) .or. (method == PPM)) then
+    ! This applies at corner (vorticity) points.
+    do j=jsc_d,jec_d ; do I=isc_d,iec_d
+      II = (dL*I + I0_off) + (dL-1)
+      JJ = (dL*J + J0_off) + (dL-1)
+      if (abs(mask_in(II,JJ)) > 0.0) mask_dsamp(I,J) = 1.0
+    enddo ; enddo
+  else
+    write(method_str, '(I0)') method
+    call MOM_error(FATAL, "downsample_mask_2d: unknown sampling method "//trim(method_str))
+  endif
+
 end subroutine downsample_mask_2d
 
-!> Allocate and compute the 3d down sampled mask
+
+!> Allocate and compute the 3d down sampled mask.
 !! The masks are down sampled based on a minority rule, i.e., a coarse cell is open (1)
-!! if at least one of the sub-cells are open, otherwise it's closed (0)
-subroutine downsample_mask_3d(field_in, field_out, dl, isc_o, jsc_o, isd_o, jsd_o, &
+!! if at least one of the sub-cells are open, otherwise it's closed (0), using the same points
+!! that would appear in the downsampled sum, average or down-selection.
+subroutine downsample_mask_3d(mask_in, mask_dsamp, dL, method, isc_o, jsc_o, isd_o, jsd_o, &
                               isc_d, iec_d, jsc_d, jec_d, isd_d, ied_d, jsd_d, jed_d)
   integer, intent(in) :: isd_o !< Original data domain i-start index
   integer, intent(in) :: jsd_o !< Original data domain j-start index
-  real, dimension(isd_o:,jsd_o:,:), intent(in) :: field_in !< Original field to be down sampled in arbitrary units [A]
-  real, dimension(:,:,:), pointer :: field_out   !< down sampled field mask [nondim]
-  integer, intent(in) :: dl    !< Level of down sampling
+  real, dimension(isd_o:,jsd_o:,:), intent(in) :: mask_in !< Original mask to be down sampled [nondim]
+  real, dimension(:,:,:), pointer :: mask_dsamp   !< Down-sampled mask [nondim]
+  integer, intent(in) :: dL    !< Level of down sampling
+  integer, intent(in) :: method !< Sampling method
   integer, intent(in) :: isc_o !< Original i-start index
   integer, intent(in) :: jsc_o !< Original j-start index
   integer, intent(in) :: isc_d !< Computational i-start index of down sampled data
@@ -4880,23 +4929,66 @@ subroutine downsample_mask_3d(field_in, field_out, dl, isc_o, jsc_o, isd_o, jsd_
   integer, intent(in) :: jed_d !< Computational j-end index of down sampled data
 
   ! Local variables
-  integer :: i, j, ii, jj, i0, j0, k, ks, ke
-  real    :: tot_non_zero  ! The sum of values in the down-scaled cell [A]
+  real    :: tot_non_zero    ! The sum of mask values in the down-scaled cell or face [nondim]
+  character(len=8) :: method_str
+  integer :: i, j, i_dn, j_dn, k, ks, ke
+  integer :: ii, jj  ! The index locations on the full grid that contribute to the averages.
+  integer :: i0_off, j0_off  ! The starting point offsets between full array and reduced array
+                             ! indices when i or j is 0.
 
   ! down sampled mask = 0 unless the mask value of one of the down sampling cells is 1
-  ks = lbound(field_in,3) ; ke = ubound(field_in,3)
-  allocate(field_out(isd_d:ied_d,jsd_d:jed_d,ks:ke))
-  field_out(:,:,:) = 0.0
-  do k=ks,ke ; do j=jsc_d,jec_d ; do i=isc_d,iec_d
-    i0 = isc_o+dl*(i-isc_d)
-    j0 = jsc_o+dl*(j-jsc_d)
-    tot_non_zero = 0.0
-    do jj=j0,j0+dl-1 ; do ii=i0,i0+dl-1
-      tot_non_zero = tot_non_zero + field_in(ii,jj,k)
-    enddo ; enddo
-    if (tot_non_zero > 0.0) field_out(i,j,k)=1.0
-  enddo ; enddo ; enddo
+  ks = lbound(mask_in, 3) ; ke = ubound(mask_in, 3)
+  allocate(mask_dsamp(isd_d:ied_d, jsd_d:jed_d, ks:ke), source=0.0)
+
+  i0_off = ((isc_o-1) - dL*isc_d)
+  j0_off = ((jsc_o-1) - dL*jsc_d)
+  if ((method == MMM) .or. (method == MMP) .or. (method == MMS) .or. (method == SSS)) then
+    ! This applies at tracer points.
+    do k=ks,ke ; do j=jsc_d,jec_d ; do i=isc_d,iec_d
+      tot_non_zero = 0.0
+      do j_dn=1,dL ; do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        jj = j_dn + (dL*j + j0_off)
+        tot_non_zero = tot_non_zero + abs(mask_in(ii,jj,k))
+      enddo ; enddo
+      if (tot_non_zero > 0.0) mask_dsamp(i,j,k) = 1.0
+    enddo ; enddo ; enddo
+  elseif ((method == PMM) .or. (method == PSP) .or. (method == PMP) .or. (method == PSS)) then
+    ! This applies at u-velocity points.
+    do k=ks,ke ; do j=jsc_d,jec_d ; do I=isc_d,iec_d
+      tot_non_zero = 0.0
+      II = (dL*I + I0_off) + (dL-1)
+      do j_dn=1,dL
+        jj = j_dn + (dL*j + j0_off)
+        tot_non_zero = tot_non_zero + abs(mask_in(II,jj,k))
+      enddo
+      if (tot_non_zero > 0.0) mask_dsamp(I,j,k) = 1.0
+    enddo ; enddo ; enddo
+  elseif ((method == MPM) .or. (method == SPP) .or. (method == MPP) .or. (method == SPS)) then
+    ! This applies at v-velocity points.
+    do k=ks,ke ; do J=jsc_d,jec_d ; do i=isc_d,iec_d
+      tot_non_zero = 0.0
+      JJ = (dL*J + J0_off) + (dL-1)
+      do i_dn=1,dL
+        ii = i_dn + (dL*i + i0_off)
+        tot_non_zero = tot_non_zero + abs(mask_in(ii,JJ,k))
+      enddo
+      if (tot_non_zero > 0.0) mask_dsamp(i,J,k) = 1.0
+    enddo ; enddo ; enddo
+  elseif ((method == PPP) .or. (method == PPM)) then
+    ! This applies at corner (vorticity) points.
+    do k=ks,ke ; do j=jsc_d,jec_d ; do I=isc_d,iec_d
+      II = (dL*I + I0_off) + (dL-1)
+      JJ = (dL*J + J0_off) + (dL-1)
+      if (abs(mask_in(II,JJ,k)) > 0.0) mask_dsamp(I,J,k) = 1.0
+    enddo ; enddo ; enddo
+  else
+    write(method_str, '(I0)') method
+    call MOM_error(FATAL, "downsample_mask_3d: unknown sampling method "//trim(method_str))
+  endif
+
 end subroutine downsample_mask_3d
+
 
 !> Fakes a register of a diagnostic to find out if an obsolete
 !! parameter appears in the diag_table.

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -182,7 +182,6 @@ integer :: MMP=331  !< x:mean,y:mean,z:point
 integer :: MMS=332  !< x:mean,y:mean,z:sum
 integer :: SSS=222  !< x:sum,y:sum,z:sum
 integer :: MMM=333  !< x:mean,y:mean,z:mean
-integer :: MSK=-1   !< Use the downsample method of a mask
 
 !> This type is used to represent a diagnostic at the diag_mediator level.
 !!
@@ -1446,6 +1445,8 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
   integer :: isv, iev, jsv, jev, i, j, isv_o, jsv_o
   real, dimension(:,:), allocatable, target :: locfield_dsamp ! A downsampled version of locfield [a]
   real, dimension(:,:), allocatable, target :: locmask_dsamp  ! A downsampled version of locmask [nondim]
+  real, dimension(:,:), pointer :: ones => NULL() ! An array of ones for testing where masks do not apply [nondim]
+  real, dimension(:,:), pointer :: mask_in => NULL() ! A pointer to the input mask [nondim]
   integer :: dl
   integer :: time_days
   integer :: time_seconds
@@ -1521,8 +1522,13 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
     if ((diag%conversion_factor /= 0.) .and. (diag%conversion_factor /= 1.)) deallocate( locfield )
     locfield => locfield_dsamp
     if (present(mask)) then
-      call downsample_field_2d(locmask, locmask_dsamp, dl, MSK, locmask, diag_cs, diag, &
+      ! Replicate the downsampling of other fields to find unmasked points.
+      allocate(ones, mold=locmask) ; ones(:,:) = 1.0
+      mask_in => mask
+      call downsample_field_2d(ones, locmask_dsamp, dL, diag%xyz_method, mask_in, diag_cs, diag, &
                                isv_o, jsv_o, isv, iev, jsv, jev)
+      deallocate(ones)
+      where (abs(locmask_dsamp) > 0.0) locmask_dsamp = 1.0
       locmask => locmask_dsamp
     elseif (associated(diag%axes%dsamp(dl)%mask2d)) then
       locmask => diag%axes%dsamp(dl)%mask2d
@@ -1762,7 +1768,9 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
   integer :: isv, iev, jsv, jev, ks, ke, i, j, k, isv_c, jsv_c, isv_o, jsv_o
   real, dimension(:,:,:), allocatable, target :: locfield_dsamp ! A downsampled version of locfield [a]
   real, dimension(:,:,:), allocatable, target :: locmask_dsamp  ! A downsampled version of locmask [nondim]
-  integer :: dl
+  real, dimension(:,:,:), pointer :: ones => NULL() ! An array of ones for testing where masks do not apply [nondim]
+  real, dimension(:,:,:), pointer :: mask_in => NULL() ! A pointer to the input mask [nondim]
+  integer :: dL
 
   integer :: time_days
   integer :: time_seconds
@@ -1855,8 +1863,13 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
     if ((diag%conversion_factor /= 0.) .and. (diag%conversion_factor /= 1.)) deallocate( locfield )
     locfield => locfield_dsamp
     if (present(mask)) then
-      call downsample_field_3d(locmask, locmask_dsamp, dl, MSK, locmask, diag_cs, diag, &
+      ! Replicate the downsampling of other fields to find unmasked points.
+      allocate(ones, mold=locmask) ; ones(:,:,:) = 1.0
+      mask_in => mask
+      call downsample_field_3d(ones, locmask_dsamp, dL, diag%xyz_method, mask_in, diag_cs, diag, &
                                isv_o, jsv_o, isv, iev, jsv, jev)
+      deallocate(ones)
+      where (abs(locmask_dsamp) > 0.0) locmask_dsamp = 1.0
       locmask => locmask_dsamp
     elseif (associated(diag%axes%dsamp(dl)%mask3d)) then
       locmask => diag%axes%dsamp(dl)%mask3d
@@ -4603,16 +4616,6 @@ subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, d
       field_out(i,J,k)  = sum_1d(wtd_field_1d(1:dL), dL) / &
                          (sum_1d(wt_1d(1:dL), dL) + eps_face)  ! Eps_face avoids division by 0.
     enddo ; enddo ; enddo
-  elseif (method == MSK) then ! The input field is a mask, so subsample it instead of averaging.
-    field_out(:,:,:) = 0.0
-    do k=ks,ke ; do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      ave = 0.0
-      do j_dn=1,dL ; do i_dn=1,dL
-        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
-        ave = ave + field_in(ii,jj,k)
-      enddo ; enddo
-      if (ave > 0.0) field_out(i,j,k) = 1.0
-    enddo ; enddo ; enddo
   else
     write (mesg,*) " unknown sampling method: ",method
     call MOM_error(FATAL, "downsample_field_3d: "//trim(mesg)//" "//trim(diag%debug_str))
@@ -4744,16 +4747,6 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
       enddo
       field_out(i,J) = sum_1d(wtd_field_1d(1:dL), dL) / &
                       (sum_1d(wt_1d(1:dL), dL) + Eps_len)  ! Eps_len avoids division by 0.
-    enddo ; enddo
-  elseif (method == MSK) then ! The input field is a mask, so subsample it instead of averaging.
-    field_out(:,:) = 0.0
-    do j=jsv_d,jev_d ; do i=isv_d,iev_d
-      ave = 0.0
-      do j_dn=1,dL ; do i_dn=1,dL
-        jj = j_dn + (dL*j + j0_off) ; ii = i_dn + (dL*i + i0_off)
-        ave = ave + field_in(ii,jj)
-      enddo ; enddo
-      if (ave > 0.0) field_out(i,j) = 1.0
     enddo ; enddo
   else
     write (mesg,*) " unknown sampling method: ",method

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -2606,7 +2606,7 @@ logical function register_diag_field_expand_cmor(dm_id, module_name, field_name,
     call add_diag_to_list(diag_cs, dm_id, fms_id, this_diag, axes, module_name, field_name)
     this_diag%fms_xyave_diag_id = fms_xyave_id
     ! Encode and save the cell methods for this diagnostic
-    call add_xyz_method(this_diag, axes, x_cell_method, y_cell_method, v_cell_method, v_extensive)
+    this_diag%xyz_method = xyz_method(axes, x_cell_method, y_cell_method, v_cell_method, v_extensive)
     if (present(v_extensive)) this_diag%v_extensive = v_extensive
     if (present(conversion)) this_diag%conversion_factor = conversion
     register_diag_field_expand_cmor = .true.
@@ -2655,7 +2655,7 @@ logical function register_diag_field_expand_cmor(dm_id, module_name, field_name,
       call add_diag_to_list(diag_cs, dm_id, fms_id, this_diag, axes, module_name, field_name)
       this_diag%fms_xyave_diag_id = fms_xyave_id
       ! Encode and save the cell methods for this diagnostic
-      call add_xyz_method(this_diag, axes, x_cell_method, y_cell_method, v_cell_method, v_extensive)
+      this_diag%xyz_method = xyz_method(axes, x_cell_method, y_cell_method, v_cell_method, v_extensive)
       if (present(v_extensive)) this_diag%v_extensive = v_extensive
       if (present(conversion)) this_diag%conversion_factor = conversion
       register_diag_field_expand_cmor = .true.
@@ -2795,10 +2795,9 @@ subroutine add_diag_to_list(diag_cs, dm_id, fms_id, this_diag, axes, module_name
 
 end subroutine add_diag_to_list
 
-!> Adds the encoded "cell_methods" for a diagnostics as a diag% property
-!! This allows access to the cell_method for a given diagnostics at the time of sending
-subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_method, v_extensive)
-  type(diag_type),          pointer       :: diag !< This diagnostic
+!> Returns an integer encoding the "cell_methods" for diagnostic, allowing simpler
+!! access to the cell_method for a given diagnostic at the time of sending
+integer function xyz_method(axes, x_cell_method, y_cell_method, v_cell_method, v_extensive)
   type(axes_grp),             intent(in)  :: axes !< Container w/ up to 3 integer handles that indicates
                                                   !! axes for this field
   character(len=*), optional, intent(in)  :: x_cell_method !< Specifies the cell method for the x-direction.
@@ -2809,7 +2808,7 @@ subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_metho
                                                          !! Use '' have no method.
   logical,          optional, intent(in)  :: v_extensive !< True for vertically extensive fields
                                                          !! (vertically integrated). Default/absent for intensive.
-  integer :: xyz_method
+
   character(len=9) :: mstr
 
   ! This is a simple way to encode the cell method information made from 3 strings
@@ -2821,9 +2820,9 @@ subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_metho
 
   xyz_method = 111
 
-  mstr = diag%axes%v_cell_method
+  mstr = axes%v_cell_method
   if (present(v_extensive)) then
-    if (present(v_cell_method)) call MOM_error(FATAL, "add_xyz_method: " // &
+    if (present(v_cell_method)) call MOM_error(FATAL, "xyz_method: " // &
        'Vertical cell method was specified along with the vertically extensive flag.')
     if (v_extensive) then
       mstr='sum'
@@ -2839,7 +2838,7 @@ subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_metho
     xyz_method = xyz_method + 2
   endif
 
-  mstr = diag%axes%y_cell_method
+  mstr = axes%y_cell_method
   if (present(y_cell_method)) mstr = y_cell_method
   if (trim(mstr)=='sum') then
     xyz_method = xyz_method + 10
@@ -2847,7 +2846,7 @@ subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_metho
     xyz_method = xyz_method + 20
   endif
 
-  mstr = diag%axes%x_cell_method
+  mstr = axes%x_cell_method
   if (present(x_cell_method)) mstr = x_cell_method
   if (trim(mstr)=='sum') then
     xyz_method = xyz_method + 100
@@ -2855,8 +2854,7 @@ subroutine add_xyz_method(diag, axes, x_cell_method, y_cell_method, v_cell_metho
     xyz_method = xyz_method + 200
   endif
 
-  diag%xyz_method = xyz_method
-end subroutine add_xyz_method
+end function xyz_method
 
 !> Attaches "cell_methods" attribute to a variable based on defaults for axes_grp or optional arguments.
 subroutine attach_cell_methods(id, axes, ostring, cell_methods, &


### PR DESCRIPTION
  This PR includes a series of 3 commits that correct the downsampling of masks for diagnostics so that they are consistent with the data that are being used. The masks are now consistent with the downsampling methods used at the various grid locations, and they are now satisfying rotational symmetry, whereas before the velocity and corner point masks were changing under grid rotation.

  The first commit converts the internal subroutine `add_xyz_method()` in `MOM_diag_mediator` into the function `xyz_method()` for greater generality and code-reuse.  It no longer takes a `diag_type` argument, instead working directly with the contents of its `axes_grp` type argument.

  The second commit extensively revises `downsample_mask_2d()` and `downsample_mask_3d()` and bases the stencil for the masking based on a downsampling `method` argument analogous to the argument that was already being provided to the `downsample_field()` routines.  This commit changes the non-tracer point downsampled masks so they are now self-consistent with the calculation of the downsampled diagnostics and pass rotational symmetry.

  The third commit changes how masks that are provided via optional arguments to `post_data()` are downsampled, by using a duplicate of the call to downsample the field being masked with an array of all ones, and then setting the downsampled mask to 1 where ever the downsampled array of ones is nonzero (i.e., not masked out).  The previous `MSK` option (which has now been eliminated) is only equivalent at tracer points, but because MOM6 had only been using the mask argument with tracer point variables, this third commit probably does not change anything in practice.

  No solutions or primary diagnostics are altered by these changes, and because they only applied to downsampled diagnostics and the previous results were unambiguously wrong and self-inconstent, there is no option to recover the
previously incorrect downsampled masks.