### PR TITLE
Bug fix OBC generic tracer initialization

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2627,12 +2627,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  units="s", default=default_val, scale=US%s_to_T, do_not_read=(dtbt > 0.0))
   endif
 
-  call get_param(param_file, "MOM", "DT_OBC_SEG_UPDATE_OBGC", CS%dt_obc_seg_period, &
-               "The time between OBC segment data updates for OBGC tracers. "//&
-               "This must be an integer multiple of DT and DT_THERM. "//&
-               "The default is set to DT.", &
-               units="s", default=US%T_to_s*CS%dt, scale=US%s_to_T, do_not_log=.not.associated(OBC_in))
-
   ! This is here in case these values are used inappropriately.
   use_frazil = .false. ; bound_salinity = .false. ; use_p_surf_in_EOS = .false.
   CS%tv%P_Ref = 2.0e7*US%Pa_to_RL2_T2
@@ -2879,6 +2873,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   ! Allocate initialize time-invariant MOM variables.
   call MOM_initialize_fixed(dG_in, US, OBC_in, param_file)
+
+  call get_param(param_file, "MOM", "DT_OBC_SEG_UPDATE_OBGC", CS%dt_obc_seg_period, &
+                 "The time between OBC segment data updates for OBGC tracers.  This must be an "//&
+                 "integer multiple of DT and DT_THERM.  The default is set to DT.", units="s", &
+                 default=US%T_to_s*CS%dt, scale=US%s_to_T, do_not_log=.not.associated(OBC_in))
 
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4846,11 +4846,9 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, h, Time)
     endif
 
     ! Update tracer registry
-    do m = NUM_PHYS_FIELDS-1, segment%num_fields ! F_T = NUM_PHYS_FIELDS-1 and F_S = NUM_PHYS_FIELDS
-      if (.not. allocated(segment%field(m)%buffer_dst) .or. &
-          (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data))) then
-        cycle
-      endif
+    do m=NUM_PHYS_FIELDS-1, segment%num_fields ! F_T = NUM_PHYS_FIELDS-1 and F_S = NUM_PHYS_FIELDS
+      if ((.not. allocated(segment%field(m)%buffer_dst)) .or. &
+          (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data))) cycle
       nt = segment%field(m)%tr_index
       ! Note the following unnecessary IF-branch is kept from the old code (as recent as Jan 2026).
       ! In the old code segment%field(m)%buffer_dst is always allocated at this point, and therefore
@@ -4912,7 +4910,8 @@ subroutine initialize_OBC_segment_reservoirs(GV, OBC)
     ! Tracers
     ! If the tracer reservoir has not yet been initialized, then set to external value.
     do m=NUM_PHYS_FIELDS-1, segment%num_fields ! F_T = NUM_PHYS_FIELDS-1 and F_S = NUM_PHYS_FIELDS
-      if (.not. allocated(segment%field(m)%buffer_dst)) cycle
+      if ((.not. allocated(segment%field(m)%buffer_dst)) .or. &
+          (segment%field(m)%bgc_tracer .and. (.not. OBC%update_OBC_seg_data))) cycle
       nt = segment%field(m)%tr_index
       if (.not. segment%tr_Reg%Tr(nt)%is_initialized) then ! T/S may be initialized by fill_temp_salt_segments
         do k=1,nz ; do j=js_seg,je_seg ; do i=is_seg,ie_seg


### PR DESCRIPTION
  - Commit 6f8759ed4 restores answers broken by commit 1e9ac398, which accidentally dropped the .not. `OBC%update_OBC_seg_data` guard when splitting  `initialize_OBC_segment_reservoirs` from `update_OBC_segment_data`. Since `OBC%update_OBC_seg_data` is false by default during initialization, BGC tracer  reservoirs were being set to their external (file) values inside `initialize_OBC_segment_reservoirs`, instead of to their interior values later in `fill_obgc_segments` (called from `tracer_flow_control_init`). The answer change affects new runs only, which is why it was not caught by NWA12 (which defaults to a restart run).
    - Note 1: as the buggy commit was merged just a few weeks ago, and this PR is meant to revert to an old behavior, no bug flag is added in this PR.
    - Note 2: assigning the BGC tracer reservoir from interior values (the restored behavior) mirrors the intent of the `OBC_RESERVOIR_INIT_BUG` flag for temperature and salinity. One can argue the external-value assignment is actually more correct — this will be addressed in a separate PR at work that refactors OBC reservoir initialization.       
                                                                                                
  - Commit 0ee27a755 fixes a parameter documentation bug: `DT_OBC_SEG_UPDATE_OBGC` was never written to MOM_parameter_doc because OBC_in is NULL() at the point where get_param was originally called (before `MOM_initialize_fixed`, which is where `open_boundary_config` allocates and associates `OBC_in`). 