### PR TITLE
Refactor OBC tracer reservoir storage and eliminate OBC_inflow_conc

### DIFF
--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -165,7 +165,12 @@ type, public :: OBC_segment_tracer_type
                                                       !! data, like [S ppt-1 ~> 1] for salinity.
   logical                    :: is_initialized        !< reservoir values have been set when True
   integer                    :: ntr_index = -1        !< index of segment tracer in the global tracer registry
-  integer                    :: fd_index = -1         !< index of segment tracer in the input fields
+  real              :: resrv_lfac_in = 1.   !< The reservoir inverse length scale factor for the inward
+                                            !! direction per field [nondim].  The general 1/Lscale_in is
+                                            !! multiplied by this factor for a specific tracer or thickness.
+  real              :: resrv_lfac_out= 1.   !< The reservoir inverse length scale factor for the outward
+                                            !! direction per field [nondim].  The general 1/Lscale_out is
+                                            !! multiplied by this factor for a specific tracer or thickness.
 end type OBC_segment_tracer_type
 
 !> Thickness on OBC segment data structure, with a reservoir
@@ -5088,7 +5093,6 @@ subroutine segment_thickness_reservoir_init(GV, US, OBC, param_file)
   real :: rescale ! A multiplicatively corrected scaling factor, in units like [S ppt-1 ~> 1] for
                   ! salinity, or other various units depending on what rescaling has occurred previously.
   integer :: nseg, m, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  integer :: fd_id
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
   integer, save :: init_calls = 0
 
@@ -5111,10 +5115,6 @@ subroutine segment_thickness_reservoir_init(GV, US, OBC, param_file)
     IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
     JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
 
-    fd_id = -1
-    do m=1,segment%num_fields
-      if (lowercase(segment%field(m)%name) == lowercase(segment%h_Reg%name)) fd_id = m
-    enddo
     segment%h_Reg%scale = US%Z_to_m
     do m=1,segment%num_fields
       if (uppercase(segment%field(m)%name) == uppercase(segment%h_Reg%name)) then
@@ -5147,7 +5147,7 @@ end subroutine segment_thickness_reservoir_init
 !> Register a tracer array that is active on an OBC segment, potentially also specifying how the
 !! tracer inflow values are specified.
 subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
-                                   OBC_scalar, OBC_array, scale, fd_index)
+                                   OBC_scalar, OBC_array, scale, resrv_lfac_in, resrv_lfac_out)
   type(verticalGrid_type), intent(in)   :: GV         !< ocean vertical grid structure
   type(tracer_type), target             :: tr_ptr     !< A target that can be used to set a pointer to the
                                                       !! stored value of tr. This target must be
@@ -5169,7 +5169,8 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
                                                       !! data that is read in to convert it to the internal
                                                       !! units of this tracer, in units like [S ppt-1 ~> 1]
                                                       !! for salinity.
-  integer,      optional, intent(in)    :: fd_index   !< index of segment tracer in the input field
+  real,         optional, intent(in)    :: resrv_lfac_in   !< The reservoir inverse length scale factor
+  real,         optional, intent(in)    :: resrv_lfac_out  !< The reservoir inverse length scale factor
 
 ! Local variables
   real :: rescale ! A multiplicatively corrected scaling factor, in units like [S ppt-1 ~> 1] for
@@ -5195,7 +5196,6 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
   segment%tr_Reg%Tr(ntseg)%Tr => tr_ptr
   segment%tr_Reg%Tr(ntseg)%name = tr_ptr%name
   segment%tr_Reg%Tr(ntseg)%ntr_index = ntr_index
-  if (present(fd_index)) segment%tr_Reg%Tr(ntseg)%fd_index = fd_index
 
   segment%tr_Reg%Tr(ntseg)%scale = 1.0
   if (present(scale)) then
@@ -5219,6 +5219,9 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
   if (segment%tr_Reg%locked) call MOM_error(FATAL, &
       "MOM register_segment_tracer was called for variable "//trim(segment%tr_Reg%Tr(ntseg)%name)//&
       " with a locked tracer registry.")
+
+  if (present(resrv_lfac_in)) segment%tr_Reg%Tr(ntseg)%resrv_lfac_in = resrv_lfac_in
+  if (present(resrv_lfac_out)) segment%tr_Reg%Tr(ntseg)%resrv_lfac_out = resrv_lfac_out
 
   if (present(OBC_scalar)) segment%tr_Reg%Tr(ntseg)%OBC_inflow_conc = OBC_scalar ! initialize tracer value later
   if (present(OBC_array)) then
@@ -5340,16 +5343,21 @@ end subroutine get_obgc_segments_props
 
 !> Registers a named tracer in the segment tracer registries for the OBC segments on which it is active.
 subroutine register_obgc_segments(GV, OBC, tr_Reg, param_file, tr_name)
-  type(verticalGrid_type),    intent(in)    :: GV         !< ocean vertical grid structure
-  type(ocean_OBC_type),       pointer       :: OBC        !< Open boundary structure
-  type(tracer_registry_type), pointer       :: tr_Reg     !< Tracer registry
-  type(param_file_type),      intent(in)    :: param_file !< file to parse for  model parameter values
-  character(len=*),           intent(in)    :: tr_name    !< Tracer name
-! Local variables
-  integer :: ntr_id, fd_id
+  type(verticalGrid_type),    intent(in) :: GV         !< ocean vertical grid structure
+  type(ocean_OBC_type),       pointer    :: OBC        !< Open boundary structure
+  type(tracer_registry_type), pointer    :: tr_Reg     !< Tracer registry
+  type(param_file_type),      intent(in) :: param_file !< file to parse for model parameter values
+  character(len=*),           intent(in) :: tr_name    !< Tracer name
+
+  ! Local variables
+  integer :: ntr_id
   integer :: n, m
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
-  type(tracer_type), pointer      :: tr_ptr => NULL()
+  type(tracer_type),      pointer :: tr_ptr => NULL()
+  real                            :: resrv_lfac_in  ! Per-tracer multiplier for the inward reservoir
+                                                    ! relaxation length scale [nondim].
+  real                            :: resrv_lfac_out ! Per-tracer multiplier for the outward reservoir
+                                                    ! relaxation length scale [nondim].
 
   if (.not. associated(OBC)) return
 
@@ -5357,14 +5365,17 @@ subroutine register_obgc_segments(GV, OBC, tr_Reg, param_file, tr_name)
     segment => OBC%segment(n)
     if (.not. segment%on_pe) cycle
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, tr_name)
-    ! get the obgc field index
-    fd_id = -1
+    resrv_lfac_in  = 1.0
+    resrv_lfac_out = 1.0
     do m=1,segment%num_fields
-      if (lowercase(segment%field(m)%name) == lowercase(tr_name)) fd_id = m
+      if (lowercase(segment%field(m)%name) == lowercase(tr_name)) then
+        resrv_lfac_in  = segment%field(m)%resrv_lfac_in
+        resrv_lfac_out = segment%field(m)%resrv_lfac_out
+      endif
     enddo
-    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, OBC_array=.True., fd_index=fd_id)
+    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, OBC_array=.True., &
+                                 resrv_lfac_in=resrv_lfac_in, resrv_lfac_out=resrv_lfac_out)
   enddo
-
 end subroutine register_obgc_segments
 
 !> Stores the interior tracer values on the segment, and in some cases also sets the tracer reservoir values.
@@ -5973,7 +5984,7 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
   real    :: fac1           ! The denominator of the expression for tracer updates [nondim]
   real    :: I_scale        ! The inverse of the scaling factor for the tracers.
                             ! For salinity the units would be [ppt S-1 ~> 1]
-  integer :: i, j, k, m, n, nz, ntr_id, fd_id
+  integer :: i, j, k, m, n, nz, ntr_id
   integer :: is, ie, js, je, ii, ji
 
   if (.not. associated(OBC)) return
@@ -5998,14 +6009,8 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
       ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
       do m=1,segment%tr_Reg%ntseg ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
-        fd_id = segment%tr_Reg%Tr(m)%fd_index
-        if (fd_id == -1) then
-          resrv_lfac_out = 1.0
-          resrv_lfac_in  = 1.0
-        else
-          resrv_lfac_out = segment%field(fd_id)%resrv_lfac_out
-          resrv_lfac_in  = segment%field(fd_id)%resrv_lfac_in
-        endif
+        resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
+        resrv_lfac_in  = segment%tr_Reg%Tr(m)%resrv_lfac_in
         I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
         do k=1,nz ; do j=js,je
           ! Calculate weights. Both a and u_L are nondim. Adding them together has no meaning.
@@ -6037,14 +6042,8 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
       ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
       do m=1,segment%tr_Reg%ntseg ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
-        fd_id = segment%tr_Reg%Tr(m)%fd_index
-        if (fd_id == -1) then
-          resrv_lfac_out = 1.0
-          resrv_lfac_in  = 1.0
-        else
-          resrv_lfac_out = segment%field(fd_id)%resrv_lfac_out
-          resrv_lfac_in  = segment%field(fd_id)%resrv_lfac_in
-        endif
+        resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
+        resrv_lfac_in  = segment%tr_Reg%Tr(m)%resrv_lfac_in
         I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
         do k=1,nz ; do i=is,ie
           flux_to_res = dir * vhr(i,J,k)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3004,15 +3004,15 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
           Je_obc = min(segment%HI%JedB,G%jed-1)
           do k=1,nz ; do J=Js_obc,Je_obc
             rx_avg = rx_tang_rad(I,J,k)
-!           if (G%mask2dCu(I-1,j) > 0.0 .and. G%mask2dCu(I-1,j+1) > 0.0) then
-!             rx_avg = 0.5*(u_new(I-1,j,k) + u_new(I-1,j+1,k)) * dt * G%IdxBu(I-1,J)
-!           elseif (G%mask2dCu(I-1,j) > 0.0) then
-!             rx_avg = u_new(I-1,j,k) * dt * G%IdxBu(I-1,J)
-!           elseif (G%mask2dCu(I-1,j+1) > 0.0) then
-!             rx_avg = u_new(I-1,j+1,k) * dt * G%IdxBu(I-1,J)
-!           else
-!             rx_avg = 0.0
-!           endif
+            !           if (G%mask2dCu(I-1,j) > 0.0 .and. G%mask2dCu(I-1,j+1) > 0.0) then
+            !             rx_avg = 0.5*(u_new(I-1,j,k) + u_new(I-1,j+1,k)) * dt * G%IdxBu(I-1,J)
+            !           elseif (G%mask2dCu(I-1,j) > 0.0) then
+            !             rx_avg = u_new(I-1,j,k) * dt * G%IdxBu(I-1,J)
+            !           elseif (G%mask2dCu(I-1,j+1) > 0.0) then
+            !             rx_avg = u_new(I-1,j+1,k) * dt * G%IdxBu(I-1,J)
+            !           else
+            !             rx_avg = 0.0
+            !           endif
             segment%tangential_grad(I,J,k) = ((v_new(i,J,k) - v_new(i-1,J,k))*G%IdxBu(I-1,J) + &
                               rx_avg*(v_new(i-1,J,k) - v_new(i-2,J,k))*G%IdxBu(I-2,J)) / (1.0+rx_avg)
           enddo ; enddo
