### PR TITLE
(*)Always allocate MLD array for offline tracers

### DIFF
--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -621,7 +621,7 @@ end subroutine offline_add_diurnal_sw
 !! in a previous integration of the online model
 subroutine update_offline_from_files(G, GV, US, nk_input, mean_file, sum_file, snap_file, &
                 surf_file, h_end, uhtr, vhtr, temp_mean, salt_mean, mld, Kd, fluxes, &
-                ridx_sum, ridx_snap, read_mld, read_sw, read_ts_uvh, do_ale_in)
+                ridx_sum, ridx_snap, read_mld, mld_var_name, read_sw, read_ts_uvh, do_ale_in)
 
   type(ocean_grid_type),   intent(inout) :: G         !< Horizontal grid type
   type(verticalGrid_type), intent(in   ) :: GV        !< Vertical grid type
@@ -650,6 +650,8 @@ subroutine update_offline_from_files(G, GV, US, nk_input, mean_file, sum_file, s
   integer,                 intent(in   ) :: ridx_sum  !< Read index for sum, mean, and surf files
   integer,                 intent(in   ) :: ridx_snap !< Read index for snapshot file
   logical,                 intent(in   ) :: read_mld  !< True if reading in MLD
+  character(len=*),        intent(in   ) :: mld_var_name !< Name of the mixed layer depth variable
+                                                      !! to read from a file.
   logical,                 intent(in   ) :: read_sw   !< True if reading in radiative fluxes
   logical,                 intent(in   ) :: read_ts_uvh !< True if reading in uh, vh, and h
   logical,       optional, intent(in   ) :: do_ale_in !< True if using ALE algorithms
@@ -726,7 +728,7 @@ subroutine update_offline_from_files(G, GV, US, nk_input, mean_file, sum_file, s
   endif
 
   if (read_mld) then
-    call MOM_read_data(surf_file, 'ePBL_h_ML', mld, G%Domain, timelevel=ridx_sum, scale=US%m_to_Z)
+    call MOM_read_data(surf_file, mld_var_name, mld, G%Domain, timelevel=ridx_sum, scale=US%m_to_Z)
   endif
 
   if (read_sw) then

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -102,6 +102,7 @@ type, public :: offline_transport_CS ; private
   logical :: skip_diffusion    !< Skips horizontal diffusion of tracers
   logical :: read_sw           !< Read in averaged values for shortwave radiation
   logical :: read_mld          !< Check to see whether mixed layer depths should be read in
+  real    :: Hmix_fixed        !< A fixed mixed layer depth to use when read_mld is false [Z ~> m]
   logical :: diurnal_sw        !< Adds a synthetic diurnal cycle on shortwave radiation
   logical :: debug             !< If true, write verbose debugging messages
   logical :: redistribute_barotropic !< Redistributes column-summed residual transports throughout
@@ -1051,8 +1052,9 @@ subroutine update_offline_fields(CS, G, GV, US, h, fluxes, do_ale)
   ! Most fields will be read in from files
   call update_offline_from_files( G, GV, US, CS%nk_input, CS%mean_file, CS%sum_file, CS%snap_file, &
                                   CS%surf_file, CS%h_end, CS%uhtr, CS%vhtr, CS%tv%T, CS%tv%S, &
-                                  CS%mld, CS%Kd, fluxes, CS%ridx_sum, CS%ridx_snap, CS%read_mld, &
-                                  CS%read_sw, .not.CS%read_all_ts_uvh, do_ale)
+                                  CS%mld, CS%Kd, fluxes, CS%ridx_sum, CS%ridx_snap, &
+                                  CS%read_mld, CS%mld_var_name, CS%read_sw, &
+                                  .not.CS%read_all_ts_uvh, do_ale)
   ! If uh, vh, h_end, temp, salt were read in at the beginning, fields are copied from those arrays
   if (CS%read_all_ts_uvh) then
     call update_offline_from_arrays(G, GV, CS%nk_input, CS%ridx_sum, CS%mean_file, CS%sum_file, &
@@ -1413,6 +1415,15 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV, US)
     "when in offline tracer mode", default=.false.)
   call get_param(param_file, mdl, "MLD_VAR_NAME", CS%mld_var_name, &
     "Name of the variable containing the depth of active mixing", default='ePBL_h_ML')
+  if (CS%read_mld) then
+    CS%Hmix_fixed = 0.0
+  else
+    call get_param(param_file, mdl, "HMIX_FIXED", CS%Hmix_fixed, &
+                 "The prescribed depth over which the near-surface viscosity and "//&
+                 "diffusivity are elevated when the bulk mixed layer is not used.", &
+                 units="m", scale=US%m_to_Z, fail_if_missing=.true.)
+  endif
+
   call get_param(param_file, mdl, "OFFLINE_ADD_DIURNAL_SW", CS%diurnal_sw, &
     "Adds a synthetic diurnal cycle in the same way that the ice "//&
     "model would have when time-averaged fields of shortwave "//&
@@ -1477,7 +1488,7 @@ subroutine offline_transport_init(param_file, CS, diabatic_CSp, G, GV, US)
   allocate(CS%ebtr(isd:ied,jsd:jed,nz), source=0.0)
   allocate(CS%h_end(isd:ied,jsd:jed,nz), source=0.0)
   allocate(CS%Kd(isd:ied,jsd:jed,nz+1), source=0.0)
-  if (CS%read_mld) allocate(CS%mld(G%isd:G%ied,G%jsd:G%jed), source=0.0)
+  allocate(CS%mld(G%isd:G%ied,G%jsd:G%jed), source=CS%Hmix_fixed)
 
   if (CS%read_all_ts_uvh) then
     call read_all_input(CS, G, GV, US)
@@ -1549,7 +1560,7 @@ subroutine offline_transport_end(CS)
   deallocate(CS%ebtr)
   deallocate(CS%h_end)
   deallocate(CS%Kd)
-  if (CS%read_mld) deallocate(CS%mld)
+  if (allocated(CS%mld)) deallocate(CS%mld)
   if (CS%read_all_ts_uvh) then
     deallocate(CS%uhtr_all)
     deallocate(CS%vhtr_all)


### PR DESCRIPTION
  Modified the offline tracer code to always allocate the offline mixed layer depth when offline tracers are being used, and set it to `HMIX_FIXED` when `READ_MLD` is false.  In addition, `MLD_VAR_NAME` is now passed to `update_offline_from_files()`, whereas it was previously just being set and ignored.  As a follow up, it might be useful to add the option of setting the mixed layer in offline tracer mode dynamically using `diagnoseMLDbyEnergy()` or `diagnoseMLDbyDensityDifference()`, but that is beyond the scope of this commit. This commit addresses the bugs identified at https://github.com/NOAA-GFDL/MOM6/issues/1100.  All answers are bitwise identical in all cases that worked previously, but some offline tracer cases that had been failing previously with a segmentation fault should work properly now.