### PR TITLE
+(*)Use OBC info to remap velocity diagnostics

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -16,7 +16,7 @@ use MOM_cpu_clock,            only : cpu_clock_id, cpu_clock_begin, cpu_clock_en
 use MOM_cpu_clock,            only : CLOCK_COMPONENT, CLOCK_SUBCOMPONENT
 use MOM_cpu_clock,            only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
 use MOM_diag_mediator,        only : diag_mediator_init, enable_averaging, enable_averages
-use MOM_diag_mediator,        only : diag_mediator_infrastructure_init
+use MOM_diag_mediator,        only : diag_mediator_infrastructure_init, diag_mediator_set_OBC_info
 use MOM_diag_mediator,        only : diag_set_state_ptrs, diag_update_remap_grids
 use MOM_diag_mediator,        only : disable_averaging, post_data, safe_alloc_ptr
 use MOM_diag_mediator,        only : register_diag_field, register_cell_measure
@@ -3461,6 +3461,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   diag => CS%diag
   ! Initialize the diag mediator.
   call diag_mediator_init(G, GV, US, GV%ke, param_file, diag, doc_file_dir=dirs%output_directory)
+  if (associated(CS%OBC)) then
+    call diag_mediator_set_OBC_info(G, CS%OBC%segnum_u, CS%OBC%segnum_v, diag)
+  endif
   if (present(diag_ptr)) diag_ptr => CS%diag
 
   ! Initialize the diagnostics masks for native arrays.

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -55,7 +55,7 @@ public post_data_1d_k
 public safe_alloc_ptr, safe_alloc_alloc
 public enable_averaging, enable_averages, disable_averaging, query_averaging_enabled
 public diag_mediator_init, diag_mediator_end, set_diag_mediator_grid
-public diag_mediator_infrastructure_init
+public diag_mediator_infrastructure_init, diag_mediator_set_OBC_info
 public diag_mediator_close_registration, get_diag_time_end
 public diag_axis_init, ocean_register_diag, register_static_field
 public register_scalar_field
@@ -354,6 +354,14 @@ type, public :: diag_ctrl
   !> Number of checksum-only diagnostics
   integer :: num_chksum_diags
 
+  integer, dimension(:,:), allocatable :: OBC_u !< An array that indicates the presence and direction
+                                                !! of any open boundary conditions at u-points,
+                                                !! with a value of 0 for no OBC, 1 for an
+                                                !! Eastern OBC or -1 for a Western OBC
+  integer, dimension(:,:), allocatable :: OBC_v !< An array that indicates the presence and direction
+                                                !! of any open boundary conditions at v-points,
+                                                !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                                !! or -1 for a Southern OBC
   real, dimension(:,:,:), allocatable :: h_begin !< Layer thicknesses at the beginning of the timestep used
                                                  !! for remapping of extensive variables [H ~> m or kg m-2]
   real, dimension(:,:,:), allocatable :: dz_begin !< Layer vertical extents at the beginning of the timestep used
@@ -1659,12 +1667,12 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
         call vertically_reintegrate_diag_field(                                    &
                 diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), diag_cs%G, &
                 diag_cs%dz_begin, diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%h_extensive, &
-                staggered_in_x, staggered_in_y, diag%axes%mask3d, field, remapped_field)
+                diag_cs%OBC_u, diag_cs%OBC_v, staggered_in_x, staggered_in_y, diag%axes%mask3d, field, remapped_field)
       else
         call vertically_reintegrate_diag_field(                                    &
                 diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), diag_cs%G, &
                 diag_cs%h_begin, diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%h_extensive, &
