### PR TITLE
(*)Avoid uninitialized use of USE_KH_IN_MEKE

### DIFF
--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -2384,6 +2384,8 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                    "The minimum total depth over which to average the diffusivity used for MEKE.  "//&
                    "When the total depth is less than this, the diffusivity is scaled away.", &
                    units="m", default=1.0, scale=GV%m_to_H, do_not_log=.not.CS%Use_KH_in_MEKE)
+  else
+    CS%Use_KH_in_MEKE = .false.
   endif
 
   call get_param(param_file, mdl, "USE_GME", CS%use_GME_thickness_diffuse, &


### PR DESCRIPTION
  Moved the `get_param()` call for `USE_KE_IN_MEKE` outside of the logical test for `USE_MEKE`, to avoid the possible problems with segmentation faults due to an uninitialized variable, as documented in https://github.com/mom-ocean/MOM6/issues/1696. A `do_not_log` argument in this `get_param()` call prevents there from being any changes to the MOM_parameter_doc files, and code setting the local version of this variable to false when `USE_MEKE` is false avoids the possibility of there being cases where the added code is used inadvertently.  All answers that worked previously will be bitwise identical, but this could fix problems with a segmentation fault arising from an uninitialized logical variable.