### PR TITLE
Add MIN_RATIO_SRESTORE and MAX_DELTA_SRESTORE_FROM_FILE

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -134,6 +134,7 @@ type, public :: surface_forcing_CS ; private
                                             !! for salinity restoring.
   real    :: ice_salt_concentration         !< Salt concentration for sea ice [kg/kg]
   logical :: mask_srestore_marginal_seas    !< If true, then mask SSS restoring in marginal seas
+  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_srestore             !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_trestore             !< Maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin [nondim]
@@ -381,7 +382,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     if (CS%salt_restore_as_sflux) then
       do j=js,je ; do i=is,ie
         delta_sss = data_restore(i,j) - sfc_state%SSS(i,j)
-        delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+        if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
+          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+        endif
         fluxes%salt_flux(i,j) = 1.e-3*US%S_to_ppt*G%mask2dT(i,j) * (CS%rho_restore*CS%Flux_const_salt)* &
              (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) * delta_sss  ! R Z T-1 ~> kg Salt m-2 s-1
       enddo ; enddo
@@ -403,7 +406,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       do j=js,je ; do i=is,ie
         if (G%mask2dT(i,j) > 0.0) then
           delta_sss = sfc_state%SSS(i,j) - data_restore(i,j)
-          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
+            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          endif
           fluxes%vprec(i,j) = (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j))* &
                       (CS%rho_restore*CS%Flux_const_salt) * &
                       delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
@@ -1514,6 +1519,9 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
     call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                  "The maximum salinity difference used in restoring terms.", &
                  units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
+                 "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&
+                 "is less than this value.", units="nondim", default=0.0) 
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", CS%mask_srestore_under_ice, &
                  "If true, disables SSS restoring under sea-ice based on a frazil "//&
                  "criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.",      &

--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -134,8 +134,14 @@ type, public :: surface_forcing_CS ; private
                                             !! for salinity restoring.
   real    :: ice_salt_concentration         !< Salt concentration for sea ice [kg/kg]
   logical :: mask_srestore_marginal_seas    !< If true, then mask SSS restoring in marginal seas
-  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
+  logical :: max_delta_srestore_file        !< If true, apply a 2-dimensional maximum delta salinity
+                                            !! when restoring. The file should be
+                                            !! in inputdir/max_delta_srestore.nc and the field
+                                            !! should be named 'max_delta_srestore'
+  real, pointer, dimension(:,:) :: max_delta_srestore_2d => NULL()
+                                            !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_srestore             !< Maximum delta salinity used for restoring [S ~> ppt]
+  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_trestore             !< Maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin [nondim]
   integer :: answer_date        !< The vintage of the order of arithmetic and expressions in the
@@ -383,8 +389,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       do j=js,je ; do i=is,ie
         delta_sss = data_restore(i,j) - sfc_state%SSS(i,j)
         if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
-          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
-        endif
+          if (.not. CS%max_delta_srestore_file) then
+            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          else
+            if (abs(delta_sss) > abs(CS%max_delta_srestore_2d(i,j))) then
+              if (CS%max_delta_srestore_2d(i,j) < 0.0) then
+                delta_sss = 0.0  !turn off restoring
+              else !clip restoring
+                delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore_2d(i,j))
+              endif
+            endif
+          endif !max_delta_srestore_file
+        endif !min_ratio_srestore
         fluxes%salt_flux(i,j) = 1.e-3*US%S_to_ppt*G%mask2dT(i,j) * (CS%rho_restore*CS%Flux_const_salt)* &
              (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) * delta_sss  ! R Z T-1 ~> kg Salt m-2 s-1
       enddo ; enddo
@@ -407,8 +423,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
         if (G%mask2dT(i,j) > 0.0) then
           delta_sss = sfc_state%SSS(i,j) - data_restore(i,j)
           if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