@@ -3249,15 +3249,15 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
           Je_obc = min(segment%HI%JedB,G%jed-1)
           do k=1,nz ;  do J=Js_obc,Je_obc
             rx_avg = rx_tang_rad(I,J,k)
-!           if (G%mask2dCu(I+1,j) > 0.0 .and. G%mask2dCu(I+1,j+1) > 0.0) then
-!             rx_avg = 0.5*(u_new(I+1,j,k) + u_new(I+1,j+1,k)) * dt * G%IdxBu(I+1,J)
-!           elseif (G%mask2dCu(I+1,j) > 0.0) then
-!             rx_avg = u_new(I+1,j,k) * dt * G%IdxBu(I+1,J)
-!           elseif (G%mask2dCu(I+1,j+1) > 0.0) then
-!             rx_avg = u_new(I+1,j+1,k) * dt * G%IdxBu(I+1,J)
-!           else
-!             rx_avg = 0.0
-!           endif
+            !           if (G%mask2dCu(I+1,j) > 0.0 .and. G%mask2dCu(I+1,j+1) > 0.0) then
+            !             rx_avg = 0.5*(u_new(I+1,j,k) + u_new(I+1,j+1,k)) * dt * G%IdxBu(I+1,J)
+            !           elseif (G%mask2dCu(I+1,j) > 0.0) then
+            !             rx_avg = u_new(I+1,j,k) * dt * G%IdxBu(I+1,J)
+            !           elseif (G%mask2dCu(I+1,j+1) > 0.0) then
+            !             rx_avg = u_new(I+1,j+1,k) * dt * G%IdxBu(I+1,J)
+            !           else
+            !             rx_avg = 0.0
+            !           endif
             segment%tangential_grad(I,J,k) = ((v_new(i+2,J,k) - v_new(i+1,J,k))*G%IdxBu(I+1,J) + &
                               rx_avg*(v_new(i+3,J,k) - v_new(i+2,J,k))*G%IdxBu(I+2,J)) / (1.0+rx_avg)
           enddo ; enddo
@@ -3493,15 +3493,15 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
           Ie_obc = min(segment%HI%IedB,G%ied-1)
           do k=1,nz ;  do I=Is_obc,Ie_obc
             ry_avg = ry_tang_rad(I,J,k)
-!           if (G%mask2dCv(i,J-1) > 0.0 .and. G%mask2dCv(i+1,J-1) > 0.0) then
-!             ry_avg = 0.5*(v_new(i,J-1,k) + v_new(i+1,J-1,k) * dt * G%IdyBu(I,J-1))
-!           elseif (G%mask2dCv(i,J-1) > 0.0) then
-!             ry_avg = v_new(i,J-1,k) * dt *G%IdyBu(I,J-1)
-!           elseif (G%mask2dCv(i+1,J-1) > 0.0) then
-!             ry_avg = v_new(i+1,J-1,k) * dt *G%IdyBu(I,J-1)
-!           else
-!             ry_avg = 0.0
-!           endif
+            !           if (G%mask2dCv(i,J-1) > 0.0 .and. G%mask2dCv(i+1,J-1) > 0.0) then
+            !             ry_avg = 0.5*(v_new(i,J-1,k) + v_new(i+1,J-1,k) * dt * G%IdyBu(I,J-1))
+            !           elseif (G%mask2dCv(i,J-1) > 0.0) then
+            !             ry_avg = v_new(i,J-1,k) * dt *G%IdyBu(I,J-1)
+            !           elseif (G%mask2dCv(i+1,J-1) > 0.0) then
+            !             ry_avg = v_new(i+1,J-1,k) * dt *G%IdyBu(I,J-1)
+            !           else
+            !             ry_avg = 0.0
+            !           endif
             segment%tangential_grad(I,J,k) = ((u_new(I,j,k) - u_new(I,j-1,k))*G%IdyBu(I,J-1) + &
                               ry_avg*(u_new(I,j-1,k) - u_new(I,j-2,k))*G%IdyBu(I,J-2)) / (1.0+ry_avg)
           enddo ; enddo
@@ -3738,15 +3738,15 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
           Ie_obc = min(segment%HI%IedB,G%ied-1)
           do k=1,nz ;  do I=Is_obc,Ie_obc
             ry_avg = ry_tang_rad(I,J,k)
-!           if (G%mask2dCv(i,J+1) > 0.0 .and. G%mask2dCv(i+1,J+1) > 0.0) then
-!             ry_avg = 0.5*(v_new(i,J+1,k) + v_new(i+1,J+1,k)) * dt * G%IdyBu(I,J+1)
-!           elseif (G%mask2dCv(i,J+1) > 0.0) then
-!             ry_avg = v_new(i,J+1,k) * dt * G%IdyBu(I,J+1)
-!           elseif (G%mask2dCv(i+1,J+1) > 0.0) then
-!             ry_avg = v_new(i+1,J+1,k) * dt * G%IdyBu(I,J+1)
-!           else
-!             ry_avg = 0.0
-!           endif
+            !           if (G%mask2dCv(i,J+1) > 0.0 .and. G%mask2dCv(i+1,J+1) > 0.0) then
+            !             ry_avg = 0.5*(v_new(i,J+1,k) + v_new(i+1,J+1,k)) * dt * G%IdyBu(I,J+1)
+            !           elseif (G%mask2dCv(i,J+1) > 0.0) then
+            !             ry_avg = v_new(i,J+1,k) * dt * G%IdyBu(I,J+1)
+            !           elseif (G%mask2dCv(i+1,J+1) > 0.0) then
+            !             ry_avg = v_new(i+1,J+1,k) * dt * G%IdyBu(I,J+1)
+            !           else
+            !             ry_avg = 0.0
+            !           endif
             segment%tangential_grad(I,J,k) = ((u_new(I,j+2,k) - u_new(I,j+1,k))*G%IdyBu(I,J+1) + &
                               ry_avg*(u_new(I,j+3,k) - u_new(I,j+2,k))*G%IdyBu(I,J+2)) / (1.0+ry_avg)
           enddo ; enddo
@@ -5942,7 +5942,7 @@ end subroutine open_boundary_register_restarts
 !> Update the OBC tracer reservoirs after the tracers have been updated.
 subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
   type(ocean_grid_type),                      intent(in) :: G   !< The ocean's grid structure
-  type(verticalGrid_type),                    intent(in) :: GV  !<  Ocean vertical grid structure
+  type(verticalGrid_type),                    intent(in) :: GV  !< Ocean vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: uhr !< accumulated volume/mass flux through
                                                                 !! the zonal face [H L2 ~> m3 or kg]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in) :: vhr !< accumulated volume/mass flux through
@@ -5952,122 +5952,121 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
   type(ocean_OBC_type),                       pointer    :: OBC !< Open boundary structure
   type(tracer_registry_type),                 pointer    :: Reg !< pointer to tracer registry
 
-  ! Local variable
+  ! Local variables
   type(OBC_segment_type), pointer :: segment => NULL()
-  real :: u_L_in, u_L_out ! The zonal distance moved in or out of a cell, normalized by the reservoir
-                          ! length scale [nondim]
-  real :: v_L_in, v_L_out ! The meridional distance moved in or out of a cell, normalized by the reservoir
-                          ! length scale [nondim]
-  real :: fac1            ! The denominator of the expression for tracer updates [nondim]
-  real :: I_scale         ! The inverse of the scaling factor for the tracers.
-                          ! For salinity the units would be [ppt S-1 ~> 1]
-  integer :: i, j, k, m, n, ntr, nz, ntr_id, fd_id
-  integer :: ishift, idir, jshift, jdir
-  real :: resrv_lfac_out  ! The reservoir inverse length scale scaling factor for the outward
-                          ! direction per field [nondim]
-  real :: resrv_lfac_in   ! The reservoir inverse length scale scaling factor for the inward
-                          ! direction per field [nondim]
-  real :: b_in, b_out     ! The 0 and 1 switch for tracer reservoirs
-                          ! 1 if the length scale of reservoir is zero [nondim]
-  real :: a_in, a_out     ! The 0 and 1(-1) switch for reservoir source weights
-                          ! e.g. a_in is -1 only if b_in ==1 and uhr or vhr is inward
-                          ! e.g. a_out is 1 only if b_out==1 and uhr or vhr is outward
-                          ! It's clear that a_in and a_out cannot be both non-zero [nondim]
-  nz = GV%ke
-  ntr = Reg%ntr
+  integer :: dir            ! A sign factor (1/-1) to that sets velocity direction.
+  real    :: face_area      ! Interior cell face area [H L ~> m2 or kg/m].
+  real    :: flux_to_res    ! Inflow to the reservoir, flux_to_res = dir * [uv]hr, positive if the
+                            ! flow is from the interior to the reservoir [H L2 ~> m3 or kg].
+  real    :: resrv_lfac_out ! The reservoir inverse length scale scaling factor for the outward
+                            ! direction per field [nondim]
+  real    :: resrv_lfac_in  ! The reservoir inverse length scale scaling factor for the inward
+                            ! direction per field [nondim]
+  real    :: L_in, L_out    ! The distance moved in or out of a cell, normalized by the reservoir
+                            ! length scale [nondim]
+  real    :: b_in, b_out    ! The 0 and 1 switch for tracer reservoirs
+                            ! 1 if the length scale of reservoir is zero [nondim]
+  real    :: a_in, a_out    ! The 0 and 1(-1) switch for reservoir source weights
+                            ! e.g. a_in is -1 only if b_in ==1 and uhr or vhr is inward
+                            ! e.g. a_out is 1 only if b_out==1 and uhr or vhr is outward
+                            ! It's clear that a_in and a_out cannot be both non-zero [nondim]
+  real    :: fac1           ! The denominator of the expression for tracer updates [nondim]
+  real    :: I_scale        ! The inverse of the scaling factor for the tracers.
+                            ! For salinity the units would be [ppt S-1 ~> 1]
+  integer :: i, j, k, m, n, nz, ntr_id, fd_id
+  integer :: is, ie, js, je, ii, ji
 
-  if (associated(OBC)) then ; if (OBC%OBC_pe) then ; do n=1,OBC%number_of_segments
+  if (.not. associated(OBC)) return
+  if (.not. OBC%OBC_pe) return
+
+  nz = GV%ke
+
+  do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
     if (.not. associated(segment%tr_Reg)) cycle
     b_in  = 0.0 ; if (segment%Tr_InvLscale_in  == 0.0) b_in  = 1.0
     b_out = 0.0 ; if (segment%Tr_InvLscale_out == 0.0) b_out = 1.0
