### PR TITLE
Bug fix for restart reproducibility issue due to DTBT

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2622,12 +2622,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     default_val = US%T_to_s*CS%dt_therm ; if (dtbt > 0.0) default_val = -1.0
     CS%dtbt_reset_period = -1.0
     call get_param(param_file, "MOM", "DTBT_RESET_PERIOD", CS%dtbt_reset_period, &
-                 "The period between recalculations of DTBT (if DTBT <= 0). "//&
-                 "If DTBT_RESET_PERIOD is negative, DTBT is set based "//&
-                 "only on information available at initialization.  If 0, "//&
-                 "DTBT will be set every dynamics time step. The default "//&
-                 "is set by DT_THERM.  This is only used if SPLIT is true.", &
-                 units="s", default=default_val, scale=US%s_to_T, do_not_read=(dtbt > 0.0))
+                   "The period between recalculations of DTBT (if DTBT <= 0). If "//&
+                   "DTBT_RESET_PERIOD is negative, DTBT is set based only on information "//&
+                   "available at initialization.  If 0, DTBT will be set every dynamics time "//&
+                   "step. Values between 0 and DT are treated as 0.  The default is set by "//&
+                   "DT_THERM. This is only used if SPLIT is true.", &
+                   units="s", default=default_val, scale=US%s_to_T, do_not_read=(dtbt > 0.0))
   endif
 
   ! This is here in case these values are used inappropriately.
@@ -3554,16 +3554,22 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
               CS%visc, dirs, CS%ntrunc, CS%pbv, calc_dtbt=calc_dtbt, &
               cont_stencil=CS%cont_stencil, dyn_h_stencil=CS%dyn_h_stencil)
     endif
+    ! A reset period no longer than dt is equivalent to recalculating every step.
+    if (CS%dtbt_reset_period > 0.0 .and. CS%dtbt_reset_period <= CS%dt) &
+        CS%dtbt_reset_period = 0.0
     if (CS%dtbt_reset_period > 0.0) then
       CS%dtbt_reset_interval = real_to_time(CS%dtbt_reset_period, unscale=US%T_to_s)
-      ! Set dtbt_reset_time to be the next even multiple of dtbt_reset_interval.
-      CS%dtbt_reset_time = Time_init + CS%dtbt_reset_interval * &
-                                 ((Time - Time_init) / CS%dtbt_reset_interval)
-      if ((CS%dtbt_reset_time > Time) .and. calc_dtbt) then
-        ! Back up dtbt_reset_time one interval to force dtbt to be calculated,
-        ! because the restart was not aligned with the interval to recalculate
-        ! dtbt, and dtbt was not read from a restart file.
-        CS%dtbt_reset_time = CS%dtbt_reset_time - CS%dtbt_reset_interval
+      if (calc_dtbt) then
+        ! No restart DTBT (not found or new run) or DTBT_RESTART_BUG=True: set to the most recent
+        ! multiple of the interval before or equal to current time, so the set_dtbt is called on
+        ! the first step.
+        CS%dtbt_reset_time = Time_init + CS%dtbt_reset_interval * &
+                                   ((Time - Time_init) / CS%dtbt_reset_interval)
+      else
+        ! Restart DTBT available: defer to the next multiple after current time so the first step
+        ! uses the restart value unless a reset is naturally due.
+        CS%dtbt_reset_time = Time_init + CS%dtbt_reset_interval * &
+                                   ((Time - Time_init) / CS%dtbt_reset_interval + 1)
       endif
     endif
   elseif (CS%use_RK2) then

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5562,6 +5562,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
                           ! recreate the bugs, or if false bugs are only used if actively selected.
   logical :: visc_rem_bug ! Stores the value of runtime paramter VISC_REM_BUG.
+  logical :: dtbt_restart_bug ! Stores the value of runtime parameter DTBT_RESTART_BUG.
   character(len=48) :: thickness_units, flux_units
   character*(40) :: hvel_str
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
@@ -5745,7 +5746,10 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
                  "answers for some configurations that use OBCs.", &
                  default=enable_bugs, do_not_log=.true.)
   CS%interior_OBC_PV = .not.OBC_projection_bug