-            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
-          endif
+            if (.not. CS%max_delta_srestore_file) then
+              delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+            else
+              if (abs(delta_sss) > abs(CS%max_delta_srestore_2d(i,j))) then
+                if (CS%max_delta_srestore_2d(i,j) < 0.0) then
+                  delta_sss = 0.0  !turn off restoring
+                else !clip restoring
+                  delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore_2d(i,j))
+                endif
+              endif
+            endif !max_delta_srestore_file
+          endif !min_ratio_srestore
           fluxes%vprec(i,j) = (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j))* &
                       (CS%rho_restore*CS%Flux_const_salt) * &
                       delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
@@ -1516,12 +1542,24 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
-    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
-                 "The maximum salinity difference used in restoring terms.", &
-                 units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+   call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
+                 "If true, read a file (max_delta_srestore.nc) containing the field "//&
+                 "max_delta_srestore for the maximum salinity difference used in restoring terms. "//&
+                 "Where the field's value is negative turn off restoring when the salinity "//&
+                 "difference magnitude exceeds abs(value).", default=.false.)
+    if (.not. CS%max_delta_srestore_file) then
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
+                   "The maximum salinity difference used in restoring terms.", &
+                   units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    else
+      CS%max_delta_srestore = 999.0
+      call safe_alloc_ptr(CS%max_delta_srestore_2d,isd,ied,jsd,jed)
+      flnam = trim(CS%inputdir) // 'max_delta_srestore.nc'
+      call MOM_read_data(flnam,'max_delta_srestore', CS%max_delta_srestore_2d, G%domain, timelevel=1)
+    endif
     call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
                  "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&
-                 "is less than this value.", units="nondim", default=0.0) 
+                 "is less than this value.", units="nondim", default=0.0)
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", CS%mask_srestore_under_ice, &
                  "If true, disables SSS restoring under sea-ice based on a frazil "//&
                  "criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.",      &

--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -141,7 +141,7 @@ type, public :: surface_forcing_CS ; private
   real, pointer, dimension(:,:) :: max_delta_srestore_2d => NULL()
                                             !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_srestore             !< Maximum delta salinity used for restoring [S ~> ppt]
-  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
+  real    :: min_ratio_srestore             !< Minimum fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_trestore             !< Maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< Mask for surface salinity restoring by basin [nondim]
   integer :: answer_date        !< The vintage of the order of arithmetic and expressions in the
@@ -1381,13 +1381,14 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   type(time_type)    :: Time_frc
-  type(directories)  :: dirs      ! A structure containing relevant directory paths and input filenames.
+ type(directories)  :: dirs      ! A structure containing relevant directory paths and input filenames.
   character(len=200) :: TideAmp_file, gust_file, salt_file, temp_file ! Input file names.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_surface_forcing"  ! This module's name.
   character(len=48)  :: stagger
-  character(len=48)  :: flnam
+  character(len=80)  :: varnam
+  character(len=240) :: flnam
   character(len=240) :: basin_file
   integer :: i, j, isd, ied, jsd, jed
 
@@ -1543,19 +1544,25 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
-                 "If true, read a file (max_delta_srestore.nc) containing the field "//&
-                 "max_delta_srestore for the maximum salinity difference used in restoring terms. "//&
-                 "Where the field's value is negative turn off restoring when the salinity "//&
-                 "difference magnitude exceeds abs(value).", default=.false.)
+                 "If true, read a file MAX_DELTA_SRESTORE_FILE containing the field "//&
+                 "MAX_DELTA_SRESTORE_VARNAME for the maximum salinity difference used in "//&
+                 "restoring terms.  Where the field's value is negative turn off restoring when "//&
+                 "the salinity difference magnitude exceeds abs(value).", default=.false.)
     if (.not. CS%max_delta_srestore_file) then
       call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                    "The maximum salinity difference used in restoring terms.", &
                    units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
     else
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FILE", flnam, &
+                   "The path to the file containing the maximum salinity difference field.", &
+                   default="max_delta_srestore.nc")
+      flnam = trim(CS%inputdir) // trim(flnam)
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_VARNAME", varnam, &
+                   "The name of the maximum salinity difference variable in the input file.", &
+                   default="max_delta_srestore")
       CS%max_delta_srestore = 999.0
       call safe_alloc_ptr(CS%max_delta_srestore_2d,isd,ied,jsd,jed)