-    if (segment%is_E_or_W) then
-      I = segment%HI%IsdB
-      do j=segment%HI%jsd,segment%HI%jed
-        ! ishift+I corresponds to the nearest interior tracer cell index
-        ! idir switches the sign of the flow so that positive is into the reservoir
-        if (segment%direction == OBC_DIRECTION_W) then
-          ishift = 1 ; idir = -1
-        else
-          ishift = 0 ; idir = 1
-        endif
-        ! Can keep this or take it out, either way
-        if (G%mask2dT(I+ishift,j) == 0.0) cycle
-        ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
-        do m=1,segment%tr_Reg%ntseg
-          ntr_id = segment%tr_Reg%Tr(m)%ntr_index
-          fd_id = segment%tr_Reg%Tr(m)%fd_index
-          if (fd_id == -1) then
-            resrv_lfac_out = 1.0
-            resrv_lfac_in  = 1.0
-          else
-            resrv_lfac_out = segment%field(fd_id)%resrv_lfac_out
-            resrv_lfac_in  = segment%field(fd_id)%resrv_lfac_in
-          endif
-          I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
-          if (allocated(segment%tr_Reg%Tr(m)%tres)) then ; do k=1,nz
-            ! Calculate weights. Both a and u_L are nondim. Adding them together has no meaning.
-            ! However, since they cannot be both non-zero, adding them works like a switch.
-            ! When InvLscale_out is 0 and outflow, only interior data is applied to reservoirs
-            ! When InvLscale_in is 0 and inflow, only nudged data is applied to reservoirs
-            a_out = b_out * max(0.0, sign(1.0, idir*uhr(I,j,k)))
-            a_in  = b_in  * min(0.0, sign(1.0, idir*uhr(I,j,k)))
-            u_L_out = max(0.0, (idir*uhr(I,j,k))*segment%Tr_InvLscale_out*resrv_lfac_out / &
-                      ((h(i+ishift,j,k) + GV%H_subroundoff)*G%dyCu(I,j)))
-            u_L_in  = min(0.0, (idir*uhr(I,j,k))*segment%Tr_InvLscale_in*resrv_lfac_in  / &
-                      ((h(i+ishift,j,k) + GV%H_subroundoff)*G%dyCu(I,j)))
-            fac1 = (1.0 - (a_out - a_in)) + ((u_L_out + a_out) - (u_L_in + a_in))
-            segment%tr_Reg%Tr(m)%tres(I,j,k) = (1.0/fac1) * &
-                              ((1.0-a_out+a_in)*segment%tr_Reg%Tr(m)%tres(I,j,k)+ &
-                              ((u_L_out+a_out)*Reg%Tr(ntr_id)%t(I+ishift,j,k) - &
-                               (u_L_in+a_in)*segment%tr_Reg%Tr(m)%t(I,j,k)))
-            if (allocated(OBC%tres_x)) OBC%tres_x(I,j,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(I,j,k)
-          enddo ; endif
-        enddo
-      enddo
-    elseif (segment%is_N_or_S) then
-      J = segment%HI%JsdB
-      do i=segment%HI%isd,segment%HI%ied
-        ! jshift+J corresponds to the nearest interior tracer cell index
-        ! jdir switches the sign of the flow so that positive is into the reservoir
-        if (segment%direction == OBC_DIRECTION_S) then
-          jshift = 1 ; jdir = -1
-        else
-          jshift = 0 ; jdir = 1
-        endif
-        ! Can keep this or take it out, either way
-        if (G%mask2dT(i,j+jshift) == 0.0) cycle
-        ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
-        do m=1,segment%tr_Reg%ntseg
-          ntr_id = segment%tr_Reg%Tr(m)%ntr_index
-          fd_id = segment%tr_Reg%Tr(m)%fd_index
-          if (fd_id == -1) then
-            resrv_lfac_out = 1.0
-            resrv_lfac_in  = 1.0
-          else
-            resrv_lfac_out = segment%field(fd_id)%resrv_lfac_out
-            resrv_lfac_in  = segment%field(fd_id)%resrv_lfac_in
-          endif
-          I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
-          if (allocated(segment%tr_Reg%Tr(m)%tres)) then ; do k=1,nz
-            a_out = b_out * max(0.0, sign(1.0, jdir*vhr(i,J,k)))
-            a_in  = b_in  * min(0.0, sign(1.0, jdir*vhr(i,J,k)))
-            v_L_out = max(0.0, (jdir*vhr(i,J,k))*segment%Tr_InvLscale_out*resrv_lfac_out / &
-                      ((h(i,j+jshift,k) + GV%H_subroundoff)*G%dxCv(i,J)))
-            v_L_in  = min(0.0, (jdir*vhr(i,J,k))*segment%Tr_InvLscale_in*resrv_lfac_in  / &
-                      ((h(i,j+jshift,k) + GV%H_subroundoff)*G%dxCv(i,J)))
-            fac1 = (1.0 - (a_out - a_in)) + ((v_L_out + a_out) - (v_L_in + a_in))
-            segment%tr_Reg%Tr(m)%tres(i,J,k) = (1.0/fac1) * &
-                              ((1.0-a_out+a_in)*segment%tr_Reg%Tr(m)%tres(i,J,k) + &
-                              ((v_L_out+a_out)*Reg%Tr(ntr_id)%t(i,J+jshift,k) - &
-                               (v_L_in+a_in)*segment%tr_Reg%Tr(m)%t(i,J,k)))
-            if (allocated(OBC%tres_y)) OBC%tres_y(i,J,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(i,J,k)
-          enddo ; endif
-        enddo
-      enddo
+    ! dir switches the sign of the flow so that positive is into the reservoir
+    if ((segment%direction == OBC_DIRECTION_W) .or. (segment%direction == OBC_DIRECTION_S)) then
+      dir = -1
+    else
+      dir = 1
     endif
-  enddo ; endif ; endif
-
+    if (segment%is_E_or_W) then
+      I = segment%HI%IsdB ; ii = segment%HI%isd
+      js = segment%HI%jsd ; je = segment%HI%jed
+      ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
+      do m=1,segment%tr_Reg%ntseg ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+        ntr_id = segment%tr_Reg%Tr(m)%ntr_index
+        fd_id = segment%tr_Reg%Tr(m)%fd_index
+        if (fd_id == -1) then
+          resrv_lfac_out = 1.0
+          resrv_lfac_in  = 1.0
+        else
+          resrv_lfac_out = segment%field(fd_id)%resrv_lfac_out
+          resrv_lfac_in  = segment%field(fd_id)%resrv_lfac_in
+        endif
+        I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
+        do k=1,nz ; do j=js,je
+          ! Calculate weights. Both a and u_L are nondim. Adding them together has no meaning.
+          ! However, since they cannot be both non-zero, adding them works like a switch.
+          ! When InvLscale_out is 0 and outflow, only interior data is applied to reservoirs
+          ! When InvLscale_in is 0 and inflow, only nudged data is applied to reservoirs
+          flux_to_res = dir * uhr(I,j,k)
+          ! I_face_area would be more efficient but it changes answers.
+          face_area = (h(ii,j,k) + GV%H_subroundoff) * G%dyCu(I,j)
+          a_out = b_out * max(0.0, sign(1.0, flux_to_res))
+          a_in  = b_in  * min(0.0, sign(1.0, flux_to_res))
+          L_out = G%mask2dT(ii,j) * max(0.0, &
+                flux_to_res * segment%Tr_InvLscale_out * resrv_lfac_out / face_area)
+          L_in  = G%mask2dT(ii,j) * min(0.0, &
+                flux_to_res * segment%Tr_InvLscale_in  * resrv_lfac_in  / face_area)
+          fac1 = 1.0 + (L_out - L_in)
+          segment%tr_Reg%Tr(m)%tres(I,j,k) = (1.0 / fac1) * &
+                            ((1.0 - a_out + a_in) * segment%tr_Reg%Tr(m)%tres(I,j,k) + &
+                             ((L_out + a_out) * Reg%Tr(ntr_id)%t(ii,j,k) - &
+                              (L_in  + a_in ) * segment%tr_Reg%Tr(m)%t(I,j,k)))
+        enddo ; enddo
+        if (allocated(OBC%tres_x)) then ; do k=1,nz ; do j=js,je
+          OBC%tres_x(I,j,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(I,j,k)
+        enddo ; enddo ; endif
+      endif ; enddo
+    elseif (segment%is_N_or_S) then
+      J = segment%HI%JsdB ; ji = segment%HI%jsd
+      is = segment%HI%isd ; ie = segment%HI%ied
+      ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
+      do m=1,segment%tr_Reg%ntseg ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+        ntr_id = segment%tr_Reg%Tr(m)%ntr_index
+        fd_id = segment%tr_Reg%Tr(m)%fd_index
+        if (fd_id == -1) then
+          resrv_lfac_out = 1.0
+          resrv_lfac_in  = 1.0
+        else
+          resrv_lfac_out = segment%field(fd_id)%resrv_lfac_out
+          resrv_lfac_in  = segment%field(fd_id)%resrv_lfac_in
+        endif
+        I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
+        do k=1,nz ; do i=is,ie
+          flux_to_res = dir * vhr(i,J,k)
+          face_area = (h(i,ji,k) + GV%H_subroundoff) * G%dxCv(i,J)
+          a_out = b_out * max(0.0, sign(1.0, flux_to_res))
+          a_in  = b_in  * min(0.0, sign(1.0, flux_to_res))
+          L_out = G%mask2dT(i,ji) * max(0.0, &
+                flux_to_res * segment%Tr_InvLscale_out * resrv_lfac_out / face_area)
+          L_in  = G%mask2dT(i,ji) * min(0.0, &
+                flux_to_res * segment%Tr_InvLscale_in  * resrv_lfac_in  / face_area)
+          fac1 = 1.0 + (L_out - L_in)
+          segment%tr_Reg%Tr(m)%tres(i,J,k) = (1.0 / fac1) * &
+                            ((1.0 - a_out + a_in) * segment%tr_Reg%Tr(m)%tres(i,J,k) + &
+                             ((L_out + a_out) * Reg%Tr(ntr_id)%t(i,ji,k) - &
+                              (L_in  + a_in ) * segment%tr_Reg%Tr(m)%t(i,J,k)))
+        enddo ; enddo
+        if (allocated(OBC%tres_y)) then ; do k=1,nz ; do i=is,ie
+          OBC%tres_y(i,J,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(i,J,k)
+        enddo ; enddo ; endif
+      endif ; enddo
+    endif
+  enddo
 end subroutine update_segment_tracer_reservoirs
 
 !> Update the OBC thickness reservoirs after the thicknesses have been updated.

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -166,11 +166,23 @@ type, public :: OBC_segment_tracer_type
   logical                    :: is_initialized        !< reservoir values have been set when True
   integer                    :: ntr_index = -1        !< index of segment tracer in the global tracer registry
   real              :: resrv_lfac_in = 1.   !< The reservoir inverse length scale factor for the inward
-                                            !! direction per field [nondim].  The general 1/Lscale_in is
+                                            !! direction per tracer [nondim].  The general 1/Lscale_in is
                                             !! multiplied by this factor for a specific tracer or thickness.
+                                                     !! Set to -1 to force an infinite effective length scale
+                                                     !! regardless of Tr_InvLscale_in.
   real              :: resrv_lfac_out= 1.   !< The reservoir inverse length scale factor for the outward
-                                            !! direction per field [nondim].  The general 1/Lscale_out is
+                                            !! direction per tracer [nondim].  The general 1/Lscale_out is
                                             !! multiplied by this factor for a specific tracer or thickness.
+                                                     !! Set to -1 to force an infinite effective length scale
+                                                     !! regardless of Tr_InvLscale_out.
+  real                       :: I_Lscale_in  = 0.0   !< Per-tracer inverse length scale for flow into the reservoir
+                                                     !! direction per field.  For Lscale >=0, I_Lscale_in =
+                                                     !! resrv_lfac_in * Tr_InvLscale_in [L-1 ~> m-1].  For infinite
+                                                     !! length scale, I_Lscale_in = -1 [nondim].
+  real                       :: I_Lscale_out = 0.0   !< Per-tracer inverse length scale for flow out of the reservoir
+                                                     !! direction per field.  For Lscale >=0, I_Lscale_out =
+                                                     !! resrv_lfac_out * Tr_InvLscale_out [L-1 ~> m-1].  For infinite
+                                                     !! length scale, I_Lscale_out = -1 [nondim].
 end type OBC_segment_tracer_type
 
 !> Thickness on OBC segment data structure, with a reservoir
@@ -818,30 +830,50 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                    units="nondim", default=0.3)
   endif
 
+  if (mask_outside) call mask_outside_OBCs(G, US, param_file, OBC)
+
   Lscale_in = 0.
   Lscale_out = 0.
   if (open_boundary_query(OBC, apply_open_OBC=.true.)) then
-    call get_param(param_file, mdl, "OBC_TRACER_RESERVOIR_LENGTH_SCALE_OUT ", Lscale_out, &
-                   "An effective length scale for restoring the tracer concentration "//&
-                   "at the boundaries to externally imposed values when the flow "//&
-                   "is exiting the domain.", units="m", default=0.0, scale=US%m_to_L)
-
-    call get_param(param_file, mdl, "OBC_TRACER_RESERVOIR_LENGTH_SCALE_IN ", Lscale_in, &
-                   "An effective length scale for restoring the tracer concentration "//&
-                   "at the boundaries to values from the interior when the flow "//&
-                   "is entering the domain.", units="m", default=0.0, scale=US%m_to_L)
+    call get_param(param_file, mdl, "OBC_TRACER_RESERVOIR_LENGTH_SCALE_OUT", Lscale_out, &
+                   "An effective length scale for the tracer reservoir update when the flow "//&
+                   "is exiting the domain. If positive, the reservoir relaxes toward the "//&
+                   "interior concentration with this length scale. If zero (default), the "//&
+                   "length scale is truly zero: the reservoir is set instantly to the "//&
+                   "interior concentration on outflow. If negative, the length scale is "//&
+                   "effectively infinite: the reservoir is never updated on outflow.", &
+                   units="m", default=0.0, scale=US%m_to_L)
+    call get_param(param_file, mdl, "OBC_TRACER_RESERVOIR_LENGTH_SCALE_IN", Lscale_in, &
+                   "An effective length scale for the tracer reservoir update when the flow "//&
+                   "is entering the domain. If positive, the reservoir relaxes toward the "//&
+                   "external OBC concentration with this length scale. If zero (default), "//&
+                   "the length scale is truly zero: the reservoir is set instantly to the "//&
+                   "external OBC concentration on inflow. If negative, the length scale is "//&
+                   "effectively infinite: the reservoir is never updated on inflow.", &
+                   units="m", default=0.0, scale=US%m_to_L)
   endif
-
-  if (mask_outside) call mask_outside_OBCs(G, US, param_file, OBC)
 
   ! All tracers are using the same restoring length scale for now, but we may want to make this
   ! tracer-specific in the future for example, in cases where certain tracers are poorly constrained
   ! by data while others are well constrained - MJH.
+  ! All segments also have the same restoring length scale. Internally, each tracer has
+  ! resrv_lfac_in/out attributes to rescale the length scales. resrv_lfac_in/out is only
+  ! used by BGC tracers at the moment.
   do n=1,OBC%number_of_segments
-    OBC%segment(n)%Tr_InvLscale_in = 0.0
-    if (Lscale_in>0.) OBC%segment(n)%Tr_InvLscale_in =  1.0/Lscale_in
-    OBC%segment(n)%Tr_InvLscale_out = 0.0
-    if (Lscale_out>0.) OBC%segment(n)%Tr_InvLscale_out =  1.0/Lscale_out
+    if (Lscale_in  > 0.0) then
+      OBC%segment(n)%Tr_InvLscale_in  = 1.0 / Lscale_in
+    elseif (Lscale_in  < 0.0) then
+      OBC%segment(n)%Tr_InvLscale_in  = 0.0
+    else ! (Lscale_in  == 0.0) then
+      OBC%segment(n)%Tr_InvLscale_in  = -1.0 ! A nondim sentinel value
+    endif
+    if (Lscale_out > 0.0) then
+      OBC%segment(n)%Tr_InvLscale_out = 1.0 / Lscale_out
+    elseif (Lscale_out < 0.0) then
+      OBC%segment(n)%Tr_InvLscale_out = 0.0
+    else ! (Lscale_out == 0.0) then
+      OBC%segment(n)%Tr_InvLscale_out = -1.0 ! A nondim sentinel value
+    endif
   enddo
 
   Lscale_in = 0.
@@ -5236,6 +5268,25 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
     endif
   endif
 
+  ! Assign per-tracer inverse length scales from the per-tracer factor (resrv_lfac) and the
+  ! segment-level inverse length scale (Tr_InvLscale). Three regimes for each direction:
+  !   I_Lscale > 0  : finite relaxation length scale.
+  !   I_Lscale = 0  : infinite length scale; reservoir does not update.
+  !   I_Lscale = -1 : instant-update sentinel; reservoir is immediately replaced by interior or
+  !                   external values.
+  ! For the two edge cases, resrv_lfac overrides Tr_InvLscale entirely, i.e.,
+  !   resrv_lfac = 0  : I_Lscale = 0
+  !   resrv_lfac = -1 : I_Lscale = -1
+  segment%tr_Reg%Tr(ntseg)%I_Lscale_in  = &
+      segment%tr_Reg%Tr(ntseg)%resrv_lfac_in  * segment%Tr_InvLscale_in
+  if ((segment%tr_Reg%Tr(ntseg)%resrv_lfac_in  == -1.0) .or. &
+      (segment%tr_Reg%Tr(ntseg)%I_Lscale_in  < 0.0)) &
+    segment%tr_Reg%Tr(ntseg)%I_Lscale_in  = -1.0
+  segment%tr_Reg%Tr(ntseg)%I_Lscale_out = &
+      segment%tr_Reg%Tr(ntseg)%resrv_lfac_out * segment%Tr_InvLscale_out
+  if ((segment%tr_Reg%Tr(ntseg)%resrv_lfac_out == -1.0) .or. &
+      (segment%tr_Reg%Tr(ntseg)%I_Lscale_out < 0.0)) &
+    segment%tr_Reg%Tr(ntseg)%I_Lscale_out = -1.0
 end subroutine register_segment_tracer
 
 !> Clean up the segment tracer registry.
@@ -5965,23 +6016,27 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
 
   ! Local variables
   type(OBC_segment_type), pointer :: segment => NULL()
-  integer :: dir            ! A sign factor (1/-1) to that sets velocity direction.
-  real    :: face_area      ! Interior cell face area [H L ~> m2 or kg/m].
-  real    :: flux_to_res    ! Inflow to the reservoir, flux_to_res = dir * [uv]hr, positive if the
-                            ! flow is from the interior to the reservoir [H L2 ~> m3 or kg].
-  real    :: resrv_lfac_out ! The reservoir inverse length scale scaling factor for the outward
-                            ! direction per field [nondim]
-  real    :: resrv_lfac_in  ! The reservoir inverse length scale scaling factor for the inward
-                            ! direction per field [nondim]
-  real    :: L_in, L_out    ! The distance moved in or out of a cell, normalized by the reservoir
-                            ! length scale [nondim]
-  real    :: b_in, b_out    ! The 0 and 1 switch for tracer reservoirs
-                            ! 1 if the length scale of reservoir is zero [nondim]
-  real    :: a_in, a_out    ! The 0 and 1(-1) switch for reservoir source weights
-                            ! e.g. a_in is -1 only if b_in ==1 and uhr or vhr is inward
-                            ! e.g. a_out is 1 only if b_out==1 and uhr or vhr is outward
-                            ! It's clear that a_in and a_out cannot be both non-zero [nondim]
-  real    :: fac1           ! The denominator of the expression for tracer updates [nondim]
+  integer :: dir            ! Sign convention so that positive flux_to_res means flow toward the
+                            ! reservoir: -1 for W/S segments, +1 for E/N segments.
+  real    :: face_area      ! Interior cell face area adjacent to the OBC boundary [H L ~> m2 or kg m-1].
+  real    :: flux_to_res    ! Signed volume/mass flux directed toward the reservoir (positive = interior
+                            ! to reservoir), equals dir * uhr or dir * vhr [H L2 ~> m3 or kg].
+  real    :: resrv_lfac_out ! Per-tracer multiplier on segment%Tr_InvLscale_out for the outward
+                            ! direction [nondim].
+  real    :: resrv_lfac_in  ! Per-tracer multiplier on segment%Tr_InvLscale_in for the inward
+                            ! direction [nondim].
+  real    :: L_out, L_in    ! Nondimensional exchange weight = flux * InvLscale * resrv_lfac / face_area
+                            ! for the outflow (L_out >= 0) and inflow (L_in <= 0) directions [nondim].
+                            ! Active only in finite/infinite length-scale mode (mask_L = 1).
+  real    :: a_out, a_in    ! In instant-update (zero length scale) mode: +1 on outflow (a_out) or
+                            ! -1 on inflow (a_in), selecting which boundary value is applied instantly
+                            ! to the reservoir. Both are 0 in finite/infinite length-scale mode, and
+                            ! a_out and a_in cannot be simultaneously non-zero [nondim].
+  real    :: mask_L_out, mask_L_in ! 1 in finite/infinite length-scale mode (activates L term);
+                            ! 0 in instant-update mode [nondim]. mask_L = 1 - mask_a.
+  real    :: mask_a_out, mask_a_in ! 1 in instant-update (zero length scale) mode (activates a term);
+                            ! 0 in finite/infinite length-scale mode [nondim].
+  real    :: fac1           ! Implicit-update denominator = 1 + L_out - L_in [nondim].
   real    :: I_scale        ! The inverse of the scaling factor for the tracers.
                             ! For salinity the units would be [ppt S-1 ~> 1]
   integer :: i, j, k, m, n, nz, ntr_id
@@ -5995,8 +6050,6 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
   do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
     if (.not. associated(segment%tr_Reg)) cycle
-    b_in  = 0.0 ; if (segment%Tr_InvLscale_in  == 0.0) b_in  = 1.0
-    b_out = 0.0 ; if (segment%Tr_InvLscale_out == 0.0) b_out = 1.0
     ! dir switches the sign of the flow so that positive is into the reservoir
     if ((segment%direction == OBC_DIRECTION_W) .or. (segment%direction == OBC_DIRECTION_S)) then
       dir = -1
@@ -6011,20 +6064,24 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
         resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
         resrv_lfac_in  = segment%tr_Reg%Tr(m)%resrv_lfac_in
+        mask_a_in  = max(0.0, -segment%tr_Reg%Tr(m)%I_Lscale_in)  ; mask_L_in  = 1.0 - mask_a_in
+        mask_a_out = max(0.0, -segment%tr_Reg%Tr(m)%I_Lscale_out) ; mask_L_out = 1.0 - mask_a_out
         I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
         do k=1,nz ; do j=js,je
-          ! Calculate weights. Both a and u_L are nondim. Adding them together has no meaning.
+          ! Calculate weights. Both a and L are nondim. Adding them together has no meaning.
           ! However, since they cannot be both non-zero, adding them works like a switch.
           ! When InvLscale_out is 0 and outflow, only interior data is applied to reservoirs
           ! When InvLscale_in is 0 and inflow, only nudged data is applied to reservoirs
           flux_to_res = dir * uhr(I,j,k)
           ! I_face_area would be more efficient but it changes answers.
           face_area = (h(ii,j,k) + GV%H_subroundoff) * G%dyCu(I,j)
-          a_out = b_out * max(0.0, sign(1.0, flux_to_res))
-          a_in  = b_in  * min(0.0, sign(1.0, flux_to_res))
-          L_out = G%mask2dT(ii,j) * max(0.0, &
+          a_out = mask_a_out * max(0.0, sign(1.0, flux_to_res))
+          a_in  = mask_a_in  * min(0.0, sign(1.0, flux_to_res))
+          ! Below, segment%Tr_InvLscale_out * resrv_lfac_out can be replaced by segment%I_Lscale_out,
+          ! but it changes answers.
+          L_out = mask_L_out * G%mask2dT(ii,j) * max(0.0, &
                 flux_to_res * segment%Tr_InvLscale_out * resrv_lfac_out / face_area)
-          L_in  = G%mask2dT(ii,j) * min(0.0, &
+          L_in  = mask_L_in  * G%mask2dT(ii,j) * min(0.0, &
                 flux_to_res * segment%Tr_InvLscale_in  * resrv_lfac_in  / face_area)
           fac1 = 1.0 + (L_out - L_in)
           segment%tr_Reg%Tr(m)%tres(I,j,k) = (1.0 / fac1) * &
@@ -6044,15 +6101,17 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
         resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
         resrv_lfac_in  = segment%tr_Reg%Tr(m)%resrv_lfac_in
+        mask_a_in  = max(0.0, -segment%tr_Reg%Tr(m)%I_Lscale_in)  ; mask_L_in  = 1.0 - mask_a_in
+        mask_a_out = max(0.0, -segment%tr_Reg%Tr(m)%I_Lscale_out) ; mask_L_out = 1.0 - mask_a_out
         I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
         do k=1,nz ; do i=is,ie
           flux_to_res = dir * vhr(i,J,k)
           face_area = (h(i,ji,k) + GV%H_subroundoff) * G%dxCv(i,J)
-          a_out = b_out * max(0.0, sign(1.0, flux_to_res))
-          a_in  = b_in  * min(0.0, sign(1.0, flux_to_res))
-          L_out = G%mask2dT(i,ji) * max(0.0, &
+          a_out = mask_a_out * max(0.0, sign(1.0, flux_to_res))
+          a_in  = mask_a_in  * min(0.0, sign(1.0, flux_to_res))
+          L_out = mask_L_out * G%mask2dT(i,ji) * max(0.0, &
                 flux_to_res * segment%Tr_InvLscale_out * resrv_lfac_out / face_area)
-          L_in  = G%mask2dT(i,ji) * min(0.0, &
+          L_in  = mask_L_in  * G%mask2dT(i,ji) * min(0.0, &
                 flux_to_res * segment%Tr_InvLscale_in  * resrv_lfac_in  / face_area)
           fac1 = 1.0 + (L_out - L_in)
           segment%tr_Reg%Tr(m)%tres(i,J,k) = (1.0 / fac1) * &
@@ -6106,8 +6165,8 @@ subroutine update_segment_thickness_reservoirs(G, GV, uhr, vhr, h, OBC)
   if (associated(OBC)) then ; if (OBC%OBC_pe) then ; do n=1,OBC%number_of_segments
     segment=>OBC%segment(n)
     if (.not. associated(segment%h_Reg)) cycle
-    b_in  = 0.0 ; if (segment%Tr_InvLscale_in  == 0.0) b_in  = 1.0
-    b_out = 0.0 ; if (segment%Tr_InvLscale_out == 0.0) b_out = 1.0
+    b_in  = 0.0 ; if (segment%Tr_InvLscale_in  < 0.0) b_in  = 1.0
+    b_out = 0.0 ; if (segment%Tr_InvLscale_out < 0.0) b_out = 1.0
     if (segment%is_E_or_W) then
       I = segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -153,49 +153,54 @@ end type OBC_segment_data_type
 
 !> Tracer on OBC segment data structure, for putting into a segment tracer registry.
 type, public :: OBC_segment_tracer_type
-  real, allocatable          :: t(:,:,:)              !< tracer concentration array in rescaled units,
-                                                      !! like [S ~> ppt] for salinity.
-  real                       :: OBC_inflow_conc = 0.0 !< tracer concentration for generic inflows in rescaled units,
-                                                      !! like [S ~> ppt] for salinity.
-  character(len=32)          :: name                  !< tracer name used for error messages
-  type(tracer_type), pointer :: Tr => NULL()          !< metadata describing the tracer
-  real, allocatable          :: tres(:,:,:)           !< tracer reservoir array in rescaled units,
-                                                      !! like [S ~> ppt] for salinity.
-  real                       :: scale                 !< A scaling factor for converting the units of input
-                                                      !! data, like [S ppt-1 ~> 1] for salinity.
-  logical                    :: is_initialized        !< reservoir values have been set when True
-  integer                    :: ntr_index = -1        !< index of segment tracer in the global tracer registry
-  real              :: resrv_lfac_in = 1.   !< The reservoir inverse length scale factor for the inward
-                                            !! direction per tracer [nondim].  The general 1/Lscale_in is
-                                            !! multiplied by this factor for a specific tracer or thickness.
-                                                     !! Set to -1 to force an infinite effective length scale
-                                                     !! regardless of Tr_InvLscale_in.
-  real              :: resrv_lfac_out= 1.   !< The reservoir inverse length scale factor for the outward
-                                            !! direction per tracer [nondim].  The general 1/Lscale_out is
-                                            !! multiplied by this factor for a specific tracer or thickness.
-                                                     !! Set to -1 to force an infinite effective length scale
-                                                     !! regardless of Tr_InvLscale_out.
-  real                       :: I_Lscale_in  = 0.0   !< Per-tracer inverse length scale for flow into the reservoir
-                                                     !! direction per field.  For Lscale >=0, I_Lscale_in =
-                                                     !! resrv_lfac_in * Tr_InvLscale_in [L-1 ~> m-1].  For infinite
-                                                     !! length scale, I_Lscale_in = -1 [nondim].
-  real                       :: I_Lscale_out = 0.0   !< Per-tracer inverse length scale for flow out of the reservoir
-                                                     !! direction per field.  For Lscale >=0, I_Lscale_out =
-                                                     !! resrv_lfac_out * Tr_InvLscale_out [L-1 ~> m-1].  For infinite
-                                                     !! length scale, I_Lscale_out = -1 [nondim].
+  logical           :: is_initialized       !< Reservoir values have been set when True
+  character(len=32) :: name                 !< Tracer name used for error messages
+  integer           :: ntr_index = -1       !< Index of segment tracer in the global tracer registry
+  real, allocatable :: t(:,:,:)             !< External tracer concentration array in rescaled
+                                            !! units, like [S ~> ppt] for salinity.
+  real, allocatable :: tres(:,:,:)          !< Tracer reservoir array in rescaled units, like
+                                            !! [S ~> ppt] for salinity.
+  real              :: scale                !< A scaling factor for converting the units of input
+                                            !! data, like [S ppt-1 ~> 1] for salinity.
+  real              :: resrv_lfac_in  = 1.0 !< The reservoir inverse length scale factor for the
+                                            !! inward direction per tracer [nondim].  The general
+                                            !! 1/Lscale_in is multiplied by this factor for a
+                                            !! specific tracer or thickness.  Set to -1 to force
+                                            !! an infinite effective length scale regardless of
+                                            !! Tr_InvLscale_in.
+  real              :: resrv_lfac_out = 1.0 !< The reservoir inverse length scale factor for the
+                                            !! outward direction per tracer [nondim].  The general
+                                            !! 1/Lscale_out is multiplied by this factor for a
+                                            !! specific tracer or thickness.  Set to -1 to force
+                                            !! an infinite effective length scale regardless of
+                                            !! Tr_InvLscale_out.
+  real              :: I_Lscale_in  = 0.0   !< Per-tracer inverse length scale for flow into the
+                                            !! reservoir direction.  Three regimes:
+                                            !! - Positive: finite length scale; I_Lscale_in =
+                                            !!   resrv_lfac_in * Tr_InvLscale_in [L-1 ~> m-1].
+                                            !! - Zero: infinite length scale; reservoir is frozen
+                                            !!   [nondim].
+                                            !! - Negative (-1): instant-update sentinel (zero
+                                            !!   effective length scale) [nondim].
+  real              :: I_Lscale_out = 0.0   !< Per-tracer inverse length scale for flow out of the
+                                            !! reservoir direction.  Three regimes:
+                                            !! - Positive: finite length scale; I_Lscale_out =
+                                            !!   resrv_lfac_out * Tr_InvLscale_out [L-1 ~> m-1].
+                                            !! - Zero: infinite length scale; reservoir is frozen
+                                            !!   [nondim].
+                                            !! - Negative (-1): instant-update sentinel (zero
+                                            !!   effective length scale) [nondim].
 end type OBC_segment_tracer_type
 
 !> Thickness on OBC segment data structure, with a reservoir
 type, public :: OBC_segment_thickness_type
-  real, allocatable          :: h(:,:,:)              !< layer thickness array in rescaled units, [Z ~> m].
-  real                       :: OBC_inflow_conc = 0.0 !< layer thickness for generic inflows in rescaled units,
-                                                      !! [Z ~> m].
-  character(len=32)          :: name                  !< thickness name used for error messages
-  real, allocatable          :: h_res(:,:,:)          !< thickness reservoir array in rescaled units,
+  logical                    :: is_initialized        !< Reservoir values have been set when True
+  character(len=32)          :: name                  !< Thickness name used for error messages
+  real, allocatable          :: h(:,:,:)              !< Layer thickness array in rescaled units, [Z ~> m].
+  real, allocatable          :: h_res(:,:,:)          !< Thickness reservoir array in rescaled units,
                                                       !! [Z ~> m].
   real                       :: scale                 !< A scaling factor for converting the units of input
                                                       !! data, [Z m-1 ~> 1].
-  logical                    :: is_initialized        !< reservoir values have been set when True
   integer                    :: fd_index = -1         !< index of segment thickness in the input fields
 end type OBC_segment_thickness_type
 
@@ -245,8 +250,6 @@ type, public :: OBC_segment_type
   real :: Velocity_nudging_timescale_in  !< Nudging timescale on inflow [T ~> s].
   real :: Velocity_nudging_timescale_out !< Nudging timescale on outflow [T ~> s].
   logical :: on_pe          !< true if any portion of the segment is located in this PE's data domain
-  logical :: temp_segment_data_exists !< true if temperature data arrays are present
-  logical :: salt_segment_data_exists !< true if salinity data arrays are present
   real, allocatable :: Htot(:,:)  !< The total column thickness [H ~> m or kg m-2] at OBC-points.
   real, allocatable :: dZtot(:,:) !< The total column vertical extent [Z ~> m] at OBC segment faces.
   real, allocatable :: normal_vel(:,:,:)      !< The layer velocity normal to the OB
@@ -1219,11 +1222,6 @@ subroutine allocate_segment_field_data(field, OBC, segment, US, inputdir, filena
   else
     allocate(field%buffer_dst(isd:ied, JsdB:JedB, nk_dst), source=init_value_dst)
   endif
-
-  ! This can be removed.
-  if (field%name == 'TEMP') segment%temp_segment_data_exists = .true.
-  if (field%name == 'SALT') segment%salt_segment_data_exists = .true.
-
 end subroutine allocate_segment_field_data
 
 !> Get and store properties about the fields on the OBC segments and allocate space for reading
@@ -1340,10 +1338,6 @@ subroutine initialize_segment_data(GV, US, OBC, PF, turns, use_temperature)
       endif
       phys_idx(idx) = m
     enddo
-
-    ! These can be removed.
-    segment%temp_segment_data_exists = .false.
-    segment%salt_segment_data_exists = .false.
 
     ! Allocate physical fields
     do m = 1, NUM_PHYS_FIELDS
@@ -2616,7 +2610,7 @@ subroutine setup_OBC_tracer_reservoirs(G, GV, OBC, restart_CS)
 
     do n=1,OBC%number_of_segments
       segment => OBC%segment(n)
-      if (associated(segment%tr_Reg)) then ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+      if (associated(segment%tr_Reg)) then
         I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
 
         if (segment%is_E_or_W .and. set_tres_x) then
@@ -2642,7 +2636,7 @@ subroutine setup_OBC_tracer_reservoirs(G, GV, OBC, restart_CS)
             enddo ; enddo
           endif
         endif
-      endif ; endif
+      endif
     enddo
   enddo
 
@@ -2889,11 +2883,11 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
   ! Now tracers (if any)
   do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
-    if (associated(segment%tr_Reg)) then
+    if (segment%on_pe .and. associated(segment%tr_Reg)) then
       if (segment%is_E_or_W) then
         I = segment%HI%IsdB
-        do m=1,OBC%ntr
-          if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+        do m=1,segment%tr_Reg%ntseg
+          if (allocated(OBC%tres_x)) then
             do k=1,GV%ke
               do j=segment%HI%jsd,segment%HI%jed
                 segment%tr_Reg%Tr(m)%tres(I,j,k) = segment%tr_Reg%Tr(m)%scale * OBC%tres_x(I,j,k,m)
@@ -2903,8 +2897,8 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
         enddo
       else
         J = segment%HI%JsdB
-        do m=1,OBC%ntr
-          if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+        do m=1,segment%tr_Reg%ntseg
+          if (allocated(OBC%tres_y)) then
             do k=1,GV%ke
               do i=segment%HI%isd,segment%HI%ied
                 segment%tr_Reg%Tr(m)%tres(i,J,k) = segment%tr_Reg%Tr(m)%scale * OBC%tres_y(i,J,k,m)
@@ -4887,16 +4881,9 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, h, Time)
       if ((.not. allocated(segment%field(m)%buffer_dst)) .or. &
           (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data))) cycle
       nt = segment%field(m)%tr_index
-      ! Note the following unnecessary IF-branch is kept from the old code (as recent as Jan 2026).
-      ! In the old code segment%field(m)%buffer_dst is always allocated at this point, and therefore
-      ! the "else" section is unreachable. This will be fixed when OBC_inflow_conc is reworked.
-      if (allocated(segment%field(m)%buffer_dst)) then
-        do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
-          segment%tr_Reg%Tr(nt)%t(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
-        enddo ; enddo ; enddo
-      else
-        segment%tr_Reg%Tr(nt)%OBC_inflow_conc = segment%field(m)%value
-      endif
+      do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg
+        segment%tr_Reg%Tr(nt)%t(i,j,k) = segment%field(m)%buffer_dst(i,j,k)
+      enddo ; enddo ; enddo
     enddo ! end tracer field loop
   enddo ! end segment loop
 end subroutine update_OBC_segment_data
@@ -5179,7 +5166,7 @@ end subroutine segment_thickness_reservoir_init
 !> Register a tracer array that is active on an OBC segment, potentially also specifying how the
 !! tracer inflow values are specified.
 subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
-                                   OBC_scalar, OBC_array, scale, resrv_lfac_in, resrv_lfac_out)
+                                   OBC_inflow_conc, scale, resrv_lfac_in, resrv_lfac_out)
   type(verticalGrid_type), intent(in)   :: GV         !< ocean vertical grid structure
   type(tracer_type), target             :: tr_ptr     !< A target that can be used to set a pointer to the
                                                       !! stored value of tr. This target must be
@@ -5191,24 +5178,29 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
   integer, intent(in)                   :: ntr_index  !< index of segment tracer in the global tracer registry
   type(param_file_type),  intent(in)    :: param_file !< file to parse for model parameter values
   type(OBC_segment_type), intent(inout) :: segment    !< current segment data structure
-  real,         optional, intent(in)    :: OBC_scalar !< If present, use scalar value for segment tracer
-                                                      !! inflow concentration, including any rescaling to
-                                                      !! put the tracer concentration into its internal units,
-                                                      !! like [S ~> ppt] for salinity.
-  logical,      optional, intent(in)    :: OBC_array  !< If true, use array values for segment tracer
-                                                      !! inflow concentration.
+  real,         optional, intent(in)    :: OBC_inflow_conc !< If present, use this spatially uniform value as the
+                                                          !! OBC inflow concentration in the tracer's internal
+                                                          !! units, like [S ~> ppt] for salinity.  Mutually
+                                                          !! exclusive with resrv_lfac_in and resrv_lfac_out.
   real,         optional, intent(in)    :: scale      !< A scaling factor that should be used with any
                                                       !! data that is read in to convert it to the internal
                                                       !! units of this tracer, in units like [S ppt-1 ~> 1]
                                                       !! for salinity.
-  real,         optional, intent(in)    :: resrv_lfac_in   !< The reservoir inverse length scale factor
-  real,         optional, intent(in)    :: resrv_lfac_out  !< The reservoir inverse length scale factor
+  real,         optional, intent(in)    :: resrv_lfac_in   !< Per-tracer multiplier for the inward reservoir
+                                                           !! relaxation length scale [nondim].
+  real,         optional, intent(in)    :: resrv_lfac_out  !< Per-tracer multiplier for the outward reservoir
+                                                           !! relaxation length scale [nondim].
 
-! Local variables
+  ! Local variables
   real :: rescale ! A multiplicatively corrected scaling factor, in units like [S ppt-1 ~> 1] for
                   ! salinity, or other various units depending on what rescaling has occurred previously.
   integer :: ntseg, m, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   character(len=256) :: mesg    ! Message for error messages.
+  real :: init_value  ! Initial tracer concentration in OBC-rescaled units [A ~> a]
+
+  if (present(OBC_inflow_conc) .and. (present(resrv_lfac_in) .or. present(resrv_lfac_out))) &
+    call MOM_error(FATAL, "register_segment_tracer: OBC_inflow_conc and resrv_lfac_in/out are "// &
+                          "mutually exclusive for tracer "//trim(tr_ptr%name))
 
   call segment_tracer_registry_init(param_file, segment)
 
@@ -5225,7 +5217,6 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
   IsdB = segment%HI%IsdB ; IedB = segment%HI%IedB
   JsdB = segment%HI%JsdB ; JedB = segment%HI%JedB
 
-  segment%tr_Reg%Tr(ntseg)%Tr => tr_ptr
   segment%tr_Reg%Tr(ntseg)%name = tr_ptr%name
   segment%tr_Reg%Tr(ntseg)%ntr_index = ntr_index
 
@@ -5252,20 +5243,25 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
       "MOM register_segment_tracer was called for variable "//trim(segment%tr_Reg%Tr(ntseg)%name)//&
       " with a locked tracer registry.")
 
-  if (present(resrv_lfac_in)) segment%tr_Reg%Tr(ntseg)%resrv_lfac_in = resrv_lfac_in
-  if (present(resrv_lfac_out)) segment%tr_Reg%Tr(ntseg)%resrv_lfac_out = resrv_lfac_out
+  if (present(OBC_inflow_conc)) then
+    init_value = OBC_inflow_conc
+    segment%tr_Reg%Tr(ntseg)%is_initialized = .true.
+    segment%tr_Reg%Tr(ntseg)%resrv_lfac_in  = 0.0
+    segment%tr_Reg%Tr(ntseg)%resrv_lfac_out = 0.0
+  else
+    init_value = 0.0
+    segment%tr_Reg%Tr(ntseg)%is_initialized = .false.
+    ! Currently, resrv_lfac_in/out are for BGC tracers only.
+    if (present(resrv_lfac_in))  segment%tr_Reg%Tr(ntseg)%resrv_lfac_in  = resrv_lfac_in
+    if (present(resrv_lfac_out)) segment%tr_Reg%Tr(ntseg)%resrv_lfac_out = resrv_lfac_out
+  endif
 
-  if (present(OBC_scalar)) segment%tr_Reg%Tr(ntseg)%OBC_inflow_conc = OBC_scalar ! initialize tracer value later
-  if (present(OBC_array)) then
-    if (segment%is_E_or_W) then
-      allocate(segment%tr_Reg%Tr(ntseg)%t(IsdB:IedB,jsd:jed,1:GV%ke), source=0.0)
-      allocate(segment%tr_Reg%Tr(ntseg)%tres(IsdB:IedB,jsd:jed,1:GV%ke), source=0.0)
-      segment%tr_Reg%Tr(ntseg)%is_initialized = .false.
-    elseif (segment%is_N_or_S) then
-      allocate(segment%tr_Reg%Tr(ntseg)%t(isd:ied,JsdB:JedB,1:GV%ke), source=0.0)
-      allocate(segment%tr_Reg%Tr(ntseg)%tres(isd:ied,JsdB:JedB,1:GV%ke), source=0.0)
-      segment%tr_Reg%Tr(ntseg)%is_initialized = .false.
-    endif
+  if (segment%is_E_or_W) then
+    allocate(segment%tr_Reg%Tr(ntseg)%t(IsdB:IedB,jsd:jed,1:GV%ke), source=init_value)
+    allocate(segment%tr_Reg%Tr(ntseg)%tres(IsdB:IedB,jsd:jed,1:GV%ke), source=init_value)
+  elseif (segment%is_N_or_S) then
+    allocate(segment%tr_Reg%Tr(ntseg)%t(isd:ied,JsdB:JedB,1:GV%ke), source=init_value)
+    allocate(segment%tr_Reg%Tr(ntseg)%tres(isd:ied,JsdB:JedB,1:GV%ke), source=init_value)
   endif
 
   ! Assign per-tracer inverse length scales from the per-tracer factor (resrv_lfac) and the
@@ -5293,12 +5289,13 @@ end subroutine register_segment_tracer
 subroutine segment_tracer_registry_end(Reg)
   type(segment_tracer_registry_type), pointer :: Reg        !< pointer to tracer registry
 
-! Local variables
-  integer n
+  ! Local variables
+  integer :: n
 
   if (associated(Reg)) then
-    do n = 1, Reg%ntseg
+    do n=1, Reg%ntseg
       if (allocated(Reg%Tr(n)%t)) deallocate(Reg%Tr(n)%t)
+      if (allocated(Reg%Tr(n)%tres)) deallocate(Reg%Tr(n)%tres)
     enddo
     deallocate(Reg)
   endif
@@ -5307,8 +5304,6 @@ end subroutine segment_tracer_registry_end
 !> Clean up the segment thickness object
 subroutine segment_thickness_registry_end(Reg)
   type(OBC_segment_thickness_type), pointer :: Reg        !< pointer to thickness reservoir
-
-! Local variables
 
   if (associated(Reg)) then
     if (allocated(Reg%h)) deallocate(Reg%h)
@@ -5342,12 +5337,10 @@ subroutine register_temp_salt_segments(GV, US, OBC, tr_Reg, param_file)
 
     name = 'temp'
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
-    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, &
-                                 OBC_array=segment%temp_segment_data_exists, scale=US%degC_to_C)
+    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, scale=US%degC_to_C)
     name = 'salt'
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
-    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, &
-                                 OBC_array=segment%salt_segment_data_exists, scale=US%ppt_to_S)
+    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, scale=US%ppt_to_S)
   enddo
 
 end subroutine register_temp_salt_segments
@@ -5424,7 +5417,7 @@ subroutine register_obgc_segments(GV, OBC, tr_Reg, param_file, tr_name)
         resrv_lfac_out = segment%field(m)%resrv_lfac_out
       endif
     enddo
-    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, OBC_array=.True., &
+    call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, segment, &
                                  resrv_lfac_in=resrv_lfac_in, resrv_lfac_out=resrv_lfac_out)
   enddo
 end subroutine register_obgc_segments