-                staggered_in_x, staggered_in_y, diag%axes%mask3d, field, remapped_field)
+                diag_cs%OBC_u, diag_cs%OBC_v, staggered_in_x, staggered_in_y, diag%axes%mask3d, field, remapped_field)
       endif
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
@@ -1688,12 +1696,12 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
       allocate(remapped_field(size(field,1), size(field,2), diag%axes%nz))
       if (diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%Z_based_coord) then
         call diag_remap_do_remap(diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
-                diag_cs%G, diag_cs%GV, diag_cs%US, dz_diag, staggered_in_x, staggered_in_y, &
-                diag%axes%mask3d, field, remapped_field)
+                diag_cs%G, diag_cs%GV, diag_cs%US, dz_diag, diag_cs%OBC_u, diag_cs%OBC_v, &
+                staggered_in_x, staggered_in_y, diag%axes%mask3d, field, remapped_field)
       else
         call diag_remap_do_remap(diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
-                diag_cs%G, diag_cs%GV, diag_cs%US, h_diag, staggered_in_x, staggered_in_y, &
-                diag%axes%mask3d, field, remapped_field)
+                diag_cs%G, diag_cs%GV, diag_cs%US, h_diag, diag_cs%OBC_u, diag_cs%OBC_v, &
+                staggered_in_x, staggered_in_y, diag%axes%mask3d, field, remapped_field)
       endif
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
@@ -1717,11 +1725,11 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
       allocate(remapped_field(size(field,1), size(field,2), diag%axes%nz+1))
       if (diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%Z_based_coord) then
         call vertically_interpolate_diag_field(diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
-                diag_cs%G, dz_diag, staggered_in_x, staggered_in_y, &
+                diag_cs%G, dz_diag, diag_cs%OBC_u, diag_cs%OBC_v, staggered_in_x, staggered_in_y, &
                 diag%axes%mask3d, field, remapped_field)
       else
         call vertically_interpolate_diag_field(diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
-                diag_cs%G, h_diag, staggered_in_x, staggered_in_y, &
+                diag_cs%G, h_diag, diag_cs%OBC_u, diag_cs%OBC_v, staggered_in_x, staggered_in_y, &
                 diag%axes%mask3d, field, remapped_field)
       endif
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
@@ -3408,6 +3416,7 @@ subroutine diag_mediator_infrastructure_init(err_msg)
   call MOM_diag_manager_init(err_msg=err_msg)
 end subroutine diag_mediator_infrastructure_init
 
+
 !> diag_mediator_init initializes the MOM diag_mediator and opens the available
 !! diagnostics file, if appropriate.
 subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
@@ -3536,9 +3545,10 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   allocate(diag_cs%h_begin(G%isd:G%ied,G%jsd:G%jed,nz))
   if (dz_diag_needed) allocate(diag_cs%dz_begin(G%isd:G%ied,G%jsd:G%jed,nz))
 #if defined(DEBUG) || defined(__DO_SAFETY_CHECKS__)
-  allocate(diag_cs%h_old(G%isd:G%ied,G%jsd:G%jed,nz))
-  diag_cs%h_old(:,:,:) = 0.0
+  allocate(diag_cs%h_old(G%isd:G%ied,G%jsd:G%jed,nz), source=0.0)
 #endif
+  allocate(diag_cs%OBC_u(G%IsdB:G%IedB,G%jsd:G%jed), source=0)
+  allocate(diag_cs%OBC_v(G%isd:G%ied,G%JsdB:G%JedB), source=0)
 
   diag_cs%is = G%isc - (G%isd-1) ; diag_cs%ie = G%iec - (G%isd-1)
   diag_cs%js = G%jsc - (G%jsd-1) ; diag_cs%je = G%jec - (G%jsd-1)
@@ -3643,6 +3653,39 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   endif
 
 end subroutine diag_mediator_init
+
+!> diag_mediator_set_OBC_info stores limited information about the locations and orientations
+!! of open boundary condition segments at velocity points..
+subroutine diag_mediator_set_OBC_info(G, OBC_seg_u, OBC_seg_v, diag_cs)
+  type(ocean_grid_type), intent(inout) :: G  !< The ocean grid type.
+  integer, dimension(G%IsdB:G%IedB,G%jsd:G%jed),  &
+                         intent(in) :: OBC_seg_u !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at u-points,
+                                             !! with a value of 0 for no OBC, a positive value for an
+                                             !! Eastern OBC or a negative value for a Western OBC
+  integer, dimension(G%isd:G%ied,G%JsdB:G%JedB), &
+                         intent(in) :: OBC_seg_v !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at v-points,
+                                             !! with a value of 0 for no OBC, a positive value for a
+                                             !! Northern OBC or a negative value for a Southern OBC
+  type(diag_ctrl),       intent(inout) :: diag_cs !< A defined type used to regulate diagnostics
+
+  integer :: i, j
+
+  do j=G%jsd,G%jed ; do i=G%IsdB,G%IedB
+    diag_cs%OBC_u(I,j) = 0
+    if (OBC_seg_u(I,j) > 0) diag_cs%OBC_u(I,j) = 1
+    if (OBC_seg_u(I,j) < 0) diag_cs%OBC_u(I,j) = -1
+  enddo ; enddo
+
+  do J=G%JsdB,G%JedB ; do i=G%isd,G%ied
+    diag_cs%OBC_v(i,J) = 0.0
+    if (OBC_seg_v(i,J) > 0) diag_cs%OBC_v(i,J) = 1
+    if (OBC_seg_v(i,J) < 0) diag_cs%OBC_v(i,J) = -1
+  enddo ; enddo
+
+end subroutine diag_mediator_set_OBC_info
+
 
 !> Set pointers to the default state fields used to remap diagnostics.
 subroutine diag_set_state_ptrs(h, tv, diag_cs)