-      flnam = trim(CS%inputdir) // 'max_delta_srestore.nc'
-      call MOM_read_data(flnam,'max_delta_srestore', CS%max_delta_srestore_2d, G%domain, timelevel=1)
+      call MOM_read_data(flnam,varnam, CS%max_delta_srestore_2d, G%domain, timelevel=1)
     endif
     call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
                  "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&

--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -116,6 +116,7 @@ type, public :: surface_forcing_CS ; private
 
   real    :: ice_salt_concentration         !< salt concentration for sea ice [kg/kg]
   logical :: mask_srestore_marginal_seas    !< if true, then mask SSS restoring in marginal seas
+  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
@@ -364,7 +365,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     if (CS%salt_restore_as_sflux) then
       do j=js,je ; do i=is,ie
         delta_sss = data_restore(i,j) - sfc_state%SSS(i,j)
-        delta_sss = sign(1.0,delta_sss)*min(abs(delta_sss),CS%max_delta_srestore)
+        if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
+          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+        endif
         fluxes%salt_flux(i,j) = 1.e-3*US%S_to_ppt*G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)* &
              (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) *delta_sss  ! R Z T-1 ~> kg Salt m-2 s-1
       enddo ; enddo
@@ -385,7 +388,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       do j=js,je ; do i=is,ie
         if (G%mask2dT(i,j) > 0.0) then
           delta_sss = sfc_state%SSS(i,j) - data_restore(i,j)
-          delta_sss = sign(1.0,delta_sss)*min(abs(delta_sss),CS%max_delta_srestore)
+          if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
+            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          endif
           fluxes%vprec(i,j) = (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j))* &
                (CS%Rho0*CS%Flux_const) * &
                delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
@@ -1193,6 +1198,10 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "MAX_DELTA_TRESTORE", CS%max_delta_trestore, &
                  "The maximum sst difference used in restoring terms.", &
                  units="degC ", default=999.0, scale=US%degC_to_C)
+
+    call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
+                 "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&
+                 "is less than this value.", units="nondim", default=0.0)
 
     call get_param(param_file, mdl, "MASK_TRESTORE", CS%mask_trestore, &
                  "If true, read a file (temp_restore_mask) containing "//&

--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -116,8 +116,14 @@ type, public :: surface_forcing_CS ; private
 
   real    :: ice_salt_concentration         !< salt concentration for sea ice [kg/kg]
   logical :: mask_srestore_marginal_seas    !< if true, then mask SSS restoring in marginal seas
-  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
+  logical :: max_delta_srestore_file        !< If true, apply a 2-dimensional maximum delta salinity
+                                            !! when restoring. The file should be
+                                            !! in inputdir/max_delta_srestore.nc and the field
+                                            !! should be named 'max_delta_srestore'
+  real, pointer, dimension(:,:) :: max_delta_srestore_2d => NULL()
+                                            !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
+  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
   logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
@@ -366,8 +372,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       do j=js,je ; do i=is,ie
         delta_sss = data_restore(i,j) - sfc_state%SSS(i,j)
         if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
-          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
-        endif
+          if (.not. CS%max_delta_srestore_file) then
+            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          else
+            if (abs(delta_sss) > abs(CS%max_delta_srestore_2d(i,j))) then
+              if (CS%max_delta_srestore_2d(i,j) < 0.0) then
+                delta_sss = 0.0  !turn off restoring
+              else !clip restoring
+                delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore_2d(i,j))
+              endif
+            endif
+          endif !max_delta_srestore_file
+        endif !min_ratio_srestore
         fluxes%salt_flux(i,j) = 1.e-3*US%S_to_ppt*G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)* &
              (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) *delta_sss  ! R Z T-1 ~> kg Salt m-2 s-1
       enddo ; enddo
@@ -389,8 +405,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
         if (G%mask2dT(i,j) > 0.0) then
           delta_sss = sfc_state%SSS(i,j) - data_restore(i,j)
           if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
