### PR TITLE
docs: optional AI-agent skill for MOM6 (community contribution, no code changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ or activity by DOC or the United States Government.
 
 This project code is made available through GitHub but is managed by NOAA-GFDL
 at https://gitlab.gfdl.noaa.gov.
+
+## Community resources
+
+- Unofficial, community-maintained AI-agent skill for onboarding new users (not an official NOAA-GFDL resource): [earth-space-ai/mom6-skill](https://github.com/earth-space-ai/mom6-skill). It restructures the existing MOM6 documentation for AI coding agents and defers to this repository as the source of truth.
+


### PR DESCRIPTION
Hi MOM6 maintainers,

I'm Koutian Wu (ktwu@utexas.edu), a researcher working on AI-assisted scientific
computing workflows at UT Austin. I write **agent "skills"**: structured
markdown documentation that lets an AI coding agent (e.g. a CLI coding agent or
AI IDE) install, build, configure, run, debug, and contribute to a model with
less hand-holding than a cold prompt. I'm doing this for a family of
Earth-system models; MOM6 is one of them, so I'll note up front that the
shape of this message is shared across that family. The MOM6 skill itself is
specific to MOM6, and lives here:

  https://github.com/earth-space-ai/mom6-skill

**This PR is a single small, optional pointer**, concretely, adds one line under a 'Community resources' section in README.md linking the skill repo, noting
that an unofficial, community-maintained agent skill exists. **It changes no model
code, no build system, and no scientific defaults.** If you'd rather not link it,
that's completely fine: close this and I'll keep maintaining the skill on my side.
The offer stands either way.

### What a "skill" is

A directory (`SKILL.md` + `reference/*.md`): a routing hub the agent reads
first, then deep-dive docs it loads on demand. It encodes the *procedural*
knowledge usually picked up by working alongside an experienced developer.

### Honest disclaimers (stated up front in the skill)

- It's a **helper for new users**, not a gold-standard reference. Upstream
  remains the source of truth; where the skill and upstream disagree, **upstream
  wins** and I treat that as a bug.
- It was assembled with **AI assistance, and AI makes mistakes** (wrong paths,
  drifted line numbers, stale fields, hallucinated flags). The skill says so and
  tells the agent to cross-check upstream before acting.
- It is **MIT-licensed on my side**; MOM6 stays governed by its own upstream
  license, which the skill links to and does not relicense.

### Why it might be worth a look

It helps onboarding. The most-exercised skill in this family so far is the Noah-MP one, so I'll give that as the data point and flag plainly that it's a **sibling skill, not the MOM6 one**: I used it to help an undergraduate go from zero to a scoped, runnable regional simulation plan (Texas, 12.5 km, NLDAS-2 forcing, on TACC) **in about 3 DAYS**, spin-up reasoning and a budget/smoke-test plan included. The MOM6 skill is built the same way, drawing on your community's own docs.

### Credit where it's due

The skill draws on the NOAA-GFDL/MOM6 repository, Sphinx docs, wiki, and MOM6-examples; it restructures that material for agent use. The acknowledgments section names the upstream maintainers and the
specific docs it draws on. Any errors or oversimplifications in the skill are
mine, not the upstream community's.

### Happy to collaborate

I'd genuinely enjoy collaborating on AI-assisted workflows for MOM6. If
there's an official place such a skill should live, conventions to follow, or
checks to enforce, I'm glad to adapt it.

Either way, thank you for maintaining MOM6.

Koutian Wu
ktwu@utexas.edu
UT Austin
Google Scholar: https://scholar.google.com/citations?user=s9w1k-cAAAAJ
LinkedIn: https://www.linkedin.com/in/ktwu01/

