### PR TITLE
Simpler logic in reset_face_lengths_list

### DIFF
--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -872,15 +872,12 @@ subroutine reset_face_lengths_list(G, param_file, US)
   real    :: lon_p, lon_m ! The longitude of a point shifted by 360 degrees [degrees_E].
   logical :: check_360    ! If true, check for longitudes that are shifted by
                           ! +/- 360 degrees from the specified range of values.
-  logical :: found_u, found_v
   logical :: unit_in_use
   logical :: fatal_unused_lengths
   integer :: unused
-  integer :: ios, iounit, isu, isv
+  integer :: ios, iounit, isu, isv, isu_por, isv_por
   integer :: num_lines, nl_read, ln, npt, u_pt, v_pt
   integer :: i, j, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  integer :: isu_por, isv_por
-  logical :: found_u_por, found_v_por
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -970,19 +967,17 @@ subroutine reset_face_lengths_list(G, param_file, US)
     do ln=1,num_lines
       line = lines(ln)
       ! Detect keywords
-      found_u = .false. ; found_v = .false.
-      found_u_por = .false. ; found_v_por = .false.
-      isu = index(uppercase(line), "U_WIDTH") ; if (isu > 0) found_u = .true.
-      isv = index(uppercase(line), "V_WIDTH") ; if (isv > 0) found_v = .true.
-      isu_por = index(uppercase(line), "U_WIDTH_POR") ; if (isu_por > 0) found_u_por = .true.
-      isv_por = index(uppercase(line), "V_WIDTH_POR") ; if (isv_por > 0) found_v_por = .true.
+      isu = index(uppercase(line), "U_WIDTH")
+      isv = index(uppercase(line), "V_WIDTH")
+      isu_por = index(uppercase(line), "U_WIDTH_POR")
+      isv_por = index(uppercase(line), "V_WIDTH_POR")
 
       ! Store and check the relevant values.
-      if (found_u) then
+      if (isu > 0) then  ! This line includes "U_WIDTH".
         u_pt = u_pt + 1
-        if (found_u_por .eqv. .false.) then
+        if (isu_por <= 0) then  ! This line sets "U_WIDTH"
           read(line(isu+8:),*) u_lon(1:2,u_pt), u_lat(1:2,u_pt), u_width(u_pt)
-        elseif (found_u_por) then
+        else  ! This line sets "U_WIDTH_POR"
           read(line(isu_por+12:),*) u_lon(1:2,u_pt), u_lat(1:2,u_pt), u_width(u_pt), &
                 Dmin_u(u_pt), Dmax_u(u_pt), Davg_u(u_pt)
         endif
@@ -1019,12 +1014,12 @@ subroutine reset_face_lengths_list(G, param_file, US)
                "topographical min/max found when reading line "//trim(line)//" from file "//&
                trim(filename))
         endif
-      elseif (found_v) then
+      elseif (isv > 0) then  ! This line includes "V_WIDTH".
         v_pt = v_pt + 1
-        if (found_v_por .eqv. .false.) then
+        if (isv_por <= 0) then  ! This line sets "V_WIDTH"
           read(line(isv+8:),*) v_lon(1:2,v_pt), v_lat(1:2,v_pt), v_width(v_pt)
-        elseif (found_v_por) then
-          read(line(isv+12:),*) v_lon(1:2,v_pt), v_lat(1:2,v_pt), v_width(v_pt), &
+        else  ! This line sets "V_WIDTH_POR"
+          read(line(isv_por+12:),*) v_lon(1:2,v_pt), v_lat(1:2,v_pt), v_width(v_pt), &
                 Dmin_v(v_pt), Dmax_v(v_pt), Davg_v(v_pt)
         endif
         v_width(v_pt) = US%m_to_L*v_width(v_pt) ! Rescale units equivalently to scale=US%m_to_L during read.
@@ -1185,7 +1180,7 @@ subroutine read_face_length_list(iounit, filename, num_lines, lines)
   ! list file, after removing comments.
   character(len=120) :: line, line_up
   logical :: found_u, found_v
-  integer :: isu, isv, icom
+  integer :: icom
   integer :: last
 
   num_lines = 0
@@ -1202,9 +1197,8 @@ subroutine read_face_length_list(iounit, filename, num_lines, lines)
 
     ! Detect keywords
     line_up = uppercase(line)
-    found_u = .false. ; found_v = .false.
-    isu = index(line_up(:last), "U_WIDTH") ; if (isu > 0) found_u = .true.
-    isv = index(line_up(:last), "V_WIDTH") ; if (isv > 0) found_v = .true.
+    found_u = (index(line_up(:last), "U_WIDTH") > 0)
+    found_v = (index(line_up(:last), "V_WIDTH") > 0)
 
     if (found_u .and. found_v) call MOM_error(FATAL, &
       "read_face_length_list : both U_WIDTH and V_WIDTH found when "//&


### PR DESCRIPTION
  This commit simplifies the logic in `reset_face_lengths_list()` and `read_face_length_list()`, leading to shorter and clearer code with more obvious symmetry between the u- and v-versions of the code.  All answers are bitwise identical.