-            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
-          endif
+            if (.not. CS%max_delta_srestore_file) then
+              delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+            else
+              if (abs(delta_sss) > abs(CS%max_delta_srestore_2d(i,j))) then
+                if (CS%max_delta_srestore_2d(i,j) < 0.0) then
+                  delta_sss = 0.0  !turn off restoring
+                else !clip restoring
+                  delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore_2d(i,j))
+                endif
+              endif
+            endif !max_delta_srestore_file
+          endif !min_ratio_srestore
           fluxes%vprec(i,j) = (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j))* &
                (CS%Rho0*CS%Flux_const) * &
                delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
@@ -1153,9 +1179,21 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
-    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
-                 "The maximum salinity difference used in restoring terms.", &
-                 units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
+                 "If true, read a file (max_delta_srestore.nc) containing the field "//&
+                 "max_delta_srestore for the maximum salinity difference used in restoring terms. "//&
+                 "Where the field's value is negative turn off restoring when the salinity "//&
+                 "difference magnitude exceeds abs(value).", default=.false.)
+    if (.not. CS%max_delta_srestore_file) then
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
+                   "The maximum salinity difference used in restoring terms.", &
+                   units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    else
+      CS%max_delta_srestore = 999.0
+      call safe_alloc_ptr(CS%max_delta_srestore_2d,isd,ied,jsd,jed)
+      flnam = trim(CS%inputdir) // 'max_delta_srestore.nc'
+      call MOM_read_data(flnam,'max_delta_srestore', CS%max_delta_srestore_2d, G%domain, timelevel=1)
+    endif
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
                  "If true, disables SSS restoring under sea-ice based on a frazil "//&

--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -123,7 +123,7 @@ type, public :: surface_forcing_CS ; private
   real, pointer, dimension(:,:) :: max_delta_srestore_2d => NULL()
                                             !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
-  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
+  real    :: min_ratio_srestore             !< Minimim fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
   logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
@@ -1067,7 +1067,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_surface_forcing_mct"  ! This module's name.
   character(len=48)  :: stagger
-  character(len=48)  :: flnam
+  character(len=80)  :: varnam
+  character(len=240) :: flnam
   character(len=240) :: basin_file
   integer :: i, j, isd, ied, jsd, jed
 
@@ -1179,20 +1180,26 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
-    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
-                 "If true, read a file (max_delta_srestore.nc) containing the field "//&
-                 "max_delta_srestore for the maximum salinity difference used in restoring terms. "//&
-                 "Where the field's value is negative turn off restoring when the salinity "//&
-                 "difference magnitude exceeds abs(value).", default=.false.)
+   call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
+                 "If true, read a file MAX_DELTA_SRESTORE_FILE containing the field "//&
+                 "MAX_DELTA_SRESTORE_VARNAME for the maximum salinity difference used in "//&
+                 "restoring terms.  Where the field's value is negative turn off restoring when "//&
+                 "the salinity difference magnitude exceeds abs(value).", default=.false.)
     if (.not. CS%max_delta_srestore_file) then
       call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                    "The maximum salinity difference used in restoring terms.", &
                    units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
     else
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FILE", flnam, &
+                   "The path to the file containing the maximum salinity difference field.", &
+                   default="max_delta_srestore.nc")
+      flnam = trim(CS%inputdir) // trim(flnam)
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_VARNAME", varnam, &
+                   "The name of the maximum salinity difference variable in the input file.", &
+                   default="max_delta_srestore")
       CS%max_delta_srestore = 999.0
       call safe_alloc_ptr(CS%max_delta_srestore_2d,isd,ied,jsd,jed)
-      flnam = trim(CS%inputdir) // 'max_delta_srestore.nc'
-      call MOM_read_data(flnam,'max_delta_srestore', CS%max_delta_srestore_2d, G%domain, timelevel=1)
+      call MOM_read_data(flnam,varnam, CS%max_delta_srestore_2d, G%domain, timelevel=1)
     endif
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -133,7 +133,7 @@ type, public :: surface_forcing_CS ; private
   real, pointer, dimension(:,:) :: max_delta_srestore_2d => NULL()
                                             !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
-  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
+  real    :: min_ratio_srestore             !< Minimum fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
   logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
