### PR TITLE
Fix restart reproducibility OBC+ DIABATIC_FIRST=True

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -124,6 +124,7 @@ use MOM_open_boundary,         only : open_boundary_setup_vert, initialize_segme
 use MOM_open_boundary,         only : update_OBC_segment_data, rotate_OBC_config
 use MOM_open_boundary,         only : open_boundary_halo_update, write_OBC_info, chksum_OBC_segments
 use MOM_open_boundary,         only : segment_thickness_reservoir_init
+use MOM_open_boundary,         only : copy_OBC_radiation_coefs
 use MOM_open_boundary,         only : copy_OBC_tracer_reservoirs, copy_OBC_thickness_reservoirs
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
@@ -3724,6 +3725,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     call setup_OBC_tracer_reservoirs(G, GV, CS%OBC, restart_CSp)
     call setup_OBC_thickness_reservoirs(G, GV, CS%OBC, restart_CSp)
     call open_boundary_halo_update(G, CS%OBC)
+    call copy_OBC_radiation_coefs(CS%OBC)
     if (.not. (CS%OBC%reservoir_init_bug .and. new_sim .and. CS%diabatic_first)) &
       ! The if-guard is needed to preserve old answers with OBC_RESERVOIR_INIT_BUG=True, in which case
       ! segment T/S reservoir %tres and global restart arrays OBC%tres_x/y have diverged at this point.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -124,6 +124,7 @@ use MOM_open_boundary,         only : open_boundary_setup_vert, initialize_segme
 use MOM_open_boundary,         only : update_OBC_segment_data, rotate_OBC_config
 use MOM_open_boundary,         only : open_boundary_halo_update, write_OBC_info, chksum_OBC_segments
 use MOM_open_boundary,         only : segment_thickness_reservoir_init
+use MOM_open_boundary,         only : copy_OBC_tracer_reservoirs
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML, set_visc_CS
@@ -3723,6 +3724,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     call setup_OBC_tracer_reservoirs(G, GV, CS%OBC, restart_CSp)
     call setup_OBC_thickness_reservoirs(G, GV, CS%OBC, restart_CSp)
     call open_boundary_halo_update(G, CS%OBC)
+    if (.not. (CS%OBC%reservoir_init_bug .and. new_sim .and. CS%diabatic_first)) &
+      ! The if-guard is needed to preserve old answers with OBC_RESERVOIR_INIT_BUG=True, in which case
+      ! segment T/S reservoir %tres and global restart arrays OBC%tres_x/y have diverged at this point.
+      call copy_OBC_tracer_reservoirs(CS%OBC)
   endif
 
   call register_obsolete_diagnostics(param_file, CS%diag)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -124,7 +124,7 @@ use MOM_open_boundary,         only : open_boundary_setup_vert, initialize_segme
 use MOM_open_boundary,         only : update_OBC_segment_data, rotate_OBC_config
 use MOM_open_boundary,         only : open_boundary_halo_update, write_OBC_info, chksum_OBC_segments
 use MOM_open_boundary,         only : segment_thickness_reservoir_init
-use MOM_open_boundary,         only : copy_OBC_tracer_reservoirs
+use MOM_open_boundary,         only : copy_OBC_tracer_reservoirs, copy_OBC_thickness_reservoirs
 use MOM_porous_barriers,       only : porous_widths_layer, porous_widths_interface, porous_barriers_init
 use MOM_porous_barriers,       only : porous_barrier_CS
 use MOM_set_visc,              only : set_viscous_BBL, set_viscous_ML, set_visc_CS
@@ -3728,6 +3728,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       ! The if-guard is needed to preserve old answers with OBC_RESERVOIR_INIT_BUG=True, in which case
       ! segment T/S reservoir %tres and global restart arrays OBC%tres_x/y have diverged at this point.
       call copy_OBC_tracer_reservoirs(CS%OBC)
