### PR TITLE
Diag buffers: Use `final` to avoid slow GCC builds

### DIFF
--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -30,7 +30,6 @@ type, abstract :: diag_buffer_base ; private
   integer :: ie !< The end slot of the array i-direction
   integer :: je !< The end slot of the array j-direction
   real :: fill_value = 0. !< Set the fill value to use when growing the buffer [arbitrary]
-
   integer, allocatable, dimension(:) :: ids  !< List of diagnostic ids whose slot corresponds to the row in the buffer
   integer :: length = 0 !< The number of slots in the buffer
 
@@ -54,6 +53,9 @@ type, extends(diag_buffer_base), public :: diag_buffer_2d ; private
   procedure, public :: grow => grow_2d !< Increase the size of the buffer
   procedure, public :: store => store_2d !< Store a field in the buffer, increasing as necessary
   procedure, public :: set_extents_from_array => set_extents_from_array_2d !< Set extents from array bounds
+
+  final :: finalize_diag_buffer_2d
+    !< Finalization stub to improve optimized build time
 end type diag_buffer_2d
 
 !> Dynamically growing buffer for 3D arrays.
@@ -68,6 +70,9 @@ type, extends(diag_buffer_base), public :: diag_buffer_3d ; private
   procedure, public :: grow => grow_3d !< Increase the size of the buffer
   procedure, public :: store => store_3d !< Store a field in the buffer, increasing as necessary
   procedure, public :: set_extents_from_array => set_extents_from_array_3d !< Set extents from array bounds
+
+  final :: finalize_diag_buffer_3d
+    !< Finalization stub to improve optimized build time
 end type diag_buffer_3d
 
 contains
@@ -265,6 +270,21 @@ subroutine store_3d(this, data, id)
   slot = this%check_capacity_by_id(id)
   this%buffer(slot)%field(:,:,:) = data(:,:,:)
 end subroutine store_3d
+
+
+!> A dummy finalize method to resolve optimization overhead in GCC.
+subroutine finalize_diag_buffer_2d(this)
+  type(diag_buffer_2d) :: this
+    !< Diagnostic buffer
+end subroutine finalize_diag_buffer_2d
+
+
+!> A dummy finalize method to resolve optimization overhead in GCC.
+subroutine finalize_diag_buffer_3d(this)
+  type(diag_buffer_3d) :: this
+    !< Diagnostic buffer
+end subroutine finalize_diag_buffer_3d
+
 
 !> Unit tests for the 2d version of the diag buffer
 function diag_buffer_unit_tests_2d(verbose) result(fail)
@@ -544,4 +564,3 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
 end function diag_buffer_unit_tests_3d
 
 end module MOM_diag_buffers
-


### PR DESCRIPTION
Building MOM_diag_mediator.F90 with GCC and -O2 became much slower after diagnostic buffers were added.
```
    commit 6f6975ab788daecbd2fe21aa9d94ddeedd6d6867
    Author: Andrew Shao <andrew.shao@hpe.com>
    Date:   Wed Mar 18 12:17:43 2026 -0700

        +Extend diag_mediator to allow the piecemeal posting of diagnostics (#809)
```
Before this commit, MOM_diag_mediator.F90 built in about 15 seconds. After this commit, build time increased to more than 170 seconds.

The slowdown was isolated to derived types with multiple allocatable array components, not to abstract types, inheritance, or type-bound methods.  A minimal form of the triggering pattern is shown below.
```
  type :: diag_buffer_2d
    real, allocatable :: buffer(:,:,:)
    integer, allocatable :: ids(:)
  end type
```
The component did not need to be referenced in MOM_diag_mediator.F90. It was enough for diag_buffer_2d to appear as a component of axes_grp.

Somehow, this was resolved by defining an explicit dummy finalizer in `diag_buffer_2d`.
```
  type :: diag_buffer_2d
    ! ...
  contains
    final :: finalize_diag_buffer_2d
  end type diag_buffer_2d

  subroutine finalize_diag_buffer_2d
    type(diag_buffer_2d), intent(inout) :: this
  end subroutine finalize_diag_buffer_2d
```
With this change, build time returns to about 15 seconds.

* The finalizers are intentionally empty.  Allocatable components are automatically deallocated by the language, so no explicit deallocate() calls are needed here.

  Finalizers should only be used for custom cleanup, such as external resources or manually managed pointer targets.

* `diag_buffer_[23]d` contains an array of `buffer_[23]d` objects.  The language standard notes that components are finalized before the parent.

* No similar compile-time benefit was seen from adding dummy finalizers to buffer_[23]d, so those types are left unchanged.