@@ -1206,7 +1206,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_surface_forcing_nuopc"  ! This module's name.
   character(len=48)  :: stagger
-  character(len=48)  :: flnam
+  character(len=80)  :: varnam
+  character(len=240) :: flnam
   character(len=240) :: basin_file
   integer :: i, j, isd, ied, jsd, jed
 
@@ -1327,20 +1328,26 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
-    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
-                 "If true, read a file (max_delta_srestore.nc) containing the field "//&
-                 "max_delta_srestore for the maximum salinity difference used in restoring terms. "//&
-                 "Where the field's value is negative turn off restoring when the salinity "//&
-                 "difference magnitude exceeds abs(value).", default=.false.)
+   call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
+                 "If true, read a file MAX_DELTA_SRESTORE_FILE containing the field "//&
+                 "MAX_DELTA_SRESTORE_VARNAME for the maximum salinity difference used in "//&
+                 "restoring terms.  Where the field's value is negative turn off restoring when "//&
+                 "the salinity difference magnitude exceeds abs(value).", default=.false.)
     if (.not. CS%max_delta_srestore_file) then
       call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                    "The maximum salinity difference used in restoring terms.", &
                    units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
     else
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FILE", flnam, &
+                   "The path to the file containing the maximum salinity difference field.", &
+                   default="max_delta_srestore.nc")
+      flnam = trim(CS%inputdir) // trim(flnam)
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_VARNAME", varnam, &
+                   "The name of the maximum salinity difference variable in the input file.", &
+                   default="max_delta_srestore")
       CS%max_delta_srestore = 999.0
       call safe_alloc_ptr(CS%max_delta_srestore_2d,isd,ied,jsd,jed)
-      flnam = trim(CS%inputdir) // 'max_delta_srestore.nc'
-      call MOM_read_data(flnam,'max_delta_srestore', CS%max_delta_srestore_2d, G%domain, timelevel=1)
+      call MOM_read_data(flnam,varnam, CS%max_delta_srestore_2d, G%domain, timelevel=1)
     endif
     call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
                  "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -126,8 +126,14 @@ type, public :: surface_forcing_CS ; private
                                             !! criteria for salinity restoring.
   real    :: ice_salt_concentration         !< salt concentration for sea ice [kg/kg]
   logical :: mask_srestore_marginal_seas    !< if true, then mask SSS restoring in marginal seas
-  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
+  logical :: max_delta_srestore_file        !< If true, apply a 2-dimensional maximum delta salinity
+                                            !! when restoring. The file should be
+                                            !! in inputdir/max_delta_srestore.nc and the field
+                                            !! should be named 'max_delta_srestore'
+  real, pointer, dimension(:,:) :: max_delta_srestore_2d => NULL()
+                                            !< Maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
+  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
   logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
@@ -416,8 +422,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       do j=js,je ; do i=is,ie
         delta_sss = data_restore(i,j) - sfc_state%SSS(i,j)
         if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
-          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
-        endif
+          if (.not. CS%max_delta_srestore_file) then
+            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          else
+            if (abs(delta_sss) > abs(CS%max_delta_srestore_2d(i,j))) then
+              if (CS%max_delta_srestore_2d(i,j) < 0.0) then
+                delta_sss = 0.0  !turn off restoring
+              else !clip restoring
+                delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore_2d(i,j))
+              endif
+            endif
+          endif !max_delta_srestore_file
+        endif !min_ratio_srestore
         fluxes%salt_flux(i,j) = 1.e-3*US%S_to_ppt*G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)* &
                   (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) *delta_sss  ! kg Salt m-2 s-1
       enddo ; enddo
@@ -439,8 +455,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
         if (G%mask2dT(i,j) > 0.0) then
           delta_sss = sfc_state%SSS(i,j) - data_restore(i,j)
           if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