+    call copy_OBC_thickness_reservoirs(CS%OBC, G, GV)
   endif
 
   call register_obsolete_diagnostics(param_file, CS%diag)

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -62,7 +62,6 @@ use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, radiation_open_bdry_conds
 use MOM_open_boundary,         only : open_boundary_zero_normal_flow, open_boundary_query
 use MOM_open_boundary,         only : open_boundary_test_extern_h, update_OBC_ramp
-use MOM_open_boundary,         only : copy_thickness_reservoirs
 use MOM_open_boundary,         only : update_segment_thickness_reservoirs
 use MOM_PressureForce,         only : PressureForce, PressureForce_CS
 use MOM_PressureForce,         only : PressureForce_init
@@ -650,9 +649,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (G%nonblocking_updates) &
     call complete_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
-
-  if (associated(CS%OBC)) &
-    call copy_thickness_reservoirs(CS%OBC, G, GV)
 
 ! u_accel_bt = layer accelerations due to barotropic solver
   if (associated(CS%BT_cont) .or. CS%BT_use_layer_fluxes) then

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -61,7 +61,6 @@ use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, radiation_open_bdry_conds
 use MOM_open_boundary,         only : open_boundary_zero_normal_flow, open_boundary_query
 use MOM_open_boundary,         only : open_boundary_test_extern_h, update_OBC_ramp
-use MOM_open_boundary,         only : copy_thickness_reservoirs
 use MOM_open_boundary,         only : update_segment_thickness_reservoirs
 use MOM_PressureForce,         only : PressureForce, PressureForce_CS
 use MOM_PressureForce,         only : PressureForce_init
@@ -670,9 +669,6 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
   enddo ; enddo ; enddo
   call cpu_clock_end(id_clock_mom_update)
   call do_group_pass(CS%pass_uv_inst, G%Domain, clock=id_clock_pass)
-
-  if (associated(CS%OBC)) &
-    call copy_thickness_reservoirs(CS%OBC, G, GV)
 
 ! u_accel_bt = layer accelerations due to barotropic solver
   call cpu_clock_begin(id_clock_continuity)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -71,6 +71,7 @@ public set_obgc_segments_props
 public setup_OBC_tracer_reservoirs
 public setup_OBC_thickness_reservoirs
 public open_boundary_register_restarts
+public copy_OBC_radiation_coefs
 public copy_OBC_tracer_reservoirs
 public copy_OBC_thickness_reservoirs
 public update_segment_tracer_reservoirs
@@ -2732,6 +2733,55 @@ subroutine set_initialized_OBC_tracer_reservoirs(G, OBC, restart_CS)
 
 end subroutine set_initialized_OBC_tracer_reservoirs
 
+!> Copy radiation and oblique boundary condition coefficients (phase speeds and normalizing
+!! denominator) from the global restart arrays into the per-segment arrays.
+subroutine copy_OBC_radiation_coefs(OBC)
+  type(ocean_OBC_type), pointer :: OBC !< Open boundary control structure
+
+  ! Local variables
+  type(OBC_segment_type), pointer :: segment => NULL()
+  integer :: nz, i, j, k, n, is, ie, js, je
+
+  if (.not. associated(OBC)) return
+  if (OBC%gamma_uv >= 1.0) return
+
+  nz = OBC%ke
+  do n=1,OBC%number_of_segments
+    segment => OBC%segment(n)
+    if (.not. segment%on_pe) cycle
+    if (segment%is_E_or_W) then ! EW segment
+      I = segment%HI%IsdB ; js = segment%HI%jsd ; je = segment%HI%jed
+      if (segment%radiation) then
+        do k=1,nz ; do j=js,je
+          segment%rx_norm_rad(I,j,k) = OBC%rx_normal(I,j,k)
+        enddo ; enddo
+      endif
+      if (segment%oblique) then
+        do k=1,nz ; do j=js,je
+          segment%rx_norm_obl(I,j,k) = OBC%rx_oblique_u(I,j,k)
+          segment%ry_norm_obl(I,j,k) = OBC%ry_oblique_u(I,j,k)
+          segment%cff_normal(I,j,k)  = OBC%cff_normal_u(I,j,k)
+        enddo ; enddo
+      endif
+    elseif (segment%is_N_or_S) then ! NS segment
+      J = segment%HI%JsdB ; is = segment%HI%isd ; ie = segment%HI%ied
+      if (segment%radiation) then
+        do k=1,nz ; do i=is,ie
+          segment%ry_norm_rad(i,J,k) = OBC%ry_normal(i,J,k)
+        enddo ; enddo
+      endif
+      if (segment%oblique) then
+        do k=1,nz ; do i=is,ie
+          segment%rx_norm_obl(i,J,k) = OBC%rx_oblique_v(i,J,k)
+          segment%ry_norm_obl(i,J,k) = OBC%ry_oblique_v(i,J,k)
+          segment%cff_normal(i,J,k)  = OBC%cff_normal_v(i,J,k)
+        enddo ; enddo
+      endif
+    endif
+  enddo
+
+end subroutine copy_OBC_radiation_coefs
+
 !> Copy restart fields OBC%tres_x/y to per-segment tracer reservoir segment%tr_Reg%Tr(m)%tres.
 subroutine copy_OBC_tracer_reservoirs(OBC)
   type(ocean_OBC_type), pointer :: OBC !< Open boundary control structure
