### PR TITLE
Revert "Diag buffers: Use `final` to avoid slow GCC builds"

### DIFF
--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -30,6 +30,7 @@ type, abstract :: diag_buffer_base ; private
   integer :: ie !< The end slot of the array i-direction
   integer :: je !< The end slot of the array j-direction
   real :: fill_value = 0. !< Set the fill value to use when growing the buffer [arbitrary]
+
   integer, allocatable, dimension(:) :: ids  !< List of diagnostic ids whose slot corresponds to the row in the buffer
   integer :: length = 0 !< The number of slots in the buffer
 
@@ -53,9 +54,6 @@ type, extends(diag_buffer_base), public :: diag_buffer_2d ; private
   procedure, public :: grow => grow_2d !< Increase the size of the buffer
   procedure, public :: store => store_2d !< Store a field in the buffer, increasing as necessary
   procedure, public :: set_extents_from_array => set_extents_from_array_2d !< Set extents from array bounds
-
-  final :: finalize_diag_buffer_2d
-    !< Finalization stub to improve optimized build time
 end type diag_buffer_2d
 
 !> Dynamically growing buffer for 3D arrays.
@@ -70,9 +68,6 @@ type, extends(diag_buffer_base), public :: diag_buffer_3d ; private
   procedure, public :: grow => grow_3d !< Increase the size of the buffer
   procedure, public :: store => store_3d !< Store a field in the buffer, increasing as necessary
   procedure, public :: set_extents_from_array => set_extents_from_array_3d !< Set extents from array bounds
-
-  final :: finalize_diag_buffer_3d
-    !< Finalization stub to improve optimized build time
 end type diag_buffer_3d
 
 contains
@@ -270,21 +265,6 @@ subroutine store_3d(this, data, id)
   slot = this%check_capacity_by_id(id)
   this%buffer(slot)%field(:,:,:) = data(:,:,:)
 end subroutine store_3d
-
-
-!> A dummy finalize method to resolve optimization overhead in GCC.
-subroutine finalize_diag_buffer_2d(this)
-  type(diag_buffer_2d) :: this
-    !< Diagnostic buffer
-end subroutine finalize_diag_buffer_2d
-
-
-!> A dummy finalize method to resolve optimization overhead in GCC.
-subroutine finalize_diag_buffer_3d(this)
-  type(diag_buffer_3d) :: this
-    !< Diagnostic buffer
-end subroutine finalize_diag_buffer_3d
-
 
 !> Unit tests for the 2d version of the diag buffer
 function diag_buffer_unit_tests_2d(verbose) result(fail)
@@ -564,3 +544,4 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
 end function diag_buffer_unit_tests_3d
 
 end module MOM_diag_buffers
+


### PR DESCRIPTION
This reverts commit 56001bc25bce79e73a0bc7c836c9bf517bfed3c0.

The dummy `final` functions in `MOM_diag_buffers` cause segmentation faults in NVIDIA.  Rather than work around a potential optimization issue in GCC, the safer option is to remove this patch and revisit it later if necessary.