-            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
-          endif
+            if (.not. CS%max_delta_srestore_file) then
+              delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+            else
+              if (abs(delta_sss) > abs(CS%max_delta_srestore_2d(i,j))) then
+                if (CS%max_delta_srestore_2d(i,j) < 0.0) then
+                  delta_sss = 0.0  !turn off restoring
+                else !clip restoring
+                  delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore_2d(i,j))
+                endif
+              endif
+            endif !max_delta_srestore_file
+          endif !min_ratio_srestore
           fluxes%vprec(i,j) = (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j))* &
                       (CS%Rho0*CS%Flux_const) * &
                       delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
@@ -1301,12 +1327,24 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "SRESTORE_AS_SFLUX", CS%salt_restore_as_sflux, &
                  "If true, the restoring of salinity is applied as a salt "//&
                  "flux instead of as a freshwater flux.", default=.false.)
-    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
-                 "The maximum salinity difference used in restoring terms.", &
-                 units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    call get_param(param_file, mdl, "MAX_DELTA_SRESTORE_FROM_FILE", CS%max_delta_srestore_file, &
+                 "If true, read a file (max_delta_srestore.nc) containing the field "//&
+                 "max_delta_srestore for the maximum salinity difference used in restoring terms. "//&
+                 "Where the field's value is negative turn off restoring when the salinity "//&
+                 "difference magnitude exceeds abs(value).", default=.false.)
+    if (.not. CS%max_delta_srestore_file) then
+      call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
+                   "The maximum salinity difference used in restoring terms.", &
+                   units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    else
+      CS%max_delta_srestore = 999.0
+      call safe_alloc_ptr(CS%max_delta_srestore_2d,isd,ied,jsd,jed)
+      flnam = trim(CS%inputdir) // 'max_delta_srestore.nc'
+      call MOM_read_data(flnam,'max_delta_srestore', CS%max_delta_srestore_2d, G%domain, timelevel=1)
+    endif
     call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
                  "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&
-                 "is less than this value.", units="nondim", default=0.0) 
+                 "is less than this value.", units="nondim", default=0.0)
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
                  "If true, disables SSS restoring under sea-ice based on a frazil "//&

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -126,6 +126,7 @@ type, public :: surface_forcing_CS ; private
                                             !! criteria for salinity restoring.
   real    :: ice_salt_concentration         !< salt concentration for sea ice [kg/kg]
   logical :: mask_srestore_marginal_seas    !< if true, then mask SSS restoring in marginal seas
+  real    :: min_ratio_srestore             !< Minimm fraction of restoring salinity to preserve [nondim]
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
@@ -414,7 +415,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     if (CS%salt_restore_as_sflux) then
       do j=js,je ; do i=is,ie
         delta_sss = data_restore(i,j) - sfc_state%SSS(i,j)
-        delta_sss = sign(1.0,delta_sss)*min(abs(delta_sss),CS%max_delta_srestore)
+        if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
+          delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+        endif
         fluxes%salt_flux(i,j) = 1.e-3*US%S_to_ppt*G%mask2dT(i,j) * (CS%Rho0*CS%Flux_const)* &
                   (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j)) *delta_sss  ! kg Salt m-2 s-1
       enddo ; enddo
@@ -435,7 +438,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       do j=js,je ; do i=is,ie
         if (G%mask2dT(i,j) > 0.0) then
           delta_sss = sfc_state%SSS(i,j) - data_restore(i,j)
-          delta_sss = sign(1.0,delta_sss)*min(abs(delta_sss),CS%max_delta_srestore)
+          if (sfc_state%SSS(i,j) >= data_restore(i,j)*CS%min_ratio_srestore) then
+            delta_sss = sign(1.0,delta_sss) * min(abs(delta_sss), CS%max_delta_srestore)
+          endif
           fluxes%vprec(i,j) = (CS%basin_mask(i,j)*open_ocn_mask(i,j)*CS%srestore_mask(i,j))* &
                       (CS%Rho0*CS%Flux_const) * &
                       delta_sss / (0.5*(sfc_state%SSS(i,j) + data_restore(i,j)))
@@ -1299,6 +1304,9 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "MAX_DELTA_SRESTORE", CS%max_delta_srestore, &
                  "The maximum salinity difference used in restoring terms.", &
                  units="PSU or g kg-1", default=999.0, scale=US%ppt_to_S)