@@ -4481,7 +4524,7 @@ subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, d
   real, dimension(:,:,:), allocatable :: field_out !< Downsampled field in the same arbitrary units [A ~> a]
   integer, intent(in) :: dL                !< Level of down sampling
   integer,  intent(in) :: method           !< Sampling method
-  real,  dimension(:,:,:), pointer :: mask !< Mask for field [nondim]
+  real,  dimension(:,:,:), pointer :: mask !< Mask for input field [nondim]
   type(diag_ctrl), intent(in) :: diag_CS   !< Structure used to regulate diagnostic output
   type(diag_type), intent(in) :: diag      !< A structure describing the diagnostic to post
   integer, intent(in) :: isv_o             !< Original i-start index
@@ -4511,6 +4554,7 @@ subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, d
                     ! value [nondim], [L2 ~> m2], [H L ~> m2 or kg m-1] or [H L2 ~> m3 or kg]
   real :: total_weight ! The sum of weights contributing to a point [nondim], [L2 ~> m2],
                     ! [H L ~> m2 or kg m-1] or [H L2 ~> m3 or kg]
+  real :: h_face    ! The thickness at a velocity face [H ~> m or kg m-2]
   real :: eps_vol   ! A negligibly small volume or mass [H L2 ~> m3 or kg]
   real :: eps_area  ! A negligibly small area [L2 ~> m2]
   real :: eps_face  ! A negligibly small face area [H L ~> m2 or kg m-1]
@@ -4537,7 +4581,7 @@ subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, d
     f1 = f1 + mod(f_in1, dL)
     f2 = f2 + mod(f_in2, dL)
   endif
-  allocate(field_out(1:f1,1:f2,ks:ke))
+  allocate(field_out(1:f1,1:f2,ks:ke), source=0.0)
 
   ! These are the starting point offsets between full array and reduced array indices when i or j is 0.
   i0_off = (isv_o-1) - dL*isv_d
@@ -4579,8 +4623,14 @@ subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, d
       II = dL*I + I0_off + (dL-1)
       do j_dn=1,dL
         jj = j_dn + (dL*j + j0_off)
-        !### The thickness here is offset by have a grid point from the rest of the expression.
-        wt_1d(j_dn) = mask(II,jj,k) * diag_cs%G%dyCu(II,jj) * diag_cs%h(ii,jj,k)
+        if (diag_cs%OBC_u(II,jj) == 0) then    ! This is not an OBC face.
+          h_face = 0.5*(diag_cs%h(ii,jj,k) + diag_cs%h(ii+1,jj,k))
+        elseif (diag_cs%OBC_u(II,jj) < 0) then ! This is a western OBC face.
+          h_face = diag_cs%h(ii+1,jj,k)
+        else  ! (diag_cs%OBC_u(II,jj) > 0)     ! This is an eastern OBC face.
+          h_face = diag_cs%h(ii,jj,k)
+        endif
+        wt_1d(j_dn) = mask(II,jj,k) * diag_cs%G%dyCu(II,jj) * h_face
         wtd_field_1d(j_dn) = field_in(II,jj,k) * wt_1d(j_dn)
       enddo
       field_out(I,j,k)  = sum_1d(wtd_field_1d(1:dL), dL) / &
