### PR TITLE
Add present_and_true() to 5 modules

### DIFF
--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -540,14 +540,10 @@ subroutine extractFluxes1d(G, GV, US, fluxes, optics, nsw, j, dt, &
   ! Initializes/sets logicals if 'rates' are requested
   ! These factors are required for legacy reasons
   !  and therefore computed only when optional outputs are requested
-  do_NHR = .false.
-  do_NSR = .false.
-  do_NMIOR = .false.
-  do_PSWBR = .false.
-  if (present(net_heat_rate)) do_NHR = .true.
-  if (present(net_salt_rate)) do_NSR = .true.
-  if (present(netmassinout_rate)) do_NMIOR = .true.
-  if (present(pen_sw_bnd_rate)) do_PSWBR = .true.
+  do_NHR = present(net_heat_rate)
+  do_NSR = present(net_salt_rate)
+  do_NMIOR = present(netmassinout_rate)
+  do_PSWBR = present(pen_sw_bnd_rate)
   !}BGR
 
   ! GMM: by default heat content from mass entering and leaving the ocean (enthalpy)
@@ -1198,7 +1194,7 @@ subroutine find_ustar_fluxes(fluxes, tv, U_star, G, GV, US, halo, H_T_units)
   hs = 0 ; if (present(halo)) hs = max(halo, 0)
   is = G%isc - hs ; ie = G%iec + hs ; js = G%jsc - hs ; je = G%jec + hs
 
-  Z_T_units = .true. ; if (present(H_T_units)) Z_T_units = .not.H_T_units
+  Z_T_units = .not. present_and_true(H_T_units)
 
   if (.not.(associated(fluxes%ustar) .or. associated(fluxes%tau_mag))) &
     call MOM_error(FATAL, "find_ustar_fluxes requires that either ustar or tau_mag be associated.")
@@ -1263,7 +1259,7 @@ subroutine find_ustar_mech_forcing(forces, tv, U_star, G, GV, US, halo, H_T_unit
   hs = 0 ; if (present(halo)) hs = max(halo, 0)
   is = G%isc - hs ; ie = G%iec + hs ; js = G%jsc - hs ; je = G%jec + hs
 
-  Z_T_units = .true. ; if (present(H_T_units)) Z_T_units = .not.H_T_units
+  Z_T_units = .not. present_and_true(H_T_units)
 
   if (.not.(associated(forces%ustar) .or. associated(forces%tau_mag))) &
     call MOM_error(FATAL, "find_ustar_mech requires that either ustar or tau_mag be associated.")
@@ -1588,34 +1584,30 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
   handles%id_omega_w2x = register_diag_field('ocean_model', 'omega_w2x', diag%axesT1, Time, &
       'Counter-clockwise angle of the wind stress from the horizontal axis.', 'rad', conversion=1.0)
 
-  if (present(use_berg_fluxes)) then
-    if (use_berg_fluxes) then
-      handles%id_ustar_berg = register_diag_field('ocean_model', 'ustar_berg', diag%axesT1, Time, &
-          'Friction velocity below iceberg ', 'm s-1', conversion=US%Z_to_m*US%s_to_T)
+  if (present_and_true(use_berg_fluxes)) then
+    handles%id_ustar_berg = register_diag_field('ocean_model', 'ustar_berg', diag%axesT1, Time, &
+        'Friction velocity below iceberg ', 'm s-1', conversion=US%Z_to_m*US%s_to_T)
 
-      handles%id_area_berg = register_diag_field('ocean_model', 'area_berg', diag%axesT1, Time, &
-          'Area of grid cell covered by iceberg ', 'm2 m-2', conversion=1.0)
+    handles%id_area_berg = register_diag_field('ocean_model', 'area_berg', diag%axesT1, Time, &
+        'Area of grid cell covered by iceberg ', 'm2 m-2', conversion=1.0)
 
-      handles%id_mass_berg = register_diag_field('ocean_model', 'mass_berg', diag%axesT1, Time, &
-          'Mass of icebergs ', 'kg m-2', conversion=US%RZ_to_kg_m2)
+    handles%id_mass_berg = register_diag_field('ocean_model', 'mass_berg', diag%axesT1, Time, &
+        'Mass of icebergs ', 'kg m-2', conversion=US%RZ_to_kg_m2)
 
-      handles%id_ustar_ice_cover = register_diag_field('ocean_model', 'ustar_ice_cover', diag%axesT1, Time, &
-          'Friction velocity below iceberg and ice shelf together', 'm s-1', conversion=US%Z_to_m*US%s_to_T)
+    handles%id_ustar_ice_cover = register_diag_field('ocean_model', 'ustar_ice_cover', diag%axesT1, Time, &
+        'Friction velocity below iceberg and ice shelf together', 'm s-1', conversion=US%Z_to_m*US%s_to_T)
 
-      handles%id_frac_ice_cover = register_diag_field('ocean_model', 'frac_ice_cover', diag%axesT1, Time, &
-          'Area of grid cell below iceberg and ice shelf together ', 'm2 m-2', conversion=1.0)
-    endif
+    handles%id_frac_ice_cover = register_diag_field('ocean_model', 'frac_ice_cover', diag%axesT1, Time, &
+        'Area of grid cell below iceberg and ice shelf together ', 'm2 m-2', conversion=1.0)
   endif
 
   ! See:
-  if (present(use_cfcs)) then
-    if (use_cfcs) then
-      handles%id_ice_fraction = register_diag_field('ocean_model', 'ice_fraction', diag%axesT1, Time, &
-          'Fraction of cell area covered by sea ice', 'm2 m-2', conversion=1.0)
+  if (present_and_true(use_cfcs)) then
+    handles%id_ice_fraction = register_diag_field('ocean_model', 'ice_fraction', diag%axesT1, Time, &
+        'Fraction of cell area covered by sea ice', 'm2 m-2', conversion=1.0)
 
-      handles%id_u10_sqr = register_diag_field('ocean_model', 'u10_sqr', diag%axesT1, Time, &
-          'Wind magnitude at 10m, squared', 'm2 s-2', conversion=US%L_to_m**2*US%s_to_T**2)
-    endif
+    handles%id_u10_sqr = register_diag_field('ocean_model', 'u10_sqr', diag%axesT1, Time, &
+        'Wind magnitude at 10m, squared', 'm2 s-2', conversion=US%L_to_m**2*US%s_to_T**2)
   endif
 
   handles%id_psurf = register_diag_field('ocean_model', 'p_surf', diag%axesT1, Time, &
@@ -1694,7 +1686,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
         cmor_standard_name='water_flux_into_sea_water_from_rivers',                           &
         cmor_long_name='Water Flux into Sea Water From Rivers')
 
-  if (present(use_glc_runoff)) then
+  if (present_and_true(use_glc_runoff)) then
     handles%id_frunoff_glc = register_diag_field('ocean_model', 'frunoff_glc', diag%axesT1, Time,    &
           'Frozen glacier runoff (calving) and iceberg melt into ocean', &
           units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s, &
@@ -1788,7 +1780,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
       cmor_standard_name='water_flux_into_sea_water_from_rivers_area_integrated',             &
       cmor_long_name='Water Flux into Sea Water From Rivers Area Integrated')
 
-  if (present(use_glc_runoff)) then
+  if (present_and_true(use_glc_runoff)) then
     handles%id_total_frunoff_glc = register_scalar_field('ocean_model', 'total_frunoff_glc', Time, diag, &
         long_name='Area integrated frozen glacier runoff (calving) & iceberg melt into ocean', &
         units='kg s-1', conversion=US%RZL2_to_kg*US%s_to_T)
@@ -1858,15 +1850,13 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
         'W m-2', conversion=US%QRZ_T_to_W_m2, &
         standard_name='temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water')
 
