### PR TITLE
+Add ability to control when verbosity is reset

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2365,7 +2365,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call get_MOM_input(param_file, dirs, default_input_filename=input_restart_file, ensemble_num=ensemble_num)
 
   verbosity = 2 ; call read_param(param_file, "VERBOSITY", verbosity)
-  call MOM_set_verbosity(verbosity)
+  call MOM_set_verbosity(verbosity, .true.)
   call callTree_enter("initialize_MOM(), MOM.F90")
 
   call find_obsolete_params(param_file)
@@ -2380,6 +2380,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "Integer controlling level of messaging\n" // &
                  "\t0 = Only FATAL messages\n" // &
                  "\t2 = Only FATAL, WARNING, NOTE [default]\n" // &
+                 "\t6 = Above plus call tree messages\n" //&
                  "\t9 = All)", default=2, debuggingParam=.true.)
   call get_param(param_file, "MOM", "DO_UNIT_TESTS", do_unit_tests, &
                  "If True, exercises unit tests at model start up.", &

--- a/src/framework/MOM_error_handler.F90
+++ b/src/framework/MOM_error_handler.F90
@@ -49,6 +49,8 @@ integer :: verbosity = 6
 !   Also note that this is a module variable rather than contained in
 ! a type passed by argument (preferred for most data) for convenience
 ! and to reduce obfuscation of code
+logical :: verbosity_set = .false.
+!< True if the verbosity has already been set at run-time.
 
 integer :: callTreeIndentLevel = 0
 !< The level of calling within the call tree
@@ -205,14 +207,20 @@ subroutine loc_MOM_err(level, message)
 end subroutine loc_MOM_err
 
 !> This subroutine sets the level of verbosity filtering MOM error messages
-subroutine MOM_set_verbosity(verb)
+subroutine MOM_set_verbosity(verb, may_reset)
   integer, intent(in) :: verb !< A level of verbosity to set
+  logical, optional, intent(in) :: may_reset !< If true, set the verbosity even if it has been set
+                              !! before, perhaps by another component like SIS2.
   character(len=80) :: msg
-  if (verb>0 .and. verb<10) then
-    verbosity=verb
+  if (verb>=0 .and. verb<10) then
+    if (.not.verbosity_set) verbosity = verb
+    if (present(may_reset)) then
+      if (may_reset) verbosity = verb
+    endif
+    verbosity_set = .true.
   else
-    write(msg(1:80),'("Attempt to set verbosity outside of range (0-9). verb=",I0)') verb
-    call MOM_error(FATAL,msg)
+    write(msg,'("Attempt to set verbosity outside of range (0-9). verb=",I0)') verb
+    call MOM_error(FATAL, msg)
   endif
 end subroutine MOM_set_verbosity
 


### PR DESCRIPTION
  Added the optional runtime parameter `may_reset` to `MOM_set_verbosity()` to help regulate when the verbosity can be changed in repeated calls on the same PEs. Also added a new module variable, `verbosity_set`, to the `MOM_error_handler` module to record whether the verbosity has already been set by a call to `MOM_set_verbosity()`.  In addition, the primary call `MOM_set_verbosity()` in `initialize_MOM()` now includes the new argument with the value that will cause the MOM6 setting for `VERBOSITY` to take precedence over any values coming from other components (like SIS2 in some cases) that also use `MOM_error_handler` code and run on the same PEs.  Also extended the description of the `VERBOSITY` parameter to note the setting that causes the call tree messages to be printed. All answers are bitwise identical, but there is a new optional argument to a publicly visible routine.

This PR will help reestablish the precedence of MOM6 in setting the verbosity for itself in all cases once the VERBOSITY option for SIS2 has been added via https://github.com/NOAA-GFDL/SIS2/pull/257, and it helps to address https://github.com/NOAA-GFDL/SIS2/issues/256.