@@ -4609,8 +4659,14 @@ subroutine downsample_field_3d(field_in, field_out, dL, method, mask, diag_cs, d
       JJ = dL*J + J0_off + (dL-1)
       do i_dn=1,dL
         ii = i_dn + (dL*i + i0_off)
-        !### The thickness here is offset by have a grid point from the rest of the expression.
-        wt_1d(i_dn) = mask(ii,JJ,k) * diag_cs%G%dxCv(ii,JJ) * diag_cs%h(ii,jj,k)
+        if (diag_cs%OBC_v(ii,JJ) == 0) then    ! This is not an OBC face.
+          h_face = 0.5*(diag_cs%h(ii,jj,k) + diag_cs%h(ii,jj+1,k))
+        elseif (diag_cs%OBC_v(ii,JJ) < 0) then ! This is a southern OBC face.
+          h_face = diag_cs%h(ii,jj+1,k)
+        else  ! (diag_cs%OBC_v(ii,JJ) > 0)     ! This is a northern OBC face.
+          h_face = diag_cs%h(ii,jj,k)
+        endif
+        wt_1d(i_dn) = mask(ii,JJ,k) * diag_cs%G%dxCv(ii,JJ) * h_face
         wtd_field_1d(i_dn) = field_in(ii,JJ,k) * wt_1d(i_dn)
       enddo
       field_out(i,J,k)  = sum_1d(wtd_field_1d(1:dL), dL) / &
@@ -4632,7 +4688,7 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   real, dimension(:,:), allocatable :: field_out !< Downsampled field in the same arbitrary units [A ~> a]
   integer, intent(in) :: dl                !< Level of down sampling
   integer,  intent(in) :: method           !< Sampling method
-  real, dimension(:,:), pointer :: mask    !< Mask for field [nondim]
+  real, dimension(:,:), pointer :: mask    !< Mask for input field [nondim]
   type(diag_ctrl),   intent(in) :: diag_CS !< Structure used to regulate diagnostic output
   type(diag_type),   intent(in) :: diag    !< A structure describing the diagnostic to post
   integer, intent(in) :: isv_o             !< Original i-start index
@@ -4641,6 +4697,7 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   integer, intent(in) :: iev_d             !< i-end index of down sampled data
   integer, intent(in) :: jsv_d             !< j-start index of down sampled data
   integer, intent(in) :: jev_d             !< j-end index of down sampled data
+
   ! Local variables
   character(len=240) :: mesg
   integer :: i, j, i_dn, j_dn, i0, j0, f1, f2, f_in1, f_in2
@@ -4673,8 +4730,8 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
   ! Fill the down sampled field on the down sampled diagnostics (almost always compute) domain
   f_in1 = size(field_in,1)
   f_in2 = size(field_in,2)
-  f1 = f_in1/dl
-  f2 = f_in2/dl
+  f1 = f_in1 / dL
+  f2 = f_in2 / dL
   ! Correction for the symmetric case
   if (diag_cs%G%symmetric) then
     f1 = f1 + mod(f_in1,dl)
@@ -4725,7 +4782,6 @@ subroutine downsample_field_2d(field_in, field_out, dl, method, mask, diag_cs, d
     enddo ; enddo
   elseif (method == PMP) then
     do j=jsv_d,jev_d ; do I=isv_d,iev_d
-      ! This expression for ii agrees with what was here before, but is it what we want?
       II = dL*I + I0_off + (dL-1)
       do j_dn=1,dL
         jj = j_dn + (dL*j + j0_off)

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -378,7 +378,7 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state, h_targe
 end subroutine diag_remap_update
 
 !> Remap diagnostic field to alternative vertical grid.
-subroutine diag_remap_do_remap(remap_cs, G, GV, US, h, staggered_in_x, staggered_in_y, &
+subroutine diag_remap_do_remap(remap_cs, G, GV, US, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                                mask, field, remapped_field)
   type(diag_remap_ctrl),   intent(in)  :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),   intent(in)  :: G  !< Ocean grid structure
@@ -386,6 +386,14 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, US, h, staggered_in_x, staggered
   type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
   real, dimension(:,:,:),  intent(in)  :: h  !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
                                              !! depending on the value of remap_CS%Z_based_coord
+  integer, dimension(:,:), intent(in)  :: OBC_u !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at u-points,
+                                             !! with a value of 0 for no OBC, 1 for an Eastern OBC
+                                             !! or -1 for a Western OBC
+  integer, dimension(:,:), intent(in)  :: OBC_v !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at v-points,
+                                             !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                             !! or -1 for a Southern OBC
   logical,                 intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                 intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(:,:,:),  pointer     :: mask !< A mask for the field [nondim].
@@ -403,17 +411,17 @@ subroutine diag_remap_do_remap(remap_cs, G, GV, US, h, staggered_in_x, staggered
   jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
 
   if (associated(mask)) then
-    call do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+    call do_remap(remap_cs, G, GV, US, isdf, jsdf, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                   field, remapped_field, mask(:,:,1))
   else
-    call do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+    call do_remap(remap_cs, G, GV, US, isdf, jsdf, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                   field, remapped_field)
   endif
 
 end subroutine diag_remap_do_remap
 
 !> The internal routine to remap a diagnostic field to an alternative vertical grid.
-subroutine do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+subroutine do_remap(remap_cs, G, GV, US, isdf, jsdf, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                     field, remapped_field, mask)
   type(diag_remap_ctrl),   intent(in)  :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),   intent(in)  :: G  !< Ocean grid structure
@@ -424,6 +432,16 @@ subroutine do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggere
   real, dimension(G%isd:,G%jsd:,:), &
                            intent(in)  :: h  !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
                                              !! depending on the value of remap_CS%Z_based_coord
+  integer, dimension(G%IsdB:,G%jsd:), &
+                           intent(in) :: OBC_u !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at u-points,
+                                             !! with a value of 0 for no OBC, 1 for an Eastern OBC
+                                             !! or -1 for a Western OBC
+  integer, dimension(G%isd:,G%JsdB:), &
+                           intent(in) :: OBC_v !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at v-points,
+                                             !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                             !! or -1 for a Southern OBC
   logical,                 intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                 intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(isdf:,jsdf:,:), &
@@ -447,15 +465,31 @@ subroutine do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggere
     ! U-points
     if (present(mask)) then
       do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (mask(I,j) > 0.) then
-        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        if (OBC_u(I,j) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i+1,j,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        elseif (OBC_u(I,j) < 0) then ! This is a western OBC face.
+          h_src(:) = h(i+1,j,:)
+          h_dest(:) = remap_cs%h(i+1,j,:)
+        else    ! (OBC_u(I,j) > 0)   ! This is a eastern OBC face.
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(I,j,:), &
                               nz_dest, h_dest(:), remapped_field(I,j,:))
       endif ; enddo ; enddo
     else
       do j=G%jsc,G%jec ; do I=G%IscB,G%IecB
-        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        if (OBC_u(I,j) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i+1,j,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        elseif (OBC_u(I,j) < 0) then ! This is a western OBC face.
+          h_src(:) = h(i+1,j,:)
+          h_dest(:) = remap_cs%h(i+1,j,:)
+        else    ! (OBC_u(I,j) > 0)   ! This is a eastern OBC face.
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(I,j,:), &
                               nz_dest, h_dest(:), remapped_field(I,j,:))
       enddo ; enddo
@@ -464,15 +498,31 @@ subroutine do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggere
     ! V-points
     if (present(mask)) then
       do J=G%jscB,G%jecB ; do i=G%isc,G%iec ; if (mask(i,j) > 0.) then
-        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        if (OBC_v(i,J) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i,j+1,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        elseif (OBC_v(i,J) < 0) then ! This is a southern OBC face
+          h_src(:) = h(i,j+1,:)
+          h_dest(:) = remap_cs%h(i,j+1,:)
+        else    ! (OBC_v(i,J) > 0)   ! This is a northern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(i,J,:), &
                               nz_dest, h_dest(:), remapped_field(i,J,:))
       endif ; enddo ; enddo
     else
       do J=G%jscB,G%jecB ; do i=G%isc,G%iec
-        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        if (OBC_v(i,J) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i,j+1,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        elseif (OBC_v(i,J) < 0) then ! This is a southern OBC face
+          h_src(:) = h(i,j+1,:)
+          h_dest(:) = remap_cs%h(i,j+1,:)
+        else    ! (OBC_v(i,J) > 0)   ! This is a northern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(i,J,:), &
                               nz_dest, h_dest(:), remapped_field(i,J,:))
       enddo ; enddo
@@ -543,12 +593,20 @@ subroutine diag_remap_calc_hmask(remap_cs, G, mask)
 end subroutine diag_remap_calc_hmask
 
 !> Vertically re-grid an already vertically-integrated diagnostic field to alternative vertical grid.
-subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered_in_x, staggered_in_y, &
-                                             mask, field, reintegrated_field)
+subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, OBC_u, OBC_v, &
+                                             staggered_in_x, staggered_in_y, mask, field, reintegrated_field)
   type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),  intent(in)  :: G        !< Ocean grid structure
   real, dimension(:,:,:), intent(in)  :: h        !< The thicknesses of the source grid [H ~> m or kg m-2] or [Z ~> m]
   real, dimension(:,:,:), intent(in)  :: h_target !< The thicknesses of the target grid [H ~> m or kg m-2] or [Z ~> m]