@@ -2867,50 +2917,6 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
   if (OBC%debug) call chksum_OBC_segments(OBC, G, GV, US, OBC%nk_OBC_debug)
 
   eps = 1.0e-20*US%m_s_to_L_T**2
-
-  !! Copy previously calculated phase velocity from global arrays into segments
-  !! This is terribly inefficient and temporary solution for continuity across restarts
-  !! and needs to be revisited in the future.
-  if (OBC%gamma_uv < 1.0) then
-    do n=1,OBC%number_of_segments
-      segment => OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (segment%is_E_or_W .and. segment%radiation) then
-        do k=1,GV%ke
-          I=segment%HI%IsdB
-          do j=segment%HI%jsd,segment%HI%jed
-            segment%rx_norm_rad(I,j,k) = OBC%rx_normal(I,j,k)
-          enddo
-        enddo
-      elseif (segment%is_N_or_S .and. segment%radiation) then
-        do k=1,GV%ke
-          J=segment%HI%JsdB
-          do i=segment%HI%isd,segment%HI%ied
-            segment%ry_norm_rad(i,J,k) = OBC%ry_normal(i,J,k)
-          enddo
-        enddo
-      endif
-      if (segment%is_E_or_W .and. segment%oblique) then
-        do k=1,GV%ke
-          I=segment%HI%IsdB
-          do j=segment%HI%jsd,segment%HI%jed
-            segment%rx_norm_obl(I,j,k) = OBC%rx_oblique_u(I,j,k)
-            segment%ry_norm_obl(I,j,k) = OBC%ry_oblique_u(I,j,k)
-            segment%cff_normal(I,j,k) = OBC%cff_normal_u(I,j,k)
-          enddo
-        enddo
-      elseif (segment%is_N_or_S .and. segment%oblique) then
-        do k=1,GV%ke
-          J=segment%HI%JsdB
-          do i=segment%HI%isd,segment%HI%ied
-            segment%rx_norm_obl(i,J,k) = OBC%rx_oblique_v(i,J,k)
-            segment%ry_norm_obl(i,J,k) = OBC%ry_oblique_v(i,J,k)
-            segment%cff_normal(i,J,k) = OBC%cff_normal_v(i,J,k)
-          enddo
-        enddo
-      endif
-    enddo
-  endif
 
   gamma_u = OBC%gamma_uv
   rx_max = OBC%rx_max ; ry_max = OBC%rx_max

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -71,8 +71,8 @@ public set_obgc_segments_props
 public setup_OBC_tracer_reservoirs
 public setup_OBC_thickness_reservoirs
 public open_boundary_register_restarts
-public copy_thickness_reservoirs
 public copy_OBC_tracer_reservoirs
+public copy_OBC_thickness_reservoirs
 public update_segment_tracer_reservoirs
 public update_segment_thickness_reservoirs
 public set_initialized_OBC_tracer_reservoirs
