### PR TITLE
(*)Set a pointer to df_2d_y in register_tracer()

### DIFF
--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -130,10 +130,8 @@ type, public :: offline_transport_CS ; private
                         !! routine [H L2 ~> m3 or kg]
   !>@{ Diagnostic manager IDs for some fields that may be of interest when doing offline transport
   integer :: &
-    id_uhr = -1, &
-    id_vhr = -1, &
-    id_ear = -1, &
-    id_ebr = -1, &
+    id_uhr = -1, id_vhr = -1, &
+    ! Unused: id_ear = -1, id_ebr = -1, &
     id_hr = -1,  &
     id_hdiff = -1, &
     id_uhr_redist = -1, &
@@ -1179,10 +1177,10 @@ subroutine register_diags_offline_transport(Time, diag, CS, GV, US)
     'm', conversion=GV%H_to_m)
   CS%id_hr  = register_diag_field('ocean_model', 'hr', diag%axesTL, Time, &
     'Layer thickness at end of offline step', 'm', conversion=GV%H_to_m)
-  CS%id_ear  = register_diag_field('ocean_model', 'ear', diag%axesTL, Time, &
-    'Remaining thickness entrained from above', 'm')
-  CS%id_ebr  = register_diag_field('ocean_model', 'ebr', diag%axesTL, Time, &
-    'Remaining thickness entrained from below', 'm')
+  ! Unused:  CS%id_ear  = register_diag_field('ocean_model', 'ear', diag%axesTL, Time, &
+  !              'Remaining thickness entrained from above', 'm')
+  ! Unused:  CS%id_ebr  = register_diag_field('ocean_model', 'ebr', diag%axesTL, Time, &
+  !              'Remaining thickness entrained from below', 'm')
   CS%id_eta_pre_distribute = register_diag_field('ocean_model','eta_pre_distribute', &
     diag%axesT1, Time, 'Total water column height before residual transport redistribution', &
     'm', conversion=GV%H_to_m)

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -253,6 +253,7 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   if (present(ad_2d_x)) then ; if (associated(ad_2d_x)) Tr%ad2d_x => ad_2d_x ; endif
   if (present(ad_2d_y)) then ; if (associated(ad_2d_y)) Tr%ad2d_y => ad_2d_y ; endif
   if (present(df_2d_x)) then ; if (associated(df_2d_x)) Tr%df2d_x => df_2d_x ; endif
+  if (present(df_2d_y)) then ; if (associated(df_2d_y)) Tr%df2d_y => df_2d_y ; endif
 
   if (present(advection_xy)) then
     if (associated(advection_xy)) Tr%advection_xy => advection_xy


### PR DESCRIPTION
  Set a pointer to the `df_2d_y` optional argument in `register_tracer()`, treating it like `df_2d_x` and the other diagnostic arrays that can be provided as optional arrays to `register_tracer()`.  Any 2-d y-diffusion diagnostics impacted by this bug would have reported all 0 values, but now will return sensible values.  Almost all (perhaps all) tracers have their standard diagnostics set up via `register_tracer_diagnostics()`, and this bug fix does not impact them.  As a result, it is entirely possible that this bug does not impact any code that is used, which is why it was never detected.

  Additionally, this commit comments out two unused and unimplemented diagnostics (ear and ebr) from MOM_offline_main.  For now the registration calls for these diagnostics are being left in comments in case someone actually intends for them to exist, but if they are not actually implemented they should be removed altogether at a later date.  These broken diagnostics were detected while scanning for `register_diag_field()` calls that appear to be missing appropriate unit conversion factors.  Without an actual implementation, there would have been an error message about missing `post_data()` calls for these diagnostics had they ever been turned on in the diag_table of an offline tracer run, so they can not have been in use in any working simulations.

  All solutions are bitwise identical, but there will be changes in the available_diags files for offline tracer runs.