+  integer, dimension(:,:), intent(in) :: OBC_u    !< An array that indicates the presence and direction
+                                                  !! of any open boundary conditions at u-points,
+                                                  !! with a value of 0 for no OBC, 1 for an Eastern OBC
+                                                  !! or -1 for a Western OBC
+  integer, dimension(:,:), intent(in) :: OBC_v    !< An array that indicates the presence and direction
+                                                  !! of any open boundary conditions at v-points,
+                                                  !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                                  !! or -1 for a Southern OBC
   logical,                intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(:,:,:), pointer     :: mask     !< A mask for the field [nondim].  Note that because this
@@ -567,19 +625,19 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
   jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
 
   if (associated(mask)) then
-    call vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, staggered_in_x, staggered_in_y, &
-                                      field, reintegrated_field, mask(:,:,1))
+    call vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, OBC_u, OBC_v, &
+                                      staggered_in_x, staggered_in_y, field, reintegrated_field, mask(:,:,1))
   else
-    call vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, staggered_in_x, staggered_in_y, &
-                                      field, reintegrated_field)
+    call vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, OBC_u, OBC_v, &
+                                      staggered_in_x, staggered_in_y, field, reintegrated_field)
   endif
 
 end subroutine vertically_reintegrate_diag_field
 
 !> The internal routine to vertically re-grid an already vertically-integrated diagnostic field to
 !! an alternative vertical grid.
-subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, staggered_in_x, staggered_in_y, &
-                                        field, reintegrated_field, mask)
+subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, OBC_u, OBC_v, &
+                                        staggered_in_x, staggered_in_y, field, reintegrated_field, mask)
   type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),  intent(in)  :: G        !< Ocean grid structure
   integer,                intent(in)  :: isdf     !< The starting i-index in memory for field
@@ -588,6 +646,16 @@ subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, st
                           intent(in)  :: h        !< The thicknesses of the source grid [H ~> m or kg m-2] or [Z ~> m]
   real, dimension(G%isd:,G%jsd:,:), &
                           intent(in)  :: h_target !< The thicknesses of the target grid [H ~> m or kg m-2] or [Z ~> m]
+  integer, dimension(G%IsdB:,G%jsd:),  &
+                           intent(in) :: OBC_u    !< An array that indicates the presence and direction
+                                                  !! of any open boundary conditions at u-points,
+                                                  !! with a value of 0 for no OBC, 1 for an Eastern OBC
+                                                  !! or -1 for a Western OBC
+  integer, dimension(G%isd:,G%JsdB:), &
+                           intent(in) :: OBC_v    !< An array that indicates the presence and direction
+                                                  !! of any open boundary conditions at v-points,
+                                                  !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                                  !! or -1 for a Southern OBC
   logical,                intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(isdf:,jsdf:,:), &
@@ -611,15 +679,31 @@ subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, st
     ! U-points
     if (present(mask)) then
       do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (mask(I,j) > 0.0) then
-        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
-        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i+1,j,:))
+        if (OBC_u(I,j) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i+1,j,:))
+          h_dest(:) = 0.5*(h_target(i,j,:) + h_target(i+1,j,:))
+        elseif (OBC_u(I,j) < 0) then ! This is a western OBC face
+          h_src(:) = h(i+1,j,:)
+          h_dest(:) = h_target(i+1,j,:)
+        else    ! (OBC_u(I,j) > 0)   ! This is an eastern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = h_target(i,j,:)
+        endif
         call reintegrate_column(nz_src, h_src, field(I,j,:), &
                                 nz_dest, h_dest, reintegrated_field(I,j,:))
       endif ; enddo ; enddo
     else
       do j=G%jsc,G%jec ; do I=G%IscB,G%IecB
-        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
-        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i+1,j,:))
+        if (OBC_u(I,j) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i+1,j,:))
+          h_dest(:) = 0.5*(h_target(i,j,:) + h_target(i+1,j,:))
+        elseif (OBC_u(I,j) < 0) then ! This is a western OBC face
+          h_src(:) = h(i+1,j,:)
+          h_dest(:) = h_target(i+1,j,:)
+        else    ! (OBC_u(I,j) > 0)   ! This is an eastern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = h_target(i,j,:)
+        endif
         call reintegrate_column(nz_src, h_src, field(I,j,:), &
                                 nz_dest, h_dest, reintegrated_field(I,j,:))
       enddo ; enddo
@@ -628,15 +712,31 @@ subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, st
     ! V-points
     if (present(mask)) then
       do J=G%jscB,G%jecB ; do i=G%isc,G%iec ; if (mask(i,J) > 0.0) then