-
+  call get_param(param_file, mdl, "DTBT_RESTART_BUG", dtbt_restart_bug, &
+                 "If true, recover a bug where the barotropic timestep DTBT read from a "//&
+                 "restart file is immediately overridden by a recalculation on the "//&
+                 "first dynamics step.", default=.true.)
   call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
   if (use_tides .and. present(HA_CSp)) CS%HA_CSp => HA_CSp
@@ -6256,7 +6260,11 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
     CS%dtbt = dtbt_restart
   endif
 
-  calc_dtbt = .true. ; if ((dtbt_restart > 0.0) .and. (dtbt_input > 0.0)) calc_dtbt = .false.
+  if (dtbt_restart_bug) then
+    calc_dtbt = .true. ; if ((dtbt_restart > 0.0) .and. (dtbt_input > 0.0)) calc_dtbt = .false.
+  else
+    calc_dtbt = (dtbt_restart <= 0.0)
+  endif
 
   call log_param(param_file, mdl, "DTBT as used", CS%dtbt, units="s", unscale=US%T_to_s)
   call log_param(param_file, mdl, "estimated maximum DTBT", CS%dtbt_max, units="s", unscale=US%T_to_s)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -30,7 +30,7 @@ use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_self_attr_load, only : scalar_SAL_sensitivity
 use MOM_self_attr_load, only : SAL_CS
 use MOM_streaming_filter, only : Filt_register, Filt_init, Filt_accum, Filter_CS
-use MOM_time_manager, only : time_type, real_to_time, operator(+), operator(-)
+use MOM_time_manager, only : time_type, real_to_time, get_date, operator(+), operator(-)
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : BT_cont_type, alloc_bt_cont_type
 use MOM_verticalGrid, only : verticalGrid_type
@@ -3682,7 +3682,7 @@ end subroutine btstep_layer_accel
 !> This subroutine automatically determines an optimal value for dtbt based on some state of the ocean. Either pbce or
 !! gtot_est is required to calculate gravitational acceleration. Column thickness can be estimated using BT_cont, eta,
 !! and SSH_add (default=0), with priority given in that order. The subroutine sets CS%dtbt_max and CS%dtbt.
-subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add)
+subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add, Time)
   type(ocean_grid_type),        intent(inout) :: G    !< The ocean's grid structure.
   type(verticalGrid_type),      intent(in)    :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),        intent(in)    :: US   !< A dimensional unit scaling type
@@ -3699,6 +3699,7 @@ subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add)
                                                       !! anomaly [H ~> m or kg m-2].
   real,               optional, intent(in)    :: SSH_add !< An additional contribution to SSH to provide a margin of
                                                       !! error when calculating the external wave speed [Z ~> m].
+  type(time_type),    optional, intent(in)    :: Time !< Model time at the beginning of the baroclinic time step.
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
@@ -3730,7 +3731,8 @@ subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add)
                       ! barotropic time step [T-2 ~> s-2].
   logical :: use_BT_cont
   type(memory_size_type) :: MS