+    call get_param(param_file, mdl, "MIN_RATIO_SRESTORE", CS%min_ratio_srestore, &
+                 "Turn off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity "//&
+                 "is less than this value.", units="nondim", default=0.0) 
     call get_param(param_file, mdl, "MASK_SRESTORE_UNDER_ICE", &
                  CS%mask_srestore_under_ice, &
                  "If true, disables SSS restoring under sea-ice based on a frazil "//&


### PR DESCRIPTION
A large MAX_DELTA_SRESTORE, e.g. 5.0 psu, tends to damp river plumes and so a smaller value is preferable.

One reason a large MAX_DELTA_SRESTORE is typically required is that it prevents rivers (runoff) from freshening too much, i.e. becoming very close to 0.0 psu.  This should not in principle cause issues but in practice it can be problematic.

Following a feature of HYCOM, where is is always 0.5, MIN_RATIO_SRESTORE turns off MAX_DELTA_SRESTORE where the ratio of SSS to restoring salinity is less than this value.  The default of 0.0 does not change existing answers, providing SSS isn't negative.

Note that a non-zero MIN_RATIO_SRESTORE cannot make the restoring weaker, and so would typically be used with a smaller MAX_DELTA_SRESTORE or FLUXCONST.

SSS can't get much fresher than restoring salinity times MIN_RATIO_SRESTORE and if this is saltier than desired either reduce MIN_RATIO_SRESTORE or modify the input restoring salinity fields.

Another reason a large MAX_DELTA_SRESTORE is typically required is that SSS can otherwise get very salty in small bays where advection isn't sufficient to flush them.  In HYCOM this is addressed by making the delta a 2-D field, which can be small nearly everywhere but large where SSS gets too salty.

Another feature of this field in HYCOM was suggested by Mats Bentsen (initially for TOPAZ) in 2010.  Where the 2-D delta field has a negative value, turn off restoring at abs(value), e.g. -0.5 psu.  Mats found that this avoided an anomalous reduction of salinity for the water transported into the Nordic Sea in an Atlantic TOPAZ model.  NRL uses -0.5 psu nearly everywhere for almost all of its global HYCOM simulations.  Tests in 2010 showed that this improved the Gulf Strean circulation, but there are no recent twin simulations, with and without negative deltas, to confirm that this is still the case today.

When true, the new input parameter MAX_DELTA_SRESTORE_FROM_FILE reads the file max_delta_srestore.nc containing the field max_delta_srestore for the maximum salinity difference used in restoring terms.  The file and field names are hardwired like the other SRESTORE parameters involving files.

When false (the default), MAX_DELTA_SRESTORE_FROM_FILE does not change existing answers.

This has only been tested with the FMS_cap driver, but the identical code has been added to the nuopc_cap and the STALE_mct_cap which both implement MAX_DELTA_SRESTORE.

As an example, three Atlantic simulations where run,  24.2 with MAX_DELTA_SRESTORE=5.0;  24.7 with MAX_DELTA_SRESTORE=0.5 and MIN_RATIO_SRESTORE=0.5; and 24.9 with MIN_RATIO_SRESTORE=0.5 and MAX_DELTA_SRESTORE_FROM_FILE with the max_delta field -0.5 nearly everywhere.  

After 5 model years starting from a US Navy GOFS 3.1 Reanalysis initial state, the annual SSS difference 24.7-24.2 is:

<img width="486" height="498" alt="plot_SSS_247-242_atlant_1920-0" src="https://github.com/user-attachments/assets/db77cd50-2215-4eed-86a1-aa6278976c17" />

The differences are near large rivers and some coastal regions.  However the largest SSS in 24.7 is 58 (vs 43 for 24.2) psu.

The annual SSS difference 24.9-24.7 is:

<img width="486" height="498" alt="plot_SSS_249-247_atlant_1920-0" src="https://github.com/user-attachments/assets/922404d9-7dbd-4148-aef0-8f1ff367c8b8" />

With stronger coastal differences and also in the interior.  The maximum SSS is back down to 43 psu due to using max_delta 5.0 in hot spots.