-        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
-        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i,j+1,:))
+        if (OBC_v(i,J) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i,j+1,:))
+          h_dest(:) = 0.5*(h_target(i,j,:) + h_target(i,j+1,:))
+        elseif (OBC_v(i,J) < 0) then ! This is a southern OBC face
+          h_src(:) = h(i,j+1,:)
+          h_dest(:) = h_target(i,j+1,:)
+        else    ! (OBC_v(i,J) > 0)   ! This is a northern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = h_target(i,j,:)
+        endif
         call reintegrate_column(nz_src, h_src, field(i,J,:), &
                                 nz_dest, h_dest, reintegrated_field(i,J,:))
       endif ; enddo ; enddo
     else
       do J=G%jscB,G%jecB ; do i=G%isc,G%iec
-        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
-        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i,j+1,:))
+        if (OBC_v(i,J) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i,j+1,:))
+          h_dest(:) = 0.5*(h_target(i,j,:) + h_target(i,j+1,:))
+        elseif (OBC_v(i,J) < 0) then ! This is a southern OBC face
+          h_src(:) = h(i,j+1,:)
+          h_dest(:) = h_target(i,j+1,:)
+        else    ! (OBC_v(i,J) > 0)   ! This is a northern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = h_target(i,j,:)
+        endif
         call reintegrate_column(nz_src, h_src, field(i,J,:), &
                                 nz_dest, h_dest, reintegrated_field(i,J,:))
       enddo ; enddo
@@ -661,12 +761,20 @@ subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, st
 end subroutine vertically_reintegrate_field
 
 !> Vertically interpolate diagnostic field to alternative vertical grid.
-subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, staggered_in_y, &
+subroutine vertically_interpolate_diag_field(remap_cs, G, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                                              mask, field, interpolated_field)
   type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),  intent(in) :: G   !< Ocean grid structure
   real, dimension(:,:,:), intent(in) :: h   !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
                                             !! depending on the value of remap_cs%Z_based_coord
+  integer, dimension(:,:), intent(in) :: OBC_u !< An array that indicates the presence and direction
+                                            !! of any open boundary conditions at u-points,
+                                            !! with a value of 0 for no OBC, 1 for an Eastern OBC
+                                            !! or -1 for a Western OBC
+  integer, dimension(:,:), intent(in) :: OBC_v !< An array that indicates the presence and direction
+                                            !! of any open boundary conditions at v-points,
+                                            !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                            !! or -1 for a Southern OBC
   logical,                intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(:,:,:), pointer    :: mask !< A mask for the field [nondim].  Note that because this
@@ -685,18 +793,18 @@ subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, sta
   jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
 
   if (associated(mask)) then
-    call vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+    call vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                                       field, interpolated_field, mask(:,:,1))
   else
-    call vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+    call vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, OBC_u, OBC_v, staggered_in_x, staggered_in_y, &
                                       field, interpolated_field)
   endif
 
 end subroutine vertically_interpolate_diag_field
 
 !> Internal routine to vertically interpolate a diagnostic field to an alternative vertical grid.
-subroutine vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
-                                        field, interpolated_field, mask)
+subroutine vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, OBC_u, OBC_v, &
+                                        staggered_in_x, staggered_in_y, field, interpolated_field, mask)
   type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),  intent(in)  :: G    !< Ocean grid structure
   integer,                intent(in)  :: isdf !< The starting i-index in memory for field
@@ -704,6 +812,16 @@ subroutine vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in
   real, dimension(G%isd:,G%jsd:,:), &
                           intent(in)  :: h    !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
                                               !! depending on the value of remap_cs%Z_based_coord
+  integer, dimension(G%IsdB:,G%jsd:),  &
+                           intent(in) :: OBC_u !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at u-points,
+                                             !! with a value of 0 for no OBC, 1 for an Eastern OBC
+                                             !! or -1 for a Western OBC
+  integer, dimension(G%isd:,G%JsdB:), &
+                           intent(in) :: OBC_v !< An array that indicates the presence and direction
+                                             !! of any open boundary conditions at v-points,
+                                             !! with a value of 0 for no OBC, 1 for a Northern OBC
+                                             !! or -1 for a Southern OBC
   logical,                intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
   real, dimension(isdf:,jsdf:,:), &
@@ -728,15 +846,31 @@ subroutine vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in
     ! U-points
     if (present(mask)) then
       do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (mask(I,j) > 0.0) then