-
+  character(len=200) :: mesg
+  integer :: yr, mon, day, hr, minute, sec
   integer :: i, j, k, is, ie, js, je, nz
 
   if (.not.CS%module_is_initialized) call MOM_error(FATAL, &
@@ -3800,6 +3802,14 @@ subroutine set_dtbt(G, GV, US, CS, pbce, gtot_est, BT_cont, eta, SSH_add)
 
   CS%dtbt = CS%dtbt_fraction * dtbt_max
   CS%dtbt_max = dtbt_max
+
+  if (is_root_PE() .and. present(Time)) then
+    call get_date(Time, yr, mon, day, hr, minute, sec)
+    write(mesg, '("DTBT reset by set_dtbt at ",i4.4,"-",i2.2,"-",i2.2," ",i2.2,":",i2.2,":",i2.2, &
+                & ", dtbt = ",ES12.6," s, dtbt_max = ",ES12.6," s")') &
+          yr, mon, day, hr, minute, sec, (US%T_to_s*CS%dtbt), (US%T_to_s*dtbt_max)
+    call MOM_mesg(mesg, 3)
+  endif
 
   if (CS%debug) then
     call chksum0(CS%dtbt, "End set_dtbt dtbt", unscale=US%T_to_s)
@@ -6238,7 +6248,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   endif
 
   ! CS%dtbt calculated here by set_dtbt is only used when dtbt is not reset during the run, i.e. DTBT_RESET_PERIOD<0.
-  call set_dtbt(G, GV, US, CS, gtot_est=gtot_estimate, SSH_add=SSH_extra)
+  call set_dtbt(G, GV, US, CS, gtot_est=gtot_estimate, SSH_add=SSH_extra, Time=Time)
 
   if (dtbt_input > 0.0) then
     CS%dtbt = US%s_to_T * dtbt_input

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -36,7 +36,7 @@ use MOM_restart,           only : register_restart_field, register_restart_pair
 use MOM_restart,           only : query_initialized, set_initialized, save_restart
 use MOM_restart,           only : only_read_from_restarts
 use MOM_restart,           only : restart_init, is_new_run, MOM_restart_CS
-use MOM_time_manager,      only : time_type, operator(+)
+use MOM_time_manager,      only : time_type, real_to_time, operator(+)
 use MOM_time_manager,      only : operator(-), operator(>), operator(*), operator(/)
 
 use MOM_ALE,                   only : ALE_CS, ALE_remap_velocities
@@ -674,11 +674,13 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call cpu_clock_begin(id_clock_btstep)
   if (calc_dtbt) then
     if (CS%dtbt_use_bt_cont .and. associated(CS%BT_cont)) then
-      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, BT_cont=CS%BT_cont)
+      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, BT_cont=CS%BT_cont, &
+                    Time=Time_local - real_to_time(dt, unscale=US%T_to_s))
     else
       ! In the following call, eta is only used when NONLINEAR_BT_CONTINUITY is True. Otherwise, dtbt is effectively
       ! calculated with eta=0. Note that NONLINEAR_BT_CONTINUITY is False if BT_CONT is used, which is the default.
-      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, eta=eta)
+      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, eta=eta, &
+                    Time=Time_local - real_to_time(dt, unscale=US%T_to_s))
     endif
   endif
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -37,7 +37,7 @@ use MOM_restart,           only : register_restart_field, register_restart_pair
 use MOM_restart,           only : query_initialized, set_initialized, save_restart
 use MOM_restart,           only : only_read_from_restarts
 use MOM_restart,           only : restart_init, is_new_run, MOM_restart_CS
-use MOM_time_manager,      only : time_type, operator(+)
+use MOM_time_manager,      only : time_type, real_to_time, operator(+)
 use MOM_time_manager,      only : operator(-), operator(>), operator(*), operator(/)
 
 use MOM_ALE,                   only : ALE_CS, ALE_remap_velocities
@@ -690,11 +690,13 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
   call cpu_clock_begin(id_clock_btstep)
   if (calc_dtbt) then
     if (CS%dtbt_use_bt_cont .and. associated(CS%BT_cont)) then
-      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, BT_cont=CS%BT_cont)
+      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, BT_cont=CS%BT_cont, &
+                    Time=Time_local - real_to_time(dt, unscale=US%T_to_s))
     else
       ! In the following call, eta is only used when NONLINEAR_BT_CONTINUITY is True. Otherwise, dtbt is effectively
       ! calculated with eta=0. Note that NONLINEAR_BT_CONTINUITY is False if BT_CONT is used, which is the default.
-      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, eta=eta)
+      call set_dtbt(G, GV, US, CS%barotropic_CSp, CS%pbce, eta=eta, &
+                    Time=Time_local - real_to_time(dt, unscale=US%T_to_s))
     endif
   endif
   if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")


### PR DESCRIPTION
This PR has two purposes:
1) Log `DTBT` whenever it is reset by subroutine `set_dtbt`
2) Address a potential reproducibility issue across restarts for some niche cases. 

## Commit 7413b7a7c5db60903acba8c19feccca890df15cd
This commit adds an optional `Time` argument to `set_dtbt()` so that each call emits a verbosity-3 message on the root PE recording the model date, `dtbt`, and `dtbt_max` at the moment of the reset. This commit could address issue #1113.