@@ -2764,7 +2764,7 @@ subroutine copy_OBC_tracer_reservoirs(OBC)
 end subroutine copy_OBC_tracer_reservoirs
 
 !> Fill segment%h_Reg from restart fields.
-subroutine copy_thickness_reservoirs(OBC, G, GV)
+subroutine copy_OBC_thickness_reservoirs(OBC, G, GV)
   type(ocean_grid_type),          intent(inout) :: G     !< Ocean grid structure
   type(verticalGrid_type),        intent(in)    :: GV    !< The ocean's vertical grid structure
   type(ocean_OBC_type),           pointer       :: OBC   !< Open boundary control structure
@@ -2812,7 +2812,7 @@ subroutine copy_thickness_reservoirs(OBC, G, GV)
     endif
   endif
 
-end subroutine copy_thickness_reservoirs
+end subroutine copy_OBC_thickness_reservoirs
 
 !> Apply radiation conditions to 3D u,v at open boundaries
 subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US, dt)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -72,6 +72,7 @@ public setup_OBC_tracer_reservoirs
 public setup_OBC_thickness_reservoirs
 public open_boundary_register_restarts
 public copy_thickness_reservoirs
+public copy_OBC_tracer_reservoirs
 public update_segment_tracer_reservoirs
 public update_segment_thickness_reservoirs
 public set_initialized_OBC_tracer_reservoirs
@@ -2731,6 +2732,37 @@ subroutine set_initialized_OBC_tracer_reservoirs(G, OBC, restart_CS)
 
 end subroutine set_initialized_OBC_tracer_reservoirs
 
+!> Copy restart fields OBC%tres_x/y to per-segment tracer reservoir segment%tr_Reg%Tr(m)%tres.
+subroutine copy_OBC_tracer_reservoirs(OBC)
+  type(ocean_OBC_type), pointer :: OBC !< Open boundary control structure
+
+  ! Local variables
+  type(OBC_segment_type), pointer :: segment => NULL()
+  integer :: n, m, i, j, k, is, ie, js, je, nz
+
+  if (.not. associated(OBC)) return
+  ! The allocated checks are needed for some user cases (e.g. "dyed_obcs"), where per-segment
+  ! tracers are registered after global restart arrays OBC%tres_x/y are allocated (or not).
+  if (.not. (allocated(OBC%tres_x) .or. allocated(OBC%tres_y))) return
+
+  nz = OBC%ke
+  do n=1, OBC%number_of_segments
+    segment => OBC%segment(n)
+    if (.not. (segment%on_pe .and. associated(segment%tr_Reg))) cycle
+    if (segment%is_E_or_W .and. allocated(OBC%tres_x)) then ! EW segment
+      I = segment%HI%IsdB ; js = segment%HI%jsd ; je = segment%HI%jed
+      do m=1, segment%tr_Reg%ntseg ; do k=1,nz ; do j=js,je
+        segment%tr_Reg%Tr(m)%tres(I,j,k) = segment%tr_Reg%Tr(m)%scale * OBC%tres_x(I,j,k,m)
+      enddo ; enddo ; enddo
+    elseif (segment%is_N_or_S .and. allocated(OBC%tres_y)) then ! NS segment
+      J = segment%HI%JsdB ; is = segment%HI%isd ; ie = segment%HI%ied
+      do m=1, segment%tr_Reg%ntseg ; do k=1,nz ; do i=is,ie
+        segment%tr_Reg%Tr(m)%tres(i,J,k) = segment%tr_Reg%Tr(m)%scale * OBC%tres_y(i,J,k,m)
+      enddo ; enddo ; enddo
+    endif
+  enddo ! end segment loop
+end subroutine copy_OBC_tracer_reservoirs
+
 !> Fill segment%h_Reg from restart fields.
 subroutine copy_thickness_reservoirs(OBC, G, GV)
   type(ocean_grid_type),          intent(inout) :: G     !< Ocean grid structure