-        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        if (OBC_u(I,j) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i+1,j,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        elseif (OBC_u(I,j) < 0) then ! This is a western OBC face.
+          h_src(:) = h(i+1,j,:)
+          h_dest(:) = remap_cs%h(i+1,j,:)
+        else    ! (OBC_u(I,j) > 0)   ! This is a eastern OBC face.
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call interpolate_column(nz_src, h_src, field(I,j,:), &
                                 nz_dest, h_dest, interpolated_field(I,j,:), .true.)
       endif ; enddo ; enddo
     else
       do j=G%jsc,G%jec ; do I=G%IscB,G%IecB
-        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        if (OBC_u(I,j) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i+1,j,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        elseif (OBC_u(I,j) < 0) then ! This is a western OBC face.
+          h_src(:) = h(i+1,j,:)
+          h_dest(:) = remap_cs%h(i+1,j,:)
+        else    ! (OBC_u(I,j) > 0)   ! This is a eastern OBC face.
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call interpolate_column(nz_src, h_src, field(I,j,:), &
                                 nz_dest, h_dest, interpolated_field(I,j,:), .true.)
       enddo ; enddo
@@ -745,15 +879,31 @@ subroutine vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in
     ! V-points
     if (present(mask)) then
       do J=G%jscB,G%jecB ; do i=G%isc,G%iec ; if (mask(I,j) > 0.0) then
-        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        if (OBC_v(i,J) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i,j+1,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        elseif (OBC_v(i,J) < 0) then ! This is a southern OBC face
+          h_src(:) = h(i,j+1,:)
+          h_dest(:) = remap_cs%h(i,j+1,:)
+        else    ! (OBC_v(i,J) > 0)   ! This is a northern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call interpolate_column(nz_src, h_src, field(i,J,:), &
                                 nz_dest, h_dest, interpolated_field(i,J,:), .true.)
       endif ; enddo ; enddo
     else
       do J=G%jscB,G%jecB ; do i=G%isc,G%iec
-        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        if (OBC_v(i,J) == 0) then    ! This is not an OBC face.
+          h_src(:) = 0.5*(h(i,j,:) + h(i,j+1,:))
+          h_dest(:) = 0.5*(remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        elseif (OBC_v(i,J) < 0) then ! This is a southern OBC face
+          h_src(:) = h(i,j+1,:)
+          h_dest(:) = remap_cs%h(i,j+1,:)
+        else    ! (OBC_v(i,J) > 0)   ! This is a northern OBC face
+          h_src(:) = h(i,j,:)
+          h_dest(:) = remap_cs%h(i,j,:)
+        endif
         call interpolate_column(nz_src, h_src, field(i,J,:), &
                                 nz_dest, h_dest, interpolated_field(i,J,:), .true.)
       enddo ; enddo


### PR DESCRIPTION
  This commit provides the MOM6 diag_mediator with information about the locations and orientations of any open boundary condition segments at velocity points, and then uses this to select the correct thicknesses to use for vertical remapping of diagnostics onto alternative diagnostic grids (e.g., z or rho2). It also makes a change to properly interpolate the thicknesses that are used as weights for downsampling velocities.  Previously a one-sided estimate of the thicknesses was being used, which did not satisfy rotational consistency.

  The specific changes here include:

 . The addition of the new publicly visible routine `diag_mediator_set_OBC_info()` and a call to this routine from `initialize_MOM()` when OBCs are being used.  This routine stores information about the location and orientation of OBC segments.  It does not need to be called when OBCs are not being used.

 . The addition of two new real arrays to the `diag_ctrl` type with values of 0, -1 or 1, depending on the presence and orientation of OBCs at velocity faces.

 . The addition of `OBC_u` and `OBC_v` arguments to 3 publicly visible routines in `MOM_diag_remap (diag_remap_do_remap()`, `vertically_reintegrate_diag_field()` and `vertically_interpolate_diag_field()`) and to their private counterparts (`do_remap vertically_reintegrate_field()` and `vertically_interpolate_field()`). These arrays are used to select the appropriately interpolated thicknesses at velocity points to use as weights for remapping.

  In tests of these changes in the loop current test case, the changes to the remapped velocities and transports at OBC points are subtle but real, while in the interior (away from OBCs) the diagnostics are unaltered.

  All solutions are bitwise identical and no primary diagnostics are changed, but there are changes to remapped diagnostics in cases with open boundary conditions.  Within this commit this a new publicly visible subroutine, several changes to the interfaces of 3 publicly visible routines and the addition of two new 2-d arrays to the diagnostics control structure.