-  if (present(use_carbon_runoff)) then
-    if (use_carbon_runoff) then
-       handles%id_carbon_content_lrunoff = register_diag_field('ocean_model', 'carbon_content_lrunoff', &
-             diag%axesT1, Time, 'Carbon content of liquid runoff into ocean',        &
-             'kg m-2 s-1', standard_name='carbon_flux_due_to_runoff')
-    endif
+  if (present_and_true(use_carbon_runoff)) then
+     handles%id_carbon_content_lrunoff = register_diag_field('ocean_model', 'carbon_content_lrunoff', &
+           diag%axesT1, Time, 'Carbon content of liquid runoff into ocean',        &
+           'kg m-2 s-1', standard_name='carbon_flux_due_to_runoff')
   endif
 
-  if (present(use_glc_runoff)) then
+  if (present_and_true(use_glc_runoff)) then
     handles%id_heat_content_frunoff_glc = register_diag_field('ocean_model', 'heat_content_frunoff_glc', &
           diag%axesT1, Time, 'Heat content (relative to 0C) of solid glacier runoff into ocean',         &
           'W m-2', conversion=US%QRZ_T_to_W_m2)
@@ -1980,7 +1970,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
         cmor_standard_name='heat_flux_into_sea_water_due_to_iceberg_thermodynamics',               &
         cmor_long_name='Latent Heat to Melt Frozen Runoff/Iceberg')
 
-  if (present(use_glc_runoff)) then
+  if (present_and_true(use_glc_runoff)) then
     handles%id_lat_frunoff_glc = register_diag_field('ocean_model', 'latent_frunoff_glc', diag%axesT1, Time, &
           'Latent heat flux into ocean due to melting of frozen glacier runoff', 'W m-2', conversion=US%QRZ_T_to_W_m2)
   endif
@@ -2024,7 +2014,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
       cmor_long_name=                                                                        &
       'Temperature Flux due to Runoff Expressed as Heat Flux into Sea Water Area Integrated')
 
-  if (present(use_glc_runoff)) then
+  if (present_and_true(use_glc_runoff)) then
     handles%id_total_heat_content_frunoff_glc = register_scalar_field('ocean_model',                 &
         'total_heat_content_frunoff_glc', Time, diag,                                                &
         long_name='Area integrated heat content (relative to 0C) of solid glacier runoff',           &
@@ -2153,7 +2143,7 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
       cmor_long_name=                                                                             &
       'Heat Flux into Sea Water due to Iceberg Thermodynamics Area Integrated')
 
