### PR TITLE
Bug fix restart reproducibility of OBC BGC data

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2335,6 +2335,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   logical :: use_KPP           ! If true, diabatic is using KPP vertical mixing
   logical :: MLE_use_PBL_MLD   ! If true, use stored boundary layer depths for submesoscale restratification.
   logical :: OBC_reservoir_init_bug
+  logical :: OBC_bgc_time_ref_bug  ! If true, use the start of the current run (not the overall
+                               ! start time) as the reference for OBC BGC tracer update schedule.
   integer :: nkml, nkbl, verbosity, write_geom, number_of_OBC_segments
   integer :: dynamics_stencil  ! The computational stencil for the calculations
                                ! in the dynamic core.
@@ -2879,6 +2881,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "The time between OBC segment data updates for OBGC tracers.  This must be an "//&
                  "integer multiple of DT and DT_THERM.  The default is set to DT.", units="s", &
                  default=US%T_to_s*CS%dt, scale=US%s_to_T, do_not_log=.not.associated(OBC_in))
+  call get_param(param_file, "MOM", "OBC_BGC_TIME_REF_BUG", OBC_bgc_time_ref_bug, &
+                 "If true, recover a bug that the BGC OBC segment update schedule is "//&
+                 "referenced to the start of the current run rather than the overall start "//&
+                 "time, which can lead to restart reproducibility failures.", &
+                 default=.true., do_not_log=.not.associated(OBC_in))
 
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)
@@ -3574,10 +3581,18 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
   CS%dyn_h_stencil = max(2, CS%dyn_h_stencil)
 
-  !Set OBC segment data update period
-  if (associated(CS%OBC) .and. CS%dt_obc_seg_period > 0.0) then
+  ! Set the next time to update OBC segment BGC tracer data
+  if (associated(CS%OBC) .and. (CS%dt_obc_seg_period > 0.0)) then
     CS%dt_obc_seg_interval = real_to_time(CS%dt_obc_seg_period, unscale=US%T_to_s)
-    CS%dt_obc_seg_time = Time + CS%dt_obc_seg_interval
+    if (OBC_bgc_time_ref_bug) then
+      CS%dt_obc_seg_time = Time + CS%dt_obc_seg_interval
+    else
+      ! Set to the next update point after current time, so that %t read from initialization is
+      ! not overwritten.  Note that even though this line by itself is correct, there are still
+      ! issue with restart runs, as external data %t is not saved in restart files.
+      CS%dt_obc_seg_time = Time_init + CS%dt_obc_seg_interval * &
+                           ((Time - Time_init) / CS%dt_obc_seg_interval + 1)
+    endif
   endif
 
   call callTree_waypoint("dynamics initialized (initialize_MOM)")

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3583,6 +3583,19 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   ! Set the next time to update OBC segment BGC tracer data
   if (associated(CS%OBC) .and. (CS%dt_obc_seg_period > 0.0)) then
+    if (CS%dt_obc_seg_period > CS%dt_tr_adv) then
+      if (new_sim) then
+        call MOM_error(WARNING, "DT_OBC_SEG_UPDATE_OBGC > DT_TRACER_ADVECT: this run will "//&
+            "proceed normally, but any restart from it will fail with a FATAL error because "//&
+            "BGC OBC external data is not saved in restart files. "//&
+            "Set DT_OBC_SEG_UPDATE_OBGC = DT_TRACER_ADVECT or 0 until this is fixed.")
+      else
+        call MOM_error(FATAL, "DT_OBC_SEG_UPDATE_OBGC > DT_TRACER_ADVECT is not supported "//&
+            "for restart runs: BGC OBC external data is not saved in restart files, so the "//&
+            "first tracer advection step after restart may use incorrect boundary data. "//&
+            "Set DT_OBC_SEG_UPDATE_OBGC = DT_TRACER_ADVECT or 0 until this is fixed.")
+      endif
+    endif
     CS%dt_obc_seg_interval = real_to_time(CS%dt_obc_seg_period, unscale=US%T_to_s)
     if (OBC_bgc_time_ref_bug) then
       CS%dt_obc_seg_time = Time + CS%dt_obc_seg_interval


### PR DESCRIPTION
`DT_OBC_SEG_UPDATE_OBGC` controls how often BGC tracer data is read from OBC segment files. As it is now, there are at least two problems with it that could lead to restart reproducibility issues and this PR *partially* addresses them.

1. **Time reference bug (`OBC_BGC_TIME_REF_BUG`)**

The time reference for `CS%dt_obc_seg_time` was initialized from `Time` (the start of the current run segment) rather than `Time_init` (the overall simulation start time).  After a restart, Time > Time_init, so the first scheduled update could happen at a different phase than it would in a continuous run, breaking restart reproducibility.

The fix b09481e3207cf7219ce1b854ec21cfff621b09f3 anchors `dt_obc_seg_time` to `Time_init` so the update schedule is phase-invariant across restarts. The old behavior is preserved by `OBC_BGC_TIME_REF_BUG`, which defaults to `True`.

2. **Deprecate the use of `DT_OBC_SEG_UPDATE_OBGC > DT_TRACER_ADVECT`**

BGC OBC external data (`%t`) is not saved in restart files. When `DT_OBC_SEG_UPDATE_OBGC > DT_TRACER_ADVECT`, the model cannot reconstruct the boundary state at restart, as it is agnostic of the thickness used for remapping during the last update. So the first tracer advection step after any restart may use incorrect data regardless of the time-reference fix above.

To protect users from this silent error:
- A **FATAL** is issued when this condition is detected on a restart run.
- A **WARNING** is issued on a new run to alert the user that any future restart from it will fail.

Both messages direct users to set `DT_OBC_SEG_UPDATE_OBGC = DT_TRACER_ADVECT` or `0` until `%t` is added to restart files.

Comments: 
1. The time reference bug only affects the cases when the difference between restart time and initial time is not an integer multiple of `DT_OBC_SEG_UPDATE_OBGC`, which is probably very rare. By default, `DT_OBC_SEG_UPDATE_OBGC` is baroclinic `DT` and in practice, it is usually (and should be) an integer multiple of `DT_TRACER_ADVECT`.
2. There is a third, perhaps more substantial issue for all OBC tracers, that their updates happen at the beginning every dynamics time step rather than tracer time step. Not only is this unnecessary, but it also uses a pre-updated thickness for remapping external data. This issue will be addressed in a subsequent PR.
3. Therefore, the only valid value for `DT_OBC_SEG_UPDATE_OBGC` is `DT_TRACER_ADVECT` until external data is saved in restart files. Doing so would require the model to carry two additional 4D arrays (the %t-counterpart of `OBC%tres_[xy]`) across restarts, which is a substantial memory cost. Given that the parameter is currently broken for all but a narrow range of values, it may be worth a broader discussion about whether to deprecate it entirely.