## Commit 862d755dfa02f0e8afc6b7fbc6b8a023d53b3833
This commit fixes a bug that DTBT from restart being discarded on the first step. The root cause of the bug is that `dtbt_reset_time` was initialized incorrectly for restart runs. It was always set to the most recent multiple of `DTBT_RESET_INTERVAL` before or equal to the current time using floor division, guaranteeing `dtbt_reset_time ≤ Time`. Since `Time_local` (end of step) always exceeds `Time`, the check `Time_local >= CS%dtbt_reset_time` was true on the very first step, causing `set_dtbt` to run and discard the restart DTBT unconditionally.

This commit also internally normalizes 0<dtbt_reset_period <= DT to zero.

### A test case
Below is a carefully design example to demonstrate the bug. Here, DT = 720s, DTBT_RESET_PERIOD = 5400s and SET_DTBT_USE_BT_CONT = True.
`ocean.stats` from the continuous run
```
  Step,       Time, Truncs,      Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err
         [7.20E+02 s]              [m2 s-2]           [Nondim]        [m]             [kg]           [Nondim]
     0,       0.000,     0, En 1.8279940583180578E-27, CFL  0.00000, SL  9.4147E-14, Mass 8.95738E+18, Me  0.00E+00
     5,       5.000,     0, En 1.0866523747614250E-03, CFL  0.00521, SL  9.4147E-14, Mass 8.95738E+18, Me  1.50E-19
    10,      10.000,     0, En 3.8103513398852979E-03, CFL  0.01136, SL  9.4147E-14, Mass 8.95738E+18, Me -1.31E-19

```
`ocean.stats` from the restart run
```
     0,       5.000,     0, En 1.0866523747614250E-03, CFL  0.00521, SL  9.4147E-14, Mass 8.95738E+18, Me  0.00E+00
     5,      10.000,     0, En 3.8102873865953420E-03, CFL  0.01142, SL  9.4147E-14, Mass 8.95738E+18, Me  2.10E-19
```
The answer change is due to DTBT, as shown by the DTBT log,

DTBT logs from the continuous run
```
DTBT reset by set_dtbt at 0001-01-01 00:00:00, dtbt = 3.002004E+02 s, dtbt_max = 3.160004E+02 s
DTBT reset by set_dtbt at 0001-01-01 00:00:00, dtbt = 3.621545E+02 s, dtbt_max = 3.812153E+02 s
DTBT reset by set_dtbt at 0001-01-01 01:24:00, dtbt = 3.572066E+02 s, dtbt_max = 3.760069E+02 s
```
DTBT logs from the restart run
```
DTBT reset by set_dtbt at 0001-01-01 01:00:00, dtbt = 3.002004E+02 s, dtbt_max = 3.160004E+02 s
DTBT reset by set_dtbt at 0001-01-01 01:00:00, dtbt = 3.572358E+02 s, dtbt_max = 3.760377E+02 s
DTBT reset by set_dtbt at 0001-01-01 01:24:00, dtbt = 3.572057E+02 s, dtbt_max = 3.760060E+02 s
```
Note how the restart run recalculates `DTBT` at 0001-01-01 01:00:00, instead of using the one from restart file.

### Comments
This bug is probably highly unusual. Because for the actual barotropic time step, it is the number of steps within a baroclinic time step that matters. So this can only happen when the change in DTBT results in different number of barotropic step. This is even more unlikely when SET_DTBT_USE_BT_CONT = False (default).   

https://github.com/NOAA-GFDL/MOM6/blob/ac31b32b98a3e41e0ee9a49caf85be18ce8f7539/src/core/MOM_dynamics_split_RK2.F90#L675-L683

As explained by the comment in the above code, `set_dtbt` essentially estimates DTBT with a zero SSH (accurate enough for the real ocean), so it is very unlikely DTBT varies a lot across recalculation.


All answers are bitwise identical. There is a new runtime parameter.
Claude Opus 4.7 is used to realize the idea and implement the code. All changes are verified by human.