### PR TITLE
Removed dead code branch in fill_miss_2d

### DIFF
--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -212,13 +212,6 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, acrit, num_pass, relc, debug,
         aout(i,j) = prev(i,j)
         fill_pts(i,j) = 0.0
       endif ; enddo ; enddo
-    elseif (nfill == nfill_prev) then
-      call MOM_error(WARNING, &
-           'Unable to fill missing points using either data at the same vertical level from a connected basin '//&
-           'or using a point from a previous vertical level.  Make sure that the original data has some valid '//&
-           'data in all basins.', .true.)
-      write(mesg,*) 'nfill=',nfill
-      call MOM_error(WARNING, mesg, .true.)
     endif
 
     ! Determine the number of remaining points to fill globally.


### PR DESCRIPTION
  At one point, `fill_miss_2d()` had an optional `prev` array that could be used to fill in values that were not horizontally connected to other points at the same level, and it issued a warning when that array was not provided.  However, `prev` was always being provided, so in 2022 as a part of some more extensive refactoring and clean-up of MOM_horizontal_regridding.F90 this optional argument was made mandatory, and the extra logical test around the warning block became identical to the first.  As noted in https://github.com/NOAA-GFDL/MOM6/issues/929, this lead to a block of code that would clearly never be reached.  This extra block of code has now been removed.  All answers are bitwise identical.

  Once this PR is committed, https://github.com/NOAA-GFDL/MOM6/issues/929 can be closed.