### PR TITLE
Diag buffer: Set fill_value_3d ks/ke size

### DIFF
--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -162,8 +162,8 @@ end subroutine set_horizontal_extents
 !> Set the vertical extent of the buffer
 subroutine set_vertical_extent(this, ks, ke)
   class(diag_buffer_3d), intent(inout) :: this !< The diagnostic buffer
-  integer,               intent(in)    :: ks !< The start slot of the array i-direction
-  integer,               intent(in)    :: ke !< The end slot of the array i-direction
+  integer,               intent(in)    :: ks !< The start slot of the array k-direction
+  integer,               intent(in)    :: ke !< The end slot of the array k-direction
 
   this%ks = ks ; this%ke = ke
 end subroutine set_vertical_extent
@@ -459,14 +459,14 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
   function fill_value_3d() result(local_fail)
     type(diag_buffer_3d) :: buffer
     logical :: local_fail !< True if any of the unit tests fail
-    integer, parameter :: is=1, ie=2, js=3, je=6
+    integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10
     real, parameter :: fill_value = -123.456
     integer :: i
-
 
     local_fail = .false.
 
     call buffer%set_horizontal_extents(is=is, ie=ie, js=js, je=je)
+    call buffer%set_vertical_extent(ks=ks, ke=ke)
     call buffer%set_fill_value(fill_value)
     ! Grow the buffer 3 times
     call buffer%grow()

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -322,14 +322,12 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
     logical :: local_fail !< True if any of the unit tests fail
     integer, parameter :: is=1, ie=2, js=3, je=6
     real, parameter :: fill_value = -123.456
-    integer :: i
 
 
     local_fail = .false.
 
     call buffer%set_horizontal_extents(is=is, ie=ie, js=js, je=je)
     call buffer%set_fill_value(fill_value)
-    ! Grow the buffer 3 times
     call buffer%grow()
     if (any(buffer%buffer(1)%field(:,:) /= fill_value)) local_fail = .true.
     if (verbose) write(stdout,*) "fill_value_2d: ", local_fail
@@ -461,14 +459,12 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
     logical :: local_fail !< True if any of the unit tests fail
     integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10
     real, parameter :: fill_value = -123.456
-    integer :: i
 
     local_fail = .false.
 
     call buffer%set_horizontal_extents(is=is, ie=ie, js=js, je=je)
     call buffer%set_vertical_extent(ks=ks, ke=ke)
     call buffer%set_fill_value(fill_value)
-    ! Grow the buffer 3 times
     call buffer%grow()
     if (any(buffer%buffer(1)%field(:,:,:) /= fill_value)) local_fail = .true.
     if (verbose) write(stdout,*) "fill_value_3d: ", local_fail


### PR DESCRIPTION
The `fill_value_3d` unit test of `diag_buffer_unit_tests_3d` was not setting its vertical extent, causing inaccurate allocation sizes and potential segmentation faults.  (Or, in my case, complete memory consumption and OS meltdowns.)

This patch adds `set_vertical_extent` and uses the same 10-element width.  This appears to fix the issue for me.