@@ -2879,36 +2911,6 @@ subroutine radiation_open_bdry_conds(OBC, u_new, u_old, v_new, v_old, G, GV, US,
       endif
     enddo
   endif
-
-  ! Now tracers (if any)
-  do n=1,OBC%number_of_segments
-    segment => OBC%segment(n)
-    if (segment%on_pe .and. associated(segment%tr_Reg)) then
-      if (segment%is_E_or_W) then
-        I = segment%HI%IsdB
-        do m=1,segment%tr_Reg%ntseg
-          if (allocated(OBC%tres_x)) then
-            do k=1,GV%ke
-              do j=segment%HI%jsd,segment%HI%jed
-                segment%tr_Reg%Tr(m)%tres(I,j,k) = segment%tr_Reg%Tr(m)%scale * OBC%tres_x(I,j,k,m)
-              enddo
-            enddo
-          endif
-        enddo
-      else
-        J = segment%HI%JsdB
-        do m=1,segment%tr_Reg%ntseg
-          if (allocated(OBC%tres_y)) then
-            do k=1,GV%ke
-              do i=segment%HI%isd,segment%HI%ied
-                segment%tr_Reg%Tr(m)%tres(i,J,k) = segment%tr_Reg%Tr(m)%scale * OBC%tres_y(i,J,k,m)
-              enddo
-            enddo
-          endif
-        enddo
-      endif
-    endif
-  enddo
 
   gamma_u = OBC%gamma_uv
   rx_max = OBC%rx_max ; ry_max = OBC%rx_max


### PR DESCRIPTION
## Summary

This PR fixes restart reproducibility for configurations using OBC + `DIABATIC_FIRST=True`.

The source of the issue is the timing when per-segment arrays/reservoirs are initialized from the global restart arrays `OBC%tres_x/y`, `OBC%h_res_x/y`, and `OBC%rx_normal`/etc. Prior, per-segment **thickness reservoirs** are initialized at the beginning of each dynamic step (split only); **Tracer reservoirs** and **radiation coefficients** are effectively initialized in a call to  `radiation_open_bdry_conds`. There are two issues:

1. Per-segment arrays and global restart arrays are copied back and forth at every dynamics step, which is unnecessary and inefficient. 
2. For `DIABATIC_FIRST=True`,  all these per-segment arrays are uninitialized from restart (all =0.0, or interior values for T/S) during the first thermodynamic step. The global restart arrays are also modified by in `remap_OBC_fields` by these uninitialized per-segment arrays, so the per-segment arrays cannot be recovered in the dynamic steps.

The fix moves the per-segment mirror initialization from per-dynamics-step locations into `initialize_MOM`, so the per-segment arrays are populated from the global restart arrays before the first diabatic call.

## Commits

~cc5dbe71e2a355f3ce33f447ffa0c537bfde9d5e: Add OBC_SEGMENT_RESTART_BUG parameter — infrastructure only; reads the new flag, no behavior change.~
c33200dccd26542534a2dfbe6eb71bd9eb228efb: Move copy_OBC_tracer_reservoirs to init — extracts the inline tracer copy from `radiation_open_bdry_conds` into a public subroutine, calls it at init under the bug guard.
b5ddffe89aaaccbc883fc541dd5600cf991b5b7b: Move copy_OBC_thickness_reservoirs to init — renames `copy_thickness_reservoirs` → `copy_OBC_thickness_reservoirs`, relocates from `step_MOM_dyn_split_RK2`/`...RK2b` to init under the bug guard.
fd940fb8bbf01d905bcd27c2f9ab6bdd44629210: Move copy_OBC_radiation_coefs to init — extracts the inline phase-speed / oblique-coefficient copy from `radiation_open_bdry_conds` into a new public subroutine, calls it at init under the bug guard.

## Comments for reviewers
- Tested with loop current + ESMG user cases.
- There is no answer change. ~And for continuous runs with `DIABATIC_FIRST=True`, the bug flag is irrelevant and has the same results. So even though I opt to include a bug flag, I am not sure if it is necessary, i.e. if we want to preserve the reproducibility issue. [There are already quite a few bug flags in OBC and more incoming ...]~