-  if (present(use_glc_runoff)) then
+  if (present_and_true(use_glc_runoff)) then
     handles%id_total_lat_frunoff_glc = register_scalar_field('ocean_model',                             &
         'total_lat_frunoff_glc', Time, diag,                                                            &
         long_name='Area integrated latent heat flux due to melting frozen glacier runoff',              &
@@ -2309,11 +2299,9 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
 
   !===============================================================
   ! wave forcing diagnostics
-  if (present(use_waves)) then
-    if (use_waves) then
-      handles%id_lamult = register_diag_field('ocean_model', 'lamult', &
+  if (present_and_true(use_waves)) then
+    handles%id_lamult = register_diag_field('ocean_model', 'lamult', &
         diag%axesT1, Time, long_name='Langmuir enhancement factor received from WW3', units="nondim", conversion=1.0)
-    endif
   endif
 
 end subroutine register_forcing_type_diags
@@ -2536,11 +2524,8 @@ subroutine copy_common_forcing_fields(forces, fluxes, G, skip_pres)
   type(ocean_grid_type),   intent(in)    :: G        !< grid type
   logical,       optional, intent(in)    :: skip_pres !< If present and true, do not copy pressure fields.
 
-  logical :: do_pres
   integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
-
-  do_pres = .true. ; if (present(skip_pres)) do_pres = .not.skip_pres
 
   if (associated(forces%ustar) .and. associated(fluxes%ustar)) then
     do j=js,je ; do i=is,ie
@@ -2558,7 +2543,7 @@ subroutine copy_common_forcing_fields(forces, fluxes, G, skip_pres)
     enddo ; enddo
   endif
 
-  if (do_pres) then
+  if (.not. present_and_true(skip_pres)) then
     if (associated(forces%p_surf) .and. associated(fluxes%p_surf)) then
       do j=js,je ; do i=is,ie
         fluxes%p_surf(i,j) = forces%p_surf(i,j)
@@ -2803,8 +2788,7 @@ subroutine forcing_diagnostics(fluxes_in, sfc_state, G_in, US, time_end, diag, h
 
   call cpu_clock_begin(handles%id_clock_forcing)
 
-  mom_enthalpy = .true.
-  if (present(enthalpy)) mom_enthalpy = .not. enthalpy
+  mom_enthalpy = .not. present_and_true(enthalpy)
 
   ! NOTE: post_data expects data to be on the rotated index map, so any
   !   rotations must be applied before saving the output.
@@ -3470,17 +3454,13 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
 
   ! Local variables
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  logical :: shelf_sfc_acc, enthalpy_mom
+  logical :: enthalpy_mom
 
   ! if true, allocate fluxes needed to calculate enthalpy terms in MOM6
-  enthalpy_mom = .true.
-  if (present (hevap)) enthalpy_mom = .not. hevap
+  enthalpy_mom = .not. present_and_true(hevap)
 
   isd  = G%isd   ; ied  = G%ied    ; jsd  = G%jsd   ; jed  = G%jed
   IsdB = G%IsdB  ; IedB = G%IedB   ; JsdB = G%JsdB  ; JedB = G%JedB
-
-  shelf_sfc_acc = .false.
-  if (present(shelf_sfc_accumulation)) shelf_sfc_acc = shelf_sfc_accumulation
 
   call myAlloc(fluxes%ustar,isd,ied,jsd,jed, ustar)
   call myAlloc(fluxes%ustar_gustless,isd,ied,jsd,jed, ustar)
@@ -3514,7 +3494,7 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
   call myAlloc(fluxes%salt_flux,isd,ied,jsd,jed, salt)
   call myAlloc(fluxes%carbon_content_lrunoff,isd,ied,jsd,jed, carbon)
 
-  if (present(heat) .and. present(water)) then ; if (heat .and. water) then
+  if (present_and_true(heat) .and. present_and_true(water)) then
     call myAlloc(fluxes%heat_content_cond,isd,ied,jsd,jed, .true.)
     call myAlloc(fluxes%heat_content_evap,isd,ied,jsd,jed, .not. enthalpy_mom)
     call myAlloc(fluxes%heat_content_lprec,isd,ied,jsd,jed, .true.)
@@ -3526,17 +3506,18 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
     call myAlloc(fluxes%heat_content_frunoff_glc,isd,ied,jsd,jed, .true.)
     call myAlloc(fluxes%heat_content_massout,isd,ied,jsd,jed, enthalpy_mom)
     call myAlloc(fluxes%heat_content_massin,isd,ied,jsd,jed,  enthalpy_mom)
-  endif ; endif
+  endif
 
   call myAlloc(fluxes%p_surf,isd,ied,jsd,jed, press)
 
   ! These fields should only be allocated if ice shelf is enabled.
-  if (present(shelf)) then ; if (shelf) then
+  if (present_and_true(shelf)) then
     call myAlloc(fluxes%frac_shelf_h,isd,ied,jsd,jed, shelf)
     call myAlloc(fluxes%ustar_shelf,isd,ied,jsd,jed, shelf)
     call myAlloc(fluxes%iceshelf_melt,isd,ied,jsd,jed, shelf)
-    if (shelf_sfc_acc) call myAlloc(fluxes%shelf_sfc_mass_flux,isd,ied,jsd,jed, shelf_sfc_acc)
-  endif ; endif
+    if (present_and_true(shelf_sfc_accumulation)) &
+      call myAlloc(fluxes%shelf_sfc_mass_flux,isd,ied,jsd,jed, .true.)
+  endif
 
   !These fields should only be allocated when iceberg area is being passed through the coupler.
   call myAlloc(fluxes%ustar_berg,isd,ied,jsd,jed, iceberg)
@@ -3680,7 +3661,7 @@ subroutine allocate_mech_forcing_by_group(G, forces, stress, ustar, shelf, &
   call myAlloc(forces%mass_berg,isd,ied,jsd,jed, iceberg)
 
   !These fields should only be allocated when waves
-  if (present(waves)) then ; if (waves) then
+  if (present_and_true(waves)) then
     if (.not. present(num_stk_bands)) then
       call MOM_error(FATAL,"Requested to &
       &initialize with waves, but no waves are present.")
@@ -3692,7 +3673,7 @@ subroutine allocate_mech_forcing_by_group(G, forces, stress, ustar, shelf, &
         allocate(forces%vstkb(isd:ied,jsd:jed,num_stk_bands), source=0.0)
       endif
     endif
-  endif ; endif
+  endif
 
 end subroutine allocate_mech_forcing_by_group
 
@@ -3785,9 +3766,9 @@ subroutine myAlloc_2d(array, is, ie, js, je, flag)
   integer,           intent(in) :: je !< End j-index
   logical, optional, intent(in) :: flag !< Flag to indicate to allocate
 
-  if (present(flag)) then ; if (flag) then ; if (.not.associated(array)) then
-    allocate(array(is:ie,js:je), source=0.0)
-  endif ; endif ; endif
+  if (present_and_true(flag)) then
+    if (.not.associated(array)) allocate(array(is:ie,js:je), source=0.0)
+  endif
 end subroutine myAlloc_2d
 
 subroutine myAlloc_3d(array, is, ie, js, je, ks, ke, flag)
@@ -3800,9 +3781,9 @@ subroutine myAlloc_3d(array, is, ie, js, je, ks, ke, flag)
   integer,             intent(in) :: ke !< End k-index
   logical, optional,   intent(in) :: flag !< Flag to indicate to allocate
 
-  if (present(flag)) then ; if (flag) then ; if (.not.associated(array)) then
-    allocate(array(is:ie,js:je,ks:ke), source=0.0)
-  endif ; endif ; endif
+  if (present_and_true(flag)) then
+    if (.not.associated(array)) allocate(array(is:ie,js:je,ks:ke), source=0.0)
+  endif
 end subroutine myAlloc_3d
 
 !> Deallocate the forcing type
@@ -4115,15 +4096,12 @@ subroutine homogenize_mech_forcing(forces, G, US, Rho0, UpdateUstar)
   real :: tx_mean, ty_mean ! Mean wind stresses [R L Z T-2 ~> Pa]
   real :: tau_mag      ! The magnitude of the wind stresses [R Z2 T-2 ~> Pa]
   real :: Irho0        ! Inverse of the mean density [R-1 ~> m3 kg-1]
-  logical :: do_stress, do_ustar, do_taumag, do_shelf, do_press, do_iceberg, tau2ustar
+  logical :: do_stress, do_ustar, do_taumag, do_shelf, do_press, do_iceberg
   integer :: i, j, is, ie, js, je, isB, ieB, jsB, jeB
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isB = G%iscB ; ieB = G%iecB ; jsB = G%jscB ; jeB = G%jecB
 
   Irho0 = 1.0 / Rho0
-
-  tau2ustar = .false.
-  if (present(UpdateUstar)) tau2ustar = UpdateUstar
 
   call get_mech_forcing_groups(forces, do_stress, do_ustar, do_taumag, do_shelf, &
                               do_press, do_iceberg)
@@ -4137,7 +4115,7 @@ subroutine homogenize_mech_forcing(forces, G, US, Rho0, UpdateUstar)
     do j=jsB,jeB ; do i=is,ie
       if (G%mask2dCv(i,J) > 0.0) forces%tauy(i,J) = ty_mean
     enddo ; enddo
-    if (tau2ustar) then
+    if (present_and_true(UpdateUstar)) then
       tau_mag = US%L_to_Z*sqrt((tx_mean**2) + (ty_mean**2))
       if (associated(forces%tau_mag)) then ; do j=js,je ; do i=is,ie ; if (G%mask2dT(i,j) > 0.0) then
         forces%tau_mag(i,j) = tau_mag
@@ -4356,6 +4334,15 @@ subroutine homogenize_field_u(var, G, tmp_scale)
   enddo ; enddo
 
 end subroutine homogenize_field_u
+
+
+!> This routine returns true if its single optional argument is both present and true.
+logical function present_and_true(arg)
+  logical, optional, intent(in) :: arg !< An optional logical to argument to use.
+
+  present_and_true = .false.
+  if (present(arg)) present_and_true = arg
+end function present_and_true
 
 !> \namespace mom_forcing_type
 !!

--- a/src/diagnostics/MOM_debugging.F90
+++ b/src/diagnostics/MOM_debugging.F90
@@ -636,15 +636,12 @@ subroutine chksum_vec_C3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
                                                              !! scalars that are being checked.
   real,                    optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
                                                              !! arrays to give consistent output [a A-1 ~> 1]
-  ! Local variables
-  logical :: are_scalars
-  are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
     call uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
-    if (are_scalars) then
+    if (present_and_true(scalars)) then
       call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
       call check_redundant_C(mesg, u_comp, v_comp, G, unscale=unscale)
@@ -668,15 +665,12 @@ subroutine chksum_vec_C2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
                                                            !! scalars that are being checked.
   real,                  optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
                                                            !! arrays to give consistent output [a A-1 ~> 1]
-  ! Local variables
-  logical :: are_scalars
-  are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
     call uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
-    if (are_scalars) then
+    if (present_and_true(scalars)) then
       call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
       call check_redundant_C(mesg, u_comp, v_comp, G, unscale=unscale)
@@ -700,16 +694,13 @@ subroutine chksum_vec_B3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
                                                               !! scalars that are being checked.
   real,                     optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
                                                               !! arrays to give consistent output [a A-1 ~> 1]
-  ! Local variables
-  logical :: are_scalars
-  are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
     call Bchksum(u_comp, mesg//"(u)", G%HI, halos, unscale=unscale)
     call Bchksum(v_comp, mesg//"(v)", G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
-    if (are_scalars) then
+    if (present_and_true(scalars)) then
       call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
       call check_redundant_B(mesg, u_comp, v_comp, G, unscale=unscale)
@@ -735,16 +726,13 @@ subroutine chksum_vec_B2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric, un
                                                             !! full symmetric computational domain.
   real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
                                                             !! arrays to give consistent output [a A-1 ~> 1]
-  ! Local variables
-  logical :: are_scalars
-  are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
     call Bchksum(u_comp, mesg//"(u)", G%HI, halos, symmetric=symmetric, unscale=unscale)
     call Bchksum(v_comp, mesg//"(v)", G%HI, halos, symmetric=symmetric, unscale=unscale)
   endif
   if (debug_redundant) then
-    if (are_scalars) then
+    if (present_and_true(scalars)) then
       call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
       call check_redundant_B(mesg, u_comp, v_comp, G, unscale=unscale)
@@ -768,16 +756,13 @@ subroutine chksum_vec_A3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
                                                             !! scalars that are being checked.
   real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
                                                             !! arrays to give consistent output [a A-1 ~> 1]
-  ! Local variables
-  logical :: are_scalars
-  are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
     call hchksum(u_comp, mesg//"(u)", G%HI, halos, unscale=unscale)
     call hchksum(v_comp, mesg//"(v)", G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
-    if (are_scalars) then
+    if (present_and_true(scalars)) then
       call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
       call check_redundant_T(mesg, u_comp, v_comp, G, unscale=unscale)
@@ -801,16 +786,13 @@ subroutine chksum_vec_A2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
                                                           !! scalars that are being checked.
   real,                 optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
                                                           !! arrays to give consistent output [a A-1 ~> 1]
-  ! Local variables
-  logical :: are_scalars
-  are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
     call hchksum(u_comp, mesg//"(u)", G%HI, halos, unscale=unscale)
     call hchksum(v_comp, mesg//"(v)", G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
-    if (are_scalars) then
+    if (present_and_true(scalars)) then
       call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
       call check_redundant_T(mesg, u_comp, v_comp, G, unscale=unscale)
@@ -1010,5 +992,14 @@ logical function check_column_integrals(nk_1, field_1, nk_2, field_2, missing_va
   endif
 
 end function check_column_integrals
+
+
+!> This routine returns true if its single optional argument is both present and true.
+logical function present_and_true(arg)
+  logical, optional, intent(in) :: arg !< An optional logical to argument to use.
+
+  present_and_true = .false.
+  if (present(arg)) present_and_true = arg
+end function present_and_true
 
 end module MOM_debugging

--- a/src/framework/MOM_checksums.F90
+++ b/src/framework/MOM_checksums.F90
@@ -286,13 +286,10 @@ subroutine chksum_pair_h_2d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, &
                                                             !! for checksums and output [a A-1 ~> 1].
                                                             !! Here scale and unscale are synonymous, but unscale
                                                             !! takes precedence if both are present.
-  logical :: vector_pair
+
   integer :: turns
   type(hor_index_type), pointer :: HI_in
   real, dimension(:,:), pointer :: arrayA_in, arrayB_in ! Rotated arrays [A ~> a]
-
-  vector_pair = .true.
-  if (present(scalar_pair)) vector_pair = .not. scalar_pair
 
   turns = HI%turns
   if (modulo(turns, 4) /= 0) then
@@ -302,7 +299,7 @@ subroutine chksum_pair_h_2d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, &
     allocate(arrayA_in(HI_in%isd:HI_in%ied, HI_in%jsd:HI_in%jed))
     allocate(arrayB_in(HI_in%isd:HI_in%ied, HI_in%jsd:HI_in%jed))
 
-    if (vector_pair) then
+    if (.not. present_and_true(scalar_pair)) then
       call rotate_vector(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
     else
       call rotate_array_pair(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
@@ -345,13 +342,9 @@ subroutine chksum_pair_h_3d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, &
                                                                !! Here scale and unscale are synonymous, but unscale
                                                                !! takes precedence if both are present.
   ! Local variables
-  logical :: vector_pair
   integer :: turns
   type(hor_index_type), pointer :: HI_in
   real, dimension(:,:,:), pointer :: arrayA_in, arrayB_in ! Rotated arrays [A ~> a]
-
-  vector_pair = .true.
-  if (present(scalar_pair)) vector_pair = .not. scalar_pair
 
   turns = HI%turns
   if (modulo(turns, 4) /= 0) then
@@ -361,7 +354,7 @@ subroutine chksum_pair_h_3d(mesg, arrayA, arrayB, HI, haloshift, omit_corners, &
     allocate(arrayA_in(HI_in%isd:HI_in%ied, HI_in%jsd:HI_in%jed, size(arrayA, 3)))
     allocate(arrayB_in(HI_in%isd:HI_in%ied, HI_in%jsd:HI_in%jed, size(arrayB, 3)))
 
-    if (vector_pair) then
+    if (.not. present_and_true(scalar_pair)) then
       call rotate_vector(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
     else
       call rotate_array_pair(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
@@ -415,7 +408,6 @@ subroutine chksum_h_2d(array_m, mesg, HI_m, haloshift, omit_corners, scale, logu
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners
   integer :: turns                      ! Quarter turns from input to model grid
 
 
@@ -480,10 +472,7 @@ subroutine chksum_h_2d(array_m, mesg, HI_m, haloshift, omit_corners, scale, logu
   if (hshift==0) then
     if (is_root_pe()) call chk_sum_msg("h-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
-    if (do_corners) then
+    if (.not. present_and_true(omit_corners)) then
       bcSW = subchk(array, HI, -hshift, -hshift, scaling)
       bcSE = subchk(array, HI, hshift, -hshift, scaling)
       bcNW = subchk(array, HI, -hshift, hshift, scaling)
@@ -580,13 +569,9 @@ subroutine chksum_pair_B_2d(mesg, arrayA, arrayB, HI, haloshift, symmetric, &
                                                             !! takes precedence if both are present.
 
   logical :: sym
-  logical :: vector_pair
   integer :: turns
   type(hor_index_type), pointer :: HI_in
   real, dimension(:,:), pointer :: arrayA_in, arrayB_in ! Rotated arrays [A ~> a]
-
-  vector_pair = .true.
-  if (present(scalar_pair)) vector_pair = .not. scalar_pair
 
   turns = HI%turns
   if (modulo(turns, 4) /= 0) then
@@ -596,7 +581,7 @@ subroutine chksum_pair_B_2d(mesg, arrayA, arrayB, HI, haloshift, symmetric, &
     allocate(arrayA_in(HI_in%IsdB:HI_in%IedB, HI_in%JsdB:HI_in%JedB))
     allocate(arrayB_in(HI_in%IsdB:HI_in%IedB, HI_in%JsdB:HI_in%JedB))
 
-    if (vector_pair) then
+    if (.not. present_and_true(scalar_pair)) then
       call rotate_vector(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
     else
       call rotate_array_pair(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
@@ -607,7 +592,7 @@ subroutine chksum_pair_B_2d(mesg, arrayA, arrayB, HI, haloshift, symmetric, &
     arrayB_in => arrayB
   endif
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if (present(haloshift)) then
     call chksum_B_2d(arrayA_in, 'x '//mesg, HI_in, haloshift, symmetric=sym, &
@@ -646,13 +631,9 @@ subroutine chksum_pair_B_3d(mesg, arrayA, arrayB, HI, haloshift, symmetric, &
                                                                !! Here scale and unscale are synonymous, but unscale
                                                                !! takes precedence if both are present.
   ! Local variables
-  logical :: vector_pair
   integer :: turns
   type(hor_index_type), pointer :: HI_in
   real, dimension(:,:,:), pointer :: arrayA_in, arrayB_in ! Rotated arrays [A ~> a]
-
-  vector_pair = .true.
-  if (present(scalar_pair)) vector_pair = .not. scalar_pair
 
   turns = HI%turns
   if (modulo(turns, 4) /= 0) then
@@ -662,7 +643,7 @@ subroutine chksum_pair_B_3d(mesg, arrayA, arrayB, HI, haloshift, symmetric, &
     allocate(arrayA_in(HI_in%IsdB:HI_in%IedB, HI_in%JsdB:HI_in%JedB, size(arrayA, 3)))
     allocate(arrayB_in(HI_in%IsdB:HI_in%IedB, HI_in%JsdB:HI_in%JedB, size(arrayB, 3)))
 
-    if (vector_pair) then
+    if (.not. present_and_true(scalar_pair)) then
       call rotate_vector(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
     else
       call rotate_array_pair(arrayA, arrayB, -turns, arrayA_in, arrayB_in)
@@ -720,7 +701,7 @@ subroutine chksum_B_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners, sym, sym_stats
+  logical :: sym, sym_stats
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -747,7 +728,7 @@ subroutine chksum_B_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   elseif (present(scale)) then ; scaling = scale ; endif
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
-  sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
+  sym_stats = present_and_true(symmetric)
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
 
   if (calculateStatistics) then
@@ -784,15 +765,12 @@ subroutine chksum_B_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
 
   bc0 = subchk(array, HI, 0, 0, scaling)
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if ((hshift==0) .and. .not.sym) then
     if (is_root_pe()) call chk_sum_msg("B-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
-    if (do_corners) then
+    if (.not. present_and_true(omit_corners)) then
       if (sym) then
         bcSW = subchk(array, HI, -hshift-1, -hshift-1, scaling)
         bcSE = subchk(array, HI, hshift, -hshift-1, scaling)
@@ -900,13 +878,9 @@ subroutine chksum_uv_2d(mesg, arrayU, arrayV, HI, haloshift, symmetric, &
                                                              !! Here scale and unscale are synonymous, but unscale
                                                              !! takes precedence if both are present.
   ! Local variables
-  logical :: vector_pair
   integer :: turns
   type(hor_index_type), pointer :: HI_in
   real, dimension(:,:), pointer :: arrayU_in, arrayV_in ! Rotated arrays [A ~> a]
-
-  vector_pair = .true.
-  if (present(scalar_pair)) vector_pair = .not. scalar_pair
 
   turns = HI%turns
   if (modulo(turns, 4) /= 0) then
@@ -916,7 +890,7 @@ subroutine chksum_uv_2d(mesg, arrayU, arrayV, HI, haloshift, symmetric, &
     allocate(arrayU_in(HI_in%IsdB:HI_in%IedB, HI_in%jsd:HI_in%jed))
     allocate(arrayV_in(HI_in%isd:HI_in%ied, HI_in%JsdB:HI_in%JedB))
 
-    if (vector_pair) then
+    if (.not. present_and_true(scalar_pair)) then
       call rotate_vector(arrayU, arrayV, -turns, arrayU_in, arrayV_in)
     else
       call rotate_array_pair(arrayU, arrayV, -turns, arrayU_in, arrayV_in)
@@ -963,13 +937,9 @@ subroutine chksum_uv_3d(mesg, arrayU, arrayV, HI, haloshift, symmetric, &
                                                                !! Here scale and unscale are synonymous, but unscale
                                                                !! takes precedence if both are present.
   ! Local variables
-  logical :: vector_pair
   integer :: turns
   type(hor_index_type), pointer :: HI_in
   real, dimension(:,:,:), pointer :: arrayU_in, arrayV_in ! Rotated arrays [A ~> a]
-
-  vector_pair = .true.
-  if (present(scalar_pair)) vector_pair = .not. scalar_pair
 
   turns = HI%turns
   if (modulo(turns, 4) /= 0) then
@@ -979,7 +949,7 @@ subroutine chksum_uv_3d(mesg, arrayU, arrayV, HI, haloshift, symmetric, &
     allocate(arrayU_in(HI_in%IsdB:HI_in%IedB, HI_in%jsd:HI_in%jed, size(arrayU, 3)))
     allocate(arrayV_in(HI_in%isd:HI_in%ied, HI_in%JsdB:HI_in%JedB, size(arrayV, 3)))
 
-    if (vector_pair) then
+    if (.not. present_and_true(scalar_pair)) then
       call rotate_vector(arrayU, arrayV, -turns, arrayU_in, arrayV_in)
     else
       call rotate_array_pair(arrayU, arrayV, -turns, arrayU_in, arrayV_in)
@@ -1036,7 +1006,7 @@ subroutine chksum_u_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners, sym, sym_stats
+  logical :: sym, sym_stats
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -1072,7 +1042,7 @@ subroutine chksum_u_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   elseif (present(scale)) then ; scaling = scale ; endif
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
-  sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
+  sym_stats = present_and_true(symmetric)
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
 
   if (calculateStatistics) then
@@ -1109,18 +1079,15 @@ subroutine chksum_u_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
 
   bc0 = subchk(array, HI, 0, 0, scaling)
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if ((hshift==0) .and. .not.sym) then
     if (is_root_pe()) call chk_sum_msg("u-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
     if (hshift==0) then
       bcW = subchk(array, HI, -hshift-1, 0, scaling)
       if (is_root_pe()) call chk_sum_msg_W("u-point:", bc0, bcW, mesg, iounit)
-    elseif (do_corners) then
+    elseif (.not. present_and_true(omit_corners)) then
       if (sym) then
         bcSW = subchk(array, HI, -hshift-1, -hshift, scaling)
         bcNW = subchk(array, HI, -hshift-1, hshift, scaling)
@@ -1240,7 +1207,7 @@ subroutine chksum_v_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners, sym, sym_stats
+  logical :: sym, sym_stats
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -1276,7 +1243,7 @@ subroutine chksum_v_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   elseif (present(scale)) then ; scaling = scale ; endif
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
-  sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
+  sym_stats = present_and_true(symmetric)
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
 
   if (calculateStatistics) then
@@ -1313,18 +1280,15 @@ subroutine chksum_v_2d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
 
   bc0 = subchk(array, HI, 0, 0, scaling)
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if ((hshift==0) .and. .not.sym) then
     if (is_root_pe()) call chk_sum_msg("v-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
     if (hshift==0) then
       bcS = subchk(array, HI, 0, -hshift-1, scaling)
       if (is_root_pe()) call chk_sum_msg_S("v-point:", bc0, bcS, mesg, iounit)
-    elseif (do_corners) then
+    elseif (.not. present_and_true(omit_corners)) then
       if (sym) then
         bcSW = subchk(array, HI, -hshift, -hshift-1, scaling)
         bcSE = subchk(array, HI, hshift, -hshift-1, scaling)
@@ -1441,7 +1405,6 @@ subroutine chksum_h_3d(array_m, mesg, HI_m, haloshift, omit_corners, scale, logu
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -1507,10 +1470,7 @@ subroutine chksum_h_3d(array_m, mesg, HI_m, haloshift, omit_corners, scale, logu
   if (hshift==0) then
     if (is_root_pe()) call chk_sum_msg("h-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
-    if (do_corners) then
+    if (.not. present_and_true(omit_corners)) then
       bcSW = subchk(array, HI, -hshift, -hshift, scaling)
       bcSE = subchk(array, HI, hshift, -hshift, scaling)
       bcNW = subchk(array, HI, -hshift, hshift, scaling)
@@ -1617,7 +1577,7 @@ subroutine chksum_B_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners, sym, sym_stats
+  logical :: sym, sym_stats
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -1644,7 +1604,7 @@ subroutine chksum_B_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   elseif (present(scale)) then ; scaling = scale ; endif
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
-  sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
+  sym_stats = present_and_true(symmetric)
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
 
   if (calculateStatistics) then
@@ -1683,15 +1643,12 @@ subroutine chksum_B_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
 
   bc0 = subchk(array, HI, 0, 0, scaling)
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if ((hshift==0) .and. .not.sym) then
     if (is_root_pe()) call chk_sum_msg("B-point:", bc0, mesg, iounit)
   else
-  do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
-    if (do_corners) then
+    if (.not. present_and_true(omit_corners)) then
       if (sym) then
         bcSW = subchk(array, HI, -hshift-1, -hshift-1, scaling)
         bcSE = subchk(array, HI, hshift, -hshift-1, scaling)
@@ -1813,7 +1770,7 @@ subroutine chksum_u_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
-  logical :: do_corners, sym, sym_stats
+  logical :: sym, sym_stats
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -1849,7 +1806,7 @@ subroutine chksum_u_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   elseif (present(scale)) then ; scaling = scale ; endif
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
-  sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
+  sym_stats = present_and_true(symmetric)
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
 
   if (calculateStatistics) then
@@ -1886,18 +1843,15 @@ subroutine chksum_u_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
 
   bc0 = subchk(array, HI, 0, 0, scaling)
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if ((hshift==0) .and. .not.sym) then
     if (is_root_pe()) call chk_sum_msg("u-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
     if (hshift==0) then
       bcW = subchk(array, HI, -hshift-1, 0, scaling)
       if (is_root_pe()) call chk_sum_msg_W("u-point:", bc0, bcW, mesg, iounit)
-    elseif (do_corners) then
+    elseif (.not. present_and_true(omit_corners)) then
       if (sym) then
         bcSW = subchk(array, HI, -hshift-1, -hshift, scaling)
         bcNW = subchk(array, HI, -hshift-1, hshift, scaling)
@@ -2017,7 +1971,7 @@ subroutine chksum_v_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   integer :: bc0, bcSW, bcSE, bcNW, bcNE, hshift
   integer :: bcN, bcS, bcE, bcW
   real :: aMean, aMin, aMax  ! Array mean, global minimum and global maximum [a]
-  logical :: do_corners, sym, sym_stats
+  logical :: sym, sym_stats
   integer :: turns                      ! Quarter turns from input to model grid
 
   ! Rotate array to the input grid
@@ -2053,7 +2007,7 @@ subroutine chksum_v_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
   elseif (present(scale)) then ; scaling = scale ; endif
 
   iounit = error_unit ; if (present(logunit)) iounit = logunit
-  sym_stats = .false. ; if (present(symmetric)) sym_stats = symmetric
+  sym_stats = present_and_true(symmetric)
   if (present(haloshift)) then ; if (haloshift > 0) sym_stats = .true. ; endif
 
   if (calculateStatistics) then
@@ -2090,18 +2044,15 @@ subroutine chksum_v_3d(array_m, mesg, HI_m, haloshift, symmetric, omit_corners, 
 
   bc0 = subchk(array, HI, 0, 0, scaling)
 
-  sym = .false. ; if (present(symmetric)) sym = symmetric
+  sym = present_and_true(symmetric)
 
   if ((hshift==0) .and. .not.sym) then
     if (is_root_pe()) call chk_sum_msg("v-point:", bc0, mesg, iounit)
   else
-    do_corners = .true.
-    if (present(omit_corners)) do_corners = .not. omit_corners
-
     if (hshift==0) then
       bcS = subchk(array, HI, 0, -hshift-1, scaling)
       if (is_root_pe()) call chk_sum_msg_S("v-point:", bc0, bcS, mesg, iounit)
-    elseif (do_corners) then
+    elseif (.not. present_and_true(omit_corners)) then
       if (sym) then
         bcSW = subchk(array, HI, -hshift, -hshift-1, scaling)
         bcSE = subchk(array, HI, hshift, -hshift-1, scaling)
@@ -2685,5 +2636,14 @@ integer function bitcount(x)
   ! NOTE: Assumes that reals and integers of kind=xk are the same size
   bitcount = popcnt(transfer(x, 1_xk))
 end function bitcount
+
+
+!> This routine returns true if its single optional argument is both present and true.
+logical function present_and_true(arg)
+  logical, optional, intent(in) :: arg !< An optional logical to argument to use.
+
+  present_and_true = .false.
+  if (present(arg)) present_and_true = arg
+end function present_and_true
 
 end module MOM_checksums

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -113,8 +113,7 @@ subroutine doc_param_logical(doc, varname, desc, units, val, default, &
       mesg = undef_string(doc, varname, units)
     endif
 
-    equalsDefault = .false.
-    if (present(like_default)) equalsDefault = like_default
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       if (val .eqv. default) equalsDefault = .true.
       if (default) then
@@ -165,7 +164,7 @@ subroutine doc_param_logical_array(doc, varname, desc, units, vals, default, &
 
     mesg = define_string(doc, varname, valstring, units)
 
-    equalsDefault = .false.
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       equalsDefault = .true.
       do i=1,size(vals) ; if (vals(i) .neqv. default) equalsDefault = .false. ; enddo
@@ -175,7 +174,6 @@ subroutine doc_param_logical_array(doc, varname, desc, units, vals, default, &
         mesg = trim(mesg)//" default = "//STRING_FALSE
       endif
     endif
-    if (present(like_default)) then ; if (like_default) equalsDefault = .true. ; endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
     call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
@@ -209,8 +207,7 @@ subroutine doc_param_int(doc, varname, desc, units, val, default, &
     valstring = int_string(val)
     mesg = define_string(doc, varname, valstring, units)
 
-    equalsDefault = .false.
-    if (present(like_default)) equalsDefault = like_default
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       if (val == default) equalsDefault = .true.
       mesg = trim(mesg)//" default = "//(trim(int_string(default)))
@@ -254,7 +251,7 @@ subroutine doc_param_int_array(doc, varname, desc, units, vals, default, default
 
     mesg = define_string(doc, varname, valstring, units)
 
-    equalsDefault = .false.
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       equalsDefault = .true.
       do i=1,size(vals) ; if (vals(i) /= default) equalsDefault = .false. ; enddo
@@ -265,7 +262,6 @@ subroutine doc_param_int_array(doc, varname, desc, units, vals, default, default
       do i=1,size(vals) ; if (vals(i) /= defaults(i)) equalsDefault = .false. ; enddo
       mesg = trim(mesg)//" default = "//trim(int_array_string(defaults))
     endif
-    if (present(like_default)) then ; if (like_default) equalsDefault = .true. ; endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
     call writeMessageAndDesc(doc, mesg, desc, equalsDefault, &
@@ -298,8 +294,7 @@ subroutine doc_param_real(doc, varname, desc, units, val, default, debuggingPara
     valstring = real_string(val)
     mesg = define_string(doc, varname, valstring, units)
 
-    equalsDefault = .false.
-    if (present(like_default)) equalsDefault = like_default
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       if (val == default) equalsDefault = .true.
       mesg = trim(mesg)//" default = "//trim(real_string(default))
@@ -338,7 +333,7 @@ subroutine doc_param_real_array(doc, varname, desc, units, vals, default, defaul
 
     mesg = define_string(doc, varname, valstring, units)
 
-    equalsDefault = .false.
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       equalsDefault = .true.
       do i=1,size(vals) ; if (vals(i) /= default) equalsDefault = .false. ; enddo
@@ -349,7 +344,6 @@ subroutine doc_param_real_array(doc, varname, desc, units, vals, default, defaul
       do i=1,size(vals) ; if (vals(i) /= defaults(i)) equalsDefault = .false. ; enddo
       mesg = trim(mesg)//" default = "//trim(real_array_string(defaults))
     endif
-    if (present(like_default)) then ; if (like_default) equalsDefault = .true. ; endif
 
     if (mesgHasBeenDocumented(doc, varName, mesg)) return ! Avoid duplicates
     call writeMessageAndDesc(doc, mesg, desc, equalsDefault, debuggingParam=debuggingParam)
@@ -382,8 +376,7 @@ subroutine doc_param_char(doc, varname, desc, units, val, default, &
   if (doc%filesAreOpen) then
     mesg = define_string(doc, varname, '"'//trim(val)//'"', units)
 
-    equalsDefault = .false.
-    if (present(like_default)) equalsDefault = like_default
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       if (trim(val) == trim(default)) equalsDefault = .true.
       mesg = trim(mesg)//' default = "'//trim(adjustl(default))//'"'
@@ -474,8 +467,7 @@ subroutine doc_param_time(doc, varname, desc, val, default, units, debuggingPara
       mesg = define_string(doc, varname, valstring, "[days : seconds]")
     endif
 
-    equalsDefault = .false.
-    if (present(like_default)) equalsDefault = like_default
+    equalsDefault = present_and_true(like_default)
     if (present(default)) then
       if (val == default) equalsDefault = .true.
       mesg = trim(mesg)//" default = "//trim(time_string(default))
@@ -512,8 +504,8 @@ subroutine writeMessageAndDesc(doc, vmesg, desc, valueWasDefault, indent, &
   logical :: msg_done, reset_msg_pad   ! Logicals used to format messages.
   logical :: all, short, layout, debug ! Flags indicating which files to write into.
 
-  layout = .false. ; if (present(layoutParam)) layout = layoutParam
-  debug = .false. ; if (present(debuggingParam)) debug = debuggingParam
+  layout = present_and_true(layoutParam)
+  debug = present_and_true(debuggingParam)
   all = doc%complete .and. (doc%unitAll > 0) .and. .not. (layout .or. debug)
   short = doc%minimal .and. (doc%unitShort > 0) .and. .not. (layout .or. debug)
   if (present(valueWasDefault)) short = short .and. (.not. valueWasDefault)
@@ -881,17 +873,17 @@ subroutine doc_module(doc, modname, desc, log_to_all, all_default, layoutMod, de
     mesg = "! === module "//trim(modname)//" ==="
     call writeMessageAndDesc(doc, mesg, desc, valueWasDefault=all_default, indent=0, &
                              layoutParam=layoutMod, debuggingParam=debuggingMod)
-    if (present(log_to_all)) then ; if (log_to_all) then
+    if (present_and_true(log_to_all)) then
       ! Log the module version again if the previous call was intercepted for use to document
       ! a layout or debugging module.
       repeat_doc = .false.
-      if (present(layoutMod)) then ; if (layoutMod) repeat_doc = .true. ; endif
-      if (present(debuggingMod)) then ; if (debuggingMod) repeat_doc = .true. ; endif
+      if (present_and_true(layoutMod)) repeat_doc = .true.
+      if (present_and_true(debuggingMod)) repeat_doc = .true.
       if (repeat_doc) then
         call writeMessageAndDesc(doc, '', '', valueWasDefault=all_default)
         call writeMessageAndDesc(doc, mesg, desc, valueWasDefault=all_default, indent=0)
       endif
-    endif ; endif
+    endif
   endif
 end subroutine doc_module
 
@@ -1151,5 +1143,14 @@ function mesgHasBeenDocumented(doc,varName,mesg)
     last%next => newLink
   endif
 end function mesgHasBeenDocumented
+
+
+!> This routine returns true if its single optional argument is both present and true.
+logical function present_and_true(arg)
+  logical, optional, intent(in) :: arg !< An optional logical to argument to use.
+
+  present_and_true = .false.
+  if (present(arg)) present_and_true = arg
+end function present_and_true
 
 end module MOM_document

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -274,7 +274,7 @@ subroutine close_param_file(CS, quiet_close, component)
 # include "version_variable.h"
   integer :: i, n, num_unused
 
-  if (present(quiet_close)) then ; if (quiet_close) then
+  if (present_and_true(quiet_close)) then
     do i = 1, CS%nfiles
       if (is_root_pe()) close(CS%iounit(i))
       call MOM_mesg("close_param_file: "// trim(CS%filename(i))// &
@@ -290,7 +290,7 @@ subroutine close_param_file(CS, quiet_close, component)
     call doc_end(CS%doc)
     deallocate(CS%doc)
     return
-  endif ; endif
+  endif
 
   ! Log the parameters for the parser.
   docfile_default = "MOM_parameter_doc"
@@ -639,7 +639,7 @@ subroutine read_param_int(CS, varname, value, fail_if_missing, set)
     read(value_string(1),*,err = 1001) value
     if (present(set)) set = .true.
   else
-    if (present(fail_if_missing)) then ; if (fail_if_missing) then
+    if (present_and_true(fail_if_missing)) then
       if (.not.found) then
         call MOM_error(FATAL,'read_param_int: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
@@ -647,7 +647,7 @@ subroutine read_param_int(CS, varname, value, fail_if_missing, set)
         call MOM_error(FATAL,'read_param_int: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
-    endif ; endif
+    endif
     if (present(set)) set = .false.
   endif
   return
@@ -676,7 +676,7 @@ subroutine read_param_int_array(CS, varname, value, fail_if_missing, set)
     read(value_string(1),*,end=991,err=1002) value
  991 return
   else
-    if (present(fail_if_missing)) then ; if (fail_if_missing) then
+    if (present_and_true(fail_if_missing)) then
       if (.not.found) then
         call MOM_error(FATAL,'read_param_int_array: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
@@ -684,7 +684,7 @@ subroutine read_param_int_array(CS, varname, value, fail_if_missing, set)
         call MOM_error(FATAL,'read_param_int_array: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
-    endif ; endif
+    endif
     if (present(set)) set = .false.
   endif
   return
@@ -716,7 +716,7 @@ subroutine read_param_real(CS, varname, value, fail_if_missing, scale, set)
     if (present(scale)) value = scale*value
     if (present(set)) set = .true.
   else
-    if (present(fail_if_missing)) then ; if (fail_if_missing) then
+    if (present_and_true(fail_if_missing)) then
       if (.not.found) then
         call MOM_error(FATAL,'read_param_real: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
@@ -724,7 +724,7 @@ subroutine read_param_real(CS, varname, value, fail_if_missing, scale, set)
         call MOM_error(FATAL,'read_param_real: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
-    endif ; endif
+    endif
     if (present(set)) set = .false.
   endif
   return
@@ -757,7 +757,7 @@ subroutine read_param_real_array(CS, varname, value, fail_if_missing, scale, set
     if (present(scale)) value(:) = scale*value(:)
     if (present(set)) set = .true.
   else
-    if (present(fail_if_missing)) then ; if (fail_if_missing) then
+    if (present_and_true(fail_if_missing)) then
       if (.not.found) then
         call MOM_error(FATAL,'read_param_real_array: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
@@ -765,7 +765,7 @@ subroutine read_param_real_array(CS, varname, value, fail_if_missing, scale, set
         call MOM_error(FATAL,'read_param_real_array: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
-    endif ; endif
+    endif
     if (present(set)) set = .false.
   endif
   return
@@ -791,9 +791,9 @@ subroutine read_param_char(CS, varname, value, fail_if_missing, set)
   call get_variable_line(CS, varname, found, defined, value_string)
   if (found) then
     value = trim(strip_quotes(value_string(1)))
-  elseif (present(fail_if_missing)) then ; if (fail_if_missing) then
+  elseif (present_and_true(fail_if_missing)) then
     call MOM_error(FATAL, 'Unable to find variable '//trim(varname)//' in any input files.')
-  endif ; endif
+  endif
 
   if (present(set)) set = found
 
@@ -832,9 +832,9 @@ subroutine read_param_char_array(CS, varname, value, fail_if_missing, set)
       i_out = i_out+1
     endif
     do i=i_out,SIZE(value) ; value(i) = " " ; enddo
-  elseif (present(fail_if_missing)) then ; if (fail_if_missing) then
+  elseif (present_and_true(fail_if_missing)) then
     call MOM_error(FATAL, 'Unable to find variable '//trim(varname)//' in any input files.')
-  endif ; endif
+  endif
 
   if (present(set)) set = found
 
@@ -859,9 +859,9 @@ subroutine read_param_logical(CS, varname, value, fail_if_missing, set)
   call get_variable_line(CS, varname, found, defined, value_string, paramIsLogical=.true.)
   if (found) then
     value = defined
-  elseif (present(fail_if_missing)) then ; if (fail_if_missing) then
+  elseif (present_and_true(fail_if_missing)) then
     call MOM_error(FATAL, 'Unable to find variable '//trim(varname)//' in any input files.')
-  endif ; endif
+  endif
 
   if (present(set)) set = found
 
@@ -925,13 +925,13 @@ subroutine read_param_time(CS, varname, value, timeunit, fail_if_missing, date_f
     endif
     if (present(set)) set = .true.
   else
-    if (present(fail_if_missing)) then ; if (fail_if_missing) then
+    if (present_and_true(fail_if_missing)) then
       if (.not.found) then
         call MOM_error(FATAL, 'Unable to find variable '//trim(varname)//' in any input files.')
       else
         call MOM_error(FATAL, 'Variable '//trim(varname)//' found but not set in input files.')
       endif
-    endif ; endif
+    endif
     if (present(set)) set = .false.
   endif
   return
@@ -1046,16 +1046,13 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
   logical            :: found_override, found_equals
   logical            :: found_define, found_undef
   logical            :: force_cycle, defined_in_line, continuedLine
-  logical            :: variableKindIsLogical, valueIsSame
+  logical            :: valueIsSame
   logical            :: inWrongBlock, fullPathParameter
   logical, parameter :: requireNamedClose = .false.
   integer, parameter :: verbose = 1
   set = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
   continuationBuffer = repeat(" ", CS%max_line_len)
   contBufSize = 0
-
-  variableKindIsLogical=.false.
-  if (present(paramIsLogical)) variableKindIsLogical = paramIsLogical
 
   ! Find the first instance (if any) where the named variable is found, and
   ! return variables indicating whether this variable is defined and the string
@@ -1226,7 +1223,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         lname = trim(line(is:ise-1))
         if (trim(lname) /= trim(varname)) cycle
         val_str = trim(adjustl(line(ise+3:last)))
-        if (variableKindIsLogical) then ! Special handling for logicals
+        if (present_and_true(paramIsLogical)) then ! Special handling for logicals
           read(val_str(:len_trim(val_str)),*) defined_in_line
         else
           defined_in_line = .true.
@@ -1768,8 +1765,8 @@ subroutine get_param_int(CS, modulename, varname, value, desc, units, &
   logical :: new_name_used, old_name_used, same_value
   integer :: new_name_value  ! The value that is set when the standard name is used.
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (do_read) then
     if (present(default)) value = default
@@ -1835,8 +1832,8 @@ subroutine get_param_int_array(CS, modulename, varname, value, desc, units, &
   integer :: new_name_value(size(value))  ! The values that are set when the old name is used.
   integer :: m
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (present(defaults)) then
     if (present(default)) call MOM_error(FATAL, &
@@ -1911,8 +1908,8 @@ subroutine get_param_real(CS, modulename, varname, value, desc, units, &
   logical :: new_name_used, old_name_used, same_value
   real :: new_name_value  ! The value that is set when the old name is used.
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (do_read) then
     if (present(default)) value = default
@@ -1983,8 +1980,8 @@ subroutine get_param_real_array(CS, modulename, varname, value, desc, units, &
   real    :: new_name_value(size(value))  ! The values that are set when the standard name is used.
   integer :: m
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (present(defaults)) then
     if (present(default)) call MOM_error(FATAL, &
@@ -2060,8 +2057,8 @@ subroutine get_param_char(CS, modulename, varname, value, desc, units, &
   logical :: new_name_used, old_name_used, same_value
   character(len=:), allocatable :: new_name_value  ! The value that is set when the standard name is used.
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (do_read) then
     if (present(default)) value = default
@@ -2122,8 +2119,8 @@ subroutine get_param_char_array(CS, modulename, varname, value, desc, units, &
   character(len=:), allocatable :: cat_val
   character(len=:), allocatable :: new_name_value(:)  ! The value that is set when the standard name is used.
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (do_read) then
     if (present(default)) value(:) = default
@@ -2196,8 +2193,8 @@ subroutine get_param_logical(CS, modulename, varname, value, desc, units, &
   logical :: new_name_used, old_name_used, same_value
   logical :: new_name_value  ! The value that is set when the standard name is used.
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
 
   if (do_read) then
     if (present(default)) value = default
@@ -2266,8 +2263,8 @@ subroutine get_param_time(CS, modulename, varname, value, desc, units, &
   logical :: new_name_used, old_name_used, same_value
   type(time_type) :: new_name_value  ! The value that is set when the standard name is used.
 
-  do_read = .true. ; if (present(do_not_read)) do_read = .not.do_not_read
-  do_log  = .true. ; if (present(do_not_log))  do_log  = .not.do_not_log
+  do_read = .not. present_and_true(do_not_read)
+  do_log  = .not. present_and_true(do_not_log)
   log_date = .false.
 
   if (do_read) then
@@ -2349,15 +2346,11 @@ subroutine openParameterBlock(CS, blockName, desc, do_not_log)
     !< Log block entry if true.  This only prevents logging of entry to the block, and not the contents.
 
   type(parameter_block), pointer :: block => NULL()
-  logical :: do_log
-
-  do_log = .true.
-  if (present(do_not_log)) do_log = .not. do_not_log
 
   if (associated(CS%blockName)) then
     block => CS%blockName
     block%name = pushBlockLevel(block%name,blockName)
-    if (do_log) then
+    if (.not. present_and_true(do_not_log)) then
       call doc_openBlock(CS%doc, block%name, desc)
       block%log_access = .true.
     else
@@ -2418,6 +2411,15 @@ function popBlockLevel(oldblockName)
       'popBlockLevel: A pop was attempted leaving an empty block name.')
   endif
 end function popBlockLevel
+
+
+!> This routine returns true if its single optional argument is both present and true.
+logical function present_and_true(arg)
+  logical, optional, intent(in) :: arg !< An optional logical to argument to use.
+
+  present_and_true = .false.
+  if (present(arg)) present_and_true = arg
+end function present_and_true
 
 !> \namespace mom_file_parser
 !!


### PR DESCRIPTION
  This pull request consists of 5 commits that add local copies of the function `present_and_true()` to the MOM_debugging, MOM_checksums, MOM_file_parser, MOM_document and MOM_forcing_type modules, and then uses them to simplify
unnecessarily complicated code logic in a total of 95 expressions.  In 4 other cases a simple call to `present()` was able to simplify the code.  In the case of tests for `use_glc_runoff` in the MOM_forcing_type module, this effectively adds a test for the logical setting of that argument instead of just its presence, so this could prevent the unnecessary declaration of some unused diagnostics, which could show up as added entries in available_diags files for cases using the NUOPC coupler.  All answers are bitwise identical.