@@ -6060,7 +6053,7 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
       I = segment%HI%IsdB ; ii = segment%HI%isd
       js = segment%HI%jsd ; je = segment%HI%jed
       ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
-      do m=1,segment%tr_Reg%ntseg ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+      do m=1,segment%tr_Reg%ntseg
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
         resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
         resrv_lfac_in  = segment%tr_Reg%Tr(m)%resrv_lfac_in
@@ -6092,12 +6085,12 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
         if (allocated(OBC%tres_x)) then ; do k=1,nz ; do j=js,je
           OBC%tres_x(I,j,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(I,j,k)
         enddo ; enddo ; endif
-      endif ; enddo
+      enddo
     elseif (segment%is_N_or_S) then
       J = segment%HI%JsdB ; ji = segment%HI%jsd
       is = segment%HI%isd ; ie = segment%HI%ied
       ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
-      do m=1,segment%tr_Reg%ntseg ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+      do m=1,segment%tr_Reg%ntseg
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
         resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
         resrv_lfac_in  = segment%tr_Reg%Tr(m)%resrv_lfac_in
@@ -6122,7 +6115,7 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
         if (allocated(OBC%tres_y)) then ; do k=1,nz ; do i=is,ie
           OBC%tres_y(i,J,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(i,J,k)
         enddo ; enddo ; endif
-      endif ; enddo
+      enddo
     endif
   enddo
 end subroutine update_segment_tracer_reservoirs
@@ -6283,7 +6276,7 @@ subroutine remap_OBC_fields(G, GV, h_old, h_new, OBC, PCM_cell)
 
   if (associated(OBC)) then ; if (OBC%OBC_pe) then ; do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
-    if (.not.associated(segment%tr_Reg)) cycle
+    if (.not.(segment%on_pe .and. associated(segment%tr_Reg))) cycle
 
     if (segment%is_E_or_W) then
       I = segment%HI%IsdB
@@ -6303,7 +6296,7 @@ subroutine remap_OBC_fields(G, GV, h_old, h_new, OBC, PCM_cell)
         endif
 
         ! Vertically remap the reservoir tracer concentrations
-        do m=1,ntr ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+        do m=1,segment%tr_Reg%ntseg
           I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
 
           if (present(PCM_cell)) then
@@ -6321,7 +6314,7 @@ subroutine remap_OBC_fields(G, GV, h_old, h_new, OBC, PCM_cell)
             OBC%tres_x(I,j,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(I,j,k)
           enddo ; endif
 
-        endif ; enddo
+        enddo
 
         ! Vertically remap the reservoir thicknesses?
         if (associated(segment%h_Reg)) then
@@ -6392,7 +6385,7 @@ subroutine remap_OBC_fields(G, GV, h_old, h_new, OBC, PCM_cell)
         endif
 
         ! Vertically remap the reservoir tracer concentrations
-        do m=1,ntr ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then
+        do m=1,segment%tr_Reg%ntseg
           I_scale = 1.0 ; if (segment%tr_Reg%Tr(m)%scale /= 0.0) I_scale = 1.0 / segment%tr_Reg%Tr(m)%scale
 
           if (present(PCM_cell)) then
@@ -6410,7 +6403,7 @@ subroutine remap_OBC_fields(G, GV, h_old, h_new, OBC, PCM_cell)
             OBC%tres_y(i,J,k,m) = I_scale * segment%tr_Reg%Tr(m)%tres(i,J,k)
           enddo ; endif
 
-        endif ; enddo
+        enddo
 
         ! Vertically remap the reservoir thicknesses?
         if (associated(segment%h_Reg)) then
@@ -7091,9 +7084,7 @@ subroutine write_OBC_info(OBC, G, GV, US)
       if (segment%is_E_or_W)      call MOM_mesg("  is_N_or_S", verb=1)
       if (segment%is_N_or_S)      call MOM_mesg("  is_E_or_W", verb=1)
     endif
-!    if (segment%is_E_or_W_2)    call MOM_mesg("  is_E_or_W_2", verb=1)
-    if (segment%temp_segment_data_exists) call MOM_mesg("  temp_segment_data_exists", verb=1)
-    if (segment%salt_segment_data_exists) call MOM_mesg("  salt_segment_data_exists", verb=1)
+    ! if (segment%is_E_or_W_2)    call MOM_mesg("  is_E_or_W_2", verb=1)
 
     write(mesg, '("  Tr_InvLscale_out ", ES16.6)') segment%Tr_InvLscale_out*US%m_to_L
     call MOM_mesg(mesg, verb=1)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -5163,18 +5163,13 @@ subroutine segment_thickness_reservoir_init(GV, US, OBC, param_file)
 
 end subroutine segment_thickness_reservoir_init
 
-!> Register a tracer array that is active on an OBC segment, potentially also specifying how the
-!! tracer inflow values are specified.
+!> Register a tracer on an OBC segment, allocate its t and tres arrays, and set the
+!! per-tracer inverse length scales (I_Lscale_in/out) that control reservoir relaxation.
 subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
                                    OBC_inflow_conc, scale, resrv_lfac_in, resrv_lfac_out)
   type(verticalGrid_type), intent(in)   :: GV         !< ocean vertical grid structure
-  type(tracer_type), target             :: tr_ptr     !< A target that can be used to set a pointer to the
-                                                      !! stored value of tr. This target must be
-                                                      !! an enduring part of the control structure,
-                                                      !! because the tracer registry will use this memory,
-                                                      !! but it also means that any updates to this
-                                                      !! structure in the calling module will be
-                                                      !! available subsequently to the tracer registry.
+  type(tracer_type), target             :: tr_ptr     !< Tracer to register; must persist in the caller's
+                                                      !! control structure for the lifetime of the segment.
   integer, intent(in)                   :: ntr_index  !< index of segment tracer in the global tracer registry
   type(param_file_type),  intent(in)    :: param_file !< file to parse for model parameter values
   type(OBC_segment_type), intent(inout) :: segment    !< current segment data structure
@@ -5994,7 +5989,17 @@ subroutine open_boundary_register_restarts(HI, GV, US, OBC, Reg, param_file, res
 
 end subroutine open_boundary_register_restarts
 
-!> Update the OBC tracer reservoirs after the tracers have been updated.
+!> Update OBC tracer reservoirs (segment%tr_Reg%Tr%tres) using a backward-Euler implicit step,
+!! then copy the result into OBC%tres_x / OBC%tres_y for restart I/O.
+!!
+!! The reservoir at each boundary cell is nudged toward the adjacent interior tracer (on outflow)
+!! or the open-ocean boundary value (on inflow), weighted by the volume flux and the per-tracer
+!! inverse length scale I_Lscale. Three regimes, set at registration via I_Lscale_in/out:
+!! - **Frozen** (I_Lscale = 0): tres is unchanged every timestep.
+!! - **Finite length scale** (I_Lscale > 0): tres relaxes toward the interior or boundary value
+!!   at a rate proportional to the flux and I_Lscale.
+!! - **Instant update** (I_Lscale = -1): tres is immediately replaced by the interior value
+!!   (outflow) or the boundary value (inflow).
 subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
   type(ocean_grid_type),                      intent(in) :: G   !< The ocean's grid structure
   type(verticalGrid_type),                    intent(in) :: GV  !< Ocean vertical grid structure
@@ -6052,7 +6057,6 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
     if (segment%is_E_or_W) then
       I = segment%HI%IsdB ; ii = segment%HI%isd
       js = segment%HI%jsd ; je = segment%HI%jed
-      ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
       do m=1,segment%tr_Reg%ntseg
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
         resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out
@@ -6089,7 +6093,6 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, Reg)
     elseif (segment%is_N_or_S) then
       J = segment%HI%JsdB ; ji = segment%HI%jsd
       is = segment%HI%isd ; ie = segment%HI%ied
-      ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
       do m=1,segment%tr_Reg%ntseg
         ntr_id = segment%tr_Reg%Tr(m)%ntr_index
         resrv_lfac_out = segment%tr_Reg%Tr(m)%resrv_lfac_out

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -478,18 +478,10 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
             I = segment%HI%IsdB
             do m = 1,segment%tr_Reg%ntseg ! replace tracers with OBC values
               ntr_id = segment%tr_reg%Tr(m)%ntr_index
-              if (allocated(segment%tr_Reg%Tr(m)%tres)) then
-                if (segment%direction == OBC_DIRECTION_W) then
-                  T_tmp(i,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-                else
-                  T_tmp(i+1,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-                endif
+              if (segment%direction == OBC_DIRECTION_W) then
+                T_tmp(i,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
               else
-                if (segment%direction == OBC_DIRECTION_W) then
-                  T_tmp(i,ntr_id) = segment%tr_Reg%Tr(m)%OBC_inflow_conc
-                else
-                  T_tmp(i+1,ntr_id) = segment%tr_Reg%Tr(m)%OBC_inflow_conc
-                endif
+                T_tmp(i+1,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
               endif
             enddo
             do m = 1,ntr ! Apply update tracer values for slope calculation
@@ -625,9 +617,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
               ! should the reservoir evolve for this case Kate ?? - Nope
                 do m=1,segment%tr_Reg%ntseg
                   ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                  if (allocated(segment%tr_Reg%Tr(m)%tres)) then
-                    flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
-                  else ; flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%OBC_inflow_conc ; endif
+                  flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
                 enddo
               endif
             endif
@@ -649,9 +639,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
               uhh(I) = uhr(I,j,k)
               do m=1,segment%tr_Reg%ntseg
                 ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                if (allocated(segment%tr_Reg%Tr(m)%tres)) then
-                  flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
-                else; flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%OBC_inflow_conc; endif
+                flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
               enddo
             endif
           endif
@@ -880,18 +868,10 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
             J = segment%HI%JsdB
             do m = 1,segment%tr_Reg%ntseg ! replace tracers with OBC values
               ntr_id = segment%tr_reg%Tr(m)%ntr_index
-              if (allocated(segment%tr_Reg%Tr(m)%tres)) then
-                if (segment%direction == OBC_DIRECTION_S) then
-                  T_tmp(i,ntr_id,j) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-                else
-                  T_tmp(i,ntr_id,j+1) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-                endif
+              if (segment%direction == OBC_DIRECTION_S) then
+                T_tmp(i,ntr_id,j) = segment%tr_Reg%Tr(m)%tres(i,j,k)
               else
-                if (segment%direction == OBC_DIRECTION_S) then
-                  T_tmp(i,ntr_id,j) = segment%tr_Reg%Tr(m)%OBC_inflow_conc
-                else
-                  T_tmp(i,ntr_id,j+1) = segment%tr_Reg%Tr(m)%OBC_inflow_conc
-                endif
+                T_tmp(i,ntr_id,j+1) = segment%tr_Reg%Tr(m)%tres(i,j,k)
               endif
             enddo
             do m = 1,ntr ! Apply update tracer values for slope calculation
@@ -1029,11 +1009,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                   vhh(i,J) = vhr(i,J,k)
                   do m=1,segment%tr_Reg%ntseg
                     ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                    if (allocated(segment%tr_Reg%Tr(m)%tres)) then
-                      flux_y(i,ntr_id,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%tres(i,J,k)
-                    else
-                      flux_y(i,ntr_id,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%OBC_inflow_conc
-                    endif
+                    flux_y(i,ntr_id,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%tres(i,J,k)
                   enddo
                 endif
               enddo
@@ -1055,9 +1031,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                 vhh(i,J) = vhr(i,J,k)
                 do m=1,segment%tr_Reg%ntseg
                   ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                  if (allocated(segment%tr_Reg%Tr(m)%tres)) then
-                    flux_y(i,ntr_id,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%tres(i,J,k)
-                  else ; flux_y(i,ntr_id,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%OBC_inflow_conc ; endif
+                  flux_y(i,ntr_id,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%tres(i,J,k)
                 enddo
               endif
             enddo

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -247,7 +247,6 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   if (present(ad_y)) then ; if (associated(ad_y)) Tr%ad_y => ad_y ; endif
   if (present(df_x)) then ; if (associated(df_x)) Tr%df_x => df_x ; endif
   if (present(df_y)) then ; if (associated(df_y)) Tr%df_y => df_y ; endif
-! if (present(OBC_inflow)) Tr%OBC_inflow_conc = OBC_inflow
 ! if (present(OBC_in_u)) then ; if (associated(OBC_in_u)) Tr%OBC_in_u => OBC_in_u ; endif
 ! if (present(OBC_in_v)) then ; if (associated(OBC_in_v)) Tr%OBC_in_v => OBC_in_v ; endif
   if (present(ad_2d_x)) then ; if (associated(ad_2d_x)) Tr%ad2d_x => ad_2d_x ; endif

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -13,7 +13,6 @@ implicit none ; private
 type, public :: tracer_type
 
   real, dimension(:,:,:), pointer :: t              => NULL() !< tracer concentration array [CU ~> conc]
-! real                            :: OBC_inflow_conc=  0.0    !< tracer concentration for generic inflows [CU ~> conc]
 ! real, dimension(:,:,:), pointer :: OBC_in_u       => NULL() !< structured values for flow into the domain
 !                                                             !! specified in OBCs through u-face of cell
 ! real, dimension(:,:,:), pointer :: OBC_in_v       => NULL() !< structured values for flow into the domain

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -463,7 +463,7 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, US, PF, tr_Reg)
     ! In this example, all S inflows have values given by S_ref.
     name = 'salt'
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
-    call register_segment_tracer(tr_ptr, ntr_id, PF, GV, segment, OBC_scalar=S_ref, scale=US%ppt_to_S)
+    call register_segment_tracer(tr_ptr, ntr_id, PF, GV, segment, OBC_inflow_conc=S_ref, scale=US%ppt_to_S)
   endif
   if (associated(tv%T)) then
     ! In this example, the T values are set to be consistent with the layer
@@ -488,7 +488,7 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, US, PF, tr_Reg)
     enddo ; enddo ; enddo
     name = 'temp'
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
-    call register_segment_tracer(tr_ptr, ntr_id, PF, GV, segment, OBC_array=.true., scale=US%degC_to_C)
+    call register_segment_tracer(tr_ptr, ntr_id, PF, GV, segment, scale=US%degC_to_C)
   endif
 
   ! Set up dye tracers
@@ -501,14 +501,14 @@ subroutine DOME_set_OBC_data(OBC, tv, G, GV, US, PF, tr_Reg)
   enddo ; enddo ; enddo
   name = 'tr_D1'
   call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
-  call register_segment_tracer(tr_ptr, ntr_id, PF, GV, OBC%segment(1), OBC_array=.true.)
+  call register_segment_tracer(tr_ptr, ntr_id, PF, GV, OBC%segment(1))
 
   ! All tracers but the first have 0 concentration in their inflows. As 0 is the
   ! default value for the inflow concentrations, the following calls are unnecessary.
   do m=2,tr_Reg%ntr
     write(name,'("tr_D",I0)') m
     call tracer_name_lookup(tr_Reg, ntr_id, tr_ptr, name)
-    call register_segment_tracer(tr_ptr, ntr_id, PF, GV, OBC%segment(1), OBC_scalar=0.0)
+    call register_segment_tracer(tr_ptr, ntr_id, PF, GV, OBC%segment(1), OBC_inflow_conc=0.0)
   enddo
 
 end subroutine DOME_set_OBC_data

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -138,7 +138,7 @@ subroutine dyed_channel_set_OBC_tracer_data(OBC, G, GV, param_file, tr_Reg)
         dye = 0.0
       endif
       call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, &
-                                   OBC%segment(n), OBC_scalar=dye)
+                                   OBC%segment(n), OBC_inflow_conc=dye)
     enddo
   enddo
 

--- a/src/user/dyed_obcs_initialization.F90
+++ b/src/user/dyed_obcs_initialization.F90
@@ -94,7 +94,7 @@ subroutine dyed_obcs_set_OBC_data(OBC, G, GV, param_file, tr_Reg)
         dye = 0.0
       endif
       call register_segment_tracer(tr_ptr, ntr_id, param_file, GV, &
-                                   OBC%segment(n), OBC_scalar=dye)
+                                   OBC%segment(n), OBC_inflow_conc=dye)
     enddo
   enddo
 


### PR DESCRIPTION

## Motivation
* OBC tracers previously had two separate code paths for supplying inflow concentrations:                                                               
  1. A full 2D reservoir array (`%tres`) updated each advection step via `update_segment_tracer_reservoirs`
  2. A scalar `OBC_inflow_conc` used only by `dyed_channel`, `dyed_obcs` and DOME.
  The scalar path required 6 `if (allocated(tres))` branches scattered through `MOM_tracer_advect.F90`                                                  
  and an extra `OBC_inflow_conc` field on every tracer type, complicating the data model for a case                                                     
  used by only two user configurations.

* OBC tracer update subroutine `update_segment_tracer_reservoirs` covers two possible length scales: Lscale is positive/finite and Lscale is zero. Logically, there should be a third one, Lscale = infinite, i.e. a frozen reservoir, which is exactly what `OBC_inflow_conc` currently does.

This PR folds the OBC_inflow_conc route into `update_segment_tracer_reservoirs` and unconditionally allocate %tres and %t for all cases.

## Commits  
  | Commit | Description |                                                                                                                              
  |---|---|
  | e68e58edf2c7d0aebdd42bade8ed3850674bd5a7 | Preparatory cleanup of `update_segment_tracer_reservoirs`: loop reorder (`m-[ij]-k` → `m-k-[ij]`), rename `u_L_in/out`/`v_L_in/out` to `L_in/out`, hoist `dir` and `OBC%tres_[xy]` writes, add `flux_to_res`/`face_area` temporaries |                                   
  | a42e11537d985b0b0130f522ae52cdc2df9b5b78 | Copy `resrv_lfac_in/out` from `segment%field` into the segment tracer registry, accessible via new optional arguments to `register_segment_tracer`; remove `fd_index` |                                                                                                       
  | 9dff2ffb6540fe81d94446271df90cab20916925 | Introduce pre-computed per-tracer `I_Lscale_in/out` encoding three reservoir regimes by sign (frozen / finite length scale / instant update); replace segment-level `b_in`/`b_out` switches with per-tracer `mask_a`/`mask_L` |                              
  | 88169b37f24f4ace1094d2d1bec9e31bfbf1407c | Fold `OBC_inflow_conc` scalar path into the array path (broadcast into `%tres` with frozen reservoir); unconditionally allocate `%t`/`%tres` at registration; remove 6 `if (allocated(tres))` branches from `MOM_tracer_advect.F90`;  `OBC_inflow_conc`, `OBC_array`, `fd_index`, and the misused `temp/salt_segment_data_exists` flags are removed from their respective types   |                        
  | 128a24b7d8a3191fee7488b7bcb069372ae0ac9d | Improve Doxygen for `register_segment_tracer` and `update_segment_tracer_reservoirs` |


### New relaxation length scale regimes                                                                                                                                                                                                                                      
  The new pre-computed `I_Lscale_in/out` fields on `OBC_segment_tracer_type` encode the reservoir                                                       
  update mode by sign:                                      
                                                                                                                                                        
  | Value  | Regime |                                       
  |--------|--------|                                                                                                                                   
  | `> 0`  | Finite length scale — reservoir relaxes toward interior/boundary at rate ∝ flux × I_Lscale / face_area |                                               
  | `= 0`  | Infinite length scale — reservoir is frozen |                                                                                              
  | `= -1` | Instant update — reservoir is immediately replaced by the interior (outflow) or boundary (inflow) value |                                  
                                                                                                                                                        
  `resrv_lfac = 0` maps to frozen; `resrv_lfac = -1` overrides `Tr_InvLscale` and forces instant                                                        
  update regardless of the segment-level length scale.                                                                                                  

### Misc
* There are description changes to runtime parameters `OBC_TRACER_RESERVOIR_LENGTH_SCALE_OUT` and `OBC_TRACER_RESERVOIR_LENGTH_SCALE_IN`
* The exercise also exposes that `OBC%ntr` can be different from the number of tracers registered to the segments, this has been patched by replacing `OBC%ntr` with `segment%tr_Reg%ntseg`.
* It should be documented that `segment%tr_Reg` exists on all PEs, but %t and %tres are only allocated if segment%on_pe is True.

 ## Answer impact

All answers are bitwise identical.  This PR was tested with NWA12 and a suite of ESMG experiments. In particular, it is verified that passive tracer concentrations, which cannot be reflected in `ocean.stats`, are not changed in dyed OBC.

## AI assist disclaimer
Claude Sonnet 4.6 is used for generating descriptions for a number of variables and subroutines, and co-authored commit 128a24b7d8a3191fee7488b7bcb069372ae0ac9d. It is also used to draft the description of this PR.