### PR TITLE
Blocking implementation of Coriolis/Advection and Continuity

### DIFF
--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -54,6 +54,7 @@ type, public :: CoriolisAdv_CS ; private
                              !! Valid values are:
                              !! - PV_ADV_CENTERED - centered (aka Sadourny, 75)
                              !! - PV_ADV_UPWIND1  - upwind, first order
+  integer :: nkblock         !< The k block size used in Coriolis/advection calculations [nondim].
   real    :: F_eff_max_blend !< The factor by which the maximum effective Coriolis
                              !! acceleration from any point can be increased when
                              !! blending different discretizations with the
@@ -138,8 +139,51 @@ character*(20), parameter :: PV_ADV_UPWIND1_STRING = "PV_ADV_UPWIND1"
 
 contains
 
-!> Calculates the Coriolis and momentum advection contributions to the acceleration.
+!> Calculate the Coriolis and momentum advection contributions to the acceleration.
 subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Waves)
+  type(ocean_grid_type), intent(in) :: G
+      !< Ocean grid structure
+  type(verticalGrid_type), intent(in) :: GV
+      !< Vertical grid structure
+  real, intent(in) :: u(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< Zonal velocity [L T-1 ~> m s-1]
+  real, intent(in) :: v(SZI_(G),SZJB_(G),SZK_(GV))
+      !< Meridional velocity [L T-1 ~> m s-1]
+  real, intent(in) :: h(SZI_(G),SZJ_(G),SZK_(GV))
+      !< Layer thickness [H ~> m or kg m-2]
+  real, intent(in) :: uh(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< Zonal transport u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, intent(in) :: vh(SZI_(G),SZJB_(G),SZK_(GV))
+      !< Meridional transport v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, intent(out) :: CAu(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< Zonal acceleration due to Coriolis and momentum advection [L T-2 ~> m s-2]
+  real, intent(out) :: CAv(SZI_(G),SZJB_(G),SZK_(GV))
+      !< Meridional acceleration due to Coriolis and momentum advection [L T-2 ~> m s-2]
+  type(ocean_OBC_type), pointer, intent(in) :: OBC
+      !< Open boundary control structure
+  type(accel_diag_ptrs), intent(inout) :: AD
+      !< Storage for acceleration diagnostics
+  type(unit_scale_type), intent(in) :: US
+      !< A dimensional unit scaling type
+  type(CoriolisAdv_CS), intent(in) :: CS
+      !< Control structure for MOM_CoriolisAdv
+  type(porous_barrier_type), intent(in) :: pbv
+      !< porous barrier fractional cell metrics
+  type(Wave_parameters_CS), pointer, intent(in), optional :: Waves
+      !< An optional pointer to Stokes drift CS
+
+  integer :: nkk
+      ! The resolved k block size used in Coriolis/advection calculations
+
+  nkk = CS%nkblock
+  if (nkk == 0) nkk = GV%ke
+
+  call CorAdCalc_block(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, nkk, pbv, Waves)
+end subroutine CorAdCalc
+
+
+!> Calculate the Coriolis and momentum advection contributions to the acceleration for a k block size.
+subroutine CorAdCalc_block(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, nkk, pbv, Waves)
   type(ocean_grid_type),                      intent(in)    :: G  !< Ocean grid structure
   type(verticalGrid_type),                    intent(in)    :: GV !< Vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: u  !< Zonal velocity [L T-1 ~> m s-1]
@@ -153,62 +197,62 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
                                                                   !! and momentum advection [L T-2 ~> m s-2].
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(out)   :: CAv !< Meridional acceleration due to Coriolis
                                                                   !! and momentum advection [L T-2 ~> m s-2].
-  type(ocean_OBC_type),                       pointer       :: OBC !< Open boundary control structure
+  type(ocean_OBC_type), pointer,              intent(in)    :: OBC !< Open boundary control structure
   type(accel_diag_ptrs),                      intent(inout) :: AD  !< Storage for acceleration diagnostics
   type(unit_scale_type),                      intent(in)    :: US  !< A dimensional unit scaling type
   type(CoriolisAdv_CS),                       intent(in)    :: CS  !< Control structure for MOM_CoriolisAdv
+  integer,                                    intent(in)    :: nkk !< Resolved k block size [nondim].
   type(porous_barrier_type),                  intent(in)    :: pbv !< porous barrier fractional cell metrics
-  type(Wave_parameters_CS),         optional, pointer       :: Waves !< An optional pointer to Stokes drift CS
+  type(Wave_parameters_CS), pointer, optional, intent(in)   :: Waves !< An optional pointer to Stokes drift CS
 
-  ! Local variables
   real, dimension(SZIB_(G),SZJB_(G)) :: &
+    Area_q      ! The sum of the ocean areas at the 4 adjacent thickness points [L2 ~> m2].
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    Area_h      ! The ocean area at h points [L2 ~> m2].  Area_h is used to find the
+                ! average thickness in the denominator of q.  0 for land points.
+
+  real, dimension(SZIB_(G),SZJB_(G),nkk) :: &
     q, &        ! Layer potential vorticity [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
     qS, &       ! Layer Stokes vorticity [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
     Ih_q, &     ! The inverse of thickness interpolated to q points [H-1 ~> m-1 or m2 kg-1].
     h_q, &      ! The thickness interpolated to q points [H-1 ~> m-1 or m2 kg-1].
-    Area_q      ! The sum of the ocean areas at the 4 adjacent thickness points [L2 ~> m2].
-
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    a, b, c, d  ! a, b, c, & d are combinations of the potential vorticities
-                ! surrounding an h grid point.  At small scales, a = q/4,
-                ! b = q/4, etc.  All are in [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1],
-                ! and use the indexing of the corresponding u point.
-
-  real, dimension(SZI_(G),SZJ_(G)) :: &
-    Area_h, &   ! The ocean area at h points [L2 ~> m2].  Area_h is used to find the
-                ! average thickness in the denominator of q.  0 for land points.
-    KE          ! Kinetic energy per unit mass [L2 T-2 ~> m2 s-2], KE = (u^2 + v^2)/2.
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    hArea_u, &  ! The cell area weighted thickness interpolated to u points
-                ! times the effective areas [H L2 ~> m3 or kg].
-    KEx, &      ! The zonal gradient of Kinetic energy per unit mass [L T-2 ~> m s-2],
-                ! KEx = d/dx KE.
-    uh_center   ! Transport based on arithmetic mean h at u-points [H L2 T-1 ~> m3 s-1 or kg s-1]
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    hArea_v, &  ! The cell area weighted thickness interpolated to v points
-                ! times the effective areas [H L2 ~> m3 or kg].
-    KEy, &      ! The meridional gradient of Kinetic energy per unit mass [L T-2 ~> m s-2],
-                ! KEy = d/dy KE.
-    vh_center   ! Transport based on arithmetic mean h at v-points [H L2 T-1 ~> m3 s-1 or kg s-1]
-  real, dimension(SZI_(G),SZJ_(G)) :: &
-    uh_min, uh_max, &   ! The smallest and largest estimates of the zonal volume fluxes through
-                        ! the faces (i.e. u*h*dy) [H L2 T-1 ~> m3 s-1 or kg s-1]
-    vh_min, vh_max, &   ! The smallest and largest estimates of the meridional volume fluxes through
-                        ! the faces (i.e. v*h*dx) [H L2 T-1 ~> m3 s-1 or kg s-1]
-    ep_u, ep_v  ! Additional pseudo-Coriolis terms in the Arakawa and Lamb
-                ! discretization [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
-  real, dimension(SZIB_(G),SZJB_(G)) :: &
     dvdx, dudy, & ! Contributions to the circulation around q-points [L2 T-1 ~> m2 s-1]
     dvSdx, duSdy, & ! idem. for Stokes drift [L2 T-1 ~> m2 s-1]
     rel_vort, & ! Relative vorticity at q-points [T-1 ~> s-1].
     abs_vort, & ! Absolute vorticity at q-points [T-1 ~> s-1].
     stk_vort, & ! Stokes vorticity at q-points [T-1 ~> s-1].
     q2          ! Relative vorticity over thickness [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
+
+  real, dimension(SZIB_(G),SZJ_(G),nkk) :: &
+    a, b, c, d, & ! a, b, c, & d are combinations of the potential vorticities
+                  ! surrounding an h grid point.  At small scales, a = q/4,
+                  ! b = q/4, etc.  All are in [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1],
+                  ! and use the indexing of the corresponding u point.
+    hArea_u, &  ! The cell area weighted thickness interpolated to u points
+                ! times the effective areas [H L2 ~> m3 or kg].
+    KEx, &      ! The zonal gradient of Kinetic energy per unit mass [L T-2 ~> m s-2],
+                ! KEx = d/dx KE.
+    uh_center   ! Transport based on arithmetic mean h at u-points [H L2 T-1 ~> m3 s-1 or kg s-1]
+
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    KE, &       ! Kinetic energy per unit mass [L2 T-2 ~> m2 s-2], KE = (u^2 + v^2)/2.
+    uh_min, uh_max, &   ! The smallest and largest estimates of the zonal volume fluxes through
+                        ! the faces (i.e. u*h*dy) [H L2 T-1 ~> m3 s-1 or kg s-1]
+    vh_min, vh_max, &   ! The smallest and largest estimates of the meridional volume fluxes through
+                        ! the faces (i.e. v*h*dx) [H L2 T-1 ~> m3 s-1 or kg s-1]
+    ep_u, ep_v  ! Additional pseudo-Coriolis terms in the Arakawa and Lamb
+                ! discretization [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
+  real, dimension(SZI_(G),SZJB_(G),nkk) :: &
+    hArea_v, &  ! The cell area weighted thickness interpolated to v points
+                ! times the effective areas [H L2 ~> m3 or kg].
+    KEy, &      ! The meridional gradient of Kinetic energy per unit mass [L T-2 ~> m s-2],
+                ! KEy = d/dy KE.
+    vh_center   ! Transport based on arithmetic mean h at v-points [H L2 T-1 ~> m3 s-1 or kg s-1]
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)) :: &
     PV, &       ! A diagnostic array of the potential vorticities [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1].
     RV          ! A diagnostic array of the relative vorticities [T-1 ~> s-1].
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: CAuS ! Stokes contribution to CAu [L T-2 ~> m s-2]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(G)) :: CAvS ! Stokes contribution to CAv [L T-2 ~> m s-2]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: CAuS ! Stokes contribution to CAu [L T-2 ~> m s-2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: CAvS ! Stokes contribution to CAv [L T-2 ~> m s-2]
   real :: fv1, fv2, fv3, fv4   ! (f+rv)*v at the 4 points surrounding a u points[L T-2 ~> m s-2]
   real :: fu1, fu2, fu3, fu4   ! -(f+rv)*u at the 4 points surrounding a v point [L T-2 ~> m s-2]
   real :: max_fv, max_fu       ! The maximum of the neighboring Coriolis accelerations [L T-2 ~> m s-2]
@@ -247,9 +291,12 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: QUHeff,QVHeff ! More temporary variables [H L2 T-2 ~> m3 s-2 or kg s-2].
   integer :: i, j, k, n, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: Is_q, Ie_q, Js_q, Je_q  ! The scheme-dependent range of values at which vorticity is set.
+  integer :: ksb, keb   ! Start and end index of current block
+  integer :: kk, kke    ! Inblock grid index and upper bound
   logical :: Stokes_VF
   real :: u_v, v_u      ! u_v is the u velocity at v point, v_u is the v velocity at u point [L T-1 ~> m s-1]
   real :: q_v, q_u      ! PV at the u and v points [H-1 T-1 ~> m-1 s-1 or m2 kg-1 s-1]
+  logical :: use_weno   ! True if using one of the WENO schemes
   integer :: seventh_order, fifth_order, third_order ! Order of accuracy for the WENO calculations
   real :: u_q8(8) ! Eight-point zonal velocity at WENO stencils [L T-1 ~> m s-1]
   real :: u_q6(6) ! Six-point zonal velocity at WENO stencils [L T-1 ~> m s-1]
@@ -259,10 +306,10 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: v_q4(4) ! Four-point meridional velocity at WENO stencils [L T-1 ~> m s-1]
   integer :: stencil    ! Stencil size of WENO scheme
 
-! To work, the following fields must be set outside of the usual
-! is to ie range before this subroutine is called:
-!   v(is-1:ie+2,js-1:je+1), u(is-1:ie+1,js-1:je+2), h(is-1:ie+2,js-1:je+2),
-!   uh(is-1,ie,js:je+1) and vh(is:ie+1,js-1:je).
+  ! To work, the following fields must be set outside of the usual
+  ! is to ie range before this subroutine is called:
+  !   v(is-1:ie+2,js-1:je+1), u(is-1:ie+1,js-1:je+2), h(is-1:ie+2,js-1:je+2),
+  !   uh(is-1,ie,js:je+1) and vh(is:ie+1,js-1:je).
 
   if (.not.CS%initialized) call MOM_error(FATAL, &
          "MOM_CoriolisAdv: Module must be initialized before it is used.")
@@ -276,39 +323,44 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
   stencil = CoriolisAdv_stencil(CS)
 
-  if ((CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) .or. (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) .or. &
-      (CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO)) then
+  use_weno = CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO &
+      .or. CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO &
+      .or. CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO
+
+  if (use_weno) then
     Is_q = is - stencil ; Ie_q = ie + stencil - 1 ; Js_q = js - stencil ; Je_q = je + stencil - 1
   else
     Is_q = G%IscB - 1 ; Ie_q = G%IecB + 1 ; Js_q = G%JscB - 1 ; Je_q = G%JecB + 1
   endif
 
-  !$OMP parallel do default(private) shared(Is_q,Ie_q,Js_q,Je_q,G,Area_h)
   do j=Js_q,Je_q+1 ; do I=Is_q,Ie_q+1
     Area_h(i,j) = G%mask2dT(i,j) * G%areaT(i,j)
   enddo ; enddo
-  if (associated(OBC)) then ; do n=1,OBC%number_of_segments
-    if (.not. OBC%segment(n)%on_pe) cycle
-    I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
-    if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
-      do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
-        if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-          Area_h(i,j+1) = Area_h(i,j)
-        else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-          Area_h(i,j) = Area_h(i,j+1)
-        endif
-      enddo
-    elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
-      do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
-        if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-          Area_h(i+1,j) = Area_h(i,j)
-        else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-          Area_h(i,j) = Area_h(i+1,j)
-        endif
-      enddo
-    endif
-  enddo ; endif
-  !$OMP parallel do default(private) shared(Is_q,Ie_q,Js_q,Je_q,G,Area_h,Area_q)
+
+  if (associated(OBC)) then
+    do n=1,OBC%number_of_segments
+      if (.not. OBC%segment(n)%on_pe) cycle
+      I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
+      if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
+        do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
+          if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+            Area_h(i,j+1) = Area_h(i,j)
+          else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+            Area_h(i,j) = Area_h(i,j+1)
+          endif
+        enddo
+      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
+        do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
+          if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+            Area_h(i+1,j) = Area_h(i,j)
+          else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+            Area_h(i,j) = Area_h(i+1,j)
+          endif
+        enddo
+      endif
+    enddo
+  endif
+
   do J=Js_q,Je_q ; do I=Is_q,Ie_q
     Area_q(i,j) = (Area_h(i,j) + Area_h(i+1,j+1)) + &
                   (Area_h(i+1,j) + Area_h(i,j+1))
@@ -319,10 +371,22 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     Stokes_VF = Waves%Stokes_VF
   endif ; endif
 
-  !$OMP parallel do default(private) shared(u,v,h,uh,vh,CAu,CAv,G,GV,CS,AD,Area_h,Area_q,&
-  !$OMP                        RV,PV,is,ie,js,je,Isq,Ieq,Jsq,Jeq,Is_q,Ie_q,Js_q,Je_q,nz,vol_neglect,&
-  !$OMP                        h_tiny,OBC,eps_vel,area_neglect,pbv,Stokes_VF,stencil)
-  do k=1,nz
+  ! Hoist AL_BLEND k-independent scalars out of the block loop.
+  Fe_m2 = 0. ; rat_lin = 0.
+  if (CS%Coriolis_Scheme == AL_BLEND) then
+    Fe_m2 = CS%F_eff_max_blend - 2.
+    rat_lin = 1.5 * Fe_m2 / max(CS%wt_lin_blend, 1.0e-16)
+
+    ! This allows the code to always give Sadourny Energy
+    if (CS%F_eff_max_blend <= 2.0) then
+      Fe_m2 = -1.
+      rat_lin = -1.0
+    endif
+  endif
+
+  do ksb=1,nz,nkk
+    keb = min(ksb + nkk - 1, nz)
+    kke = keb - ksb + 1
 
     ! Here the second order accurate layer potential vorticities, q,
     ! are calculated.  hq is  second order accurate in space.  Relative
@@ -331,243 +395,274 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! First calculate the contributions to the circulation around the q-point.
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do J=Js_q,Je_q ; do I=Is_q,Ie_q
-          dvSdx(I,J) = (-Waves%us_y(i+1,J,k)*G%dyCv(i+1,J)) - &
-                       (-Waves%us_y(i,J,k)*G%dyCv(i,J))
-          duSdy(I,J) = (-Waves%us_x(I,j+1,k)*G%dxCu(I,j+1)) - &
-                       (-Waves%us_x(I,j,k)*G%dxCu(I,j))
-        enddo ; enddo
+        do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+          k = ksb + kk - 1
+          dvSdx(I,J,kk) = (-Waves%us_y(i+1,J,k) * G%dyCv(i+1,J)) &
+              - (-Waves%us_y(i,J,k) * G%dyCv(i,J))
+          duSdy(I,J,kk) = (-Waves%us_x(I,j+1,k) * G%dxCu(I,j+1)) &
+              - (-Waves%us_x(I,j,k) * G%dxCu(I,j))
+        enddo ; enddo ; enddo
       endif
       if (.not. Waves%Passive_Stokes_VF) then
-        do J=Js_q,Je_q ; do I=Is_q,Ie_q
-          dvdx(I,J) = ((v(i+1,J,k)-Waves%us_y(i+1,J,k))*G%dyCv(i+1,J)) - &
-                      ((v(i,J,k)-Waves%us_y(i,J,k))*G%dyCv(i,J))
-          dudy(I,J) = ((u(I,j+1,k)-Waves%us_x(I,j+1,k))*G%dxCu(I,j+1)) - &
-                      ((u(I,j,k)-Waves%us_x(I,j,k))*G%dxCu(I,j))
-        enddo ; enddo
+        do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+          k = ksb + kk - 1
+          dvdx(I,J,kk) = ((v(i+1,J,k) - Waves%us_y(i+1,J,k)) * G%dyCv(i+1,J)) &
+              - ((v(i,J,k) - Waves%us_y(i,J,k)) * G%dyCv(i,J))
+          dudy(I,J,kk) = ((u(I,j+1,k) - Waves%us_x(I,j+1,k)) * G%dxCu(I,j+1)) &
+              - ((u(I,j,k) - Waves%us_x(I,j,k)) * G%dxCu(I,j))
+        enddo ; enddo ; enddo
       else
-        do J=Js_q,Je_q ; do I=Is_q,Ie_q
-          dvdx(I,J) = (v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J))
-          dudy(I,J) = (u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j))
-        enddo ; enddo
+        do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+          k = ksb + kk - 1
+          dvdx(I,J,kk) = (v(i+1,J,k) * G%dyCv(i+1,J)) - (v(i,J,k) * G%dyCv(i,J))
+          dudy(I,J,kk) = (u(I,j+1,k) * G%dxCu(I,j+1)) - (u(I,j,k) * G%dxCu(I,j))
+        enddo ; enddo ; enddo
       endif
     else
-      do J=Js_q,Je_q ; do I=Is_q,Ie_q
-        dvdx(I,J) = (v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J))
-        dudy(I,J) = (u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j))
-      enddo ; enddo
+      do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+        k = ksb + kk - 1
+        dvdx(I,J,kk) = (v(i+1,J,k) * G%dyCv(i+1,J)) - (v(i,J,k) * G%dyCv(i,J))
+        dudy(I,J,kk) = (u(I,j+1,k) * G%dxCu(I,j+1)) - (u(I,j,k) * G%dxCu(I,j))
+      enddo ; enddo ; enddo
     endif
-    do J=Js_q,Je_q ; do i=Is_q,Ie_q+1
-      hArea_v(i,J) = 0.5*((Area_h(i,j) * h(i,j,k)) + (Area_h(i,j+1) * h(i,j+1,k)))
-    enddo ; enddo
-    do j=Js_q,Je_q+1 ; do I=Is_q,Ie_q
-      hArea_u(I,j) = 0.5*((Area_h(i,j) * h(i,j,k)) + (Area_h(i+1,j) * h(i+1,j,k)))
-    enddo ; enddo
+
+    do kk=1,kke ; do J=Js_q,Je_q ; do i=Is_q,Ie_q+1
+      k = ksb + kk - 1
+      hArea_v(i,J,kk) = 0.5 * ((Area_h(i,j) * h(i,j,k)) + (Area_h(i,j+1) * h(i,j+1,k)))
+    enddo ; enddo ; enddo
+
+    do kk=1,kke ; do j=Js_q,Je_q+1 ; do I=Is_q,Ie_q
+      k = ksb + kk - 1
+      hArea_u(I,j,kk) = 0.5 * ((Area_h(i,j) * h(i,j,k)) + (Area_h(i+1,j) * h(i+1,j,k)))
+    enddo ; enddo ; enddo
 
     if (CS%Coriolis_En_Dis) then
-      do j=Jsq,Jeq+1 ; do I=is-1,ie
-        uh_center(I,j) = 0.5 * ((G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)) * u(I,j,k)) * (h(i,j,k) + h(i+1,j,k))
-      enddo ; enddo
-      do J=js-1,je ; do i=Isq,Ieq+1
-        vh_center(i,J) = 0.5 * ((G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k)) * v(i,J,k)) * (h(i,j,k) + h(i,j+1,k))
-      enddo ; enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do I=is-1,ie
+        k = ksb + kk - 1
+        uh_center(I,j,kk) = 0.5 * ((G%dy_Cu(I,j) * pbv%por_face_areaU(I,j,k)) * u(I,j,k)) * (h(i,j,k) + h(i+1,j,k))
+      enddo ; enddo ; enddo
+
+      do kk=1,kke ; do J=js-1,je ; do i=Isq,Ieq+1
+        k = ksb + kk - 1
+        vh_center(i,J,kk) = 0.5 * ((G%dx_Cv(i,J) * pbv%por_face_areaV(i,J,k)) * v(i,J,k)) * (h(i,j,k) + h(i,j+1,k))
+      enddo ; enddo ; enddo
     endif
 
     ! Adjust circulation components to relative vorticity and thickness projected onto
     ! velocity points on open boundaries.
-    if (associated(OBC)) then ; do n=1,OBC%number_of_segments
-      if (.not. OBC%segment(n)%on_pe) cycle
-      I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
-      if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
-        select case (OBC%vorticity_config)
-          case (OBC_VORTICITY_ZERO)
-            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-              dvdx(I,J) = 0. ; dudy(I,J) = 0.
-            enddo
-          case (OBC_VORTICITY_FREESLIP)
-            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
-              dudy(I,J) = 0.
-            enddo
-          case (OBC_VORTICITY_COMPUTED)
-            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+    if (associated(OBC)) then
+      do kk=1,kke
+        k = ksb + kk - 1
+
+        do n=1,OBC%number_of_segments
+          if (.not. OBC%segment(n)%on_pe) cycle
+
+          I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
+
+          if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
+            select case (OBC%vorticity_config)
+            case (OBC_VORTICITY_ZERO)
+              do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+                dvdx(I,J,kk) = 0. ; dudy(I,J,kk) = 0.
+              enddo
+            case (OBC_VORTICITY_FREESLIP)
+              do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+                dudy(I,J,kk) = 0.
+              enddo
+            case (OBC_VORTICITY_COMPUTED)
+              do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+                if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                  dudy(I,J,kk) = 2. * (OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k)) * G%dxCu(I,j)
+                else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+                  dudy(I,J,kk) = 2. * (u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k)) * G%dxCu(I,j+1)
+                endif
+              enddo
+            case (OBC_VORTICITY_SPECIFIED)
+              do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+                if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                  dudy(I,J,kk) = OBC%segment(n)%tangential_grad(I,J,k) * G%dxCu(I,j) * G%dyBu(I,J)
+                else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+                  dudy(I,J,kk) = OBC%segment(n)%tangential_grad(I,J,k) * G%dxCu(I,j+1) * G%dyBu(I,J)
+                endif
+              enddo
+            end select
+
+            ! Project thicknesses across OBC points with a no-gradient condition.
+            do i=max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
               if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                dudy(I,J) = 2.0*(OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%dxCu(I,j)
+                hArea_v(i,J,kk) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j,k)
               else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-                dudy(I,J) = 2.0*(u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%dxCu(I,j+1)
+                hArea_v(i,J,kk) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j+1,k)
               endif
             enddo
-          case (OBC_VORTICITY_SPECIFIED)
-            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+
+            if (CS%Coriolis_En_Dis) then
+              do i=max(Isq,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
+                if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
+                  vh_center(i,J,kk) = (G%dx_Cv(i,J) * pbv%por_face_areaV(i,J,k)) * v(i,J,k) * h(i,j,k)
+                else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
+                  vh_center(i,J,kk) = (G%dx_Cv(i,J) * pbv%por_face_areaV(i,J,k)) * v(i,J,k) * h(i,j+1,k)
+                endif
+              enddo
+            endif
+          elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
+            select case (OBC%vorticity_config)
+            case (OBC_VORTICITY_ZERO)
+              do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+                dvdx(I,J,kk) = 0. ; dudy(I,J,kk) = 0.
+              enddo
+            case (OBC_VORTICITY_FREESLIP)
+              do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+                dvdx(I,J,kk) = 0.
+              enddo
+            case (OBC_VORTICITY_COMPUTED)
+              do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+                if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                  dvdx(I,J,kk) = 2. * (OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k)) * G%dyCv(i,J)
+                else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+                  dvdx(I,J,kk) = 2. * (v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k)) * G%dyCv(i+1,J)
+                endif
+              enddo
+            case (OBC_VORTICITY_SPECIFIED)
+              do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+                if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                  dvdx(I,J,kk) = OBC%segment(n)%tangential_grad(I,J,k) * G%dyCv(i,J) * G%dxBu(I,J)
+                else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+                  dvdx(I,J,kk) = OBC%segment(n)%tangential_grad(I,J,k) * G%dyCv(i+1,J) * G%dxBu(I,J)
+                endif
+              enddo
+            end select
+
+            ! Project thicknesses across OBC points with a no-gradient condition.
+            do j=max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
+              if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                hArea_u(I,j,kk) = 0.5 * (Area_h(i,j) + Area_h(i+1,j)) * h(i,j,k)
+              else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+                hArea_u(I,j,kk) = 0.5 * (Area_h(i,j) + Area_h(i+1,j)) * h(i+1,j,k)
+              endif
+            enddo
+            if (CS%Coriolis_En_Dis) then
+              do j=max(Jsq,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
+                if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
+                  uh_center(I,j,kk) = (G%dy_Cu(I,j) * pbv%por_face_areaU(I,j,k)) * u(I,j,k) * h(i,j,k)
+                else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
+                  uh_center(I,j,kk) = (G%dy_Cu(I,j) * pbv%por_face_areaU(I,j,k)) * u(I,j,k) * h(i+1,j,k)
+                endif
+              enddo
+            endif
+          endif
+        enddo
+
+        ! Now project thicknesses across cell-corner points in the OBCs.  The two
+        ! projections have to occur in sequence and can not be combined easily.
+        do n=1,OBC%number_of_segments
+          if (.not. OBC%segment(n)%on_pe) cycle
+          I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
+          if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
+            do I = max(Is_q,OBC%segment(n)%HI%IsdB), min(Ie_q,OBC%segment(n)%HI%IedB)
               if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                dudy(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dxCu(I,j)*G%dyBu(I,J)
+                if (Area_h(i,j) + Area_h(i+1,j) > 0.) then
+                  hArea_u(I,j+1,kk) = hArea_u(I,j,kk) &
+                      * ((Area_h(i,j+1) + Area_h(i+1,j+1)) / (Area_h(i,j) + Area_h(i+1,j)))
+                else ; hArea_u(I,j+1,kk) = 0. ; endif
               else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-                dudy(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dxCu(I,j+1)*G%dyBu(I,J)
+                if (Area_h(i,j+1) + Area_h(i+1,j+1) > 0.) then
+                  hArea_u(I,j,kk) = hArea_u(I,j+1,kk) &
+                      * ((Area_h(i,j) + Area_h(i+1,j)) / (Area_h(i,j+1) + Area_h(i+1,j+1)))
+                else ; hArea_u(I,j,kk) = 0. ; endif
               endif
             enddo
-        end select
-
-        ! Project thicknesses across OBC points with a no-gradient condition.
-        do i = max(Is_q,OBC%segment(n)%HI%isd), min(Ie_q+1,OBC%segment(n)%HI%ied)
-          if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-            hArea_v(i,J) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j,k)
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-            hArea_v(i,J) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j+1,k)
-          endif
-        enddo
-
-        if (CS%Coriolis_En_Dis) then
-          do i = max(Isq,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
-            if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-              vh_center(i,J) = (G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k)) * v(i,J,k) * h(i,j,k)
-            else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-              vh_center(i,J) = (G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k)) * v(i,J,k) * h(i,j+1,k)
-            endif
-          enddo
-        endif
-      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
-        select case (OBC%vorticity_config)
-          case (OBC_VORTICITY_ZERO)
-            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-              dvdx(I,J) = 0. ; dudy(I,J) = 0.
-            enddo
-          case (OBC_VORTICITY_FREESLIP)
-            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-              dvdx(I,J) = 0.
-            enddo
-          case (OBC_VORTICITY_COMPUTED)
-            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+          elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
+            do J = max(Js_q,OBC%segment(n)%HI%JsdB), min(Je_q,OBC%segment(n)%HI%JedB)
               if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                dvdx(I,J) = 2.0*(OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%dyCv(i,J)
+                if (Area_h(i,j) + Area_h(i,j+1) > 0.) then
+                  hArea_v(i+1,J,kk) = hArea_v(i,J,kk) &
+                      * ((Area_h(i+1,j) + Area_h(i+1,j+1)) / (Area_h(i,j) + Area_h(i,j+1)))
+                else ; hArea_v(i+1,J,kk) = 0. ; endif
               else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-                dvdx(I,J) = 2.0*(v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%dyCv(i+1,J)
+                hArea_v(i,J,kk) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j+1,k)
+                if (Area_h(i+1,j) + Area_h(i+1,j+1) > 0.) then
+                  hArea_v(i,J,kk) = hArea_v(i+1,J,kk) &
+                      * ((Area_h(i,j) + Area_h(i,j+1)) / (Area_h(i+1,j) + Area_h(i+1,j+1)))
+                else ; hArea_v(i,J,kk) = 0. ; endif
               endif
             enddo
-          case (OBC_VORTICITY_SPECIFIED)
-            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
-              if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                dvdx(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dyCv(i,J)*G%dxBu(I,J)
-              else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-                dvdx(I,J) = OBC%segment(n)%tangential_grad(I,J,k)*G%dyCv(i+1,J)*G%dxBu(I,J)
-              endif
-            enddo
-        end select
-
-        ! Project thicknesses across OBC points with a no-gradient condition.
-        do j = max(Js_q,OBC%segment(n)%HI%jsd), min(Je_q+1,OBC%segment(n)%HI%jed)
-          if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-            hArea_u(I,j) = 0.5*(Area_h(i,j) + Area_h(i+1,j)) * h(i,j,k)
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-            hArea_u(I,j) = 0.5*(Area_h(i,j) + Area_h(i+1,j)) * h(i+1,j,k)
           endif
         enddo
-        if (CS%Coriolis_En_Dis) then
-          do j = max(Jsq,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-              uh_center(I,j) = (G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)) * u(I,j,k) * h(i,j,k)
-            else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-              uh_center(I,j) = (G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)) * u(I,j,k) * h(i+1,j,k)
-            endif
-          enddo
-        endif
-      endif
-    enddo ; endif
-
-    if (associated(OBC)) then ; do n=1,OBC%number_of_segments
-      if (.not. OBC%segment(n)%on_pe) cycle
-      ! Now project thicknesses across cell-corner points in the OBCs.  The two
-      ! projections have to occur in sequence and can not be combined easily.
-      I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
-      if (OBC%segment(n)%is_N_or_S .and. (J >= Js_q) .and. (J <= Je_q)) then
-        do I = max(Is_q,OBC%segment(n)%HI%IsdB), min(Ie_q,OBC%segment(n)%HI%IedB)
-          if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-            if (Area_h(i,j) + Area_h(i+1,j) > 0.0) then
-              hArea_u(I,j+1) = hArea_u(I,j) * ((Area_h(i,j+1) + Area_h(i+1,j+1)) / &
-                                               (Area_h(i,j) + Area_h(i+1,j)))
-            else ; hArea_u(I,j+1) = 0.0 ; endif
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_S)
-            if (Area_h(i,j+1) + Area_h(i+1,j+1) > 0.0) then
-              hArea_u(I,j) = hArea_u(I,j+1) * ((Area_h(i,j) + Area_h(i+1,j)) / &
-                                               (Area_h(i,j+1) + Area_h(i+1,j+1)))
-            else ; hArea_u(I,j) = 0.0 ; endif
-          endif
-        enddo
-      elseif (OBC%segment(n)%is_E_or_W .and. (I >= Is_q) .and. (I <= Ie_q)) then
-        do J = max(Js_q,OBC%segment(n)%HI%JsdB), min(Je_q,OBC%segment(n)%HI%JedB)
-          if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-            if (Area_h(i,j) + Area_h(i,j+1) > 0.0) then
-              hArea_v(i+1,J) = hArea_v(i,J) * ((Area_h(i+1,j) + Area_h(i+1,j+1)) / &
-                                               (Area_h(i,j) + Area_h(i,j+1)))
-            else ; hArea_v(i+1,J) = 0.0 ; endif
-          else ! (OBC%segment(n)%direction == OBC_DIRECTION_W)
-            hArea_v(i,J) = 0.5 * (Area_h(i,j) + Area_h(i,j+1)) * h(i,j+1,k)
-            if (Area_h(i+1,j) + Area_h(i+1,j+1) > 0.0) then
-              hArea_v(i,J) = hArea_v(i+1,J) * ((Area_h(i,j) + Area_h(i,j+1)) / &
-                                               (Area_h(i+1,j) + Area_h(i+1,j+1)))
-            else ; hArea_v(i,J) = 0.0 ; endif
-          endif
-        enddo
-      endif
-    enddo ; endif
+      enddo
+    endif
 
     if (CS%no_slip) then
-      do J=Js_q,Je_q ; do I=Is_q,Ie_q
-        rel_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+        rel_vort(I,J,kk) = (2. - G%mask2dBu(I,J)) * (dvdx(I,J,kk) - dudy(I,J,kk)) * G%IareaBu(I,J)
+      enddo ; enddo ; enddo
+
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
-            stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
-          enddo ; enddo
+          do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+            stk_vort(I,J,kk) = (2. - G%mask2dBu(I,J)) * (dvSdx(I,J,kk) - duSdy(I,J,kk)) * G%IareaBu(I,J)
+          enddo ; enddo ; enddo
         endif
       endif
     else
-      do J=Js_q,Je_q ; do I=Is_q,Ie_q
-        rel_vort(I,J) = G%mask2dBu(I,J) * (dvdx(I,J) - dudy(I,J)) * G%IareaBu(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+        rel_vort(I,J,kk) = G%mask2dBu(I,J) * (dvdx(I,J,kk) - dudy(I,J,kk)) * G%IareaBu(I,J)
+      enddo ; enddo ; enddo
+
       if (Stokes_VF) then
         if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-          do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
-            stk_vort(I,J) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J) - duSdy(I,J)) * G%IareaBu(I,J)
-          enddo ; enddo
+          do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+            stk_vort(I,J,kk) = (2.0 - G%mask2dBu(I,J)) * (dvSdx(I,J,kk) - duSdy(I,J,kk)) * G%IareaBu(I,J)
+          enddo ; enddo ; enddo
         endif
       endif
     endif
 
-    do J=Js_q,Je_q ; do I=Is_q,Ie_q
-      abs_vort(I,J) = G%CoriolisBu(I,J) + rel_vort(I,J)
-    enddo ; enddo
+    do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+      abs_vort(I,J,kk) = G%CoriolisBu(I,J) + rel_vort(I,J,kk)
+    enddo ; enddo ; enddo
 
-    do J=Js_q,Je_q ; do I=Is_q,Ie_q
-      hArea_q = (hArea_u(I,j) + hArea_u(I,j+1)) + (hArea_v(i,J) + hArea_v(i+1,J))
-      Ih_q(I,J) = Area_q(I,J) / (hArea_q + vol_neglect)
-      h_q(I,J) = hArea_q / max(Area_q(I,J), area_neglect)
-      q(I,J) = abs_vort(I,J) * Ih_q(I,J)
-    enddo ; enddo
+    do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+      hArea_q = (hArea_u(I,j,kk) + hArea_u(I,j+1,kk)) + (hArea_v(i,J,kk) + hArea_v(i+1,J,kk))
+      Ih_q(I,J,kk) = Area_q(I,J) / (hArea_q + vol_neglect)
+      q(I,J,kk) = abs_vort(I,J,kk) * Ih_q(I,J,kk)
+    enddo ; enddo ; enddo
+
+    ! NOTE: `h_q` is only used by WENO, with redundant hArea_q calculation.
+    ! It may be preferable to use two full kernels under if-else.
+    if (use_weno) then
+      do kk=1,kke ; do J=Js_q,Je_q ; do I=Is_q,Ie_q
+        hArea_q = (hArea_u(I,j,kk) + hArea_u(I,j+1,kk)) + (hArea_v(i,J,kk) + hArea_v(i+1,J,kk))
+        h_q(I,J,kk) = hArea_q / max(Area_q(I,J), area_neglect)
+      enddo ; enddo ; enddo
+    endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          qS(I,J) = stk_vort(I,J) * Ih_q(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          qS(I,J,kk) = stk_vort(I,J,kk) * Ih_q(I,J,kk)
+        enddo ; enddo ; enddo
       endif
     endif
 
     if (CS%id_rv > 0) then
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        RV(I,J,k) = rel_vort(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        k = ksb + kk - 1
+        RV(I,J,k) = rel_vort(I,J,kk)
+      enddo ; enddo ; enddo
     endif
 
     if (CS%id_PV > 0) then
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        PV(I,J,k) = q(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        k = ksb + kk - 1
+        PV(I,J,k) = q(I,J,kk)
+      enddo ; enddo ; enddo
     endif
 
     if (associated(AD%rv_x_v) .or. associated(AD%rv_x_u)) then
-      do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        q2(I,J) = rel_vort(I,J) * Ih_q(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        q2(I,J,kk) = rel_vort(I,J,kk) * Ih_q(I,J,kk)
+      enddo ; enddo ; enddo
     endif
 
     !   a, b, c, and d are combinations of neighboring potential
@@ -575,37 +670,31 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     ! scheme.  All are defined at u grid points.
 
     if (CS%Coriolis_Scheme == ARAKAWA_HSU90) then
-      do j=Jsq,Jeq+1
-        do I=is-1,Ieq
-          a(I,j) = (q(I,J) + (q(I+1,J) + q(I,J-1))) * C1_12
-          d(I,j) = ((q(I,J) + q(I+1,J-1)) + q(I,J-1)) * C1_12
-        enddo
-        do I=Isq,Ieq
-          b(I,j) = (q(I,J) + (q(I-1,J) + q(I,J-1))) * C1_12
-          c(I,j) = ((q(I,J) + q(I-1,J-1)) + q(I,J-1)) * C1_12
-        enddo
-      enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do I=is-1,Ieq
+        a(I,j,kk) = (q(I,J,kk) + (q(I+1,J,kk) + q(I,J-1,kk))) * C1_12
+        d(I,j,kk) = ((q(I,J,kk) + q(I+1,J-1,kk)) + q(I,J-1,kk)) * C1_12
+      enddo ; enddo ; enddo
+
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do I=Isq,Ieq
+        b(I,j,kk) = (q(I,J,kk) + (q(I-1,J,kk) + q(I,J-1,kk))) * C1_12
+        c(I,j,kk) = ((q(I,J,kk) + q(I-1,J-1,kk)) + q(I,J-1,kk)) * C1_12
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == ARAKAWA_LAMB81) then
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
-        a(I-1,j) = (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
-        d(I-1,j) = ((q(I,j) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
-        b(I,j) =   ((q(I,J) + q(I-1,J-1)) + 2.0*(q(I-1,J) + q(I,J-1))) * C1_24
-        c(I,j) =   (2.0*(q(I,J) + q(I-1,J-1)) + (q(I-1,J) + q(I,J-1))) * C1_24
-        ep_u(i,j) = ((q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-        ep_v(i,j) = (-(q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-      enddo ; enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+        a(I-1,j,kk) = (2. * (q(I,J,kk) + q(I-1,J-1,kk)) + (q(I-1,J,kk) + q(I,J-1,kk))) * C1_24
+        d(I-1,j,kk) = ((q(I,J,kk) + q(I-1,J-1,kk)) + 2. * (q(I-1,J,kk) + q(I,J-1,kk))) * C1_24
+        b(I,j,kk) =   ((q(I,J,kk) + q(I-1,J-1,kk)) + 2. * (q(I-1,J,kk) + q(I,J-1,kk))) * C1_24
+        c(I,j,kk) =   (2. * (q(I,J,kk) + q(I-1,J-1,kk)) + (q(I-1,J,kk) + q(I,J-1,kk))) * C1_24
+        ep_u(i,j,kk) = ((q(I,J,kk) - q(I-1,J-1,kk)) + (q(I-1,J,kk) - q(I,J-1,kk))) * C1_24
+        ep_v(i,j,kk) = (-(q(I,J,kk) - q(I-1,J-1,kk)) + (q(I-1,J,kk) - q(I,J-1,kk))) * C1_24
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == AL_BLEND) then
-      Fe_m2 = CS%F_eff_max_blend - 2.0
-      rat_lin = 1.5 * Fe_m2 / max(CS%wt_lin_blend, 1.0e-16)
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
+        min_Ihq = MIN(Ih_q(I-1,J-1,kk), Ih_q(I,J-1,kk), Ih_q(I-1,J,kk), Ih_q(I,J,kk))
+        max_Ihq = MAX(Ih_q(I-1,J-1,kk), Ih_q(I,J-1,kk), Ih_q(I-1,J,kk), Ih_q(I,J,kk))
 
-      ! This allows the code to always give Sadourny Energy
-      if (CS%F_eff_max_blend <= 2.0) then ; Fe_m2 = -1. ; rat_lin = -1.0 ; endif
-
-      do j=Jsq,Jeq+1 ; do I=Isq,Ieq+1
-        min_Ihq = MIN(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
-        max_Ihq = MAX(Ih_q(I-1,J-1), Ih_q(I,J-1), Ih_q(I-1,J), Ih_q(I,J))
         rat_m1 = 1.0e15
-        if (max_Ihq < 1.0e15*min_Ihq) rat_m1 = max_Ihq / min_Ihq - 1.0
+        if (max_Ihq < 1.0e15*min_Ihq) rat_m1 = max_Ihq / min_Ihq - 1.
         ! The weights used here are designed to keep the effective Coriolis
         ! acceleration from any one point on its neighbors within a factor
         ! of F_eff_max.  The minimum permitted value is 2 (the factor for
@@ -613,40 +702,42 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
 
         ! Determine the relative weights of Arakawa & Lamb vs. Arakawa and Hsu.
         if (rat_m1 <= Fe_m2) then ; AL_wt = 1.0
-        elseif (rat_m1 < 1.5*Fe_m2) then ; AL_wt = 3.0*Fe_m2 / rat_m1 - 2.0
-        else ; AL_wt = 0.0 ; endif
+        elseif (rat_m1 < 1.5 * Fe_m2) then ; AL_wt = 3. * Fe_m2 / rat_m1 - 2.
+        else ; AL_wt = 0. ; endif
 
         ! Determine the relative weights of Sadourny Energy vs. the other two.
-        if (rat_m1 <= 1.5*Fe_m2) then ; Sad_wt = 0.0
+        if (rat_m1 <= 1.5 * Fe_m2) then ; Sad_wt = 0.
         elseif (rat_m1 <= rat_lin) then
-          Sad_wt = 1.0 - (1.5*Fe_m2) / rat_m1
-        elseif (rat_m1 < 2.0*rat_lin) then
-          Sad_wt = 1.0 - (CS%wt_lin_blend / rat_lin) * (rat_m1 - 2.0*rat_lin)
-        else ; Sad_wt = 1.0 ; endif
+          Sad_wt = 1. - (1.5 * Fe_m2) / rat_m1
+        elseif (rat_m1 < 2. * rat_lin) then
+          Sad_wt = 1. - (CS%wt_lin_blend / rat_lin) * (rat_m1 - 2. * rat_lin)
+        else ; Sad_wt = 1. ; endif
 
-        a(I-1,j) = Sad_wt * 0.25 * q(I-1,J) + (1.0 - Sad_wt) * &
-                   ( ((2.0-AL_wt)* q(I-1,J) + AL_wt*q(I,J-1)) + &
-                      2.0 * (q(I,J) + q(I-1,J-1)) ) * C1_24
-        d(I-1,j) = Sad_wt * 0.25 * q(I-1,J-1) + (1.0 - Sad_wt) * &
-                   ( ((2.0-AL_wt)* q(I-1,J-1) + AL_wt*q(I,J)) + &
-                      2.0 * (q(I-1,J) + q(I,J-1)) ) * C1_24
-        b(I,j) =   Sad_wt * 0.25 * q(I,J) + (1.0 - Sad_wt) * &
-                   ( ((2.0-AL_wt)* q(I,J) + AL_wt*q(I-1,J-1)) + &
-                      2.0 * (q(I-1,J) + q(I,J-1)) ) * C1_24
-        c(I,j) =   Sad_wt * 0.25 * q(I,J-1) + (1.0 - Sad_wt) * &
-                   ( ((2.0-AL_wt)* q(I,J-1) + AL_wt*q(I-1,J)) + &
-                      2.0 * (q(I,J) + q(I-1,J-1)) ) * C1_24
-        ep_u(i,j) = AL_wt  * ((q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-        ep_v(i,j) = AL_wt * (-(q(I,J) - q(I-1,J-1)) + (q(I-1,J) - q(I,J-1))) * C1_24
-      enddo ; enddo
+        a(I-1,j,kk) = Sad_wt * 0.25 * q(I-1,J,kk) + (1. - Sad_wt) * &
+                      (((2. - AL_wt) * q(I-1,J,kk) + AL_wt * q(I,J-1,kk)) + &
+                         2. * (q(I,J,kk) + q(I-1,J-1,kk))) * C1_24
+        d(I-1,j,kk) = Sad_wt * 0.25 * q(I-1,J-1,kk) + (1. - Sad_wt) * &
+                      ( ((2. - AL_wt) * q(I-1,J-1,kk) + AL_wt * q(I,J,kk)) + &
+                         2. * (q(I-1,J,kk) + q(I,J-1,kk)) ) * C1_24
+        b(I,j,kk) =   Sad_wt * 0.25 * q(I,J,kk) + (1.0 - Sad_wt) * &
+                      (((2. - AL_wt) * q(I,J,kk) + AL_wt * q(I-1,J-1,kk)) + &
+                         2. * (q(I-1,J,kk) + q(I,J-1,kk))) * C1_24
+        c(I,j,kk) =   Sad_wt * 0.25 * q(I,J-1,kk) + (1.0 - Sad_wt) * &
+                      ( ((2. - AL_wt) * q(I,J-1,kk) + AL_wt * q(I-1,J,kk)) + &
+                         2. * (q(I,J,kk) + q(I-1,J-1,kk)) ) * C1_24
+        ep_u(i,j,kk) = AL_wt  * ((q(I,J,kk) - q(I-1,J-1,kk)) + (q(I-1,J,kk) - q(I,J-1,kk))) * C1_24
+        ep_v(i,j,kk) = AL_wt * (-(q(I,J,kk) - q(I-1,J-1,kk)) + (q(I-1,J,kk) - q(I,J-1,kk))) * C1_24
+      enddo ; enddo ; enddo
     endif
 
     if (CS%Coriolis_En_Dis) then
     !  c1 = 1.0-1.5*RANGE ; c2 = 1.0-RANGE ; c3 = 2.0 ; slope = 0.5
       c1 = 1.0-1.5*0.5 ; c2 = 1.0-0.5 ; c3 = 2.0 ; slope = 0.5
 
-      do j=Jsq,Jeq+1 ; do I=is-1,ie
-        uhc = uh_center(I,j)
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do I=is-1,ie
+        k = ksb + kk - 1
+
+        uhc = uh_center(I,j,kk)
         uhm = uh(I,j,k)
         ! This sometimes matters with some types of open boundary conditions.
         if (G%dy_Cu(I,j) == 0.0) uhc = uhm
@@ -661,13 +752,16 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
 
         if (uhc > uhm) then
-          uh_min(I,j) = uhm ; uh_max(I,j) = uhc
+          uh_min(I,j,kk) = uhm ; uh_max(I,j,kk) = uhc
         else
-          uh_max(I,j) = uhm ; uh_min(I,j) = uhc
+          uh_max(I,j,kk) = uhm ; uh_min(I,j,kk) = uhc
         endif
-      enddo ; enddo
-      do J=js-1,je ; do i=Isq,Ieq+1
-        vhc = vh_center(i,J)
+      enddo ; enddo ; enddo
+
+      do kk=1,kke ; do J=js-1,je ; do i=Isq,Ieq+1
+        k = ksb + kk - 1
+
+        vhc = vh_center(i,J,kk)
         vhm = vh(i,J,k)
         ! This sometimes matters with some types of open boundary conditions.
         if (G%dx_Cv(i,J) == 0.0) vhc = vhm
@@ -682,15 +776,15 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         endif
 
         if (vhc > vhm) then
-          vh_min(i,J) = vhm ; vh_max(i,J) = vhc
+          vh_min(i,J,kk) = vhm ; vh_max(i,J,kk) = vhc
         else
-          vh_max(i,J) = vhm ; vh_min(i,J) = vhc
+          vh_max(i,J,kk) = vhm ; vh_min(i,J,kk) = vhc
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
 
     ! Calculate KE and the gradient of KE
-    call gradKE(u(:,:,k), v(:,:,k), h(:,:,k), KE, KEx, KEy, G, GV, US, CS)
+    call gradKE(u, v, h, KE, KEx, KEy, ksb, keb, nkk, G, GV, US, CS)
 
     ! Calculate the tendencies of zonal velocity due to the Coriolis
     ! force and momentum advection.  On a Cartesian grid, this is
@@ -698,76 +792,87 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        do j=js,je ; do I=Isq,Ieq
-          if (q(I,J)*u(I,j,k) == 0.0) then
-            temp1 = q(I,J) * ( (vh_max(i,j)+vh_max(i+1,j)) &
-                             + (vh_min(i,j)+vh_min(i+1,j)) )*0.5
-          elseif (q(I,J)*u(I,j,k) < 0.0) then
-            temp1 = q(I,J) * (vh_max(i,j)+vh_max(i+1,j))
+        do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+          k = ksb + kk - 1
+
+          if (q(I,J,kk) * u(I,j,k) == 0.0) then
+            temp1 = q(I,J,kk) * ((vh_max(i,j,kk) + vh_max(i+1,j,kk)) &
+                + (vh_min(i,j,kk) + vh_min(i+1,j,kk))) * 0.5
+          elseif (q(I,J,kk) * u(I,j,k) < 0.0) then
+            temp1 = q(I,J,kk) * (vh_max(i,j,kk) + vh_max(i+1,j,kk))
           else
-            temp1 = q(I,J) * (vh_min(i,j)+vh_min(i+1,j))
+            temp1 = q(I,J,kk) * (vh_min(i,j,kk) + vh_min(i+1,j,kk))
           endif
-          if (q(I,J-1)*u(I,j,k) == 0.0) then
-            temp2 = q(I,J-1) * ( (vh_max(i,j-1)+vh_max(i+1,j-1)) &
-                               + (vh_min(i,j-1)+vh_min(i+1,j-1)) )*0.5
-          elseif (q(I,J-1)*u(I,j,k) < 0.0) then
-            temp2 = q(I,J-1) * (vh_max(i,j-1)+vh_max(i+1,j-1))
+          if (q(I,J-1,kk) * u(I,j,k) == 0.0) then
+            temp2 = q(I,J-1,kk) * ((vh_max(i,j-1,kk) + vh_max(i+1,j-1,kk)) &
+                + (vh_min(i,j-1,kk) + vh_min(i+1,j-1,kk))) * 0.5
+          elseif (q(I,J-1,kk) * u(I,j,k) < 0.0) then
+            temp2 = q(I,J-1,kk) * (vh_max(i,j-1,kk) + vh_max(i+1,j-1,kk))
           else
-            temp2 = q(I,J-1) * (vh_min(i,j-1)+vh_min(i+1,j-1))
+            temp2 = q(I,J-1,kk) * (vh_min(i,j-1,kk) + vh_min(i+1,j-1,kk))
           endif
           CAu(I,j,k) = 0.25 * G%IdxCu(I,j) * (temp1 + temp2)
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        do j=js,je ; do I=Isq,Ieq
+        do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+          k = ksb + kk - 1
           CAu(I,j,k) = 0.25 * &
-            ((q(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
-             (q(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-        enddo ; enddo
+              ((q(I,J,kk) * (vh(i+1,J,k) + vh(i,J,k))) &
+               + (q(I,J-1,kk) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
+        enddo ; enddo ; enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      do j=js,je ; do I=Isq,Ieq
-        CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J) + q(I,J-1))) * &
-                     ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
-      enddo ; enddo
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+        CAu(I,j,k) = 0.125 * (G%IdxCu(I,j) * (q(I,J,kk) + q(I,J-1,kk))) * &
+            ((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
+      enddo ; enddo ; enddo
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      do j=js,je ; do I=Isq,Ieq
-        CAu(I,j,k) = (((a(I,j) * vh(i+1,J,k)) +  (c(I,j) * vh(i,J-1,k)))  + &
-                      ((b(I,j) * vh(i,J,k)) +  (d(I,j) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-      enddo ; enddo
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+        CAu(I,j,k) = (((a(I,j,kk) * vh(i+1,J,k)) + (c(I,j,kk) * vh(i,J-1,k))) &
+            + ((b(I,j,kk) * vh(i,J,k)) + (d(I,j,kk) * vh(i+1,J-1,k)))) * G%IdxCu(I,j)
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_v that should be returned by the
       !       continuity solver. AJA
-      do j=js,je ; do I=Isq,Ieq
-        Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel+abs(v(i,J,k)))
-        Heff1 = max(Heff1, min(h(i,j,k),h(i,j+1,k)))
-        Heff1 = min(Heff1, max(h(i,j,k),h(i,j+1,k)))
-        Heff2 = abs(vh(i,J-1,k) * G%IdxCv(i,J-1)) / (eps_vel+abs(v(i,J-1,k)))
-        Heff2 = max(Heff2, min(h(i,j-1,k),h(i,j,k)))
-        Heff2 = min(Heff2, max(h(i,j-1,k),h(i,j,k)))
-        Heff3 = abs(vh(i+1,J,k) * G%IdxCv(i+1,J)) / (eps_vel+abs(v(i+1,J,k)))
-        Heff3 = max(Heff3, min(h(i+1,j,k),h(i+1,j+1,k)))
-        Heff3 = min(Heff3, max(h(i+1,j,k),h(i+1,j+1,k)))
-        Heff4 = abs(vh(i+1,J-1,k) * G%IdxCv(i+1,J-1)) / (eps_vel+abs(v(i+1,J-1,k)))
-        Heff4 = max(Heff4, min(h(i+1,j-1,k),h(i+1,j,k)))
-        Heff4 = min(Heff4, max(h(i+1,j-1,k),h(i+1,j,k)))
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+
+        Heff1 = abs(vh(i,J,k) * G%IdxCv(i,J)) / (eps_vel + abs(v(i,J,k)))
+        Heff1 = max(Heff1, min(h(i,j,k), h(i,j+1,k)))
+        Heff1 = min(Heff1, max(h(i,j,k), h(i,j+1,k)))
+        Heff2 = abs(vh(i,J-1,k) * G%IdxCv(i,J-1)) / (eps_vel + abs(v(i,J-1,k)))
+        Heff2 = max(Heff2, min(h(i,j-1,k), h(i,j,k)))
+        Heff2 = min(Heff2, max(h(i,j-1,k), h(i,j,k)))
+        Heff3 = abs(vh(i+1,J,k) * G%IdxCv(i+1,J)) / (eps_vel + abs(v(i+1,J,k)))
+        Heff3 = max(Heff3, min(h(i+1,j,k), h(i+1,j+1,k)))
+        Heff3 = min(Heff3, max(h(i+1,j,k), h(i+1,j+1,k)))
+        Heff4 = abs(vh(i+1,J-1,k) * G%IdxCv(i+1,J-1)) / (eps_vel + abs(v(i+1,J-1,k)))
+        Heff4 = max(Heff4, min(h(i+1,j-1,k), h(i+1,j,k)))
+        Heff4 = min(Heff4, max(h(i+1,j-1,k), h(i+1,j,k)))
+
         if (CS%PV_Adv_Scheme == PV_ADV_CENTERED) then
-          CAu(I,j,k) = 0.5*(abs_vort(I,J)+abs_vort(I,J-1)) * &
-                       ((vh(i,J,k) + vh(i+1,J-1,k)) + (vh(i,J-1,k) + vh(i+1,J,k)) ) /  &
-                       (h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) * G%IdxCu(I,j)
+          CAu(I,j,k) = 0.5 * (abs_vort(I,J,kk) + abs_vort(I,J-1,kk)) &
+              * ((vh(i,J,k) + vh(i+1,J-1,k)) + (vh(i,J-1,k) + vh(i+1,J,k))) &
+              / (h_tiny + ((Heff1 + Heff4) + (Heff2 + Heff3))) * G%IdxCu(I,j)
         elseif (CS%PV_Adv_Scheme == PV_ADV_UPWIND1) then
-          VHeff = ((vh(i,J,k) + vh(i+1,J-1,k)) + (vh(i,J-1,k) + vh(i+1,J,k)) )
-          QVHeff = 0.5*( ((abs_vort(I,J)+abs_vort(I,J-1))*VHeff) &
-                       - ((abs_vort(I,J)-abs_vort(I,J-1))*abs(VHeff)) )
-          CAu(I,j,k) = (QVHeff / ( h_tiny + ((Heff1+Heff4) + (Heff2+Heff3)) ) ) * G%IdxCu(I,j)
+          VHeff = ((vh(i,J,k) + vh(i+1,J-1,k)) + (vh(i,J-1,k) + vh(i+1,J,k)))
+          QVHeff = 0.5 * (((abs_vort(I,J,kk) + abs_vort(I,J-1,kk)) * VHeff) &
+              - ((abs_vort(I,J,kk) - abs_vort(I,J-1,kk)) * abs(VHeff)))
+          CAu(I,j,k) = (QVHeff / (h_tiny + ((Heff1 + Heff4) + (Heff2 + Heff3)))) &
+              * G%IdxCu(I,j)
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) then
-      do j=js,je ; do I=Isq,Ieq
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+
         v_u = 0.25*G%IdxCu(I,j)*((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
         ! check whether there is masked land points in the stencil
         third_order = (G%mask2dCu(I,j-2) * G%mask2dCu(I,j-1) * G%mask2dCu(I,j) * &
@@ -776,13 +881,12 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         fifth_order   = third_order * G%mask2dCu(I,j-3) * G%mask2dCu(I,j+3)
         seventh_order = fifth_order * G%mask2dCu(I,j-4) * G%mask2dCu(I,j+4)
 
-
         ! compute the masking to make sure that inland values are not used
         if (seventh_order == 1) then
           ! all values are valid, we use seventh order reconstruction
           u_q8(:) = (u(I,j-4:j+3,k) + u(I,j-3:j+4,k)) * 0.5
-          call weno_seven_h_weight_reconstruction(abs_vort(I,J-4:J+3), &
-                                         h_q(I,J-4:J+3), &
+          call weno_seven_h_weight_reconstruction(abs_vort(I,J-4:J+3,kk), &
+                                         h_q(I,J-4:J+3,kk), &
                                          u_q8, &
                                          GV%H_subroundoff, v_u, q_u, cs%weno_velocity_smooth)
           CAu(I,j,k) = (q_u * v_u)
@@ -790,8 +894,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         elseif (fifth_order == 1) then
           ! all values are valid, we use fifth order reconstruction
           u_q6(:) = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
-          call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2), &
-                                        h_q(I,J-3:J+2), &
+          call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2,kk), &
+                                        h_q(I,J-3:J+2,kk), &
                                         u_q6, &
                                         GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
           CAu(I,j,k) = (q_u * v_u)
@@ -799,23 +903,25 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         elseif (third_order == 1) then
           ! only the middle values are valid, we use third order reconstruction
           u_q4(:) = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
-          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
-                                         h_q(I,J-2:J+1), &
+          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1,kk), &
+                                         h_q(I,J-2:J+1,kk), &
                                          u_q4, &
                                          GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
           CAu(I,j,k) = (q_u * v_u)
         else ! Upwind first order
           if (v_u>0.) then
-              q_u = q(I,J-1)
+              q_u = q(I,J-1,kk)
           else
-              q_u = q(I,J)
+              q_u = q(I,J,kk)
           endif
           CAu(I,j,k) = (q_u * v_u)
 
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
-      do j=js,je ; do I=Isq,Ieq
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+
         v_u = 0.25*G%IdxCu(I,j)*((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
         third_order = (G%mask2dCu(I,j-2) * G%mask2dCu(I,j-1) * G%mask2dCu(I,j) * &
                        G%mask2dCu(I,j+1) * G%mask2dCu(I,j+2))
@@ -825,8 +931,8 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         if (fifth_order == 1) then
           ! all values are valid, we use fifth order reconstruction
           u_q6(:) = (u(I,j-3:j+2,k) + u(I,j-2:j+3,k)) * 0.5
-          call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2), &
-                                        h_q(I,J-3:J+2), &
+          call weno_five_h_weight_reconstruction(abs_vort(I,J-3:J+2,kk), &
+                                        h_q(I,J-3:J+2,kk), &
                                         u_q6, &
                                         GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
           CAu(I,j,k) = (q_u * v_u)
@@ -834,89 +940,99 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         elseif (third_order == 1) then
           ! only the middle values are valid, we use third order reconstruction
           u_q4(:) = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
-          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
-                                         h_q(I,J-2:J+1), &
+          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1,kk), &
+                                         h_q(I,J-2:J+1,kk), &
                                          u_q4, &
                                          GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
           CAu(I,j,k) = (q_u * v_u)
 
         else ! Upwind first order
           if (v_u>0.) then
-              q_u = q(I,J-1)
+              q_u = q(I,J-1,kk)
           else
-              q_u = q(I,J)
+              q_u = q(I,J,kk)
           endif
           CAu(I,j,k) = (q_u * v_u)
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO) then
-      do j=js,je ; do I=Isq,Ieq
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+
         v_u = 0.25*G%IdxCu(I,j)*((vh(i+1,J,k) + vh(i,J,k)) + (vh(i,J-1,k) + vh(i+1,J-1,k)))
         third_order = (G%mask2dCu(I,j-2) * G%mask2dCu(I,j-1) * G%mask2dCu(I,j) * &
                        G%mask2dCu(I,j+1) * G%mask2dCu(I,j+2))
 
-
         if (third_order == 1) then
           ! only the middle values are valid, we use third order reconstruction
           u_q4(:) = (u(I,j-2:j+1,k) + u(I,j-1:j+2,k)) * 0.5
-          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1), &
-                                         h_q(I,J-2:J+1), &
+          call weno_three_h_weight_reconstruction(abs_vort(I,J-2:J+1,kk), &
+                                         h_q(I,J-2:J+1,kk), &
                                          u_q4, &
                                          GV%H_subroundoff, v_u, q_u, CS%weno_velocity_smooth)
           CAu(I,j,k) = (q_u * v_u)
 
         else ! Upwind first order
           if (v_u>0.) then
-              q_u = q(I,J-1)
+              q_u = q(I,J-1,kk)
           else
-              q_u = q(I,J)
+              q_u = q(I,J,kk)
           endif
           CAu(I,j,k) = (q_u * v_u)
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
+
     ! Add in the additional terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
-        (CS%Coriolis_Scheme == AL_BLEND)) then ; do j=js,je ; do I=Isq,Ieq
-      CAu(I,j,k) = CAu(I,j,k) + &
-            ((ep_u(i,j)*uh(I-1,j,k)) - (ep_u(i+1,j)*uh(I+1,j,k))) * G%IdxCu(I,j)
-    enddo ; enddo ; endif
+        (CS%Coriolis_Scheme == AL_BLEND)) then
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+        CAu(I,j,k) = CAu(I,j,k) &
+            + ((ep_u(i,j,kk) * uh(I-1,j,k)) - (ep_u(i+1,j,kk) * uh(I+1,j,k))) * G%IdxCu(I,j)
+      enddo ; enddo ; enddo
+    endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAu
-        do j=js,je ; do I=Isq,Ieq
-          CAuS(I,j,k) = 0.25 * &
-                ((qS(I,J) * (vh(i+1,J,k) + vh(i,J,k))) + &
-                 (qS(I,J-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+          k = ksb + kk - 1
+          CAuS(I,j,k) = 0.25 &
+              * ((qS(I,J,kk) * (vh(i+1,J,k) + vh(i,J,k))) &
+                 + (qS(I,J-1,kk) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
+        enddo ; enddo ; enddo
       endif
     endif
 
     if (CS%bound_Coriolis) then
-      do j=js,je ; do I=Isq,Ieq
-        fv1 = abs_vort(I,J) * v(i+1,J,k)
-        fv2 = abs_vort(I,J) * v(i,J,k)
-        fv3 = abs_vort(I,J-1) * v(i+1,J-1,k)
-        fv4 = abs_vort(I,J-1) * v(i,J-1,k)
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+
+        fv1 = abs_vort(I,J,kk) * v(i+1,J,k)
+        fv2 = abs_vort(I,J,kk) * v(i,J,k)
+        fv3 = abs_vort(I,J-1,kk) * v(i+1,J-1,k)
+        fv4 = abs_vort(I,J-1,kk) * v(i,J-1,k)
 
         max_fv = max(fv1, fv2, fv3, fv4)
         min_fv = min(fv1, fv2, fv3, fv4)
 
         CAu(I,j,k) = min(CAu(I,j,k), max_fv)
         CAu(I,j,k) = max(CAu(I,j,k), min_fv)
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
 
     ! Term - d(KE)/dx.
-    do j=js,je ; do I=Isq,Ieq
-      CAu(I,j,k) = CAu(I,j,k) - KEx(I,j)
-    enddo ; enddo
+    do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+      k = ksb + kk - 1
+      CAu(I,j,k) = CAu(I,j,k) - KEx(I,j,kk)
+    enddo ; enddo ; enddo
 
     if (associated(AD%gradKEu)) then
-      do j=js,je ; do I=Isq,Ieq
-        AD%gradKEu(I,j,k) = -KEx(I,j)
-      enddo ; enddo
+      do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+        k = ksb + kk - 1
+        AD%gradKEu(I,j,k) = -KEx(I,j,kk)
+      enddo ; enddo ; enddo
     endif
 
     ! Calculate the tendencies of meridional velocity due to the Coriolis
@@ -925,84 +1041,94 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
       if (CS%Coriolis_En_Dis) then
         ! Energy dissipating biased scheme, Hallberg 200x
-        do J=Jsq,Jeq ; do i=is,ie
-          if (q(I-1,J)*v(i,J,k) == 0.0) then
-            temp1 = q(I-1,J) * ( (uh_max(i-1,j)+uh_max(i-1,j+1)) &
-                               + (uh_min(i-1,j)+uh_min(i-1,j+1)) )*0.5
-          elseif (q(I-1,J)*v(i,J,k) > 0.0) then
-            temp1 = q(I-1,J) * (uh_max(i-1,j)+uh_max(i-1,j+1))
+        do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+          k = ksb + kk - 1
+
+          if (q(I-1,J,kk) * v(i,J,k) == 0.0) then
+            temp1 = q(I-1,J,kk) &
+                * ((uh_max(i-1,j,kk) + uh_max(i-1,j+1,kk)) &
+                   + (uh_min(i-1,j,kk) + uh_min(i-1,j+1,kk))) * 0.5
+          elseif (q(I-1,J,kk) * v(i,J,k) > 0.0) then
+            temp1 = q(I-1,J,kk) * (uh_max(i-1,j,kk) + uh_max(i-1,j+1,kk))
           else
-            temp1 = q(I-1,J) * (uh_min(i-1,j)+uh_min(i-1,j+1))
+            temp1 = q(I-1,J,kk) * (uh_min(i-1,j,kk) + uh_min(i-1,j+1,kk))
           endif
-          if (q(I,J)*v(i,J,k) == 0.0) then
-            temp2 = q(I,J) * ( (uh_max(i,j)+uh_max(i,j+1)) &
-                             + (uh_min(i,j)+uh_min(i,j+1)) )*0.5
-          elseif (q(I,J)*v(i,J,k) > 0.0) then
-            temp2 = q(I,J) * (uh_max(i,j)+uh_max(i,j+1))
+
+          if (q(I,J,kk) * v(i,J,k) == 0.0) then
+            temp2 = q(I,J,kk) &
+                * ((uh_max(i,j,kk) + uh_max(i,j+1,kk)) &
+                   + (uh_min(i,j,kk) + uh_min(i,j+1,kk))) * 0.5
+          elseif (q(I,J,kk) * v(i,J,k) > 0.0) then
+            temp2 = q(I,J,kk) * (uh_max(i,j,kk) + uh_max(i,j+1,kk))
           else
-            temp2 = q(I,J) * (uh_min(i,j)+uh_min(i,j+1))
+            temp2 = q(I,J,kk) * (uh_min(i,j,kk) + uh_min(i,j+1,kk))
           endif
+
           CAv(i,J,k) = -0.25 * G%IdyCv(i,J) * (temp1 + temp2)
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
         ! Energy conserving scheme, Sadourny 1975
-        do J=Jsq,Jeq ; do i=is,ie
-          CAv(i,J,k) = - 0.25* &
-              ((q(I-1,J)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
-               (q(I,J)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+          k = ksb + kk - 1
+          CAv(i,J,k) = -0.25 &
+              * ((q(I-1,J,kk) * (uh(I-1,j,k) + uh(I-1,j+1,k))) &
+                 + (q(I,J,kk) * (uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
+        enddo ; enddo ; enddo
       endif
     elseif (CS%Coriolis_Scheme == SADOURNY75_ENSTRO) then
-      do J=Jsq,Jeq ; do i=is,ie
-        CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J) + q(I,J))) * &
-                     ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
-      enddo ; enddo
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+        CAv(i,J,k) = -0.125 * (G%IdyCv(i,J) * (q(I-1,J,kk) + q(I,J,kk))) &
+            * ((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
+      enddo ; enddo ; enddo
     elseif ((CS%Coriolis_Scheme == ARAKAWA_HSU90) .or. &
             (CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
             (CS%Coriolis_Scheme == AL_BLEND)) then
       ! (Global) Energy and (Local) Enstrophy conserving, Arakawa & Hsu 1990
-      do J=Jsq,Jeq ; do i=is,ie
-        CAv(i,J,k) = - (((a(I-1,j)   * uh(I-1,j,k)) + &
-                         (c(I,j+1)   * uh(I,j+1,k)))  &
-                      + ((b(I,j)     * uh(I,j,k)) +   &
-                         (d(I-1,j+1) * uh(I-1,j+1,k)))) * G%IdyCv(i,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+        CAv(i,J,k) = -(((a(I-1,j,kk) * uh(I-1,j,k)) + (c(I,j+1,kk) * uh(I,j+1,k))) &
+            + ((b(I,j,kk) * uh(I,j,k)) + (d(I-1,j+1,kk) * uh(I-1,j+1,k)))) * G%IdyCv(i,J)
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == ROBUST_ENSTRO) then
       ! An enstrophy conserving scheme robust to vanishing layers
       ! Note: Heffs are in lieu of h_at_u that should be returned by the
       !       continuity solver. AJA
-      do J=Jsq,Jeq ; do i=is,ie
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+
         Heff1 = abs(uh(I,j,k) * G%IdyCu(I,j)) / (eps_vel+abs(u(I,j,k)))
-        Heff1 = max(Heff1, min(h(i,j,k),h(i+1,j,k)))
-        Heff1 = min(Heff1, max(h(i,j,k),h(i+1,j,k)))
+        Heff1 = max(Heff1, min(h(i,j,k), h(i+1,j,k)))
+        Heff1 = min(Heff1, max(h(i,j,k), h(i+1,j,k)))
         Heff2 = abs(uh(I-1,j,k) * G%IdyCu(I-1,j)) / (eps_vel+abs(u(I-1,j,k)))
-        Heff2 = max(Heff2, min(h(i-1,j,k),h(i,j,k)))
-        Heff2 = min(Heff2, max(h(i-1,j,k),h(i,j,k)))
+        Heff2 = max(Heff2, min(h(i-1,j,k), h(i,j,k)))
+        Heff2 = min(Heff2, max(h(i-1,j,k), h(i,j,k)))
         Heff3 = abs(uh(I,j+1,k) * G%IdyCu(I,j+1)) / (eps_vel+abs(u(I,j+1,k)))
-        Heff3 = max(Heff3, min(h(i,j+1,k),h(i+1,j+1,k)))
-        Heff3 = min(Heff3, max(h(i,j+1,k),h(i+1,j+1,k)))
+        Heff3 = max(Heff3, min(h(i,j+1,k), h(i+1,j+1,k)))
+        Heff3 = min(Heff3, max(h(i,j+1,k), h(i+1,j+1,k)))
         Heff4 = abs(uh(I-1,j+1,k) * G%IdyCu(I-1,j+1)) / (eps_vel+abs(u(I-1,j+1,k)))
-        Heff4 = max(Heff4, min(h(i-1,j+1,k),h(i,j+1,k)))
-        Heff4 = min(Heff4, max(h(i-1,j+1,k),h(i,j+1,k)))
+        Heff4 = max(Heff4, min(h(i-1,j+1,k), h(i,j+1,k)))
+        Heff4 = min(Heff4, max(h(i-1,j+1,k), h(i,j+1,k)))
+
         if (CS%PV_Adv_Scheme == PV_ADV_CENTERED) then
-          CAv(i,J,k) = - 0.5*(abs_vort(I,J)+abs_vort(I-1,J)) * &
-                         ((uh(I  ,j  ,k)+uh(I-1,j+1,k)) +      &
-                          (uh(I-1,j  ,k)+uh(I  ,j+1,k)) ) /    &
-                      (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
+          CAv(i,J,k) = - 0.5 * (abs_vort(I,J,kk) + abs_vort(I-1,J,kk)) &
+              * ((uh(I,j,k) + uh(I-1,j+1,k)) + (uh(I-1,j,k)+uh(I  ,j+1,k)) ) &
+              / (h_tiny + ((Heff1 + Heff4) + (Heff2 + Heff3))) * G%IdyCv(i,J)
         elseif (CS%PV_Adv_Scheme == PV_ADV_UPWIND1) then
-          UHeff = ((uh(I  ,j  ,k)+uh(I-1,j+1,k)) +      &
-                   (uh(I-1,j  ,k)+uh(I  ,j+1,k)) )
-          QUHeff = 0.5*( ((abs_vort(I,J)+abs_vort(I-1,J))*UHeff) &
-                       - ((abs_vort(I,J)-abs_vort(I-1,J))*abs(UHeff)) )
-          CAv(i,J,k) = - QUHeff / &
-                       (h_tiny + ((Heff1+Heff4) +(Heff2+Heff3)) ) * G%IdyCv(i,J)
+          UHeff = ((uh(I,j,k) + uh(I-1,j+1,k)) + (uh(I-1,j,k)+uh(I,j+1,k)))
+          QUHeff = 0.5 * (((abs_vort(I,J,kk) + abs_vort(I-1,J,kk)) * UHeff) &
+              - ((abs_vort(I,J,kk) - abs_vort(I-1,J,kk)) * abs(UHeff)))
+          CAv(i,J,k) = -QUHeff &
+              / (h_tiny + ((Heff1 + Heff4) + (Heff2 + Heff3)) ) * G%IdyCv(i,J)
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     ! Calculate the tendencies of meridional velocity due to the Coriolis
     ! force and momentum advection.  On a Cartesian grid, this is
     !     CAv = - q * uh - d(KE)/dy.
     elseif (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO) then
-      do J=Jsq,Jeq ; do i=is,ie
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+
         u_v = 0.25*G%IdyCv(i,J)*((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
 
         ! check whether there is any masked land values within the stencils
@@ -1011,197 +1137,200 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         fifth_order   = third_order * G%mask2dCv(i-3,J) * G%mask2dCv(i+3,J)
         seventh_order = fifth_order * G%mask2dCv(i-4,J) * G%mask2dCv(i+4,J)
 
-
-
         ! compute the masking to make sure that inland values are not used
         if (seventh_order == 1) then
           v_q8(:) = (v(i-4:i+3,J,k) + v(i-3:i+4,J,k)) * 0.5
           ! all values are valid, we use seventh order reconstruction
-          call weno_seven_h_weight_reconstruction(abs_vort(I-4:I+3,J), &
-                                         h_q(I-4:I+3,J), &
+          call weno_seven_h_weight_reconstruction(abs_vort(I-4:I+3,J,kk), &
+                                         h_q(I-4:I+3,J,kk), &
                                          v_q8, &
                                          GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
           CAv(i,J,k) = - (q_v * u_v)
-
         elseif (fifth_order == 1) then
           v_q6(:) = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
           ! all values are valid, we use fifth order reconstruction
-          call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J), &
-                                        h_q(I-3:I+2,J), &
+          call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J,kk), &
+                                        h_q(I-3:I+2,J,kk), &
                                         v_q6, &
                                         GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
           CAv(i,J,k) = - (q_v * u_v)
-
         elseif (third_order == 1) then
           v_q4(:) = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
-!          ! only the middle values are valid, we use third order reconstruction
-          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
-                                                 h_q(I-2:I+1,J), &
+          ! only the middle values are valid, we use third order reconstruction
+          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J,kk), &
+                                                 h_q(I-2:I+1,J,kk), &
                                                  v_q4, &
                                                  GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
           CAv(i,J,k) = - (q_v * u_v)
         else ! Upwind first order!
           if (u_v>0.) then
-              q_v = q(I-1,J)
+              q_v = q(I-1,J,kk)
           else
-              q_v = q(I,J)
+              q_v = q(I,J,kk)
           endif
           CAv(i,J,k) = - (q_v * u_v)
         endif
-
-      enddo ; enddo
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO) then
-      do J=Jsq,Jeq ; do i=is,ie
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+
         u_v = 0.25*G%IdyCv(i,J)*((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
 
         third_order = (G%mask2dCv(i-2,J) * G%mask2dCv(i-1,J) * G%mask2dCv(i,J) * G%mask2dCv(i+1,J) * &
                        G%mask2dCv(i+2,J))
         fifth_order   = third_order * G%mask2dCv(i-3,J) * G%mask2dCv(i+3,J)
 
-
         ! compute the masking to make sure that inland values are not used
         if (fifth_order == 1) then
           v_q6(:) = (v(i-3:i+2,J,k) + v(i-2:i+3,J,k)) * 0.5
           ! all values are valid, we use fifth order reconstruction
-          call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J), &
-                                        h_q(I-3:I+2,J), &
+          call weno_five_h_weight_reconstruction(abs_vort(I-3:I+2,J,kk), &
+                                        h_q(I-3:I+2,J,kk), &
                                         v_q6, &
                                         GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
           CAv(i,J,k) = - (q_v * u_v)
-
         elseif (third_order == 1) then
           v_q4(:) = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
-!          ! only the middle values are valid, we use third order reconstruction
-          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
-                                                 h_q(I-2:I+1,J), &
+          ! only the middle values are valid, we use third order reconstruction
+          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J,kk), &
+                                                 h_q(I-2:I+1,J,kk), &
                                                  v_q4, &
                                                  GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
           CAv(i,J,k) = - (q_v * u_v)
-
         else
           if (u_v>0.) then
-              q_v = q(I-1,J)
+              q_v = q(I-1,J,kk)
           else
-              q_v = q(I,J)
+              q_v = q(I,J,kk)
           endif
           CAv(i,J,k) = - (q_v * u_v)
         endif
-
-      enddo ; enddo
+      enddo ; enddo ; enddo
     elseif (CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO) then
-      do J=Jsq,Jeq ; do i=is,ie
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+
         u_v = 0.25*G%IdyCv(i,J)*((uh(I-1,j,k) + uh(I-1,j+1,k)) + (uh(I,j,k) + uh(I,j+1,k)))
 
         third_order = (G%mask2dCv(i-2,J) * G%mask2dCv(i-1,J) * G%mask2dCv(i,J) * G%mask2dCv(i+1,J) * &
                        G%mask2dCv(i+2,J))
 
-
         ! compute the masking to make sure that inland values are not used
         if (third_order == 1) then
           v_q4(:) = (v(i-2:i+1,J,k) + v(i-1:i+2,J,k)) * 0.5
-!          ! only the middle values are valid, we use third order reconstruction
-          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J), &
-                                                 h_q(I-2:I+1,J), &
+          ! only the middle values are valid, we use third order reconstruction
+          call weno_three_h_weight_reconstruction(abs_vort(I-2:I+1,J,kk), &
+                                                 h_q(I-2:I+1,J,kk), &
                                                  v_q4, &
                                                  GV%H_subroundoff, u_v, q_v, CS%weno_velocity_smooth)
           CAv(i,J,k) = - (q_v * u_v)
-
         else
           if (u_v>0.) then
-              q_v = q(I-1,J)
+              q_v = q(I-1,J,kk)
           else
-              q_v = q(I,J)
+              q_v = q(I,J,kk)
           endif
           CAv(i,J,k) = - (q_v * u_v)
         endif
-
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
     ! Add in the additonal terms with Arakawa & Lamb.
     if ((CS%Coriolis_Scheme == ARAKAWA_LAMB81) .or. &
-        (CS%Coriolis_Scheme == AL_BLEND)) then ; do J=Jsq,Jeq ; do i=is,ie
-      CAv(i,J,k) = CAv(i,J,k) + &
-            ((ep_v(i,j)*vh(i,J-1,k)) - (ep_v(i,j+1)*vh(i,J+1,k))) * G%IdyCv(i,J)
-    enddo ; enddo ; endif
+        (CS%Coriolis_Scheme == AL_BLEND)) then
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+        CAv(i,J,k) = CAv(i,J,k) &
+            + ((ep_v(i,j,kk) * vh(i,J-1,k)) - (ep_v(i,j+1,kk) * vh(i,J+1,k))) * G%IdyCv(i,J)
+      enddo ; enddo ; enddo
+    endif
 
     if (Stokes_VF) then
       if (CS%id_CAuS>0 .or. CS%id_CAvS>0) then
         ! Computing the diagnostic Stokes contribution to CAv
-        do J=Jsq,Jeq ; do i=is,ie
-          CAvS(i,J,k) = 0.25 * &
-                ((qS(I,J) * (uh(I,j+1,k) + uh(I,j,k))) + &
-                 (qS(I-1,J) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+          k = ksb + kk - 1
+          CAvS(i,J,k) = 0.25 &
+              * ((qS(I,J,kk) * (uh(I,j+1,k) + uh(I,j,k))) &
+                 + (qS(I-1,J,kk) * (uh(I-1,j,k) + uh(I-1,j+1,k)))) * G%IdyCv(i,J)
+        enddo ; enddo ; enddo
       endif
     endif
 
     if (CS%bound_Coriolis) then
-      do J=Jsq,Jeq ; do i=is,ie
-        fu1 = -abs_vort(I,J) * u(I,j+1,k)
-        fu2 = -abs_vort(I,J) * u(I,j,k)
-        fu3 = -abs_vort(I-1,J) * u(I-1,j+1,k)
-        fu4 = -abs_vort(I-1,J) * u(I-1,j,k)
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+
+        fu1 = -abs_vort(I,J,kk) * u(I,j+1,k)
+        fu2 = -abs_vort(I,J,kk) * u(I,j,k)
+        fu3 = -abs_vort(I-1,J,kk) * u(I-1,j+1,k)
+        fu4 = -abs_vort(I-1,J,kk) * u(I-1,j,k)
 
         max_fu = max(fu1, fu2, fu3, fu4)
         min_fu = min(fu1, fu2, fu3, fu4)
 
         CAv(I,j,k) = min(CAv(I,j,k), max_fu)
         CAv(I,j,k) = max(CAv(I,j,k), min_fu)
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
 
     ! Term - d(KE)/dy.
-    do J=Jsq,Jeq ; do i=is,ie
-      CAv(i,J,k) = CAv(i,J,k) - KEy(i,J)
-    enddo ; enddo
+    do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+      k = ksb + kk - 1
+      CAv(i,J,k) = CAv(i,J,k) - KEy(i,J,kk)
+    enddo ; enddo ; enddo
     if (associated(AD%gradKEv)) then
-      do J=Jsq,Jeq ; do i=is,ie
-        AD%gradKEv(i,J,k) = -KEy(i,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+        k = ksb + kk - 1
+        AD%gradKEv(i,J,k) = -KEy(i,J,kk)
+      enddo ; enddo ; enddo
     endif
 
     if (associated(AD%rv_x_u) .or. associated(AD%rv_x_v)) then
       ! Calculate the Coriolis-like acceleration due to relative vorticity.
       if (CS%Coriolis_Scheme == SADOURNY75_ENERGY) then
         if (associated(AD%rv_x_u)) then
-          do J=Jsq,Jeq ; do i=is,ie
-            AD%rv_x_u(i,J,k) = - 0.25* &
-              ((q2(I-1,j)*(uh(I-1,j,k) + uh(I-1,j+1,k))) + &
-               (q2(I,j)*(uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
-          enddo ; enddo
+          do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+            k = ksb + kk - 1
+            AD%rv_x_u(i,J,k) = -0.25 &
+                * ((q2(I-1,j,kk) * (uh(I-1,j,k) + uh(I-1,j+1,k))) &
+                   + (q2(I,j,kk) * (uh(I,j,k) + uh(I,j+1,k)))) * G%IdyCv(i,J)
+          enddo ; enddo ; enddo
         endif
 
         if (associated(AD%rv_x_v)) then
-          do j=js,je ; do I=Isq,Ieq
-            AD%rv_x_v(I,j,k) = 0.25 * &
-              ((q2(I,j) * (vh(i+1,J,k) + vh(i,J,k))) + &
-               (q2(I,j-1) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
-          enddo ; enddo
+          do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+            k = ksb + kk - 1
+            AD%rv_x_v(I,j,k) = 0.25 &
+                * ((q2(I,j,kk) * (vh(i+1,J,k) + vh(i,J,k))) &
+                   + (q2(I,j-1,kk) * (vh(i,J-1,k) + vh(i+1,J-1,k)))) * G%IdxCu(I,j)
+          enddo ; enddo ; enddo
         endif
       else
         if (associated(AD%rv_x_u)) then
-          do J=Jsq,Jeq ; do i=is,ie
+          do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+            k = ksb + kk - 1
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
-              (((((q2(I,J) + q2(I-1,J-1)) + q2(I-1,J)) * uh(I-1,j,k)) + &
-                (((q2(I-1,J) + q2(I,J+1)) + q2(I,J)) * uh(I,j+1,k))) + &
-               ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * uh(I,j,k))+ &
-                (((q2(I,J) + q2(I-1,J+1)) + q2(I-1,J)) * uh(I-1,j+1,k))))
-          enddo ; enddo
+              (((((q2(I,J,kk) + q2(I-1,J-1,kk)) + q2(I-1,J,kk)) * uh(I-1,j,k)) + &
+                (((q2(I-1,J,kk) + q2(I,J+1,kk)) + q2(I,J,kk)) * uh(I,j+1,k))) + &
+               ((((q2(I-1,J,kk) + q2(I,J-1,kk)) + q2(I,J,kk)) * uh(I,j,k))+ &
+                (((q2(I,J,kk) + q2(I-1,J+1,kk)) + q2(I-1,J,kk)) * uh(I-1,j+1,k))))
+          enddo ; enddo ; enddo
         endif
 
         if (associated(AD%rv_x_v)) then
-          do j=js,je ; do I=Isq,Ieq
+          do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+            k = ksb + kk - 1
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
-              (((((q2(I+1,J) + q2(I,J-1)) + q2(I,J)) * vh(i+1,J,k)) + &
-                (((q2(I-1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i,J-1,k))) + &
-               ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * vh(i,J,k)) + &
-                (((q2(I+1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i+1,J-1,k))))
-          enddo ; enddo
+              (((((q2(I+1,J,kk) + q2(I,J-1,kk)) + q2(I,J,kk)) * vh(i+1,J,k)) + &
+                (((q2(I-1,J-1,kk) + q2(I,J,kk)) + q2(I,J-1,kk)) * vh(i,J-1,k))) + &
+               ((((q2(I-1,J,kk) + q2(I,J-1,kk)) + q2(I,J,kk)) * vh(i,J,k)) + &
+                (((q2(I+1,J-1,kk) + q2(I,J,kk)) + q2(I,J-1,kk)) * vh(i+1,J-1,k))))
+          enddo ; enddo ; enddo
         endif
       endif
     endif
-
-  enddo ! k-loop.
+  enddo ! end of ksb block loop.
 
   ! Here the various Coriolis-related derived quantities are offered for averaging.
   if (query_averaging_enabled(CS%diag)) then
@@ -1241,159 +1370,168 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
     if (CS%id_intz_rvxv_2d > 0) call post_product_sum_u(CS%id_intz_rvxv_2d, AD%rv_x_v, AD%diag_hu, G, nz, CS%diag)
     if (CS%id_intz_rvxu_2d > 0) call post_product_sum_v(CS%id_intz_rvxu_2d, AD%rv_x_u, AD%diag_hv, G, nz, CS%diag)
   endif
+end subroutine CorAdCalc_block
 
-end subroutine CorAdCalc
 
-
-!> Calculates the acceleration due to the gradient of kinetic energy in one layer.
-subroutine gradKE(u, v, h, KE, KEx, KEy, G, GV, US, CS)
-  type(ocean_grid_type),             intent(in)  :: G   !< Ocean grid structure
-  type(verticalGrid_type),           intent(in)  :: GV  !< Vertical grid structure
-  real, dimension(SZIB_(G),SZJ_(G)), intent(in)  :: u   !< Zonal velocity [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJB_(G)), intent(in)  :: v   !< Meridional velocity [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in)  :: h   !< Layer thickness [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G)),  intent(out) :: KE  !< Kinetic energy per unit mass [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJ_(G)), intent(out) :: KEx !< Zonal acceleration due to kinetic
-                                                        !! energy gradient [L T-2 ~> m s-2]
-  real, dimension(SZI_(G),SZJB_(G)), intent(out) :: KEy !< Meridional acceleration due to kinetic
-                                                        !! energy gradient [L T-2 ~> m s-2]
-  type(unit_scale_type),             intent(in)  :: US  !< A dimensional unit scaling type
-  type(CoriolisAdv_CS),              intent(in)  :: CS  !< Control structure for MOM_CoriolisAdv
+!> Calculates the acceleration due to the gradient of kinetic energy for a k-block.
+subroutine gradKE(u, v, h, KE, KEx, KEy, ksb, keb, nkk, G, GV, US, CS)
+  type(ocean_grid_type),                      intent(in)  :: G   !< Ocean grid structure
+  type(verticalGrid_type),                    intent(in)  :: GV  !< Vertical grid structure
+  integer,                                    intent(in)  :: ksb !< First layer in the k-block [nondim].
+  integer,                                    intent(in)  :: keb   !< Last layer in the k-block [nondim].
+  integer,                                    intent(in)  :: nkk !< Size of the k-block [nondim].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)  :: u   !< Zonal velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)  :: v   !< Meridional velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h   !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),nkk),   intent(out) :: KE  !< Kinetic energy per unit mass [L2 T-2 ~> m2 s-2]
+  real, dimension(SZIB_(G),SZJ_(G),nkk),  intent(out) :: KEx !< Zonal acceleration due to kinetic
+                                                                 !! energy gradient [L T-2 ~> m s-2]
+  real, dimension(SZI_(G),SZJB_(G),nkk),  intent(out) :: KEy !< Meridional acceleration due to kinetic
+                                                                 !! energy gradient [L T-2 ~> m s-2]
+  type(unit_scale_type),                      intent(in)  :: US  !< A dimensional unit scaling type
+  type(CoriolisAdv_CS),                       intent(in)  :: CS  !< Control structure for MOM_CoriolisAdv
   ! Local variables
   real :: um, up, vm, vp         ! Temporary variables [L T-1 ~> m s-1].
   real :: um2, up2, vm2, vp2     ! Temporary variables [L2 T-2 ~> m2 s-2].
   real :: um2a, up2a, vm2a, vp2a ! Temporary variables [L4 T-2 ~> m4 s-2].
   real :: third_order_u, third_order_v  ! Product of mask values to determine the boundary
-  integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, n
+  integer :: i, j, k, kk, kke, is, ie, js, je, Isq, Ieq, Jsq, Jeq
   real, parameter     :: C1_12 = 1.0/12.0   ! The ratio of 1/12 [nondim]
 
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
-
+  kke = keb - ksb + 1
 
   ! Calculate KE (Kinetic energy for use in the -grad(KE) acceleration term).
   if (CS%KE_Scheme == KE_ARAKAWA) then
     ! The following calculation of Kinetic energy includes the metric terms
     ! identified in Arakawa & Lamb 1982 as important for KE conservation.  It
     ! also includes the possibility of partially-blocked tracer cell faces.
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      KE(i,j) = ( ( (G%areaCu( I ,j)*(u( I ,j)*u( I ,j))) + &
-                    (G%areaCu(I-1,j)*(u(I-1,j)*u(I-1,j))) ) + &
-                  ( (G%areaCv(i, J )*(v(i, J )*v(i, J ))) + &
-                    (G%areaCv(i,J-1)*(v(i,J-1)*v(i,J-1))) ) )*0.25*G%IareaT(i,j)
-    enddo ; enddo
+    do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      k = ksb + kk - 1
+      KE(i,j,kk) = ( ( (G%areaCu( I ,j)*(u( I ,j,k)*u( I ,j,k))) + &
+                       (G%areaCu(I-1,j)*(u(I-1,j,k)*u(I-1,j,k))) ) + &
+                     ( (G%areaCv(i, J )*(v(i, J ,k)*v(i, J ,k))) + &
+                       (G%areaCv(i,J-1)*(v(i,J-1,k)*v(i,J-1,k))) ) )*0.25*G%IareaT(i,j)
+    enddo ; enddo ; enddo
   elseif (CS%KE_Scheme == KE_SIMPLE_GUDONOV) then
     ! The following discretization of KE is based on the one-dimensional Gudonov
     ! scheme which does not take into account any geometric factors
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      up = 0.5*( u(I-1,j) + ABS( u(I-1,j) ) ) ; up2 = up*up
-      um = 0.5*( u( I ,j) - ABS( u( I ,j) ) ) ; um2 = um*um
-      vp = 0.5*( v(i,J-1) + ABS( v(i,J-1) ) ) ; vp2 = vp*vp
-      vm = 0.5*( v(i, J ) - ABS( v(i, J ) ) ) ; vm2 = vm*vm
-      KE(i,j) = ( max(up2,um2) + max(vp2,vm2) ) *0.5
-    enddo ; enddo
+    do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      k = ksb + kk - 1
+      up = 0.5*( u(I-1,j,k) + ABS( u(I-1,j,k) ) ) ; up2 = up*up
+      um = 0.5*( u( I ,j,k) - ABS( u( I ,j,k) ) ) ; um2 = um*um
+      vp = 0.5*( v(i,J-1,k) + ABS( v(i,J-1,k) ) ) ; vp2 = vp*vp
+      vm = 0.5*( v(i, J ,k) - ABS( v(i, J ,k) ) ) ; vm2 = vm*vm
+      KE(i,j,kk) = ( max(up2,um2) + max(vp2,vm2) ) *0.5
+    enddo ; enddo ; enddo
   elseif (CS%KE_Scheme == KE_GUDONOV) then
     ! The following discretization of KE is based on the one-dimensional Gudonov
     ! scheme but has been adapted to take horizontal grid factors into account
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-      up = 0.5*( u(I-1,j) + ABS( u(I-1,j) ) ) ; up2a = up*up*G%areaCu(I-1,j)
-      um = 0.5*( u( I ,j) - ABS( u( I ,j) ) ) ; um2a = um*um*G%areaCu( I ,j)
-      vp = 0.5*( v(i,J-1) + ABS( v(i,J-1) ) ) ; vp2a = vp*vp*G%areaCv(i,J-1)
-      vm = 0.5*( v(i, J ) - ABS( v(i, J ) ) ) ; vm2a = vm*vm*G%areaCv(i, J )
-      KE(i,j) = ( max(um2a,up2a) + max(vm2a,vp2a) )*0.5*G%IareaT(i,j)
-    enddo ; enddo
+    do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      k = ksb + kk - 1
+      up = 0.5*( u(I-1,j,k) + ABS( u(I-1,j,k) ) ) ; up2a = up*up*G%areaCu(I-1,j)
+      um = 0.5*( u( I ,j,k) - ABS( u( I ,j,k) ) ) ; um2a = um*um*G%areaCu( I ,j)
+      vp = 0.5*( v(i,J-1,k) + ABS( v(i,J-1,k) ) ) ; vp2a = vp*vp*G%areaCv(i,J-1)
+      vm = 0.5*( v(i, J ,k) - ABS( v(i, J ,k) ) ) ; vm2a = vm*vm*G%areaCv(i, J )
+      KE(i,j,kk) = ( max(um2a,up2a) + max(vm2a,vp2a) )*0.5*G%IareaT(i,j)
+    enddo ; enddo ; enddo
   elseif (CS%KE_Scheme == KE_UP3) then
     ! The following discretization of KE is based on the one-dimensional third-order
     ! upwind scheme which does not take horizontal grid factors into account
-    if (CS%KE_use_limiter) then
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        ! compute the masking to make sure that inland values are not used
-        third_order_u = (G%mask2dCu(I-2,j) * G%mask2dCu(I-1,j)* &
-                       G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
 
-        if (third_order_u == 1) then
-          up = (7.0 * (u(I-1,j) + u(I,j)) - (u(I-2,j) + u(I+1,j))) * C1_12
-          call UP3_Koren_limiter_reconstruction(u(I-2:I+1,j), up, um)
-        else
-          up = (u(I-1,j) + u(I,j))*0.5
-          if (up>0.) then
-            um = u(I-1,j)
-          elseif (up<0.) then
-            um = u(I,j)
+    do kk=1,kke
+      k = ksb + kk - 1
+
+      if (CS%KE_use_limiter) then
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          ! compute the masking to make sure that inland values are not used
+          third_order_u = (G%mask2dCu(I-2,j) * G%mask2dCu(I-1,j)* &
+                         G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
+
+          if (third_order_u == 1) then
+            up = (7.0 * (u(I-1,j,k) + u(I,j,k)) - (u(I-2,j,k) + u(I+1,j,k))) * C1_12
+            call UP3_Koren_limiter_reconstruction(u(I-2:I+1,j,k), up, um)
           else
-            um = up
+            up = (u(I-1,j,k) + u(I,j,k))*0.5
+            if (up>0.) then
+              um = u(I-1,j,k)
+            elseif (up<0.) then
+              um = u(I,j,k)
+            else
+              um = up
+            endif
           endif
-        endif
 
-        third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
-                       G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
-        if (third_order_v ==1) then
-          vp = (7.0 * (v(i,J-1) + v(i,J)) - (v(i,J-2) + v(i,J+1))) * C1_12
-          call UP3_Koren_limiter_reconstruction(v(i,J-2:J+1), vp, vm)
-        else
-          vp = (v(i,J-1) + v(i,J))*0.5
-          if (vp>0.) then
-            vm = v(i,J-1)
-          elseif (vp<0.) then
-            vm = v(i,J)
+          third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
+                         G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
+          if (third_order_v ==1) then
+            vp = (7.0 * (v(i,J-1,k) + v(i,J,k)) - (v(i,J-2,k) + v(i,J+1,k))) * C1_12
+            call UP3_Koren_limiter_reconstruction(v(i,J-2:J+1,k), vp, vm)
           else
-            vm = vp
+            vp = (v(i,J-1,k) + v(i,J,k))*0.5
+            if (vp>0.) then
+              vm = v(i,J-1,k)
+            elseif (vp<0.) then
+              vm = v(i,J,k)
+            else
+              vm = vp
+            endif
           endif
-        endif
 
-        KE(i,j) = ( (um*um) + (vm*vm) )*0.5
-      enddo ; enddo
-    else
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        ! compute the masking to make sure that inland values are not used
-        third_order_u = (G%mask2dCu(I-2,j) * G%mask2dCu(I-1,j)* &
-                       G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
+          KE(i,j,kk) = ( (um*um) + (vm*vm) )*0.5
+        enddo ; enddo
+      else
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          ! compute the masking to make sure that inland values are not used
+          third_order_u = (G%mask2dCu(I-2,j) * G%mask2dCu(I-1,j)* &
+                         G%mask2dCu(I,j) * G%mask2dCu(I+1,j))
 
-        if (third_order_u == 1) then
-          up = (7.0 * (u(I-1,j) + u(I,j)) - (u(I-2,j) + u(I+1,j))) * C1_12
-          call UP3_reconstruction(u(I-2:I+1,j), up, um)
-        else
-          up = (u(I-1,j) + u(I,j))*0.5
-          if (up>0.) then
-            um = u(I-1,j)
-          elseif (up<0.) then
-            um = u(I,j)
+          if (third_order_u == 1) then
+            up = (7.0 * (u(I-1,j,k) + u(I,j,k)) - (u(I-2,j,k) + u(I+1,j,k))) * C1_12
+            call UP3_reconstruction(u(I-2:I+1,j,k), up, um)
           else
-            um = up
+            up = (u(I-1,j,k) + u(I,j,k))*0.5
+            if (up>0.) then
+              um = u(I-1,j,k)
+            elseif (up<0.) then
+              um = u(I,j,k)
+            else
+              um = up
+            endif
           endif
-        endif
 
-        third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
-                       G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
-        if (third_order_v ==1) then
-          vp = (7.0 * (v(i,J-1) + v(i,J)) - (v(i,J-2) + v(i,J+1))) * C1_12
-          call UP3_reconstruction(v(i,J-2:J+1), vp, vm)
-        else
-          vp = (v(i,J-1) + v(i,J))*0.5
-          if (vp>0.) then
-            vm = v(i,J-1)
-          elseif (vp<0.) then
-            vm = v(i,J)
+          third_order_v = (G%mask2dCv(i,J-2) * G%mask2dCv(i,J-1)* &
+                         G%mask2dCv(i,J) * G%mask2dCv(i,J+1))
+          if (third_order_v ==1) then
+            vp = (7.0 * (v(i,J-1,k) + v(i,J,k)) - (v(i,J-2,k) + v(i,J+1,k))) * C1_12
+            call UP3_reconstruction(v(i,J-2:J+1,k), vp, vm)
           else
-            vm = vp
+            vp = (v(i,J-1,k) + v(i,J,k))*0.5
+            if (vp>0.) then
+              vm = v(i,J-1,k)
+            elseif (vp<0.) then
+              vm = v(i,J,k)
+            else
+              vm = vp
+            endif
           endif
-        endif
 
-        KE(i,j) = ( (um*um) + (vm*vm) )*0.5
-      enddo ; enddo
-    endif
+          KE(i,j,kk) = ( (um*um) + (vm*vm) )*0.5
+        enddo ; enddo
+      endif
+    enddo
   endif
 
   ! Term - d(KE)/dx.
-  do j=js,je ; do I=Isq,Ieq
-    KEx(I,j) = (KE(i+1,j) - KE(i,j)) * G%IdxCu_OBCmask(I,j)
-  enddo ; enddo
+  do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+    KEx(I,j,kk) = (KE(i+1,j,kk) - KE(i,j,kk)) * G%IdxCu_OBCmask(I,j)
+  enddo ; enddo ; enddo
 
   ! Term - d(KE)/dy.
-  do J=Jsq,Jeq ; do i=is,ie
-    KEy(i,J) = (KE(i,j+1) - KE(i,j)) * G%IdyCv_OBCmask(i,J)
-  enddo ; enddo
-
+  do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+    KEy(i,J,kk) = (KE(i,j+1,kk) - KE(i,j,kk)) * G%IdyCv_OBCmask(i,J)
+  enddo ; enddo ; enddo
 end subroutine gradKE
 
 !> Reconstruct the scalar (e.g., pv, vorticity) onto point i-1/2 using a third-order upwind scheme
@@ -1888,6 +2026,7 @@ function CoriolisAdv_stencil(CS) result(stencil)
 
 end function CoriolisAdv_stencil
 
+
 !> Initializes the control structure for MOM_CoriolisAdv
 subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
   type(time_type), target, intent(in)    :: Time !< Current model time
@@ -1904,7 +2043,9 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
   character(len=40)  :: mdl = "MOM_CoriolisAdv" ! This module's name.
   character(len=20)  :: tmpstr
   character(len=400) :: mesg
+  logical :: use_weno
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
+  integer, parameter :: default_nkblock = 1
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -1914,6 +2055,11 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
 
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "CORIOLIS_ADV_NKBLOCK", CS%nkblock, &
+                 "The k-direction block size used in Coriolis and momentum "//&
+                 "advection calculations. The default value of 1 uses "//&
+                 "single-layer blocks.", default=default_nkblock, layoutParam=.true.)
+  if (CS%nkblock < 0) call MOM_error(FATAL, "CORIOLIS_ADV_NKBLOCK must be >= 0.")
   call get_param(param_file, mdl, "NOSLIP", CS%no_slip, &
                  "If true, no slip boundary conditions are used; otherwise "//&
                  "free slip boundary conditions are assumed. The "//&
@@ -1970,8 +2116,11 @@ subroutine CoriolisAdv_init(Time, G, GV, US, param_file, diag, AD, CS)
             "#define CORIOLIS_SCHEME "//trim(tmpstr)//" found in input file.")
   end select
 
-  if (CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO .or. &
-          CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO .or. CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO) then
+  use_weno = CS%Coriolis_Scheme == wenovi7th_PV_ENSTRO &
+      .or. CS%Coriolis_Scheme == wenovi5th_PV_ENSTRO &
+      .or. CS%Coriolis_Scheme == wenovi3rd_PV_ENSTRO
+
+  if (use_weno) then
     call get_param(param_file, mdl, "WENO_VELOCITY_SMOOTH", CS%weno_velocity_smooth, &
             "If true, use velocity to compute weighting for WENO. ", &
                   default=.false.)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2853,7 +2853,8 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
   integer :: i, j, isl, iel, jsl, jel, nz, n, stencil
-  integer :: ksb, keb
+  integer :: ksb, keb   ! Start and end domain index bounds of current block
+  integer :: kke        ! Block end index of current block
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2882,17 +2883,20 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic
 
   do ksb=1,nz,nkk
     keb = min(ksb + nkk - 1, nz)
+    kke = keb - ksb + 1
 
     if (simple_2nd) then
-      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
+      do kk=1,kke ; do j=jsl,jel ; do i=isl,iel
+        k = ksb + kk - 1
+
         h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
         h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
         h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) )
         h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) )
       enddo ; enddo ; enddo
     else
-      do k=ksb,keb ; do j=jsl,jel ; do i=isl-1,iel+1
-        kk = k - ksb + 1
+      do kk=1,kke ; do j=jsl,jel ; do i=isl-1,iel+1
+        k = ksb + kk - 1
 
         if ((G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j)) == 0.0) then
           slp(i,j,kk) = 0.0
@@ -2913,9 +2917,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic
           if (.not. segment%on_pe) cycle
           if (segment%is_E_or_W) then
             I=segment%HI%IsdB
-            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
-              kk = k - ksb + 1
-
+            do kk=1,kke ; do j=segment%HI%jsd,segment%HI%jed
               slp(i+1,j,kk) = 0.0
               slp(i,j,kk) = 0.0
             enddo ; enddo
@@ -2923,8 +2925,8 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic
         enddo
       endif
 
-      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
-        kk = k - ksb + 1
+      do kk=1,kke ; do j=jsl,jel ; do i=isl,iel
+        k = ksb + kk - 1
 
         ! Neighboring values should take into account any boundaries.  The 3
         ! following sets of expressions are equivalent.
@@ -2947,14 +2949,18 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic
         if (segment%direction == OBC_DIRECTION_E) then
           I=segment%HI%IsdB
           if (associated(segment%h_Reg)) then
-            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+            do kk=1,kke ; do j=segment%HI%jsd,segment%HI%jed
+              k = ksb + kk - 1
+
               h_W(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
               h_E(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
               h_W(i,j,k) = segment%h_Reg%h_res(i,j,k)
               h_E(i,j,k) = segment%h_Reg%h_res(i,j,k)
             enddo ; enddo
           else
-            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+            do kk=1,kke ; do j=segment%HI%jsd,segment%HI%jed
+              k = ksb + kk - 1
+
               h_W(i+1,j,k) = h_in(i,j,k)
               h_E(i+1,j,k) = h_in(i,j,k)
               h_W(i,j,k) = h_in(i,j,k)
@@ -2964,14 +2970,18 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic
         elseif (segment%direction == OBC_DIRECTION_W) then
           I=segment%HI%IsdB
           if (associated(segment%h_Reg)) then
-            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+            do kk=1,kke ; do j=segment%HI%jsd,segment%HI%jed
+              k = ksb + kk - 1
+
               h_W(i,j,k) = segment%h_Reg%h_res(i,j,k)
               h_E(i,j,k) = segment%h_Reg%h_res(i,j,k)
               h_W(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
               h_E(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
             enddo ; enddo
           else
-            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+            do kk=1,kke ; do j=segment%HI%jsd,segment%HI%jed
+              k = ksb + kk - 1
+
               h_W(i,j,k) = h_in(i+1,j,k)
               h_E(i,j,k) = h_in(i+1,j,k)
               h_W(i+1,j,k) = h_in(i+1,j,k)
@@ -3021,7 +3031,8 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
   integer :: i, j, isl, iel, jsl, jel, nz, n, stencil
-  integer :: ksb, keb
+  integer :: ksb, keb   ! Start and end domain index bounds of current block
+  integer :: kke        ! Block end index of current block
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -3050,17 +3061,20 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic
 
   do ksb=1,nz,nkk
     keb = min(ksb + nkk - 1, nz)
+    kke = keb - ksb + 1
 
     if (simple_2nd) then
-      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
+      do kk=1,kke ; do j=jsl,jel ; do i=isl,iel
+        k = ksb + kk - 1
+
         h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
         h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
         h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) )
         h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) )
       enddo ; enddo ; enddo
     else
-      do k=ksb,keb ; do j=jsl-1,jel+1 ; do i=isl,iel
-        kk = k - ksb + 1
+      do kk=1,kke ; do j=jsl-1,jel+1 ; do i=isl,iel
+        k = ksb + kk - 1
 
         if ((G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1)) == 0.0) then
           slp(i,j,kk) = 0.0
@@ -3081,9 +3095,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic
           if (.not. segment%on_pe) cycle
           if (segment%is_N_or_S) then
             J=segment%HI%JsdB
-            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
-              kk = k - ksb + 1
-
+            do kk=1,kke ; do i=segment%HI%isd,segment%HI%ied
               slp(i,j+1,kk) = 0.0
               slp(i,j,kk) = 0.0
             enddo ; enddo
@@ -3091,8 +3103,8 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic
         enddo
       endif
 
-      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
-        kk = k - ksb + 1
+      do kk=1,kke ; do j=jsl,jel ; do i=isl,iel
+        k = ksb + kk - 1
 
         ! Neighboring values should take into account any boundaries.  The 3
         ! following sets of expressions are equivalent.
@@ -3113,14 +3125,18 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic
         if (segment%direction == OBC_DIRECTION_N) then
           J=segment%HI%JsdB
           if (associated(segment%h_Reg)) then
-            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+            do kk=1,kke ; do i=segment%HI%isd,segment%HI%ied
+              k = ksb + kk - 1
+
               h_S(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
               h_N(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
               h_S(i,j,k) = segment%h_Reg%h_res(i,j,k)
               h_N(i,j,k) = segment%h_Reg%h_res(i,j,k)
             enddo ; enddo
           else
-            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+            do kk=1,kke ; do i=segment%HI%isd,segment%HI%ied
+              k = ksb + kk - 1
+
               h_S(i,j+1,k) = h_in(i,j,k)
               h_N(i,j+1,k) = h_in(i,j,k)
               h_S(i,j,k) = h_in(i,j,k)
@@ -3130,14 +3146,18 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic
         elseif (segment%direction == OBC_DIRECTION_S) then
           J=segment%HI%JsdB
           if (associated(segment%h_Reg)) then
-            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+            do kk=1,kke ; do i=segment%HI%isd,segment%HI%ied
+              k = ksb + kk - 1
+
               h_S(i,j,k) = segment%h_Reg%h_res(i,j,k)
               h_N(i,j,k) = segment%h_Reg%h_res(i,j,k)
               h_S(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
               h_N(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
             enddo ; enddo
           else
-            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+            do kk=1,kke ; do i=segment%HI%isd,segment%HI%ied
+              k = ksb + kk - 1
+
               h_S(i,j,k) = h_in(i,j+1,k)
               h_N(i,j,k) = h_in(i,j+1,k)
               h_S(i,j+1,k) = h_in(i,j+1,k)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -859,7 +859,7 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
 
   local_specified_BC = .false.
   if (associated(OBC)) then ; if (OBC%OBC_pe) then
-    local_specified_BC = OBC%specified_v_BCs_exist_globally
+    local_specified_BC = OBC%specified_u_BCs_exist_globally
   endif ; endif
 
   if (present(LB_in)) then

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -69,6 +69,9 @@ type, public :: continuity_PPM_CS ; private
                              !! continuity solver for use as the weights in the
                              !! barotropic solver.  Otherwise use the transport
                              !! averaged areas.
+  integer :: niblock         !< The i block size used in array calculations.
+  integer :: njblock         !< The j block size used in array calculations.
+  integer :: nkblock         !< The k block size used in reconstruction calculations.
 end type continuity_PPM_CS
 
 !> A container for loop bounds
@@ -153,6 +156,10 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   real :: h_min  ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
   type(cont_loop_bounds_type) :: LB ! A type indicating the loop range for a phase of the updates
   logical :: x_first
+  integer :: nii, nIIB
+    ! i block size for center and face aligned blocks
+  integer :: njj, nJJB
+    ! j block size for center and face aligned blocks
 
   h_min = GV%Angstrom_H
 
@@ -166,36 +173,61 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
       "one must be present in call to continuity_PPM.")
 
   if (x_first) then
+
     !  First advect zonally, with loop bounds that accomodate the subsequent meridional advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.true.)
+
+    nIIB = CS%niblock
+    if (CS%niblock == 0) nIIB = LB%ieh - LB%ish + 2
+    njj = CS%njblock
+    if (CS%njblock == 0) njj = LB%jeh - LB%jsh + 1
+
     call zonal_edge_thickness(hin, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, hin, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
-                         LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
+                         nIIB, njj, LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
     call continuity_zonal_convergence(h, uh, dt, G, GV, LB, hin)
 
     !  Now advect meridionally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
+
+    nii = CS%niblock
+    if (CS%niblock == 0) nii = LB%ieh - LB%ish + 1
+    nJJB = CS%njblock
+    if (CS%njblock == 0) nJJB = LB%jeh - LB%jsh + 2
+
     call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
-                              LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
+                              nii, nJJB, LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
     call continuity_merdional_convergence(h, vh, dt, G, GV, LB, hmin=h_min)
 
   else  ! .not. x_first
+
     !  First advect meridionally, with loop bounds that accomodate the subsequent zonal advection.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.true., j_stencil=.false.)
+
+    nii = CS%niblock
+    if (CS%niblock == 0) nii = LB%ieh - LB%ish + 1
+    nJJB = CS%njblock
+    if (CS%njblock == 0) nJJB = LB%jeh - LB%jsh + 2
+
     call meridional_edge_thickness(hin, h_S, h_N, G, GV, US, CS, OBC, LB)
     call meridional_mass_flux(v, hin, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
-                              LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
+                              nii, nJJB, LB, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
     call continuity_merdional_convergence(h, vh, dt, G, GV, LB, hin)
 
     !  Now advect zonally, using the updated thicknesses to determine the fluxes.
     LB = set_continuity_loop_bounds(G, CS, i_stencil=.false., j_stencil=.false.)
+
+    nIIB = CS%niblock
+    if (CS%niblock == 0) nIIB = LB%ieh - LB%ish + 2
+    njj = CS%njblock
+    if (CS%njblock == 0) njj = LB%jeh - LB%jsh + 1
+
     call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC, LB)
     call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
-                         LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
+                         nIIB, njj, LB, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
     call continuity_zonal_convergence(h, uh, dt, G, GV, LB, hmin=h_min)
   endif
-
 end subroutine continuity_PPM
 
 !> Finds the thickness fluxes from the continuity solver without actually updating the
@@ -228,12 +260,30 @@ subroutine continuity_3d_fluxes(u, v, h, uh, vh, dt, G, GV, US, CS, OBC, pbv)
   real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
   real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
   real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+  integer :: nii, nIIB
+    ! i block size for center and face aligned blocks
+  integer :: njj, nJJB
+    ! j block size for center and face aligned blocks
 
   call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
+
+  nIIB = CS%niblock
+  if (CS%niblock == 0) nIIB = G%iec - G%isc + 2
+  njj = CS%njblock
+  if (CS%njblock == 0) njj = G%jec - G%jsc + 1
+
+  call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, &
+      pbv%por_face_areaU, nIIB=nIIB, njj=njj)
 
   call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
+
+  nii = CS%niblock
+  if (CS%niblock == 0) nii = G%iec - G%isc + 1
+  nJJB = CS%njblock
+  if (CS%njblock == 0) nJJB = G%jec - G%jsc + 2
+
+  call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, &
+      pbv%por_face_areaV, nii=nii, nJJB=nJJB)
 
 end subroutine continuity_3d_fluxes
 
@@ -332,6 +382,10 @@ subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhb
   real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
   real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
   real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+  integer :: nii, nIIB
+    ! i block size for center and face aligned blocks
+  integer :: njj, nJJB
+    ! j block size for center and face aligned blocks
 
   ! It might not be necessary to separate the input velocity array from the adjusted velocities,
   ! but it seems safer to do so, even if it might be less efficient.
@@ -339,11 +393,25 @@ subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhb
   v_in(:,:,:) = v(:,:,:)
 
   call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  call zonal_mass_flux(u_in, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
+
+  nIIB = CS%niblock
+  if (CS%niblock == 0) nIIB = G%iec - G%isc + 2
+  njj = CS%njblock
+  if (CS%njblock == 0) njj = G%jec - G%jsc + 1
+
+  call zonal_mass_flux(u_in, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, &
+                       pbv%por_face_areaU, nIIB, njj, &
                        uhbt=uhbt, visc_rem_u=visc_rem_u, u_cor=u)
 
   call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  call meridional_mass_flux(v_in, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
+
+  nii = CS%niblock
+  if (CS%niblock == 0) nii = G%iec - G%isc + 1
+  nJJB = CS%njblock
+  if (CS%njblock == 0) nJJB = G%jec - G%jsc + 2
+
+  call meridional_mass_flux(v_in, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, &
+                            pbv%por_face_areaV, nii, nJJB, &
                             vhbt=vhbt, visc_rem_v=visc_rem_v, v_cor=v)
 
 end subroutine continuity_adjust_vel
@@ -365,20 +433,20 @@ subroutine continuity_zonal_convergence(h, uh, dt, G, GV, LB, hin, hmin)
   real,              optional, intent(in)    :: hmin !< The minimum layer thickness [H ~> m or kg m-2]
 
   real :: h_min  ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
-  integer :: i, j, k
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz
 
   call cpu_clock_begin(id_clock_update)
 
   h_min = 0.0 ; if (present(hmin)) h_min = hmin
 
+  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
+
   if (present(hin)) then
-    !$OMP parallel do default(shared)
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do k=1,nz ; do j=jsh,jeh ; do i=ish,ieh
       h(i,j,k) = max( hin(i,j,k) - dt * G%IareaT(i,j) * (uh(I,j,k) - uh(I-1,j,k)), h_min )
     enddo ; enddo ; enddo
   else
-    !$OMP parallel do default(shared)
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do k=1,nz ; do j=jsh,jeh ; do i=ish,ieh
       h(i,j,k) = max( h(i,j,k) - dt * G%IareaT(i,j) * (uh(I,j,k) - uh(I-1,j,k)), h_min )
     enddo ; enddo ; enddo
   endif
@@ -403,20 +471,20 @@ subroutine continuity_merdional_convergence(h, vh, dt, G, GV, LB, hin, hmin)
   real,              optional, intent(in)    :: hmin !< The minimum layer thickness [H ~> m or kg m-2]
 
   real :: h_min  ! The minimum layer thickness [H ~> m or kg m-2].  h_min could be 0.
-  integer :: i, j, k
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz
 
   call cpu_clock_begin(id_clock_update)
+
+  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
   h_min = 0.0 ; if (present(hmin)) h_min = hmin
 
   if (present(hin)) then
-    !$OMP parallel do default(shared)
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do k=1,nz ; do j=jsh,jeh ; do i=ish,ieh
       h(i,j,k) = max( hin(i,j,k) - dt * G%IareaT(i,j) * (vh(i,J,k) - vh(i,J-1,k)), h_min )
     enddo ; enddo ; enddo
   else
-    !$OMP parallel do default(shared)
-    do k=1,GV%ke ; do j=LB%jsh,LB%jeh ; do i=LB%ish,LB%ieh
+    do k=1,nz ; do j=jsh,jeh ; do i=ish,ieh
       h(i,j,k) = max( h(i,j,k) - dt * G%IareaT(i,j) * (vh(i,J,k) - vh(i,J-1,k)), h_min )
     enddo ; enddo ; enddo
   endif
@@ -444,7 +512,7 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
 
   ! Local variables
   type(cont_loop_bounds_type) :: LB
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz, nkblock
 
   call cpu_clock_begin(id_clock_reconstruct)
 
@@ -454,18 +522,16 @@ subroutine zonal_edge_thickness(h_in, h_W, h_E, G, GV, US, CS, OBC, LB_in)
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
   endif
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
+  nkblock = CS%nkblock
+  if (nkblock == 0) nkblock = nz
 
   if (CS%upwind_1st) then
-    !$OMP parallel do default(shared)
     do k=1,nz ; do j=jsh,jeh ; do i=ish-1,ieh+1
       h_W(i,j,k) = h_in(i,j,k) ; h_E(i,j,k) = h_in(i,j,k)
     enddo ; enddo ; enddo
   else
-    !$OMP parallel do default(shared)
-    do k=1,nz
-      call PPM_reconstruction_x(h_in(:,:,k), h_W(:,:,k), h_E(:,:,k), G, LB, &
-                                2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC, k)
-    enddo
+    call PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkblock, &
+        2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
   endif
 
   call cpu_clock_end(id_clock_reconstruct)
@@ -491,7 +557,7 @@ subroutine meridional_edge_thickness(h_in, h_S, h_N, G, GV, US, CS, OBC, LB_in)
 
   ! Local variables
   type(cont_loop_bounds_type) :: LB
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, nz, nkblock
 
   call cpu_clock_begin(id_clock_reconstruct)
 
@@ -501,18 +567,16 @@ subroutine meridional_edge_thickness(h_in, h_S, h_N, G, GV, US, CS, OBC, LB_in)
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
   endif
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
+  nkblock = CS%nkblock
+  if (nkblock == 0) nkblock = nz
 
   if (CS%upwind_1st) then
-    !$OMP parallel do default(shared)
     do k=1,nz ; do j=jsh-1,jeh+1 ; do i=ish,ieh
       h_S(i,j,k) = h_in(i,j,k) ; h_N(i,j,k) = h_in(i,j,k)
     enddo ; enddo ; enddo
   else
-    !$OMP parallel do default(shared)
-    do k=1,nz
-      call PPM_reconstruction_y(h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), G, LB, &
-                                2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC, k)
-    enddo
+    call PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkblock, &
+        2.0*GV%Angstrom_H, CS%monotonic, CS%simple_2nd, OBC)
   endif
 
   call cpu_clock_end(id_clock_reconstruct)
@@ -522,7 +586,7 @@ end subroutine meridional_edge_thickness
 
 !> Calculates the mass or volume fluxes through the zonal faces, and other related quantities.
 subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_face_areaU, &
-                           LB_in, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
+                           nIIB, njj, LB_in, uhbt, visc_rem_u, u_cor, BT_cont, du_cor)
   type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
@@ -542,6 +606,8 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   type(ocean_OBC_type),    pointer       :: OBC  !< Open boundaries control structure.
   real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
                            intent(in)    :: por_face_areaU !< fractional open area of U-faces [nondim]
+  integer,                 intent(in)    :: nIIB !< I block size for array calculations.
+  integer,                 intent(in)    :: njj !< j block size for array calculations.
   type(cont_loop_bounds_type), &
                  optional, intent(in)    :: LB_in !< Loop bounds structure.
   real, dimension(SZIB_(G),SZJ_(G)), &
@@ -564,18 +630,25 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
                                                  !! as the depth-integrated transports [L T-1 ~> m s-1].
 
   ! Local variables
-  real, dimension(SZIB_(G),SZK_(GV)) :: duhdu ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G)) :: &
+  ! The block-sized work arrays below are dimensioned (nIIB,njj[,nz]).  In this zonal
+  ! routine their first (nIIB) block index is staggered at the zonal velocity (u, C-grid I)
+  ! points, while the second (njj) block index is at the tracer-row (j) points.
+  real, dimension(nIIB,njj,SZK_(GV)) :: &
+    duhdu,      & ! Partial derivative of uh with u, at u points [H L ~> m2 or kg m-1].
+    visc_rem      ! A 2-D copy of visc_rem_u or an array of 1's, at u points [nondim].
+  real, dimension(nIIB,njj) :: &
     du, &         ! Corrective barotropic change in the velocity to give uhbt [L T-1 ~> m s-1].
     du_min_CFL, & ! Lower limit on du correction to avoid CFL violations [L T-1 ~> m s-1]
     du_max_CFL, & ! Upper limit on du correction to avoid CFL violations [L T-1 ~> m s-1]
     duhdu_tot_0, & ! Summed partial derivative of uh with u [H L ~> m2 or kg m-1].
     uh_tot_0, &   ! Summed transport with no barotropic correction [H L2 T-1 ~> m3 s-1 or kg s-1].
     visc_rem_max  ! The column maximum of visc_rem [nondim].
-  logical, dimension(SZIB_(G)) :: do_I
-  real, dimension(SZIB_(G),SZK_(GV)) :: &
-    visc_rem      ! A 2-D copy of visc_rem_u or an array of 1's [nondim].
-  real, dimension(SZIB_(G)) :: FAuI  ! A list of sums of zonal face areas [H L ~> m2 or kg m-1].
+  logical, dimension(nIIB,njj) :: do_ij
+  real, dimension(nIIB,njj,SZK_(GV)) :: &
+    uh_b          ! A block-sized copy of uh [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(nIIB,njj) :: &
+    uhbt_b        ! A block-sized copy of uhbt [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(nIIB,njj) :: FAuI  ! A list of sums of zonal face areas [H L ~> m2 or kg m-1].
   real :: FA_u    ! A sum of zonal face areas [H L ~> m2 or kg m-1].
   real :: I_vrm   ! 1.0 / visc_rem_max [nondim]
   real :: CFL_dt  ! The maximum CFL ratio of the adjusted velocities divided by
@@ -584,11 +657,15 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   real :: du_lim  ! The velocity change that give a relative CFL of 1 [L T-1 ~> m s-1].
   real :: dx_E, dx_W ! Effective x-grid spacings to the east and west [L ~> m].
   type(cont_loop_bounds_type) :: LB
-  integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, n, nz, II, jj
   integer :: l_seg ! The OBC segment number
   logical :: use_visc_rem, set_BT_cont
   logical :: local_specified_BC, local_Flather_OBC, local_open_BC, any_simple_OBC  ! OBC-related logicals
-  logical :: simple_OBC_pt(SZIB_(G))  ! Indicates points in a row with specified transport OBCs
+  logical :: simple_OBC_pt(nIIB,njj)  ! Indicates points in a row with specified transport OBCs
+  integer :: jsb, jeb !< The j-index bounds of the current block.
+  integer :: IsbB, IebB !< The I-index bounds of the current block.
+  integer :: jje, IIe !< The block-local j- and I-index end bounds.
+  integer :: nteams
 
   call cpu_clock_begin(id_clock_correct)
 
@@ -603,7 +680,11 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
     local_open_BC = OBC%open_u_BCs_exist_globally
   endif ; endif
 
-  if (present(du_cor)) du_cor(:,:) = 0.0
+  if (present(du_cor)) then
+    do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
+      du_cor(I,j) = 0.0
+    enddo ; enddo
+  endif
 
   if (present(LB_in)) then
     LB = LB_in
@@ -616,174 +697,294 @@ subroutine zonal_mass_flux(u, h_in, h_W, h_E, uh, dt, G, GV, US, CS, OBC, por_fa
   I_dt = 1.0 / dt
   if (CS%aggress_adjust) CFL_dt = I_dt
 
-  if (.not.use_visc_rem) visc_rem(:,:) = 1.0
-  !$OMP parallel do default(shared) private(do_I,duhdu,du,du_max_CFL,du_min_CFL,uh_tot_0, &
-  !$OMP                                     duhdu_tot_0,FAuI,visc_rem_max,I_vrm,du_lim,dx_E,dx_W, &
-  !$OMP                                     simple_OBC_pt,any_simple_OBC,l_seg) &
-  !$OMP                        firstprivate(visc_rem)
-  do j=jsh,jeh
-    do I=ish-1,ieh ; do_I(I) = .true. ; enddo
+  if (.not.use_visc_rem) then
+    do k=1,nz ; do jj=1,njj ; do II=1,nIIB
+      visc_rem(II,jj,k) = 1.0
+    enddo ; enddo ; enddo
+  endif
+
+  do jsb=jsh,jeh,njj ; do IsbB=ish-1,ieh,nIIB
+    IebB = min(IsbB + nIIB - 1, ieh)
+    jeb = min(jsb + njj - 1, jeh)
+    IIe = IebB - IsbB + 1
+    jje = jeb - jsb + 1
+
+    do jj=1,jje ; do II=1,IIe
+      do_ij(II,jj) = .true.
+    enddo ; enddo
+
     ! Set uh and duhdu.
     do k=1,nz
-      if (use_visc_rem) then ; do I=ish-1,ieh
-        visc_rem(I,k) = visc_rem_u(I,j,k)
-      enddo ; endif
-      call zonal_flux_layer(u(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), &
-                            uh(:,j,k), duhdu(:,k), visc_rem(:,k), &
-                            dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k), &
-                            CS%h_marg_min, OBC)
+      if (use_visc_rem) then
+        do jj=1,jje ; do II=1,IIe
+          I = IsbB + II - 1
+          j = jsb + jj - 1
+          visc_rem(II,jj,k) = visc_rem_u(I,j,k)
+        enddo ; enddo
+      endif
+
+      do jj=1,jje ; do II=1,IIe
+        I = IsbB + II - 1
+        j = jsb + jj - 1
+
+        call flux_elem(u(I,j,k), h_in(i,j,k), h_in(i+1,j,k), &
+            h_W(i,j,k), h_W(i+1,j,k), h_E(i,j,k), h_E(i+1,j,k), &
+            uh_b(II,jj,k), duhdu(II,jj,k), visc_rem(II,jj,k), G%dy_Cu(I,j), &
+            G%IareaT(i,j), G%IareaT(i+1,j), G%IdxT(i,j), G%IdxT(i+1,j), dt, &
+            CS%vol_CFL, por_face_areaU(I,j,k), CS%h_marg_min)
+
+        if (local_open_BC) &
+          call flux_elem_OBC(u(I,j,k), h_in(i,j,k), h_in(i+1,j,k), &
+              uh_b(II,jj,k), duhdu(II,jj,k), visc_rem(II,jj,k), &
+              por_face_areaU(I,j,k), G%dy_Cu(I,j), OBC, OBC%segnum_u(I,j), &
+              CS%h_marg_min)
+      enddo ; enddo
+
       if (local_specified_BC) then
-        do I=ish-1,ieh ; if (OBC%segnum_u(I,j) /= 0) then
-          l_seg = abs(OBC%segnum_u(I,j))
-          if (OBC%segment(l_seg)%specified) uh(I,j,k) = OBC%segment(l_seg)%normal_trans(I,j,k)
-        endif ; enddo
+        do jj=1,jje ; do II=1,IIe
+          I = IsbB + II - 1
+          j = jsb + jj - 1
+
+          if (OBC%segnum_u(I,j) /= 0) then
+            l_seg = abs(OBC%segnum_u(I,j))
+            if (OBC%segment(l_seg)%specified) &
+              uh_b(II,jj,k) = OBC%segment(l_seg)%normal_trans(I,j,k)
+          endif
+        enddo ; enddo
       endif
     enddo
 
     if (present(uhbt) .or. set_BT_cont) then
       if (use_visc_rem .and. CS%use_visc_rem_max) then
-        visc_rem_max(:) = 0.0
-        do k=1,nz ; do I=ish-1,ieh
-          visc_rem_max(I) = max(visc_rem_max(I), visc_rem(I,k))
+        do jj=1,jje ; do II=1,IIe
+          visc_rem_max(II,jj) = 0.0
         enddo ; enddo
+
+        do k=1,nz ; do jj=1,jje ; do II=1,IIe
+          visc_rem_max(II,jj) = max(visc_rem_max(II,jj), visc_rem(II,jj,k))
+        enddo ; enddo ; enddo
       else
-        visc_rem_max(:) = 1.0
+        do jj=1,jje ; do II=1,IIe
+          visc_rem_max(II,jj) = 1.0
+        enddo ; enddo
       endif
       !   Set limits on du that will keep the CFL number between -1 and 1.
       ! This should be adequate to keep the root bracketed in all cases.
-      do I=ish-1,ieh
+      do jj=1,jje ; do II=1,IIe
+        I = IsbB + II - 1
+        j = jsb + jj - 1
+
         I_vrm = 0.0
-        if (visc_rem_max(I) > 0.0) I_vrm = 1.0 / visc_rem_max(I)
+        if (visc_rem_max(II,jj) > 0.0) I_vrm = 1.0 / visc_rem_max(II,jj)
         if (CS%vol_CFL) then
           dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
           dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
         else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
-        du_max_CFL(I) = 2.0* (CFL_dt * dx_W) * I_vrm
-        du_min_CFL(I) = -2.0 * (CFL_dt * dx_E) * I_vrm
-        uh_tot_0(I) = 0.0 ; duhdu_tot_0(I) = 0.0
-      enddo
-      do k=1,nz ; do I=ish-1,ieh
-        duhdu_tot_0(I) = duhdu_tot_0(I) + duhdu(I,k)
-        uh_tot_0(I) = uh_tot_0(I) + uh(I,j,k)
+        du_max_CFL(II,jj) = 2.0* (CFL_dt * dx_W) * I_vrm
+        du_min_CFL(II,jj) = -2.0 * (CFL_dt * dx_E) * I_vrm
+        uh_tot_0(II,jj) = 0.0 ; duhdu_tot_0(II,jj) = 0.0
       enddo ; enddo
+
+      do k=1,nz
+        do jj=1,jje ; do II=1,IIe
+          I = IsbB + II - 1
+          j = jsb + jj - 1
+          duhdu_tot_0(II,jj) = duhdu_tot_0(II,jj) + duhdu(II,jj,k)
+          uh_tot_0(II,jj) = uh_tot_0(II,jj) + uh_b(II,jj,k)
+        enddo ; enddo
+      enddo
+
       if (use_visc_rem) then
         if (CS%aggress_adjust) then
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+          do k=1,nz
+            do jj=1,jje ; do II=1,IIe
+              I = IsbB + II - 1
+              j = jsb + jj - 1
 
-            du_lim = 0.499*((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k)))
-            if (du_max_CFL(I) * visc_rem(I,k) > du_lim) &
-              du_max_CFL(I) = du_lim / visc_rem(I,k)
+              if (CS%vol_CFL) then
+                dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+                dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+              else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
 
-            du_lim = 0.499*((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k)))
-            if (du_min_CFL(I) * visc_rem(I,k) < du_lim) &
-              du_min_CFL(I) = du_lim / visc_rem(I,k)
-          enddo ; enddo
+              du_lim = 0.499*((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k)))
+              if (du_max_CFL(II,jj) * visc_rem(II,jj,k) > du_lim) &
+                du_max_CFL(II,jj) = du_lim / visc_rem(II,jj,k)
+
+              du_lim = 0.499*((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k)))
+              if (du_min_CFL(II,jj) * visc_rem(II,jj,k) < du_lim) &
+                du_min_CFL(II,jj) = du_lim / visc_rem(II,jj,k)
+            enddo ; enddo
+          enddo
         else
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+          do k=1,nz
+            do jj=1,jje ; do II=1,IIe
+              I = IsbB + II - 1
+              j = jsb + jj - 1
 
-            if (du_max_CFL(I) * visc_rem(I,k) > dx_W*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
-              du_max_CFL(I) = (dx_W*CFL_dt - u(I,j,k)) / visc_rem(I,k)
-            if (du_min_CFL(I) * visc_rem(I,k) < -dx_E*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
-              du_min_CFL(I) = -(dx_E*CFL_dt + u(I,j,k)) / visc_rem(I,k)
-          enddo ; enddo
+              if (CS%vol_CFL) then
+                dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+                dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+              else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+
+              if (du_max_CFL(II,jj) * visc_rem(II,jj,k) > dx_W*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
+                du_max_CFL(II,jj) = (dx_W*CFL_dt - u(I,j,k)) / visc_rem(II,jj,k)
+              if (du_min_CFL(II,jj) * visc_rem(II,jj,k) < -dx_E*CFL_dt - u(I,j,k)*G%mask2dCu(I,j)) &
+                du_min_CFL(II,jj) = -(dx_E*CFL_dt + u(I,j,k)) / visc_rem(II,jj,k)
+            enddo ; enddo
+          enddo
         endif
       else
         if (CS%aggress_adjust) then
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+          do k=1,nz
+            do jj=1,jje ; do II=1,IIe
+              I = IsbB + II - 1
+              j = jsb + jj - 1
 
-            du_max_CFL(I) = MIN(du_max_CFL(I), 0.499 * &
-                        ((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k))) )
-            du_min_CFL(I) = MAX(du_min_CFL(I), 0.499 * &
-                        ((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k))) )
-          enddo ; enddo
+              if (CS%vol_CFL) then
+                dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+                dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+              else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+
+              du_max_CFL(II,jj) = MIN(du_max_CFL(II,jj), 0.499 * &
+                          ((dx_W*I_dt - u(I,j,k)) + MIN(0.0,u(I-1,j,k))) )
+              du_min_CFL(II,jj) = MAX(du_min_CFL(II,jj), 0.499 * &
+                          ((-dx_E*I_dt - u(I,j,k)) + MAX(0.0,u(I+1,j,k))) )
+            enddo ; enddo
+          enddo
         else
-          do k=1,nz ; do I=ish-1,ieh
-            if (CS%vol_CFL) then
-              dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
-              dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
-            else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+          do k=1,nz
+            do jj=1,jje ; do II=1,IIe
+              I = IsbB + II - 1
+              j = jsb + jj - 1
 
-            du_max_CFL(I) = MIN(du_max_CFL(I), dx_W*CFL_dt - u(I,j,k))
-            du_min_CFL(I) = MAX(du_min_CFL(I), -(dx_E*CFL_dt + u(I,j,k)))
-          enddo ; enddo
+              if (CS%vol_CFL) then
+                dx_W = ratio_max(G%areaT(i,j), G%dy_Cu(I,j), 1000.0*G%dxT(i,j))
+                dx_E = ratio_max(G%areaT(i+1,j), G%dy_Cu(I,j), 1000.0*G%dxT(i+1,j))
+              else ; dx_W = G%dxT(i,j) ; dx_E = G%dxT(i+1,j) ; endif
+
+              du_max_CFL(II,jj) = MIN(du_max_CFL(II,jj), dx_W*CFL_dt - u(I,j,k))
+              du_min_CFL(II,jj) = MAX(du_min_CFL(II,jj), -(dx_E*CFL_dt + u(I,j,k)))
+            enddo ; enddo
+          enddo
         endif
       endif
-      do I=ish-1,ieh
-        du_max_CFL(I) = max(du_max_CFL(I),0.0)
-        du_min_CFL(I) = min(du_min_CFL(I),0.0)
-      enddo
+      do jj=1,jje ; do II=1,IIe
+        du_max_CFL(II,jj) = max(du_max_CFL(II,jj),0.0)
+        du_min_CFL(II,jj) = min(du_min_CFL(II,jj),0.0)
+      enddo ; enddo
 
       any_simple_OBC = .false.
       if (present(uhbt) .or. set_BT_cont) then
-        if (local_specified_BC .or. local_Flather_OBC) then ; do I=ish-1,ieh
-          l_seg = abs(OBC%segnum_u(I,j))
+        if (local_specified_BC .or. local_Flather_OBC) then
+          do jj=1,jje ; do II=1,IIe
+            I = IsbB + II - 1
+            j = jsb + jj - 1
 
-          ! Avoid reconciling barotropic/baroclinic transports if transport is specified
-          simple_OBC_pt(I) = .false.
-          if (l_seg /= OBC_NONE) simple_OBC_pt(I) = OBC%segment(l_seg)%specified
-          do_I(I) = .not.simple_OBC_pt(I)
-          any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(I)
-        enddo ; else ; do I=ish-1,ieh
-          do_I(I) = .true.
-        enddo ; endif
+            l_seg = abs(OBC%segnum_u(I,j))
+
+            ! Avoid reconciling barotropic/baroclinic transports if transport is specified
+            simple_OBC_pt(II,jj) = .false.
+            if (l_seg /= OBC_NONE) simple_OBC_pt(II,jj) = OBC%segment(l_seg)%specified
+            do_ij(II,jj) = .not.simple_OBC_pt(II,jj)
+            any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(II,jj)
+          enddo ; enddo
+        else
+          do jj=1,jje ; do II=1,IIe
+            do_ij(II,jj) = .true.
+          enddo ; enddo
+        endif
       endif
 
       if (present(uhbt)) then
-        ! Find du and uh.
-        call zonal_flux_adjust(u, h_in, h_W, h_E, uhbt(:,j), uh_tot_0, duhdu_tot_0, du, &
-                               du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                               j, ish, ieh, do_I, por_face_areaU, uh, OBC=OBC)
+        do jj=1,jje ; do II=1,IIe
+          I = IsbB + II - 1
+          j = jsb + jj - 1
+          uhbt_b(II,jj) = uhbt(I,j)
+        enddo ; enddo
 
-        if (present(u_cor)) then ; do k=1,nz
-          do I=ish-1,ieh ; u_cor(I,j,k) = u(I,j,k) + du(I) * visc_rem(I,k) ; enddo
-          if (any_simple_OBC) then ; do I=ish-1,ieh ; if (simple_OBC_pt(I)) then
-            u_cor(I,j,k) = OBC%segment(abs(OBC%segnum_u(I,j)))%normal_vel(I,j,k)
-          endif ; enddo ; endif
-        enddo ; endif ! u-corrected
+        ! Find du and uh.
+        call zonal_flux_adjust(u, h_in, h_W, h_E, uhbt_b, uh_tot_0, duhdu_tot_0, du, &
+                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
+                              IsbB, IebB, jsb, jeb, do_ij, por_face_areaU, nIIB, njj, &
+                              uh_b, OBC=OBC)
+
+        if (present(u_cor)) then
+          do k=1,nz ; do jj=1,jje ; do II=1,IIe
+            I = IsbB + II - 1
+            j = jsb + jj - 1
+            u_cor(I,j,k) = u(I,j,k) + du(II,jj) * visc_rem(II,jj,k)
+          enddo ; enddo ; enddo
+
+          if (any_simple_OBC) then
+            do k=1,nz ; do jj=1,jje ; do II=1,IIe
+              if (simple_OBC_pt(II,jj)) then
+                I = IsbB + II - 1
+                j = jsb + jj - 1
+                u_cor(I,j,k) = OBC%segment(abs(OBC%segnum_u(I,j)))%normal_vel(I,j,k)
+              endif
+            enddo ; enddo ; enddo
+          endif
+        endif ! u-corrected
 
         if (present(du_cor)) then
-          do I=ish-1,ieh ; du_cor(I,j) = du(I) ; enddo
+          do jj=1,jje ; do II=1,IIe
+            I = IsbB + II - 1
+            j = jsb + jj - 1
+            du_cor(I,j) = du(II,jj)
+          enddo ; enddo
         endif
 
       endif
 
       if (set_BT_cont) then
         call set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0,&
-                               du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                               visc_rem_max, j, ish, ieh, do_I, por_face_areaU)
+                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
+                              visc_rem_max, IsbB, IebB, jsb, jeb, do_ij, &
+                              por_face_areaU, nIIB, njj)
         if (any_simple_OBC) then
-          do I=ish-1,ieh
-            if (simple_OBC_pt(I)) FAuI(I) = GV%H_subroundoff*G%dy_Cu(I,j)
+          do jj=1,jje ; do II=1,IIe
+            if (simple_OBC_pt(II,jj)) then
+              I = IsbB + II - 1
+              j = jsb + jj - 1
+              FAuI(II,jj) = GV%H_subroundoff*G%dy_Cu(I,j)
+            endif
+          enddo ; enddo
+
+          ! NOTE: simple_OBC_pt should prevent access to segment OBC_NONE
+          do k=1,nz
+            do jj=1,jje ; do II=1,IIe
+              if (simple_OBC_pt(II,jj)) then
+                I = IsbB + II - 1
+                j = jsb + jj - 1
+
+                l_seg = abs(OBC%segnum_u(I,j))
+                if ((abs(OBC%segment(l_seg)%normal_vel(I,j,k)) > 0.0) .and. &
+                    (OBC%segment(l_seg)%specified)) &
+                  FAuI(II,jj) = FAuI(II,jj) + &
+                    OBC%segment(l_seg)%normal_trans(I,j,k) / OBC%segment(l_seg)%normal_vel(I,j,k)
+              endif
+            enddo ; enddo
           enddo
-          ! NOTE: simple_OBC_pt(I) should prevent access to segment OBC_NONE
-          do k=1,nz ; do I=ish-1,ieh ; if (simple_OBC_pt(I)) then
-            l_seg = abs(OBC%segnum_u(I,j))
-            if ((abs(OBC%segment(l_seg)%normal_vel(I,j,k)) > 0.0) .and. (OBC%segment(l_seg)%specified)) &
-              FAuI(I) = FAuI(I) + OBC%segment(l_seg)%normal_trans(I,j,k) / OBC%segment(l_seg)%normal_vel(I,j,k)
-          endif ; enddo ; enddo
-          do I=ish-1,ieh ; if (simple_OBC_pt(I)) then
-            BT_cont%FA_u_W0(I,j) = FAuI(I) ; BT_cont%FA_u_E0(I,j) = FAuI(I)
-            BT_cont%FA_u_WW(I,j) = FAuI(I) ; BT_cont%FA_u_EE(I,j) = FAuI(I)
-            BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
-          endif ; enddo
+
+          do jj=1,jje ; do II=1,IIe
+            if (simple_OBC_pt(II,jj)) then
+              I = IsbB + II - 1
+              j = jsb + jj - 1
+              BT_cont%FA_u_W0(I,j) = FAuI(II,jj) ; BT_cont%FA_u_E0(I,j) = FAuI(II,jj)
+              BT_cont%FA_u_WW(I,j) = FAuI(II,jj) ; BT_cont%FA_u_EE(I,j) = FAuI(II,jj)
+              BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
+            endif
+          enddo ; enddo
         endif
       endif ! set_BT_cont
-
     endif ! present(uhbt) or set_BT_cont
 
-  enddo ! j-loop
+    do k=1,nz ; do jj=1,jje ; do II=1,IIe
+      I = IsbB + II - 1
+      j = jsb + jj - 1
+      uh(I,j,k) = uh_b(II,jj,k)
+    enddo ; enddo ; enddo
+  enddo ; enddo ! ij block loop
 
   if (local_open_BC .and. set_BT_cont) then
     do n = 1, OBC%number_of_segments
@@ -850,16 +1051,15 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
   ! Local variables
   real :: uh(SZIB_(G))      ! Volume flux through zonal faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1]
   real :: duhdu(SZIB_(G))   ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
-  logical, dimension(SZIB_(G)) :: do_I
-  real :: ones(SZIB_(G))    ! An array of 1's [nondim]
   integer :: i, j, k, ish, ieh, jsh, jeh, nz, l_seg
-  logical :: local_specified_BC, OBC_in_row
+  logical :: local_specified_BC, local_open_BC, OBC_in_row
 
   call cpu_clock_begin(id_clock_correct)
 
-  local_specified_BC = .false.
+  local_specified_BC = .false. ; local_open_BC = .false.
   if (associated(OBC)) then ; if (OBC%OBC_pe) then
     local_specified_BC = OBC%specified_u_BCs_exist_globally
+    local_open_BC = OBC%open_u_BCs_exist_globally
   endif ; endif
 
   if (present(LB_in)) then
@@ -867,8 +1067,6 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
   else
     ish = G%isc ; ieh = G%iec ; jsh = G%jsc ; jeh = G%jec ; nz = GV%ke
   endif
-
-  ones(:) = 1.0 ; do_I(:) = .true.
 
   uhbt(:,:) = 0.0
   !$OMP parallel do default(shared) private(uh,duhdu,OBC_in_row)
@@ -880,9 +1078,18 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
     endif ; enddo ; endif
     do k=1,nz
       ! This sets uh and duhdu.
-      call zonal_flux_layer(u(:,j,k), h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh, duhdu, ones, &
-                            dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k), &
-                            CS%h_marg_min, OBC)
+      do I=ish-1,ieh
+        call flux_elem(u(I,j,k), h_in(I,j,k), h_in(I+1,j,k), &
+            h_W(I,j,k), h_W(I+1,j,k), h_E(I,j,k), h_E(I+1,j,k), &
+            uh(I), duhdu(I), 1.0, G%dy_Cu(I,j), &
+            G%IareaT(I,j), G%IareaT(I+1,j), G%IdxT(I,j), G%IdxT(I+1,j), dt, &
+            CS%vol_CFL, por_face_areaU(I,j,k), CS%h_marg_min)
+
+        if (local_open_BC) &
+          call flux_elem_OBC(u(I,j,k), h_in(I,j,k), h_in(I+1,j,k), &
+              uh(I), duhdu(I), 1.0, por_face_areaU(I,j,k), G%dy_Cu(I,j), &
+              OBC, OBC%segnum_u(I,j), CS%h_marg_min)
+      enddo
       if (OBC_in_row) then ; do I=ish-1,ieh ; if (OBC%segnum_u(I,j) /= 0) then
         l_seg = abs(OBC%segnum_u(I,j))
         if (OBC%segment(l_seg)%specified) uh(I) = OBC%segment(l_seg)%normal_trans(I,j,k)
@@ -894,89 +1101,153 @@ subroutine zonal_BT_mass_flux(u, h_in, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, p
       enddo
     enddo ! k-loop
   enddo ! j-loop
+
   call cpu_clock_end(id_clock_correct)
 
 end subroutine zonal_BT_mass_flux
 
 
-!> Evaluates the zonal mass or volume fluxes in a layer.
-subroutine zonal_flux_layer(u, h, h_W, h_E, uh, duhdu, visc_rem, dt, G, US, j, &
-                            ish, ieh, do_I, vol_CFL, por_face_areaU, h_marg_min, OBC)
-  type(ocean_grid_type),        intent(in)    :: G        !< Ocean's grid structure.
-  real, dimension(SZIB_(G)),    intent(in)    :: u        !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G)),    intent(in)    :: visc_rem !< Both the fraction of the
-                        !! momentum originally in a layer that remains after a time-step
-                        !! of viscosity, and the fraction of a time-step's worth of a barotropic
-                        !! acceleration that a layer experiences after viscosity is applied [nondim].
-                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G)),     intent(in)    :: h        !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G)),     intent(in)    :: h_W      !< West edge thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G)),     intent(in)    :: h_E      !< East edge thickness [H ~> m or kg m-2].
-  real, dimension(SZIB_(G)),    intent(inout) :: uh       !< Zonal mass or volume
-                                                          !! transport [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G)),    intent(inout) :: duhdu    !< Partial derivative of uh
-                                                          !! with u [H L ~> m2 or kg m-1].
-  real,                         intent(in)    :: dt       !< Time increment [T ~> s]
-  type(unit_scale_type),        intent(in)    :: US       !< A dimensional unit scaling type
-  integer,                      intent(in)    :: j        !< Spatial index.
-  integer,                      intent(in)    :: ish      !< Start of index range.
-  integer,                      intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZIB_(G)), intent(in)    :: do_I     !< Which i values to work on.
-  logical,                      intent(in)    :: vol_CFL  !< If true, rescale the
-  real, dimension(SZIB_(G)),    intent(in)    :: por_face_areaU !< fractional open area of U-faces [nondim]
-          !! ratio of face areas to the cell areas when estimating the CFL number.
-  real,                         intent(in)    :: h_marg_min !< Negligible floor on h_marg [H ~> m or kg m-2]
-  type(ocean_OBC_type), optional, pointer     :: OBC !< Open boundaries control structure.
-  ! Local variables
-  real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
-  real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
-  real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
-  integer :: i
-  logical :: local_open_BC
+!> Evaluate the mass or volume flux through a single face of an element.
+elemental subroutine flux_elem(u, h, h_p1, h_L, h_L_p1, h_R, h_R_p1, uh, &
+    duhdu, visc_rem, G_dy_Cu, G_IareaT, G_IareaT_p1, G_IdxT, G_IdxT_p1, dt, &
+    vol_CFL, por_face_area, h_marg_min)
+  real, intent(in) :: u
+      !< Zonal or meridional velocity [L T-1 ~> m s-1]
+  real, intent(in) :: h
+      !< Layer thickness [H ~> m or kg m-2]
+  real, intent(in) :: h_p1
+      !< Layer thickness - offset by 1 [ H ~> m or kg m-2]
+  real, intent(in) :: h_L
+      !< West/South edge thickness [H ~> m or kg m-2]
+  real, intent(in) :: h_L_p1
+      !< West/South edge thickness - offset by 1 [H ~> m or kg m-2]
+  real, intent(in) :: h_R
+      !< East/North edge thickness [H ~> m or kg m-2]
+  real, intent(in) :: h_R_p1
+      !< East/North edge thickness - offset by 1 [H ~> m or kg m-2]
+  real, intent(out) :: uh
+      !< Zonal or meridional mass or volume transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, intent(out) :: duhdu
+      !< Partial derivative of uh with u [H L ~> m2 or kg m-1]
+  real, intent(in) :: visc_rem
+      !< Both the fraction of the momentum originally in a layer that remains
+      !! after a time-step of viscosity, and the fraction of a time-step's
+      !! worth of a barotropic acceleration that a layer experiences after
+      !! viscosity is applied.  Visc_rem is between 0 (at the bottom) and 1
+      !! (far above the bottom).  [nondim]
+  real, intent(in) :: G_dy_Cu
+      !< The grid cell's unblocked lengths of u/v-faces of the h-cell [L ~> m]
+  real, intent(in) :: G_IareaT
+      !< The grid cell's 1/areaT [L-2 ~> m-2]
+  real, intent(in) :: G_IareaT_p1
+      !< The grid cell's 1/areaT - offset by 1 [L-2 ~> m-2]
+  real, intent(in) :: G_IdxT
+      !< The grid cell's 1/dxT [L-1 ~> m-1]
+  real, intent(in) :: G_IdxT_p1
+      !< The grid cell's 1/dxT - offset by 1 [L-1 ~> m-1]
+  real, intent(in) :: dt
+      !< Time increment [T ~> s]
+  logical, intent(in) :: vol_CFL
+      !< If true, rescale the ratio of face areas to the cell areas when
+      !! estimating the CFL number
+  real, intent(in) :: por_face_area
+      !< fractional open area of U/V-faces [nondim]
+  real, intent(in) :: h_marg_min
+      !< Negligible floor on h_marg [H ~> m or kg m-2]
 
-  local_open_BC = .false.
-  if (present(OBC)) then ; if (associated(OBC)) then
-    local_open_BC = OBC%open_u_BCs_exist_globally
-  endif ; endif
+  real :: CFL
+      ! CFL number based on the local velocity and grid spacing [nondim]
+  real :: curv_3
+      ! Measure of thickness curvature over a grid length [H ~> m or kg m-2]
+  real :: h_marg
+      ! Marginal thickness of a flux [H ~> m or kg m-2].
+  real :: tmp
+      ! temporary variable to store precalculated values
+  real :: dh
+      ! h differential between E/W
 
-  do I=ish-1,ieh ; if (do_I(I)) then
-    ! Set new values of uh and duhdu.
-    if (u(I) > 0.0) then
-      if (vol_CFL) then ; CFL = (u(I) * dt) * (G%dy_Cu(I,j) * G%IareaT(i,j))
-      else ; CFL = u(I) * dt * G%IdxT(i,j) ; endif
-      curv_3 = (h_W(i) + h_E(i)) - 2.0*h(i)
-      uh(I) = (G%dy_Cu(I,j) * por_face_areaU(I)) * u(I) * &
-          (h_E(i) + CFL * (0.5*(h_W(i) - h_E(i)) + curv_3*(CFL - 1.5)))
-      h_marg = h_E(i) + CFL * ((h_W(i) - h_E(i)) + 3.0*curv_3*(CFL - 1.0))
-    elseif (u(I) < 0.0) then
-      if (vol_CFL) then ; CFL = (-u(I) * dt) * (G%dy_Cu(I,j) * G%IareaT(i+1,j))
-      else ; CFL = -u(I) * dt * G%IdxT(i+1,j) ; endif
-      curv_3 = (h_W(i+1) + h_E(i+1)) - 2.0*h(i+1)
-      uh(I) = (G%dy_Cu(I,j) * por_face_areaU(I)) * u(I) * &
-          (h_W(i+1) + CFL * (0.5*(h_E(i+1)-h_W(i+1)) + curv_3*(CFL - 1.5)))
-      h_marg = h_W(i+1) + CFL * ((h_E(i+1)-h_W(i+1)) + 3.0*curv_3*(CFL - 1.0))
+  ! Set new values of uh and duhdu.
+  tmp = G_dy_Cu * por_face_area ! precalculate things
+
+  if (u > 0.) then
+    if (vol_CFL) then
+      CFL = (u * dt) * (G_dy_Cu * G_IareaT)
     else
-      uh(I) = 0.0
-      h_marg = 0.5 * (h_W(i+1) + h_E(i))
+      CFL = u * dt * G_IdxT
     endif
-    h_marg = max(h_marg, h_marg_min)
-    duhdu(I) = (G%dy_Cu(I,j) * por_face_areaU(I)) * h_marg * visc_rem(I)
-  endif ; enddo
 
-  if (local_open_BC) then
-    do I=ish-1,ieh ; if (do_I(I)) then ; if (OBC%segnum_u(I,j) /= 0) then
-      if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
-        if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
-          uh(I) = (G%dy_Cu(I,j) * por_face_areaU(I)) * u(I) * h(i)
-          duhdu(I) = (G%dy_Cu(I,j) * por_face_areaU(I)) * max(h(i), h_marg_min) * visc_rem(I)
-        else !  OBC_DIRECTION_W
-          uh(I) = (G%dy_Cu(I,j) * por_face_areaU(I)) * u(I) * h(i+1)
-          duhdu(I) = (G%dy_Cu(I,j)* por_face_areaU(I)) * max(h(i+1), h_marg_min) * visc_rem(I)
-        endif
-      endif
-    endif ; endif ; enddo
+    curv_3 = (h_L + h_R) - 2. * h
+    dh = h_L - h_R
+    uh = tmp * u * (h_R + CFL * (0.5 * dh + curv_3 * (CFL - 1.5)))
+    h_marg = h_R + CFL * (dh + 3. * curv_3 * (CFL - 1.))
+  elseif (u < 0.) then
+    if (vol_CFL) then
+      CFL = (-u * dt) * (G_dy_Cu * G_IareaT_p1)
+    else
+      CFL = -u * dt * G_IdxT_p1
+    endif
+
+    curv_3 = (h_L_p1 + h_R_p1) - 2. * h_p1
+    dh = h_R_p1 - h_L_p1
+    uh = tmp * u * (h_L_p1 + CFL * (0.5 * dh + curv_3 * (CFL - 1.5)))
+    h_marg = h_L_p1 + CFL * (dh + 3. * curv_3 * (CFL - 1.))
+  else
+    uh = 0.
+    h_marg = 0.5 * (h_L_p1 + h_R)
   endif
-end subroutine zonal_flux_layer
+
+  h_marg = max(h_marg, h_marg_min)
+  duhdu = tmp * h_marg * visc_rem
+end subroutine flux_elem
+
+
+!> Overrides the zonal or meridional mass or volume flux through a single face of an element
+!! with the value set by an open boundary condition.
+elemental subroutine flux_elem_OBC(u, h, h_p1, uh, duhdu, visc_rem, &
+    por_face_area, G_dy_Cu, OBC, l_seg, h_marg_min)
+  real, intent(in) :: u
+    !< Zonal/meridional velocity [L T-1 ~> m s-1].
+  real, intent(in) :: h
+    !< Layer thickness [H ~> m or kg m-2].
+  real, intent(in) :: h_p1
+    !< Layer thickness offset by 1 [H ~> m or kg m-2].
+  real, intent(inout) :: uh
+    !< Zonal/meridional mass or volume transport [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, intent(inout) :: duhdu
+    !< Partial derivative of uh with u [H L ~> m2 or kg m-1].
+  real, intent(in) :: visc_rem
+    !< Both the fraction of the momentum originally in a layer that remains
+    !! after a time-step of viscosity, and the fraction of a time-step's worth
+    !! of a barotropic acceleration that a layer experiences after viscosity is
+    !! applied.  Visc_rem is between 0 (at the bottom) and 1 (far above the
+    !! bottom).  [nondim]
+  real, intent(in) :: por_face_area
+    !< fractional open area of U/V-faces [nondim].
+  real, intent(in) :: G_dy_Cu
+    !< The grid cell's unblocked lengths of the u/v-faces of the h-cell [L ~> m].
+    !! ratio of face areas to the cell areas when estimating the CFL number.
+  type(ocean_OBC_type), intent(in) :: OBC
+    !< Open boundaries control structure.
+  integer, intent(in) :: l_seg
+    !< Segment index.
+  real, intent(in) :: h_marg_min
+    !< Negligible floor on h [H ~> m or kg m-2]
+
+  if (l_seg /= 0) then
+    if (OBC%segment(abs(l_seg))%open) then
+      if (l_seg > 0) then
+        ! OBC_DIRECTION_E or OBC_DIRECTION_N
+        uh = (G_dy_Cu * por_face_area) * u * h
+        duhdu = (G_dy_Cu * por_face_area) * max(h, h_marg_min) * visc_rem
+      else
+        ! OBC_DIRECTION_W or OBC_DIRECTION_S
+        uh = (G_dy_Cu * por_face_area) * u * h_p1
+        duhdu = (G_dy_Cu * por_face_area) * max(h_p1, h_marg_min) * visc_rem
+      endif
+    endif
+  endif
+end subroutine flux_elem_OBC
+
 
 !> Sets the effective interface thickness associated with the fluxes at each zonal velocity point,
 !! optionally scaling back these thicknesses to account for viscosity and fractional open areas.
@@ -1015,53 +1286,49 @@ subroutine zonal_flux_thickness(u, h, h_W, h_E, h_u, dt, G, GV, US, LB, vol_CFL,
   ! Local variables
   real :: CFL  ! The CFL number based on the local velocity and grid spacing [nondim]
   real :: curv_3 ! A measure of the thickness curvature over a grid length [H ~> m or kg m-2]
-  real :: h_avg  ! The average thickness of a flux [H ~> m or kg m-2].
-  real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
   logical :: local_open_BC
   integer :: i, j, k, ish, ieh, jsh, jeh, nz, n
+  real :: dh
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
-  !$OMP parallel do default(shared) private(CFL,curv_3,h_marg,h_avg)
   do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
     if (u(I,j,k) > 0.0) then
       if (vol_CFL) then ; CFL = (u(I,j,k) * dt) * (G%dy_Cu(I,j) * G%IareaT(i,j))
       else ; CFL = u(I,j,k) * dt * G%IdxT(i,j) ; endif
       curv_3 = (h_W(i,j,k) + h_E(i,j,k)) - 2.0*h(i,j,k)
-      h_avg = h_E(i,j,k) + CFL * (0.5*(h_W(i,j,k) - h_E(i,j,k)) + curv_3*(CFL - 1.5))
-      h_marg = h_E(i,j,k) + CFL * ((h_W(i,j,k) - h_E(i,j,k)) + 3.0*curv_3*(CFL - 1.0))
+      dh = h_W(i,j,k) - h_E(i,j,k)
+      if (marginal) then
+        h_u(I,j,k) = h_E(i,j,k) + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
+      else
+        h_u(I,j,k) = h_E(i,j,k) + CFL * (0.5*dh + curv_3*(CFL - 1.5))
+      endif
     elseif (u(I,j,k) < 0.0) then
       if (vol_CFL) then ; CFL = (-u(I,j,k)*dt) * (G%dy_Cu(I,j) * G%IareaT(i+1,j))
       else ; CFL = -u(I,j,k) * dt * G%IdxT(i+1,j) ; endif
       curv_3 = (h_W(i+1,j,k) + h_E(i+1,j,k)) - 2.0*h(i+1,j,k)
-      h_avg = h_W(i+1,j,k) + CFL * (0.5*(h_E(i+1,j,k)-h_W(i+1,j,k)) + curv_3*(CFL - 1.5))
-      h_marg = h_W(i+1,j,k) + CFL * ((h_E(i+1,j,k)-h_W(i+1,j,k)) + &
-                                    3.0*curv_3*(CFL - 1.0))
+      dh = h_E(i+1,j,k)-h_W(i+1,j,k)
+      if (marginal) then
+        h_u(I,j,k) = h_W(i+1,j,k) + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
+      else
+        h_u(I,j,k) = h_W(i+1,j,k) + CFL * (0.5*dh + curv_3*(CFL - 1.5))
+      endif
     else
-      h_avg = 0.5 * (h_W(i+1,j,k) + h_E(i,j,k))
       !   The choice to use the arithmetic mean here is somewhat arbitrarily, but
       ! it should be noted that h_W(i+1,j,k) and h_E(i,j,k) are usually the same.
-      h_marg = 0.5 * (h_W(i+1,j,k) + h_E(i,j,k))
+      h_u(I,j,k) = 0.5 * (h_W(i+1,j,k) + h_E(i,j,k))
  !    h_marg = (2.0 * h_W(i+1,j,k) * h_E(i,j,k)) / &
  !             (h_W(i+1,j,k) + h_E(i,j,k) + GV%H_subroundoff)
     endif
 
-    if (marginal) then ; h_u(I,j,k) = h_marg
-    else ; h_u(I,j,k) = h_avg ; endif
-  enddo ; enddo ; enddo
-  if (present(visc_rem_u)) then
-    ! Scale back the thickness to account for the effects of viscosity and the fractional open
-    ! thickness to give an appropriate non-normalized weight for each layer in determining the
-    ! barotropic acceleration.
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+    if (present(visc_rem_u)) then
+      ! Scale back the thickness to account for the effects of viscosity and the fractional open
+      ! thickness to give an appropriate non-normalized weight for each layer in determining the
+      ! barotropic acceleration.
       h_u(I,j,k) = h_u(I,j,k) * (visc_rem_u(I,j,k) * por_face_areaU(I,j,k))
-    enddo ; enddo ; enddo
-  else
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do j=jsh,jeh ; do I=ish-1,ieh
+    else
       h_u(I,j,k) = h_u(I,j,k) * por_face_areaU(I,j,k)
-    enddo ; enddo ; enddo
-  endif
+    endif
+  enddo ; enddo ; enddo
 
   local_open_BC = .false.
   if (associated(OBC)) local_open_BC = OBC%open_u_BCs_exist_globally
@@ -1070,86 +1337,91 @@ subroutine zonal_flux_thickness(u, h, h_W, h_E, h_u, dt, G, GV, US, LB, vol_CFL,
       if (OBC%segment(n)%open .and. OBC%segment(n)%is_E_or_W) then
         I = OBC%segment(n)%HI%IsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-          if (present(visc_rem_u)) then ; do k=1,nz
-            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+          if (present(visc_rem_u)) then
+            do k=1,nz ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
               h_u(I,j,k) = h(i,j,k) * (visc_rem_u(I,j,k) * por_face_areaU(I,j,k))
-            enddo
-          enddo ; else ; do k=1,nz
-            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+            enddo ; enddo
+          else
+            do k=1,nz ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
               h_u(I,j,k) = h(i,j,k) * por_face_areaU(I,j,k)
-            enddo
-          enddo ; endif
+            enddo ; enddo
+          endif
         else
-          if (present(visc_rem_u)) then ; do k=1,nz
-            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+          if (present(visc_rem_u)) then
+            do k=1,nz ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
               h_u(I,j,k) = h(i+1,j,k) * (visc_rem_u(I,j,k) * por_face_areaU(I,j,k))
-            enddo
-          enddo ; else ; do k=1,nz
-            do j = OBC%segment(n)%HI%jsd, OBC%segment(n)%HI%jed
+            enddo ; enddo
+          else
+            do k=1,nz ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
               h_u(I,j,k) = h(i+1,j,k) * por_face_areaU(I,j,k)
-            enddo
-          enddo ; endif
+            enddo ; enddo
+          endif
         endif
       endif
     enddo
   endif
-
 end subroutine zonal_flux_thickness
 
 !> Returns the barotropic velocity adjustment that gives the
 !! desired barotropic (layer-summed) transport.
 subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
                              du, du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             j, ish, ieh, do_I_in, por_face_areaU, uh_3d, OBC)
-
+                             IsbB, IebB, jsb, jeb, do_ij_in, por_face_areaU, nIIB, njj, &
+                             uh_3d, OBC)
+  integer,                                    intent(in) :: nIIB !< I block size for array calculations.
+  integer,                                    intent(in) :: njj !< j block size for array calculations.
   type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)   :: u    !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u  !< Zonal velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to
                                                                    !! calculate fluxes [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_W  !< West edge thickness in the
                                                                    !! reconstruction [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_E  !< East edge thickness in the
                                                                    !! reconstruction [H ~> m or kg m-2].
-  real, dimension(SZIB_(G),SZK_(GV)),        intent(in)    :: visc_rem !< Both the fraction of the
+  real, dimension(nIIB,njj,SZK_(GV)),intent(in) :: visc_rem !< Both the fraction of the
                        !! momentum originally in a layer that remains after a time-step of viscosity, and
                        !! the fraction of a time-step's worth of a barotropic acceleration that a layer
                        !! experiences after viscosity is applied [nondim].
                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZIB_(G)),                 intent(in)    :: uhbt !< The summed volume flux
+  real, dimension(nIIB,njj),   intent(in)    :: uhbt !< The summed volume flux
                        !! through zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
 
-  real, dimension(SZIB_(G)),                 intent(in)    :: du_max_CFL  !< Maximum acceptable
+  real, dimension(nIIB,njj),   intent(in)    :: du_max_CFL  !< Maximum acceptable
                        !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: du_min_CFL  !< Minimum acceptable
+  real, dimension(nIIB,njj),   intent(in)    :: du_min_CFL  !< Minimum acceptable
                        !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: uh_tot_0    !< The summed transport
+  real, dimension(nIIB,njj),   intent(in)    :: uh_tot_0    !< The summed transport
                        !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: duhdu_tot_0 !< The partial derivative
+  real, dimension(nIIB,njj),   intent(in)    :: duhdu_tot_0 !< The partial derivative
                        !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G)),                 intent(out)   :: du !<
+  real, dimension(nIIB,njj),   intent(out)   :: du !<
                        !! The barotropic velocity adjustment [L T-1 ~> m s-1].
   real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
   type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
   type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  integer,                                   intent(in)    :: j    !< Spatial index.
-  integer,                                   intent(in)    :: ish  !< Start of index range.
-  integer,                                   intent(in)    :: ieh  !< End of index range.
-  logical, dimension(SZIB_(G)),              intent(in)    :: do_I_in     !<
-                       !! A logical flag indicating which I values to work on.
+  integer,                                   intent(in)    :: IsbB !< Start of I index range.
+  integer,                                   intent(in)    :: IebB !< End of I index range.
+  integer,                                   intent(in)    :: jsb  !< Start of j index range.
+  integer,                                   intent(in)    :: jeb  !< End of j index range.
+  logical, dimension(nIIB,njj), intent(in) :: do_ij_in
+    !< A logical flag indicating which block points to work on.
   real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
                                       intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), optional, intent(inout) :: uh_3d !<
+  real, dimension(nIIB,njj,SZK_(GV)), intent(inout), optional :: uh_3d !<
                        !! Volume flux through zonal faces = u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
   type(ocean_OBC_type),            optional, pointer       :: OBC !< Open boundaries control structure.
   ! Local variables
-  real, dimension(SZIB_(G),SZK_(GV)) :: &
-    uh_aux, &  ! An auxiliary zonal volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+  ! The block-sized work arrays below are dimensioned (nIIB,njj).  In this zonal routine
+  ! their first (nIIB) block index is staggered at the zonal velocity (u, C-grid I) points,
+  ! while the second (njj) block index is at the tracer-row (j) points.
+  real :: &
+    u_new, &   ! The velocity with the correction added [L T-1 ~> m s-1].
+    uh, &      ! The volume flux through a zonal face [H L2 T-1 ~> m3 s-1 or kg s-1].
     duhdu      ! Partial derivative of uh with u [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G)) :: &
+  real, dimension(nIIB,njj) :: &
     uh_err, &  ! Difference between uhbt and the summed uh [H L2 T-1 ~> m3 s-1 or kg s-1].
     uh_err_best, & ! The smallest value of uh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
-    u_new, &   ! The velocity with the correction added [L T-1 ~> m s-1].
     duhdu_tot,&! Summed partial derivative of uh with u [H L ~> m2 or kg m-1].
     du_min, &  ! Lower limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
     du_max     ! Upper limit on du correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
@@ -1157,23 +1429,27 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
   real :: ddu     ! The change in du from the previous iteration [L T-1 ~> m s-1].
   real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
   real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
-  integer :: i, k, nz, itt, max_itts = 20
-  logical :: domore, do_I(SZIB_(G))
+  integer :: i, j, k, nz, itt, II, jj, IIe, jje
+  logical :: domore, do_ij(nIIB,njj)
+  logical :: local_open_BC ! True if there are open OBC points on this PE [nondim].
+  integer, parameter :: max_itts = 20
 
   nz = GV%ke
+  IIe = IebB - IsbB + 1
+  jje = jeb - jsb + 1
+  local_open_BC = .false.
+  if (present(OBC)) then ; if (associated(OBC)) local_open_BC = OBC%open_u_BCs_exist_globally ; endif
 
-  uh_aux(:,:) = 0.0 ; duhdu(:,:) = 0.0
+  tol_vel = CS%tol_vel
 
-  if (present(uh_3d)) then ; do k=1,nz ; do I=ish-1,ieh
-    uh_aux(i,k) = uh_3d(I,j,k)
-  enddo ; enddo ; endif
-
-  do I=ish-1,ieh
-    du(I) = 0.0 ; do_I(I) = do_I_in(I)
-    du_max(I) = du_max_CFL(I) ; du_min(I) = du_min_CFL(I)
-    uh_err(I) = uh_tot_0(I) - uhbt(I) ; duhdu_tot(I) = duhdu_tot_0(I)
-    uh_err_best(I) = abs(uh_err(I))
-  enddo
+  do jj=1,jje ; do II=1,IIe
+    I = IsbB + II - 1
+    j = jsb + jj - 1
+    du(II,jj) = 0.0 ; do_ij(II,jj) = do_ij_in(II,jj)
+    du_max(II,jj) = du_max_CFL(II,jj) ; du_min(II,jj) = du_min_CFL(II,jj)
+    uh_err(II,jj) = uh_tot_0(II,jj) - uhbt(II,jj) ; duhdu_tot(II,jj) = duhdu_tot_0(II,jj)
+    uh_err_best(II,jj) = abs(uh_err(II,jj))
+  enddo ; enddo
 
   do itt=1,max_itts
     select case (itt)
@@ -1182,82 +1458,104 @@ subroutine zonal_flux_adjust(u, h_in, h_W, h_E, uhbt, uh_tot_0, duhdu_tot_0, &
       case (3)  ; tol_eta = 1e-2 * CS%tol_eta
       case default ; tol_eta = CS%tol_eta
     end select
-    tol_vel = CS%tol_vel
 
-    do I=ish-1,ieh
-      if (uh_err(I) > 0.0) then ; du_max(I) = du(I)
-      elseif (uh_err(I) < 0.0) then ; du_min(I) = du(I)
-      else ; do_I(I) = .false. ; endif
-    enddo
+    do jj=1,jje ; do II=1,IIe
+      if (uh_err(II,jj) > 0.0) then ; du_max(II,jj) = du(II,jj)
+      elseif (uh_err(II,jj) < 0.0) then ; du_min(II,jj) = du(II,jj)
+      else ; do_ij(II,jj) = .false. ; endif
+    enddo ; enddo
+
     domore = .false.
-    do I=ish-1,ieh ; if (do_I(I)) then
-      if ((dt * min(G%IareaT(i,j),G%IareaT(i+1,j))*abs(uh_err(I)) > tol_eta) .or. &
-          (CS%better_iter .and. ((abs(uh_err(I)) > tol_vel * duhdu_tot(I)) .or. &
-                                 (abs(uh_err(I)) > uh_err_best(I))) )) then
-      !   Use Newton's method, provided it stays bounded.  Otherwise bisect
-      ! the value with the appropriate bound.
-        ddu = -uh_err(I) / duhdu_tot(I)
-        du_prev = du(I)
-        du(I) = du(I) + ddu
-        if (abs(ddu) < 1.0e-15*abs(du(I))) then
-          do_I(I) = .false. ! ddu is small enough to quit.
-        elseif (ddu > 0.0) then
-          if (du(I) >= du_max(I)) then
-            du(I) = 0.5*(du_prev + du_max(I))
-            if (du_max(I) - du_prev < 1.0e-15*abs(du(I))) do_I(I) = .false.
+    do jj=1,jje ; do II=1,IIe
+      I = IsbB + II - 1
+      j = jsb + jj - 1
+
+      if (do_ij(II,jj)) then
+        if ((dt * min(G%IareaT(i,j),G%IareaT(i+1,j))*abs(uh_err(II,jj)) > tol_eta) .or. &
+            (CS%better_iter .and. ((abs(uh_err(II,jj)) > tol_vel * duhdu_tot(II,jj)) .or. &
+                                   (abs(uh_err(II,jj)) > uh_err_best(II,jj))) )) then
+        !   Use Newton's method, provided it stays bounded.  Otherwise bisect
+        ! the value with the appropriate bound.
+          ddu = -uh_err(II,jj) / duhdu_tot(II,jj)
+          du_prev = du(II,jj)
+          du(II,jj) = du(II,jj) + ddu
+          if (abs(ddu) < 1.0e-15*abs(du(II,jj))) then
+            do_ij(II,jj) = .false. ! ddu is small enough to quit.
+          elseif (ddu > 0.0) then
+            if (du(II,jj) >= du_max(II,jj)) then
+              du(II,jj) = 0.5*(du_prev + du_max(II,jj))
+              if (du_max(II,jj) - du_prev < 1.0e-15*abs(du(II,jj))) do_ij(II,jj) = .false.
+            endif
+          else ! ddu < 0.0
+            if (du(II,jj) <= du_min(II,jj)) then
+              du(II,jj) = 0.5*(du_prev + du_min(II,jj))
+              if (du_prev - du_min(II,jj) < 1.0e-15*abs(du(II,jj))) do_ij(II,jj) = .false.
+            endif
           endif
-        else ! ddu < 0.0
-          if (du(I) <= du_min(I)) then
-            du(I) = 0.5*(du_prev + du_min(I))
-            if (du_prev - du_min(I) < 1.0e-15*abs(du(I))) do_I(I) = .false.
-          endif
+          if (do_ij(II,jj)) domore = .true.
+        else
+          do_ij(II,jj) = .false.
         endif
-        if (do_I(I)) domore = .true.
-      else
-        do_I(I) = .false.
       endif
-    endif ; enddo
+    enddo ; enddo
+
     if (.not.domore) exit
 
-    if ((itt < max_itts) .or. present(uh_3d)) then ; do k=1,nz
-      do I=ish-1,ieh ; u_new(I) = u(I,j,k) + du(I) * visc_rem(I,k) ; enddo
-      call zonal_flux_layer(u_new, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), &
-                            uh_aux(:,k), duhdu(:,k), visc_rem(:,k), &
-                            dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, por_face_areaU(:,j,k), &
-                            CS%h_marg_min, OBC)
-    enddo ; endif
+    do jj=1,jje ; do II=1,IIe
+      I = IsbB + II - 1
+      j = jsb + jj - 1
+      uh_err(II,jj) = -uhbt(II,jj) ; duhdu_tot(II,jj) = 0.0
+    enddo ; enddo
 
-    if (itt < max_itts) then
-      do I=ish-1,ieh
-        uh_err(I) = -uhbt(I) ; duhdu_tot(I) = 0.0
-      enddo
-      do k=1,nz ; do I=ish-1,ieh
-        uh_err(I) = uh_err(I) + uh_aux(I,k)
-        duhdu_tot(I) = duhdu_tot(I) + duhdu(I,k)
-      enddo ; enddo
-      do I=ish-1,ieh
-        uh_err_best(I) = min(uh_err_best(I), abs(uh_err(I)))
-      enddo
-    endif
+    do k=1,nz
+      do jj=1,jje ; do II=1,IIe ; if (do_ij(II,jj)) then
+        I = IsbB + II - 1
+        j = jsb + jj - 1
+
+        u_new = u(I,j,k) + du(II,jj) * visc_rem(II,jj,k)
+
+        call flux_elem(u_new, h_in(i,j,k), h_in(i+1,j,k), &
+            h_W(i,j,k), h_W(i+1,j,k), h_E(i,j,k), h_E(i+1,j,k), &
+            uh, duhdu, visc_rem(II,jj,k), G%dy_Cu(I,j), &
+            G%IareaT(i,j), G%IareaT(i+1,j), G%IdxT(i,j), G%IdxT(i+1,j), &
+            dt, CS%vol_CFL, por_face_areaU(I,j,k), CS%h_marg_min)
+
+        if (local_open_BC) &
+          call flux_elem_OBC(u_new, h_in(i,j,k), h_in(i+1,j,k), &
+              uh, duhdu, visc_rem(II,jj,k), &
+              por_face_areaU(I,j,k), G%dy_Cu(I,j), OBC, OBC%segnum_u(I,j), &
+              CS%h_marg_min)
+
+        if (present(uh_3d)) uh_3d(II,jj,k) = uh
+        uh_err(II,jj) = uh_err(II,jj) + uh
+        duhdu_tot(II,jj) = duhdu_tot(II,jj) + duhdu
+      endif ; enddo ; enddo
+    enddo
+
+    do jj=1,jje ; do II=1,IIe
+      I = IsbB + II - 1
+      j = jsb + jj - 1
+      uh_err_best(II,jj) = min(uh_err_best(II,jj), abs(uh_err(II,jj)))
+    enddo ; enddo
   enddo ! itt-loop
   ! If there are any faces which have not converged to within the tolerance,
   ! so-be-it, or else use a final upwind correction?
   ! This never seems to happen with 20 iterations as max_itt.
 
-  if (present(uh_3d)) then ; do k=1,nz ; do I=ish-1,ieh
-    uh_3d(I,j,k) = uh_aux(I,k)
-  enddo ; enddo ; endif
-
 end subroutine zonal_flux_adjust
+
 
 !> Sets a structure that describes the zonal barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
 subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, &
                              du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             visc_rem_max, j, ish, ieh, do_I, por_face_areaU)
+                             visc_rem_max, IsbB, IebB, jsb, jeb, do_ij, &
+                             por_face_areaU, nIIB, njj)
+  integer,                                   intent(in)    :: nIIB !< I block size for array calculations.
+  integer,                                   intent(in)    :: njj !< j block size for array calculations.
   type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: u    !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in) :: u  !< Zonal velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to
                                                                    !! calculate fluxes [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_W  !< West edge thickness in the
@@ -1266,48 +1564,55 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, 
                                                                    !! reconstruction [H ~> m or kg m-2].
   type(BT_cont_type),                        intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZIB_(G)),                 intent(in)    :: uh_tot_0    !< The summed transport
+  real, dimension(nIIB,njj),   intent(in)    :: uh_tot_0    !< The summed transport
                        !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: duhdu_tot_0 !< The partial derivative
+  real, dimension(nIIB,njj),   intent(in)    :: duhdu_tot_0 !< The partial derivative
                        !! of du_err with du at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: du_max_CFL  !< Maximum acceptable
+  real, dimension(nIIB,njj),   intent(in)    :: du_max_CFL  !< Maximum acceptable
                        !! value of du [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G)),                 intent(in)    :: du_min_CFL  !< Minimum acceptable
+  real, dimension(nIIB,njj),   intent(in)    :: du_min_CFL  !< Minimum acceptable
                        !! value of du [L T-1 ~> m s-1].
   real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
   type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
   type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  real, dimension(SZIB_(G),SZK_(GV)),        intent(in)    :: visc_rem !< Both the fraction of the
+  real, dimension(nIIB,njj,SZK_(GV)),intent(in) :: visc_rem !< Both the fraction of the
                        !! momentum originally in a layer that remains after a time-step of viscosity, and
                        !! the fraction of a time-step's worth of a barotropic acceleration that a layer
                        !! experiences after viscosity is applied [nondim].
                        !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZIB_(G)),                 intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim].
-  integer,                                   intent(in)    :: j        !< Spatial index.
-  integer,                                   intent(in)    :: ish      !< Start of index range.
-  integer,                                   intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZIB_(G)),              intent(in)    :: do_I     !< A logical flag indicating
-                       !! which I values to work on.
+  real, dimension(nIIB,njj),   intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim].
+  integer,                                   intent(in)    :: IsbB !< Start of I index range.
+  integer,                                   intent(in)    :: IebB !< End of I index range.
+  integer,                                   intent(in)    :: jsb  !< Start of j index range.
+  integer,                                   intent(in)    :: jeb  !< End of j index range.
+  logical, dimension(nIIB,njj), intent(in) :: do_ij
+    !< A logical flag indicating which block points to work on.
   real, dimension(SZIB_(G), SZJ_(G), SZK_(G)), &
                                     intent(in) :: por_face_areaU !< fractional open area of U-faces [nondim]
   ! Local variables
-  real, dimension(SZIB_(G)) :: &
-    du0, &        ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
+  ! The block-sized work arrays below are dimensioned (nIIB,njj[,nz]).  In this zonal
+  ! routine their first (nIIB) block index is staggered at the zonal velocity (u, C-grid I)
+  ! points, while the second (njj) block index is at the tracer-row (j) points.
+  real, dimension(nIIB,njj) :: &
+    du0           ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
+  real, dimension(nIIB,njj) :: &
+    zeros         ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(nIIB,njj) :: &
     duL, duR, &   ! The barotropic velocity increments that give the westerly
                   ! (duL) and easterly (duR) test velocities [L T-1 ~> m s-1].
-    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
     du_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
+    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
+    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
+    uhtot_L, &    ! The summed transport with the westerly (uhtot_L) and
+    uhtot_R       ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real :: &
     u_L, u_R, &   ! The westerly (u_L), easterly (u_R), and zero-barotropic
     u_0, &        ! transport (u_0) layer test velocities [L T-1 ~> m s-1].
     duhdu_L, &    ! The effective layer marginal face areas with the westerly
     duhdu_R, &    ! (_L), easterly (_R), and zero-barotropic (_0) test
     duhdu_0, &    ! velocities [H L ~> m2 or kg m-1].
     uh_L, uh_R, & ! The layer transports with the westerly (_L), easterly (_R),
-    uh_0, &       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
-    FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
-    FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
-    uhtot_L, &    ! The summed transport with the westerly (uhtot_L) and
-    uhtot_R       ! and easterly (uhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+    uh_0       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
   real :: FA_0    ! The effective face area with 0 barotropic transport [L H ~> m2 or kg m-1].
   real :: FA_avg  ! The average effective face area [L H ~> m2 or kg m-1], nominally given by
                   ! the realized transport divided by the barotropic velocity.
@@ -1321,108 +1626,156 @@ subroutine set_zonal_BT_cont(u, h_in, h_W, h_E, BT_cont, uh_tot_0, duhdu_tot_0, 
   real :: CFL_min ! A minimal increment in the CFL to try to ensure that the
                   ! flow is truly upwind [nondim]
   real :: Idt     ! The inverse of the time step [T-1 ~> s-1].
-  logical :: domore
-  integer :: i, k, nz
+  integer :: i, j, k, nz, II, jj, IIe, jje !< Tile loop indices.
 
   nz = GV%ke ; Idt = 1.0 / dt
+  IIe = IebB - IsbB + 1 ; jje = jeb - jsb + 1
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
  ! Diagnose the zero-transport correction, du0.
-  do I=ish-1,ieh ; zeros(I) = 0.0 ; enddo
+  do jj=1,jje ; do II=1,IIe
+    zeros(II,jj) = 0.0
+  enddo ; enddo
   call zonal_flux_adjust(u, h_in, h_W, h_E, zeros, uh_tot_0, duhdu_tot_0, du0, &
                          du_max_CFL, du_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                         j, ish, ieh, do_I, por_face_areaU)
+                         IsbB, IebB, jsb, jeb, do_ij, por_face_areaU, &
+                         nIIB, njj)
 
   ! Determine the westerly- and easterly- fluxes.  Choose a sufficiently
   ! negative velocity correction for the easterly-flux, and a sufficiently
   ! positive correction for the westerly-flux.
-  domore = .false.
-  do I=ish-1,ieh
-    if (do_I(I)) domore = .true.
-    du_CFL(I) = (CFL_min * Idt) * G%dxCu(I,j)
-    duR(I) = min(0.0,du0(I) - du_CFL(I))
-    duL(I) = max(0.0,du0(I) + du_CFL(I))
-    FAmt_L(I) = 0.0 ; FAmt_R(I) = 0.0 ; FAmt_0(I) = 0.0
-    uhtot_L(I) = 0.0 ; uhtot_R(I) = 0.0
-  enddo
-
-  if (.not.domore) then
-    do k=1,nz ; do I=ish-1,ieh
-      BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
-      BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
-      BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
-    enddo ; enddo
-    return
-  endif
-
-  do k=1,nz ; do I=ish-1,ieh ; if (do_I(I)) then
-    visc_rem_lim = max(visc_rem(I,k), min_visc_rem*visc_rem_max(I))
-    if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
-      if (u(I,j,k) + duR(I)*visc_rem_lim > -du_CFL(I)*visc_rem(I,k)) &
-        duR(I) = -(u(I,j,k) + du_CFL(I)*visc_rem(I,k)) / visc_rem_lim
-      if (u(I,j,k) + duL(I)*visc_rem_lim < du_CFL(I)*visc_rem(I,k)) &
-        duL(I) = -(u(I,j,k) - du_CFL(I)*visc_rem(I,k)) / visc_rem_lim
-    endif
-  endif ; enddo ; enddo
+  do jj=1,jje ; do II=1,IIe
+    I = IsbB + II - 1
+    j = jsb + jj - 1
+    du_CFL(II,jj) = (CFL_min * Idt) * G%dxCu(I,j)
+    duR(II,jj) = min(0.0,du0(II,jj) - du_CFL(II,jj))
+    duL(II,jj) = max(0.0,du0(II,jj) + du_CFL(II,jj))
+    FAmt_L(II,jj) = 0.0 ; FAmt_R(II,jj) = 0.0 ; FAmt_0(II,jj) = 0.0
+    uhtot_L(II,jj) = 0.0 ; uhtot_R(II,jj) = 0.0
+  enddo ; enddo
 
   do k=1,nz
-    do I=ish-1,ieh ; if (do_I(I)) then
-      u_L(I) = u(I,j,k) + duL(I) * visc_rem(I,k)
-      u_R(I) = u(I,j,k) + duR(I) * visc_rem(I,k)
-      u_0(I) = u(I,j,k) + du0(I) * visc_rem(I,k)
-    endif ; enddo
-    call zonal_flux_layer(u_0, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_0, duhdu_0, &
-                          visc_rem(:,k), dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, &
-                          por_face_areaU(:,j,k), CS%h_marg_min)
-    call zonal_flux_layer(u_L, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_L, duhdu_L, &
-                          visc_rem(:,k), dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, &
-                          por_face_areaU(:,j,k), CS%h_marg_min)
-    call zonal_flux_layer(u_R, h_in(:,j,k), h_W(:,j,k), h_E(:,j,k), uh_R, duhdu_R, &
-                          visc_rem(:,k), dt, G, US, j, ish, ieh, do_I, CS%vol_CFL, &
-                          por_face_areaU(:,j,k), CS%h_marg_min)
-    do I=ish-1,ieh ; if (do_I(I)) then
-      FAmt_0(I) = FAmt_0(I) + duhdu_0(I)
-      FAmt_L(I) = FAmt_L(I) + duhdu_L(I)
-      FAmt_R(I) = FAmt_R(I) + duhdu_R(I)
-      uhtot_L(I) = uhtot_L(I) + uh_L(I)
-      uhtot_R(I) = uhtot_R(I) + uh_R(I)
-    endif ; enddo
+    do jj=1,jje ; do II=1,IIe
+      I = IsbB + II - 1
+      j = jsb + jj - 1
+
+      if (do_ij(II,jj)) then
+        visc_rem_lim = max(visc_rem(II,jj,k), min_visc_rem*visc_rem_max(II,jj))
+        if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
+          if (u(I,j,k) + duR(II,jj)*visc_rem_lim > -du_CFL(II,jj)*visc_rem(II,jj,k)) &
+            duR(II,jj) = -(u(I,j,k) + du_CFL(II,jj)*visc_rem(II,jj,k)) / visc_rem_lim
+          if (u(I,j,k) + duL(II,jj)*visc_rem_lim < du_CFL(II,jj)*visc_rem(II,jj,k)) &
+            duL(II,jj) = -(u(I,j,k) - du_CFL(II,jj)*visc_rem(II,jj,k)) / visc_rem_lim
+        endif
+      endif
+    enddo ; enddo
   enddo
-  do I=ish-1,ieh ; if (do_I(I)) then
-    FA_0 = FAmt_0(I) ; FA_avg = FAmt_0(I)
-    if ((duL(I) - du0(I)) /= 0.0) &
-      FA_avg = uhtot_L(I) / (duL(I) - du0(I))
-    if (FA_avg > max(FA_0, FAmt_L(I))) then ; FA_avg = max(FA_0, FAmt_L(I))
-    elseif (FA_avg < min(FA_0, FAmt_L(I))) then ; FA_0 = FA_avg ; endif
 
-    BT_cont%FA_u_W0(I,j) = FA_0 ; BT_cont%FA_u_WW(I,j) = FAmt_L(I)
-    if (abs(FA_0-FAmt_L(I)) <= 1e-12*FA_0) then ; BT_cont%uBT_WW(I,j) = 0.0 ; else
-      BT_cont%uBT_WW(I,j) = (1.5 * (duL(I) - du0(I))) * &
-                            ((FAmt_L(I) - FA_avg) / (FAmt_L(I) - FA_0))
+  do k=1,nz
+    do jj=1,jje ; do II=1,IIe
+      I = IsbB + II - 1
+      j = jsb + jj - 1
+
+      if (do_ij(II,jj)) then
+        u_L = u(I,j,k) + duL(II,jj) * visc_rem(II,jj,k)
+        u_R = u(I,j,k) + duR(II,jj) * visc_rem(II,jj,k)
+        u_0 = u(I,j,k) + du0(II,jj) * visc_rem(II,jj,k)
+
+        call flux_elem(u_0, h_in(i,j,k), h_in(i+1,j,k), &
+            h_W(i,j,k), h_W(i+1,j,k), h_E(i,j,k), h_E(i+1,j,k), &
+            uh_0, duhdu_0, visc_rem(II,jj,k), G%dy_Cu(I,j), &
+            G%IareaT(i,j), G%IareaT(i+1,j), &
+            G%IdxT(i,j), G%IdxT(i+1,j), dt, CS%vol_CFL, &
+            por_face_areaU(I,j,k), CS%h_marg_min)
+
+        call flux_elem(u_L, h_in(i,j,k), h_in(i+1,j,k), &
+            h_W(i,j,k), h_W(i+1,j,k), h_E(i,j,k), h_E(i+1,j,k), &
+            uh_L, duhdu_L, visc_rem(II,jj,k), G%dy_Cu(I,j), &
+            G%IareaT(i,j), G%IareaT(i+1,j), &
+            G%IdxT(i,j), G%IdxT(i+1,j), dt, CS%vol_CFL, &
+            por_face_areaU(I,j,k), CS%h_marg_min)
+
+        call flux_elem(u_R, h_in(i,j,k), h_in(i+1,j,k), &
+            h_W(i,j,k), h_W(i+1,j,k), h_E(i,j,k), h_E(i+1,j,k), &
+            uh_R, duhdu_R, visc_rem(II,jj,k), G%dy_Cu(I,j), &
+            G%IareaT(i,j), G%IareaT(i+1,j), G%IdxT(i,j), G%IdxT(i+1,j), dt, &
+            CS%vol_CFL, por_face_areaU(I,j,k), CS%h_marg_min)
+
+        ! XXX: Bracket duhdu to suppress FMA optimization after inlining.
+        FAmt_0(II,jj) = FAmt_0(II,jj) + (duhdu_0)
+        FAmt_L(II,jj) = FAmt_L(II,jj) + (duhdu_L)
+        FAmt_R(II,jj) = FAmt_R(II,jj) + (duhdu_R)
+        uhtot_L(II,jj) = uhtot_L(II,jj) + uh_L
+        uhtot_R(II,jj) = uhtot_R(II,jj) + uh_R
+      endif
+    enddo ; enddo
+  enddo
+
+  do jj=1,jje ; do II=1,IIe
+    I = IsbB + II - 1
+    j = jsb + jj - 1
+
+    if (do_ij(II,jj)) then
+      FA_0 = FAmt_0(II,jj)
+      FA_avg = FAmt_0(II,jj)
+
+      if (duL(II,jj) - du0(II,jj) /= 0.) &
+        FA_avg = uhtot_L(II,jj) / (duL(II,jj) - du0(II,jj))
+
+      if (FA_avg > max(FA_0, FAmt_L(II,jj))) then
+        FA_avg = max(FA_0, FAmt_L(II,jj))
+      elseif (FA_avg < min(FA_0, FAmt_L(II,jj))) then
+        FA_0 = FA_avg
+      endif
+
+      BT_cont%FA_u_W0(I,j) = FA_0
+      BT_cont%FA_u_WW(I,j) = FAmt_L(II,jj)
+
+      if (abs(FA_0-FAmt_L(II,jj)) <= 1e-12 * FA_0) then
+        BT_cont%uBT_WW(I,j) = 0.
+      else
+        BT_cont%uBT_WW(I,j) = (1.5 * (duL(II,jj) - du0(II,jj))) &
+            * ((FAmt_L(II,jj) - FA_avg) / (FAmt_L(II,jj) - FA_0))
+      endif
+
+      FA_0 = FAmt_0(II,jj)
+      FA_avg = FAmt_0(II,jj)
+
+      if (duR(II,jj) - du0(II,jj) /= 0.) &
+        FA_avg = uhtot_R(II,jj) / (duR(II,jj) - du0(II,jj))
+
+      if (FA_avg > max(FA_0, FAmt_R(II,jj))) then
+        FA_avg = max(FA_0, FAmt_R(II,jj))
+      elseif (FA_avg < min(FA_0, FAmt_R(II,jj))) then
+        FA_0 = FA_avg
+      endif
+
+      BT_cont%FA_u_E0(I,j) = FA_0 ; BT_cont%FA_u_EE(I,j) = FAmt_R(II,jj)
+
+      if (abs(FAmt_R(II,jj) - FA_0) <= 1e-12 * FA_0) then
+        BT_cont%uBT_EE(I,j) = 0.
+      else
+        BT_cont%uBT_EE(I,j) = (1.5 * (duR(II,jj) - du0(II,jj))) &
+            * ((FAmt_R(II,jj) - FA_avg) / (FAmt_R(II,jj) - FA_0))
+      endif
+    else
+      BT_cont%FA_u_W0(I,j) = 0.
+      BT_cont%FA_u_WW(I,j) = 0.
+      BT_cont%FA_u_E0(I,j) = 0.
+      BT_cont%FA_u_EE(I,j) = 0.
+      BT_cont%uBT_WW(I,j) = 0.
+      BT_cont%uBT_EE(I,j) = 0.
     endif
-
-    FA_0 = FAmt_0(I) ; FA_avg = FAmt_0(I)
-    if ((duR(I) - du0(I)) /= 0.0) &
-      FA_avg = uhtot_R(I) / (duR(I) - du0(I))
-    if (FA_avg > max(FA_0, FAmt_R(I))) then ; FA_avg = max(FA_0, FAmt_R(I))
-    elseif (FA_avg < min(FA_0, FAmt_R(I))) then ; FA_0 = FA_avg ; endif
-
-    BT_cont%FA_u_E0(I,j) = FA_0 ; BT_cont%FA_u_EE(I,j) = FAmt_R(I)
-    if (abs(FAmt_R(I) - FA_0) <= 1e-12*FA_0) then ; BT_cont%uBT_EE(I,j) = 0.0 ; else
-      BT_cont%uBT_EE(I,j) = (1.5 * (duR(I) - du0(I))) * &
-                            ((FAmt_R(I) - FA_avg) / (FAmt_R(I) - FA_0))
-    endif
-  else
-    BT_cont%FA_u_W0(I,j) = 0.0 ; BT_cont%FA_u_WW(I,j) = 0.0
-    BT_cont%FA_u_E0(I,j) = 0.0 ; BT_cont%FA_u_EE(I,j) = 0.0
-    BT_cont%uBT_WW(I,j) = 0.0 ; BT_cont%uBT_EE(I,j) = 0.0
-  endif ; enddo
-
+  enddo ; enddo
 end subroutine set_zonal_BT_cont
+
 
 !> Calculates the mass or volume fluxes through the meridional faces, and other related quantities.
 subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, por_face_areaV, &
-                                LB_in, vhbt, visc_rem_v, v_cor, BT_cont, dv_cor)
+                                nii, nJJB, LB_in, vhbt, &
+                                visc_rem_v, v_cor, BT_cont, dv_cor)
+  integer,                                    intent(in)  :: nii !< i block size for array calculations.
+  integer,                                    intent(in)  :: nJJB !< J block size for array calculations.
   type(ocean_grid_type),                      intent(in)  :: G    !< Ocean's grid structure.
   type(verticalGrid_type),                    intent(in)  :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)  :: v    !< Meridional velocity [L T-1 ~> m s-1]
@@ -1462,19 +1815,27 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
                                                                   !! transports [L T-1 ~> m s-1].
 
   ! Local variables
-  real, dimension(SZI_(G),SZK_(GV)) :: &
-    dvhdv         ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)) :: &
+  ! The block-sized work arrays below are dimensioned (nii,nJJB[,nz]).  In this meridional
+  ! routine their first (nii) block index is at the tracer-column (i) points, while the second
+  ! (nJJB) block index is staggered at the meridional velocity (v, C-grid J) points.
+  real, dimension(nii,nJJB) :: &
+    vhbt_b
+  real, dimension(nii,nJJB,SZK_(GV)) :: &
+    vh_b
+  real, dimension(nii,nJJB,SZK_(GV)) :: &
+    dvhdv         ! Partial derivative of vh with v, at v points [H L ~> m2 or kg m-1].
+  real, dimension(nii,nJJB) :: &
     dv, &         ! Corrective barotropic change in the velocity to give vhbt [L T-1 ~> m s-1].
     dv_min_CFL, & ! Lower limit on dv correction to avoid CFL violations [L T-1 ~> m s-1]
     dv_max_CFL, & ! Upper limit on dv correction to avoid CFL violations [L T-1 ~> m s-1]
     dvhdv_tot_0, & ! Summed partial derivative of vh with v [H L ~> m2 or kg m-1].
     vh_tot_0, &   ! Summed transport with no barotropic correction [H L2 T-1 ~> m3 s-1 or kg s-1].
     visc_rem_max  ! The column maximum of visc_rem [nondim]
-  logical, dimension(SZI_(G)) :: do_I
-  real, dimension(SZI_(G)) :: FAvi  ! A list of sums of meridional face areas [H L ~> m2 or kg m-1].
+  logical, dimension(nii,nJJB) :: do_ij
+  real, dimension(nii,nJJB) :: FAvi  ! A list of sums of meridional face areas
+                                                   ! [H L ~> m2 or kg m-1].
   real :: FA_v    ! A sum of meridional face areas [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G),SZK_(GV)) :: &
+  real, dimension(nii,nJJB,SZK_(GV)) :: &
     visc_rem      ! A 2-D copy of visc_rem_v or an array of 1's [nondim]
   real :: I_vrm   ! 1.0 / visc_rem_max [nondim]
   real :: CFL_dt  ! The maximum CFL ratio of the adjusted velocities divided by
@@ -1486,9 +1847,12 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
   integer :: l_seg ! The OBC segment number
   logical :: use_visc_rem, set_BT_cont
-  logical :: local_specified_BC, local_Flather_OBC, local_open_BC, any_simple_OBC  ! OBC-related logicals
-  logical :: simple_OBC_pt(SZI_(G))  ! Indicates points in a row with specified transport OBCs
+  logical :: local_specified_BC, local_Flather_OBC ! OBC-related logicals
+  logical :: local_open_BC, any_simple_OBC          ! OBC-related logicals
+  logical :: simple_OBC_pt(nii,nJJB) ! Indicates points with specified transport OBCs
   type(OBC_segment_type), pointer :: segment => NULL()
+  integer :: isb, ieb, JsbB, JebB, ii, JJ, iie, JJe
+  integer :: nteams
 
   call cpu_clock_begin(id_clock_correct)
 
@@ -1503,7 +1867,11 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
     local_open_BC = OBC%open_v_BCs_exist_globally
   endif ; endif
 
-  if (present(dv_cor)) dv_cor(:,:) = 0.0
+  if (present(dv_cor)) then
+    do J=G%jsdB,G%jedB ; do i=G%isd,G%ied
+      dv_cor(i,J) = 0.0
+    enddo ; enddo
+  endif
 
   if (present(LB_in)) then
     LB = LB_in
@@ -1516,171 +1884,293 @@ subroutine meridional_mass_flux(v, h_in, h_S, h_N, vh, dt, G, GV, US, CS, OBC, p
   I_dt = 1.0 / dt
   if (CS%aggress_adjust) CFL_dt = I_dt
 
-  if (.not.use_visc_rem) visc_rem(:,:) = 1.0
-  !$OMP parallel do default(shared) private(do_I,dvhdv,dv,dv_max_CFL,dv_min_CFL,vh_tot_0, &
-  !$OMP                                     dvhdv_tot_0,FAvi,visc_rem_max,I_vrm,dv_lim,dy_N,dy_S, &
-  !$OMP                                     simple_OBC_pt,any_simple_OBC,l_seg) &
-  !$OMP                        firstprivate(visc_rem)
-  do J=jsh-1,jeh
-    do i=ish,ieh ; do_I(i) = .true. ; enddo
+  if (.not.use_visc_rem) then
+    do k=1,nz ; do JJ=1,nJJB ; do ii=1,nii
+      visc_rem(ii,JJ,k) = 1.0
+    enddo ; enddo ; enddo
+  endif
+
+  do JsbB = jsh-1,jeh,nJJB ; do isb = ish,ieh,nii
+    JebB = min(JsbB + nJJB - 1, jeh)
+    ieb = min(isb + nii - 1, ieh)
+    JJe = JebB - JsbB + 1
+    iie = ieb - isb + 1
+
+    do JJ=1,JJe ; do ii=1,iie
+      do_ij(ii,JJ) = .true.
+    enddo ; enddo
+
     ! This sets vh and dvhdv.
     do k=1,nz
-      if (use_visc_rem) then ; do i=ish,ieh
-        visc_rem(i,k) = visc_rem_v(i,J,k)
-      enddo ; endif
-      call merid_flux_layer(v(:,J,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), &
-                            vh(:,J,k), dvhdv(:,k), visc_rem(:,k), &
-                            dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k), &
-                            CS%h_marg_min, OBC)
+      if (use_visc_rem) then
+        do JJ=1,JJe ; do ii=1,iie
+          i = isb + ii - 1
+          J = JsbB + JJ - 1
+          visc_rem(ii,JJ,k) = visc_rem_v(i,J,k)
+        enddo ; enddo
+      endif
+
+      do JJ=1,JJe ; do ii=1,iie
+        i = isb + ii - 1
+        J = JsbB + JJ - 1
+
+        call flux_elem(v(i,J,k), h_in(i,J,k), h_in(i,J+1,k), &
+            h_S(i,J,k), h_S(i,J+1,k), h_N(i,J,k), h_N(i,J+1,k), &
+            vh_b(ii,JJ,k), dvhdv(ii,JJ,k), visc_rem(ii,JJ,k), G%dx_Cv(i,J), &
+            G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, &
+            CS%vol_CFL, por_face_areaV(i,J,k), CS%h_marg_min)
+
+        if (local_open_BC) &
+          call flux_elem_OBC(v(i,J,k), h_in(i,J,k), h_in(i,J+1,k), &
+              vh_b(ii,JJ,k), dvhdv(ii,JJ,k), visc_rem(ii,JJ,k), &
+              por_face_areaV(i,J,k), G%dx_Cv(i,J), OBC, OBC%segnum_v(i,J), &
+              CS%h_marg_min)
+      enddo ; enddo
+
       if (local_specified_BC) then
-        do i=ish,ieh ; if (OBC%segnum_v(i,J) /= 0) then
-          l_seg = abs(OBC%segnum_v(i,J))
-          if (OBC%segment(l_seg)%specified) vh(i,J,k) = OBC%segment(l_seg)%normal_trans(i,J,k)
-        endif ; enddo
+        do JJ=1,JJe ; do ii=1,iie
+          i = isb + ii - 1
+          J = JsbB + JJ - 1
+
+          if (OBC%segnum_v(i,J) /= 0) then
+            l_seg = abs(OBC%segnum_v(i,J))
+            if (OBC%segment(l_seg)%specified) &
+              vh_b(ii,JJ,k) = OBC%segment(l_seg)%normal_trans(i,J,k)
+          endif
+        enddo ; enddo
       endif
     enddo ! k-loop
 
     if (present(vhbt) .or. set_BT_cont) then
       if (use_visc_rem .and. CS%use_visc_rem_max) then
-        visc_rem_max(:) = 0.0
-        do k=1,nz ; do i=ish,ieh
-          visc_rem_max(i) = max(visc_rem_max(i), visc_rem(i,k))
+        do JJ=1,JJe ; do ii=1,iie
+          visc_rem_max(ii,JJ) = 0.0
         enddo ; enddo
+
+        do k=1,nz ; do JJ=1,JJe ; do ii=1,iie
+          visc_rem_max(ii,JJ) = max(visc_rem_max(ii,JJ), visc_rem(ii,JJ,k))
+        enddo ; enddo ; enddo
       else
-        visc_rem_max(:) = 1.0
+        do JJ=1,JJe ; do ii=1,iie
+          visc_rem_max(ii,JJ) = 1.0
+        enddo ; enddo
       endif
+
       !   Set limits on dv that will keep the CFL number between -1 and 1.
       ! This should be adequate to keep the root bracketed in all cases.
-      do i=ish,ieh
+      do JJ=1,JJe ; do ii=1,iie
+        i = isb + ii - 1
+        J = JsbB + JJ - 1
+
         I_vrm = 0.0
-        if (visc_rem_max(i) > 0.0) I_vrm = 1.0 / visc_rem_max(i)
+        if (visc_rem_max(ii,JJ) > 0.0) I_vrm = 1.0 / visc_rem_max(ii,JJ)
         if (CS%vol_CFL) then
           dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(i,J), 1000.0*G%dyT(i,j))
           dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(i,J), 1000.0*G%dyT(i,j+1))
         else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
-        dv_max_CFL(i) = 2.0 * (CFL_dt * dy_S) * I_vrm
-        dv_min_CFL(i) = -2.0 * (CFL_dt * dy_N) * I_vrm
-        vh_tot_0(i) = 0.0 ; dvhdv_tot_0(i) = 0.0
-      enddo
-      do k=1,nz ; do i=ish,ieh
-        dvhdv_tot_0(i) = dvhdv_tot_0(i) + dvhdv(i,k)
-        vh_tot_0(i) = vh_tot_0(i) + vh(i,J,k)
+        dv_max_CFL(ii,JJ) = 2.0 * (CFL_dt * dy_S) * I_vrm
+        dv_min_CFL(ii,JJ) = -2.0 * (CFL_dt * dy_N) * I_vrm
+        vh_tot_0(ii,JJ) = 0.0 ; dvhdv_tot_0(ii,JJ) = 0.0
+      enddo ; enddo
+
+      do k=1,nz
+        do JJ=1,JJe ; do ii=1,iie
+          i = isb + ii - 1
+          J = JsbB + JJ - 1
+          dvhdv_tot_0(ii,JJ) = dvhdv_tot_0(ii,JJ) + dvhdv(ii,JJ,k)
+          vh_tot_0(ii,JJ) = vh_tot_0(ii,JJ) + vh_b(ii,JJ,k)
+        enddo
       enddo ; enddo
 
       if (use_visc_rem) then
         if (CS%aggress_adjust) then
-          do k=1,nz ; do i=ish,ieh
-            if (CS%vol_CFL) then
-              dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(I,j), 1000.0*G%dyT(i,j))
-              dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(I,j), 1000.0*G%dyT(i,j+1))
-            else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
-            dv_lim = 0.499*((dy_S*I_dt - v(i,J,k)) + MIN(0.0,v(i,J-1,k)))
-            if (dv_max_CFL(i) * visc_rem(i,k) > dv_lim) &
-              dv_max_CFL(i) = dv_lim / visc_rem(i,k)
+          do k=1,nz
+            do JJ=1,JJe ; do ii=1,iie
+              i = isb + ii - 1
+              J = JsbB + JJ - 1
 
-            dv_lim = 0.499*((-dy_N*CFL_dt - v(i,J,k)) + MAX(0.0,v(i,J+1,k)))
-            if (dv_min_CFL(i) * visc_rem(i,k) < dv_lim) &
-              dv_min_CFL(i) = dv_lim / visc_rem(i,k)
+              if (CS%vol_CFL) then
+                dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(i,J), 1000.0*G%dyT(i,j))
+                dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(i,J), 1000.0*G%dyT(i,j+1))
+              else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
+              dv_lim = 0.499*((dy_S*I_dt - v(i,J,k)) + MIN(0.0,v(i,J-1,k)))
+              if (dv_max_CFL(ii,JJ) * visc_rem(ii,JJ,k) > dv_lim) &
+                dv_max_CFL(ii,JJ) = dv_lim / visc_rem(ii,JJ,k)
+
+              dv_lim = 0.499*((-dy_N*CFL_dt - v(i,J,k)) + MAX(0.0,v(i,J+1,k)))
+              if (dv_min_CFL(ii,JJ) * visc_rem(ii,JJ,k) < dv_lim) &
+                dv_min_CFL(ii,JJ) = dv_lim / visc_rem(ii,JJ,k)
+            enddo
           enddo ; enddo
         else
-          do k=1,nz ; do i=ish,ieh
-            if (CS%vol_CFL) then
-              dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(I,j), 1000.0*G%dyT(i,j))
-              dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(I,j), 1000.0*G%dyT(i,j+1))
-            else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
-            if (dv_max_CFL(i) * visc_rem(i,k) > dy_S*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
-              dv_max_CFL(i) = (dy_S*CFL_dt - v(i,J,k)) / visc_rem(i,k)
-            if (dv_min_CFL(i) * visc_rem(i,k) < -dy_N*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
-              dv_min_CFL(i) = -(dy_N*CFL_dt + v(i,J,k)) / visc_rem(i,k)
-          enddo ; enddo
+          do k=1,nz
+            do JJ=1,JJe ; do ii=1,iie
+              i = isb + ii - 1
+              J = JsbB + JJ - 1
+
+              if (CS%vol_CFL) then
+                dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(i,J), 1000.0*G%dyT(i,j))
+                dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(i,J), 1000.0*G%dyT(i,j+1))
+              else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
+              if (dv_max_CFL(ii,JJ) * visc_rem(ii,JJ,k) > &
+                  dy_S*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
+                dv_max_CFL(ii,JJ) = (dy_S*CFL_dt - v(i,J,k)) / visc_rem(ii,JJ,k)
+              if (dv_min_CFL(ii,JJ) * visc_rem(ii,JJ,k) < &
+                  -dy_N*CFL_dt - v(i,J,k)*G%mask2dCv(i,J)) &
+                dv_min_CFL(ii,JJ) = -(dy_N*CFL_dt + v(i,J,k)) / visc_rem(ii,JJ,k)
+            enddo ; enddo
+          enddo
         endif
       else
         if (CS%aggress_adjust) then
-          do k=1,nz ; do i=ish,ieh
-            if (CS%vol_CFL) then
-              dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(I,j), 1000.0*G%dyT(i,j))
-              dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(I,j), 1000.0*G%dyT(i,j+1))
-            else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
-            dv_max_CFL(i) = min(dv_max_CFL(i), 0.499 * &
-                        ((dy_S*I_dt - v(i,J,k)) + MIN(0.0,v(i,J-1,k))) )
-            dv_min_CFL(i) = max(dv_min_CFL(i), 0.499 * &
-                        ((-dy_N*I_dt - v(i,J,k)) + MAX(0.0,v(i,J+1,k))) )
-          enddo ; enddo
+          do k=1,nz
+            do JJ=1,JJe ; do ii=1,iie
+              i = isb + ii - 1
+              J = JsbB + JJ - 1
+
+              if (CS%vol_CFL) then
+                dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(i,J), 1000.0*G%dyT(i,j))
+                dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(i,J), 1000.0*G%dyT(i,j+1))
+              else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
+              dv_max_CFL(ii,JJ) = min(dv_max_CFL(ii,JJ), 0.499 * &
+                          ((dy_S*I_dt - v(i,J,k)) + MIN(0.0,v(i,J-1,k))) )
+              dv_min_CFL(ii,JJ) = max(dv_min_CFL(ii,JJ), 0.499 * &
+                          ((-dy_N*I_dt - v(i,J,k)) + MAX(0.0,v(i,J+1,k))) )
+            enddo ; enddo
+          enddo
         else
-          do k=1,nz ; do i=ish,ieh
-            if (CS%vol_CFL) then
-              dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(I,j), 1000.0*G%dyT(i,j))
-              dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(I,j), 1000.0*G%dyT(i,j+1))
-            else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
-            dv_max_CFL(i) = min(dv_max_CFL(i), dy_S*CFL_dt - v(i,J,k))
-            dv_min_CFL(i) = max(dv_min_CFL(i), -(dy_N*CFL_dt + v(i,J,k)))
-          enddo ; enddo
+          do k=1,nz
+            do JJ=1,JJe ; do ii=1,iie
+              i = isb + ii - 1
+              J = JsbB + JJ - 1
+
+              if (CS%vol_CFL) then
+                dy_S = ratio_max(G%areaT(i,j), G%dx_Cv(i,J), 1000.0*G%dyT(i,j))
+                dy_N = ratio_max(G%areaT(i,j+1), G%dx_Cv(i,J), 1000.0*G%dyT(i,j+1))
+              else ; dy_S = G%dyT(i,j) ; dy_N = G%dyT(i,j+1) ; endif
+              dv_max_CFL(ii,JJ) = min(dv_max_CFL(ii,JJ), dy_S*CFL_dt - v(i,J,k))
+              dv_min_CFL(ii,JJ) = max(dv_min_CFL(ii,JJ), -(dy_N*CFL_dt + v(i,J,k)))
+            enddo ; enddo
+          enddo
         endif
       endif
-      do i=ish,ieh
-        dv_max_CFL(i) = max(dv_max_CFL(i),0.0)
-        dv_min_CFL(i) = min(dv_min_CFL(i),0.0)
-      enddo
+      do JJ=1,JJe ; do ii=1,iie
+        dv_max_CFL(ii,JJ) = max(dv_max_CFL(ii,JJ),0.0)
+        dv_min_CFL(ii,JJ) = min(dv_min_CFL(ii,JJ),0.0)
+      enddo ; enddo
 
       any_simple_OBC = .false.
       if (present(vhbt) .or. set_BT_cont) then
-        if (local_specified_BC .or. local_Flather_OBC) then ; do i=ish,ieh
-          l_seg = abs(OBC%segnum_v(i,J))
+        if (local_specified_BC .or. local_Flather_OBC) then
+          do JJ=1,JJe ; do ii=1,iie
+            i = isb + ii - 1
+            J = JsbB + JJ - 1
 
-          ! Avoid reconciling barotropic/baroclinic transports if transport is specified
-          simple_OBC_pt(i) = .false.
-          if (l_seg /= 0) simple_OBC_pt(i) = OBC%segment(l_seg)%specified
-          do_I(i) = .not.simple_OBC_pt(i)
-          any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(i)
-        enddo ; else ; do i=ish,ieh
-          do_I(i) = .true.
-        enddo ; endif
+            l_seg = abs(OBC%segnum_v(i,J))
+
+            ! Avoid reconciling barotropic/baroclinic transports if transport is specified
+            simple_OBC_pt(ii,JJ) = .false.
+            if (l_seg /= 0) simple_OBC_pt(ii,JJ) = OBC%segment(l_seg)%specified
+            do_ij(ii,JJ) = .not.simple_OBC_pt(ii,JJ)
+            any_simple_OBC = any_simple_OBC .or. simple_OBC_pt(ii,JJ)
+          enddo ; enddo
+        else
+          do JJ=1,JJe ; do ii=1,iie
+            do_ij(ii,JJ) = .true.
+          enddo ; enddo
+        endif
       endif
 
       if (present(vhbt)) then
+        do JJ=1,JJe ; do ii=1,iie
+          i = isb + ii - 1
+          J = JsbB + JJ - 1
+          vhbt_b(ii,JJ) = vhbt(i,J)
+        enddo ; enddo
         ! Find dv and vh.
-        call meridional_flux_adjust(v, h_in, h_S, h_N, vhbt(:,J), vh_tot_0, dvhdv_tot_0, dv, &
-                               dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                               j, ish, ieh, do_I, por_face_areaV, vh, OBC=OBC)
+        call meridional_flux_adjust(v, h_in, h_S, h_N, vhbt_b, vh_tot_0, dvhdv_tot_0, dv, &
+                                    dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
+                                    isb, ieb, JsbB, JebB, do_ij, por_face_areaV, &
+                                    nii, nJJB, vh_b, OBC)
 
-        if (present(v_cor)) then ; do k=1,nz
-          do i=ish,ieh ; v_cor(i,J,k) = v(i,J,k) + dv(i) * visc_rem(i,k) ; enddo
-          if (any_simple_OBC) then ; do i=ish,ieh ; if (simple_OBC_pt(i)) then
-            v_cor(i,J,k) = OBC%segment(abs(OBC%segnum_v(i,J)))%normal_vel(i,J,k)
-          endif ; enddo ; endif
-        enddo ; endif ! v-corrected
+        if (present(v_cor)) then
+          do k=1,nz ; do JJ=1,JJe ; do ii=1,iie
+            i = isb + ii - 1
+            J = JsbB + JJ - 1
+            v_cor(i,J,k) = v(i,J,k) + dv(ii,JJ) * visc_rem(ii,JJ,k)
+          enddo ; enddo ; enddo
 
-        if (present(dv_cor)) then
-          do i=ish,ieh ; dv_cor(i,J) = dv(i) ; enddo
+          if (any_simple_OBC) then
+            do k=1,nz ; do JJ=1,JJe ; do ii=1,iie
+              if (simple_OBC_pt(ii,JJ)) then
+                i = isb + ii - 1
+                J = JsbB + JJ - 1
+                v_cor(i,J,k) = OBC%segment(abs(OBC%segnum_v(i,J)))%normal_vel(i,J,k)
+              endif
+            enddo ; enddo ; enddo
+          endif
         endif
 
+        if (present(dv_cor)) then
+          do JJ=1,JJe ; do ii=1,iie
+            i = isb + ii - 1
+            J = JsbB + JJ - 1
+            dv_cor(i,J) = dv(ii,JJ)
+          enddo ; enddo
+        endif
       endif
 
       if (set_BT_cont) then
-        call set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0,&
+        call set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
                                dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                               visc_rem_max, J, ish, ieh, do_I, por_face_areaV)
+                               visc_rem_max, isb, ieb, JsbB, JebB, do_ij, &
+                               por_face_areaV, nii, nJJB)
         if (any_simple_OBC) then
-          do i=ish,ieh
-            if (simple_OBC_pt(i)) FAvi(i) = GV%H_subroundoff*G%dx_Cv(i,J)
+          do JJ=1,JJe ; do ii=1,iie
+            if (simple_OBC_pt(ii,JJ)) then
+              i = isb + ii - 1
+              J = JsbB + JJ - 1
+              FAvi(ii,JJ) = GV%H_subroundoff*G%dx_Cv(i,J)
+            endif
+          enddo ; enddo
+
+          ! NOTE: simple_OBC_pt should prevent access to segment OBC_NONE
+          do k=1,nz
+            do JJ=1,JJe ; do ii=1,iie
+              if (simple_OBC_pt(ii,JJ)) then
+                i = isb + ii - 1
+                J = JsbB + JJ - 1
+
+                l_seg = abs(OBC%segnum_v(i,J))
+                if ((abs(OBC%segment(l_seg)%normal_vel(i,J,k)) > 0.0) .and. &
+                    (OBC%segment(l_seg)%specified)) &
+                  FAvi(ii,JJ) = FAvi(ii,JJ) + &
+                    OBC%segment(l_seg)%normal_trans(i,J,k) / OBC%segment(l_seg)%normal_vel(i,J,k)
+              endif
+            enddo ; enddo
           enddo
-          ! NOTE: simple_OBC_pt(i) should prevent access to segment OBC_NONE
-          do k=1,nz ; do i=ish,ieh ; if (simple_OBC_pt(i)) then
-            segment => OBC%segment(abs(OBC%segnum_v(i,J)))
-            if ((abs(segment%normal_vel(i,J,k)) > 0.0) .and. (segment%specified)) &
-              FAvi(i) = FAvi(i) + segment%normal_trans(i,J,k) / segment%normal_vel(i,J,k)
-          endif ; enddo ; enddo
-          do i=ish,ieh ; if (simple_OBC_pt(i)) then
-            BT_cont%FA_v_S0(i,J) = FAvi(i) ; BT_cont%FA_v_N0(i,J) = FAvi(i)
-            BT_cont%FA_v_SS(i,J) = FAvi(i) ; BT_cont%FA_v_NN(i,J) = FAvi(i)
-            BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
-          endif ; enddo
+
+          do JJ=1,JJe ; do ii=1,iie
+            if (simple_OBC_pt(ii,JJ)) then
+              i = isb + ii - 1
+              J = JsbB + JJ - 1
+              BT_cont%FA_v_S0(i,J) = FAvi(ii,JJ) ; BT_cont%FA_v_N0(i,J) = FAvi(ii,JJ)
+              BT_cont%FA_v_SS(i,J) = FAvi(ii,JJ) ; BT_cont%FA_v_NN(i,J) = FAvi(ii,JJ)
+              BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
+            endif
+          enddo ; enddo
         endif
       endif ! set_BT_cont
 
     endif ! present(vhbt) or set_BT_cont
 
-  enddo ! j-loop
+    do k=1,nz ; do JJ=1,JJe ; do ii=1,iie
+      i = isb + ii - 1
+      J = JsbB + JJ - 1
+      vh(i,J,k) = vh_b(ii,JJ,k)
+    enddo ; enddo ; enddo
+
+  enddo ; enddo ! ij block loops
 
   if (local_open_BC .and. set_BT_cont) then
     do n = 1, OBC%number_of_segments
@@ -1737,7 +2227,7 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
                                                                   !! faces [H L2 T-1 ~> m3 s-1 or kg s-1].
   real,                                       intent(in)  :: dt   !< Time increment [T ~> s].
   type(unit_scale_type),                      intent(in)  :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                    intent(in)  :: CS   !< This module's control structure.G
+  type(continuity_PPM_CS),                    intent(in)  :: CS   !< This module's control structure.
   type(ocean_OBC_type),                       pointer     :: OBC  !< Open boundary condition type
                                                                   !! specifies whether, where, and what
                                                                   !! open boundary conditions are used.
@@ -1747,16 +2237,15 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
   ! Local variables
   real :: vh(SZI_(G))      ! Volume flux through meridional faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1]
   real ::  dvhdv(SZI_(G))  ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-  logical, dimension(SZI_(G)) :: do_I
-  real :: ones(SZI_(G))    ! An array of 1's [nondim]
   integer :: i, j, k, ish, ieh, jsh, jeh, nz, l_seg
-  logical :: local_specified_BC, OBC_in_row
+  logical :: local_specified_BC, local_open_BC, OBC_in_row
 
   call cpu_clock_begin(id_clock_correct)
 
-  local_specified_BC = .false.
+  local_specified_BC = .false. ; local_open_BC = .false.
   if (associated(OBC)) then ; if (OBC%OBC_pe) then
     local_specified_BC = OBC%specified_v_BCs_exist_globally
+    local_open_BC = OBC%open_v_BCs_exist_globally
   endif ; endif
 
   if (present(LB_in)) then
@@ -1764,8 +2253,6 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
   else
     ish = G%isc ; ieh = G%iec ; jsh = G%jsc ; jeh = G%jec ; nz = GV%ke
   endif
-
-  ones(:) = 1.0 ; do_I(:) = .true.
 
   vhbt(:,:) = 0.0
   !$OMP parallel do default(shared) private(vh,dvhdv,OBC_in_row)
@@ -1777,9 +2264,18 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
     endif ; enddo ; endif
     do k=1,nz
       ! This sets vh and dvhdv.
-      call merid_flux_layer(v(:,J,k), h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh, dvhdv, ones, &
-                            dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k), &
-                            CS%h_marg_min, OBC)
+      do i=ish,ieh
+        call flux_elem(v(i,J,k), h_in(i,J,k), h_in(i,J+1,k), &
+            h_S(i,J,k), h_S(i,J+1,k), h_N(i,J,k), h_N(i,J+1,k), &
+            vh(i), dvhdv(i), 1.0, G%dx_Cv(i,J), &
+            G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, &
+            CS%vol_CFL, por_face_areaV(i,J,k), CS%h_marg_min)
+
+        if (local_open_BC) &
+          call flux_elem_OBC(v(i,J,k), h_in(i,J,k), h_in(i,J+1,k), vh(i), &
+              dvhdv(i), 1.0, por_face_areaV(i,J,k), G%dx_Cv(i,J), OBC, &
+              OBC%segnum_v(i,J), CS%h_marg_min)
+      enddo
       if (OBC_in_row) then ; do i=ish,ieh ; if (OBC%segnum_v(i,J) /= 0) then
         l_seg = abs(OBC%segnum_v(i,J))
         if (OBC%segment(l_seg)%specified) vh(i) = OBC%segment(l_seg)%normal_trans(i,J,k)
@@ -1796,93 +2292,6 @@ subroutine meridional_BT_mass_flux(v, h_in, h_S, h_N, vhbt, dt, G, GV, US, CS, O
 
 end subroutine meridional_BT_mass_flux
 
-
-!> Evaluates the meridional mass or volume fluxes in a layer.
-subroutine merid_flux_layer(v, h, h_S, h_N, vh, dvhdv, visc_rem, dt, G, US, J, &
-                            ish, ieh, do_I, vol_CFL, por_face_areaV, h_marg_min, OBC)
-  type(ocean_grid_type),        intent(in)    :: G        !< Ocean's grid structure.
-  real, dimension(SZI_(G)),     intent(in)    :: v        !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)),     intent(in)    :: visc_rem !< Both the fraction of the
-         !! momentum originally in a layer that remains after a time-step
-         !! of viscosity, and the fraction of a time-step's worth of a barotropic
-         !! acceleration that a layer experiences after viscosity is applied [nondim].
-         !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in) :: h      !< Layer thickness used to calculate fluxes,
-                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in) :: h_S    !< South edge thickness in the reconstruction
-                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in) :: h_N    !< North edge thickness in the reconstruction
-                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G)),     intent(inout) :: vh       !< Meridional mass or volume transport
-                                                          !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)),     intent(inout) :: dvhdv    !< Partial derivative of vh with v
-                                                          !! [H L ~> m2 or kg m-1].
-  real,                         intent(in)    :: dt       !< Time increment [T ~> s].
-  type(unit_scale_type),        intent(in)    :: US       !< A dimensional unit scaling type
-  integer,                      intent(in)    :: j        !< Spatial index.
-  integer,                      intent(in)    :: ish      !< Start of index range.
-  integer,                      intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZI_(G)),  intent(in)    :: do_I     !< Which i values to work on.
-  logical,                      intent(in)    :: vol_CFL  !< If true, rescale the
-         !! ratio of face areas to the cell areas when estimating the CFL number.
-  real, dimension(SZI_(G),SZJB_(G)), &
-                             intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
-  real,                         intent(in)    :: h_marg_min !< Negligible floor on h_marg [H ~> m or kg m-2]
-  type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
-  ! Local variables
-  real :: CFL ! The CFL number based on the local velocity and grid spacing [nondim]
-  real :: curv_3 ! A measure of the thickness curvature over a grid length,
-                 ! with the same units as h, i.e. [H ~> m or kg m-2].
-  real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
-  integer :: i
-  logical :: local_open_BC
-
-  local_open_BC = .false.
-  if (present(OBC)) then ; if (associated(OBC)) then
-    local_open_BC = OBC%open_v_BCs_exist_globally
-  endif ; endif
-
-  do i=ish,ieh ; if (do_I(i)) then
-    if (v(i) > 0.0) then
-      if (vol_CFL) then ; CFL = (v(i) * dt) * (G%dx_Cv(i,J) * G%IareaT(i,j))
-      else ; CFL = v(i) * dt * G%IdyT(i,j) ; endif
-      curv_3 = (h_S(i,j) + h_N(i,j)) - 2.0*h(i,j)
-      vh(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * v(i) * ( h_N(i,j) + CFL * &
-          (0.5*(h_S(i,j) - h_N(i,j)) + curv_3*(CFL - 1.5)) )
-      h_marg = h_N(i,j) + CFL * ((h_S(i,j) - h_N(i,j)) + &
-                                  3.0*curv_3*(CFL - 1.0))
-    elseif (v(i) < 0.0) then
-      if (vol_CFL) then ; CFL = (-v(i) * dt) * (G%dx_Cv(i,J) * G%IareaT(i,j+1))
-      else ; CFL = -v(i) * dt * G%IdyT(i,j+1) ; endif
-      curv_3 = (h_S(i,j+1) + h_N(i,j+1)) - 2.0*h(i,j+1)
-      vh(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * v(i) * ( h_S(i,j+1) + CFL * &
-          (0.5*(h_N(i,j+1)-h_S(i,j+1)) + curv_3*(CFL - 1.5)) )
-      h_marg = h_S(i,j+1) + CFL * ((h_N(i,j+1)-h_S(i,j+1)) + &
-                                    3.0*curv_3*(CFL - 1.0))
-    else
-      vh(i) = 0.0
-      h_marg = 0.5 * (h_S(i,j+1) + h_N(i,j))
-    endif
-    h_marg = max(h_marg, h_marg_min)
-    dvhdv(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * h_marg * visc_rem(i)
-  endif ; enddo
-
-  if (local_open_BC) then
-    do i=ish,ieh ; if (do_I(i)) then
-      if (OBC%segnum_v(i,J) /= 0) then
-        if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
-          if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
-            vh(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * v(i) * h(i,j)
-            dvhdv(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * max(h(i,j), h_marg_min) * visc_rem(i)
-          else
-            vh(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * v(i) * h(i,j+1)
-            dvhdv(i) = (G%dx_Cv(i,J)*por_face_areaV(i,J)) * max(h(i,j+1), h_marg_min) * visc_rem(i)
-          endif
-        endif
-      endif
-    endif ; enddo
-  endif
-end subroutine merid_flux_layer
 
 !> Sets the effective interface thickness associated with the fluxes at each meridional velocity point,
 !! optionally scaling back these thicknesses to account for viscosity and fractional open areas.
@@ -1925,78 +2334,75 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
   real :: h_marg ! The marginal thickness of a flux [H ~> m or kg m-2].
   logical :: local_open_BC
   integer :: i, j, k, ish, ieh, jsh, jeh, n, nz
+  real :: dh
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = GV%ke
 
-  !$OMP parallel do default(shared) private(CFL,curv_3,h_marg,h_avg)
   do k=1,nz ; do J=jsh-1,jeh ; do i=ish,ieh
     if (v(i,J,k) > 0.0) then
       if (vol_CFL) then ; CFL = (v(i,J,k) * dt) * (G%dx_Cv(i,J) * G%IareaT(i,j))
       else ; CFL = v(i,J,k) * dt * G%IdyT(i,j) ; endif
       curv_3 = (h_S(i,j,k) + h_N(i,j,k)) - 2.0*h(i,j,k)
-      h_avg = h_N(i,j,k) + CFL * (0.5*(h_S(i,j,k) - h_N(i,j,k)) + curv_3*(CFL - 1.5))
-      h_marg = h_N(i,j,k) + CFL * ((h_S(i,j,k) - h_N(i,j,k)) + &
-                                3.0*curv_3*(CFL - 1.0))
+      dh = h_S(i,J,k) - h_N(i,J,k)
+      if (marginal) then
+        h_v(i,J,k) = h_N(i,j,k) + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
+      else
+        h_v(i,J,k) = h_N(i,j,k) + CFL * (0.5*dh + curv_3*(CFL - 1.5))
+      endif
     elseif (v(i,J,k) < 0.0) then
       if (vol_CFL) then ; CFL = (-v(i,J,k)*dt) * (G%dx_Cv(i,J) * G%IareaT(i,j+1))
       else ; CFL = -v(i,J,k) * dt * G%IdyT(i,j+1) ; endif
       curv_3 = (h_S(i,j+1,k) + h_N(i,j+1,k)) - 2.0*h(i,j+1,k)
-      h_avg = h_S(i,j+1,k) + CFL * (0.5*(h_N(i,j+1,k)-h_S(i,j+1,k)) + curv_3*(CFL - 1.5))
-      h_marg = h_S(i,j+1,k) + CFL * ((h_N(i,j+1,k)-h_S(i,j+1,k)) + &
-                                    3.0*curv_3*(CFL - 1.0))
+      dh = h_N(i,j+1,k)-h_S(i,j+1,k)
+      if (marginal) then
+        h_v(i,J,k) = h_S(i,j+1,k) + CFL * (dh + 3.0*curv_3*(CFL - 1.0))
+      else
+        h_v(i,J,k) = h_S(i,j+1,k) + CFL * (0.5*dh + curv_3*(CFL - 1.5))
+      endif
     else
-      h_avg = 0.5 * (h_S(i,j+1,k) + h_N(i,j,k))
       !   The choice to use the arithmetic mean here is somewhat arbitrarily, but
       ! it should be noted that h_S(i+1,j,k) and h_N(i,j,k) are usually the same.
-      h_marg = 0.5 * (h_S(i,j+1,k) + h_N(i,j,k))
+      h_v(i,J,k) = 0.5 * (h_S(i,j+1,k) + h_N(i,j,k))
  !    h_marg = (2.0 * h_S(i,j+1,k) * h_N(i,j,k)) / &
  !             (h_S(i,j+1,k) + h_N(i,j,k) + GV%H_subroundoff)
     endif
 
-    if (marginal) then ; h_v(i,J,k) = h_marg
-    else ; h_v(i,J,k) = h_avg ; endif
-  enddo ; enddo ; enddo
-
-  if (present(visc_rem_v)) then
-    ! Scale back the thickness to account for the effects of viscosity and the fractional open
-    ! thickness to give an appropriate non-normalized weight for each layer in determining the
-    ! barotropic acceleration.
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do J=jsh-1,jeh ; do i=ish,ieh
+    if (present(visc_rem_v)) then
+      ! Scale back the thickness to account for the effects of viscosity and the fractional open
+      ! thickness to give an appropriate non-normalized weight for each layer in determining the
+      ! barotropic acceleration.
       h_v(i,J,k) = h_v(i,J,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
-    enddo ; enddo ; enddo
-  else
-    !$OMP parallel do default(shared)
-    do k=1,nz ; do J=jsh-1,jeh ; do i=ish,ieh
+    else
       h_v(i,J,k) = h_v(i,J,k) * por_face_areaV(i,J,k)
-    enddo ; enddo ; enddo
-  endif
+    endif
+  enddo ; enddo ; enddo
 
   local_open_BC = .false.
   if (associated(OBC)) local_open_BC = OBC%open_v_BCs_exist_globally
+
   if (local_open_BC) then
     do n = 1, OBC%number_of_segments
       if (OBC%segment(n)%open .and. OBC%segment(n)%is_N_or_S) then
         J = OBC%segment(n)%HI%JsdB
         if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-          if (present(visc_rem_v)) then ; do k=1,nz
-            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
-              h_v(i,J,k) = h(i,j,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
-            enddo
-          enddo ; else ; do k=1,nz
-            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
-              h_v(i,J,k) = h(i,j,k) * por_face_areaV(i,J,k)
-            enddo
-          enddo ; endif
+          if (present(visc_rem_v)) then
+            do k=1,nz ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,J,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
+            enddo ; enddo
+          else
+            do k=1,nz ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,J,k) * por_face_areaV(i,J,k)
+            enddo ; enddo
+          endif
         else
-          if (present(visc_rem_v)) then ; do k=1,nz
-            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
-              h_v(i,J,k) = h(i,j+1,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
-            enddo
-          enddo ; else ; do k=1,nz
-            do i = OBC%segment(n)%HI%isd, OBC%segment(n)%HI%ied
-              h_v(i,J,k) = h(i,j+1,k) * por_face_areaV(i,J,k)
-            enddo
-          enddo ; endif
+          if (present(visc_rem_v)) then
+            do k=1,nz ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,J+1,k) * (visc_rem_v(i,J,k) * por_face_areaV(i,J,k))
+            enddo ; enddo
+          else
+            do k=1,nz ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+              h_v(i,J,k) = h(i,J+1,k) * por_face_areaV(i,J,k)
+            enddo ; enddo
+          endif
         endif
       endif
     enddo
@@ -2004,81 +2410,101 @@ subroutine meridional_flux_thickness(v, h, h_S, h_N, h_v, dt, G, GV, US, LB, vol
 
 end subroutine meridional_flux_thickness
 
+
 !> Returns the barotropic velocity adjustment that gives the desired barotropic (layer-summed) transport.
 subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0, &
                              dv, dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             j, ish, ieh, do_I_in, por_face_areaV, vh_3d, OBC)
+                             isb, ieb, JsbB, JebB, do_ij_in, por_face_areaV, &
+                             nii, nJJB, vh_3d, OBC)
+  integer,                 intent(in)    :: nii !< i block size for array calculations.
+  integer,                 intent(in)    :: nJJB !< J block size for array calculations.
   type(ocean_grid_type),   intent(in)    :: G    !< Ocean's grid structure.
   type(verticalGrid_type), intent(in)    :: GV   !< Ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
                            intent(in)    :: v    !< Meridional velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),&
-                           intent(in)    :: h_S  !< South edge thickness in the reconstruction [H ~> m or kg m-2].
+                           intent(in)    :: h_in !< Layer thickness used to calculate fluxes
+                                                 !! [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: h_N  !< North edge thickness in the reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZK_(GV)), intent(in) :: visc_rem
+                           intent(in)    :: h_S  !< South edge thickness in the reconstruction
+                                                 !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h_N  !< North edge thickness in the reconstruction
+                                                 !! [H ~> m or kg m-2].
+  real, dimension(nii,nJJB,SZK_(GV)), intent(in) :: visc_rem
                              !< Both the fraction of the momentum originally
                              !! in a layer that remains after a time-step of viscosity, and the
                              !! fraction of a time-step's worth of a barotropic acceleration that
                              !! a layer experiences after viscosity is applied [nondim].
                              !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G)), intent(in)    :: vhbt !< The summed volume flux through meridional faces
-                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)), intent(in)    :: dv_max_CFL !< Maximum acceptable value of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)), intent(in)    :: dv_min_CFL !< Minimum acceptable value of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)), intent(in)    :: vh_tot_0   !< The summed transport with 0 adjustment
-                                                  !! [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)), intent(in)    :: dvhdv_tot_0 !< The partial derivative of dv_err with
-                                                  !! dv at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)), intent(out)   :: dv   !< The barotropic velocity adjustment [L T-1 ~> m s-1].
+  real, dimension(nii,nJJB), intent(in) :: vhbt !< The summed volume flux through
+                                                 !! meridional faces [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(nii,nJJB), intent(in) :: dv_max_CFL !< Maximum acceptable value
+                                                 !! of dv [L T-1 ~> m s-1].
+  real, dimension(nii,nJJB), intent(in) :: dv_min_CFL !< Minimum acceptable value
+                                                 !! of dv [L T-1 ~> m s-1].
+  real, dimension(nii,nJJB), intent(in) :: vh_tot_0 !< The summed transport with
+                                                 !! 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(nii,nJJB), intent(in) :: dvhdv_tot_0 !< The partial derivative
+                                                 !! of dv_err with dv at 0 adjustment [H L ~> m2 or kg m-1].
+  real, dimension(nii,nJJB), intent(out) :: dv !< The barotropic velocity adjustment
+                                                  !! [L T-1 ~> m s-1].
   real,                     intent(in)    :: dt   !< Time increment [T ~> s].
   type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
   type(continuity_PPM_CS),  intent(in)    :: CS   !< This module's control structure.
-  integer,                  intent(in)    :: j    !< Spatial index.
-  integer,                  intent(in)    :: ish  !< Start of index range.
-  integer,                  intent(in)    :: ieh  !< End of index range.
-  logical, dimension(SZI_(G)), &
-                            intent(in)    :: do_I_in  !< A flag indicating which I values to work on.
+  integer,                  intent(in)    :: JsbB !< Start of J index range.
+  integer,                  intent(in)    :: JebB !< End of J index range.
+  integer,                  intent(in)    :: isb  !< Start of i index range.
+  integer,                  intent(in)    :: ieb  !< End of i index range.
+  logical, dimension(nii,nJJB), intent(in) :: do_ij_in
+    !< A flag indicating which block points to work on.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                      intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+  real, dimension(nii,nJJB,SZK_(GV)), &
                   optional, intent(inout) :: vh_3d !< Volume flux through meridional
                              !! faces = v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
   type(ocean_OBC_type), optional, pointer :: OBC !< Open boundaries control structure.
   ! Local variables
-  real, dimension(SZI_(G),SZK_(GV)) :: &
-    vh_aux, &  ! An auxiliary meridional volume flux [H L2 T-1 ~> m3 s-1 or kg s-1].
+  ! The block-sized work arrays below are dimensioned (nii,nJJB).  In this meridional routine
+  ! their first (nii) block index is at the tracer-column (i) points, while the second (nJJB)
+  ! block index is staggered at the meridional velocity (v, C-grid J) points.
+  real :: &
     dvhdv      ! Partial derivative of vh with v [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)) :: &
+  real, dimension(nii,nJJB) :: &
     vh_err, &  ! Difference between vhbt and the summed vh [H L2 T-1 ~> m3 s-1 or kg s-1].
     vh_err_best, & ! The smallest value of vh_err found so far [H L2 T-1 ~> m3 s-1 or kg s-1].
-    v_new, &   ! The velocity with the correction added [L T-1 ~> m s-1].
     dvhdv_tot,&! Summed partial derivative of vh with u [H L ~> m2 or kg m-1].
     dv_min, &  ! Lower limit on dv correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
     dv_max     ! Upper limit on dv correction based on CFL limits and previous iterations [L T-1 ~> m s-1]
+  real :: &
+    vh, &      ! The volume flux through a meridional face [H L2 T-1 ~> m3 s-1 or kg s-1].
+    v_new   ! The velocity with the correction added [L T-1 ~> m s-1].
   real :: dv_prev ! The previous value of dv [L T-1 ~> m s-1].
   real :: ddv     ! The change in dv from the previous iteration [L T-1 ~> m s-1].
   real :: tol_eta ! The tolerance for the current iteration [H ~> m or kg m-2].
   real :: tol_vel ! The tolerance for velocity in the current iteration [L T-1 ~> m s-1].
-  integer :: i, k, nz, itt, max_itts = 20
-  logical :: domore, do_I(SZI_(G))
+  integer :: i, j, k, nz, itt, ii, JJ, iie, JJe
+  logical :: domore, do_ij(nii,nJJB), local_open_BC
+  integer, parameter :: max_itts = 20
+
+  local_open_BC = .false.
+  if (present(OBC)) then ; if (associated(OBC)) then
+    local_open_BC = OBC%open_v_BCs_exist_globally
+  endif ; endif
 
   nz = GV%ke
+  iie = ieb - isb + 1
+  JJe = JebB - JsbB + 1
+  tol_vel = CS%tol_vel
 
-  vh_aux(:,:) = 0.0 ; dvhdv(:,:) = 0.0
-
-  if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
-    vh_aux(i,k) = vh_3d(i,J,k)
-  enddo ; enddo ; endif
-
-  do i=ish,ieh
-    dv(i) = 0.0 ; do_I(i) = do_I_in(i)
-    dv_max(i) = dv_max_CFL(i) ; dv_min(i) = dv_min_CFL(i)
-    vh_err(i) = vh_tot_0(i) - vhbt(i) ; dvhdv_tot(i) = dvhdv_tot_0(i)
-    vh_err_best(i) = abs(vh_err(i))
-  enddo
+  do JJ=1,JJe ; do ii=1,iie
+    i = isb + ii - 1
+    J = JsbB + JJ - 1
+    dv(ii,JJ) = 0.0 ; do_ij(ii,JJ) = do_ij_in(ii,JJ)
+    dv_max(ii,JJ) = dv_max_CFL(ii,JJ) ; dv_min(ii,JJ) = dv_min_CFL(ii,JJ)
+    vh_err(ii,JJ) = vh_tot_0(ii,JJ) - vhbt(ii,JJ) ; dvhdv_tot(ii,JJ) = dvhdv_tot_0(ii,JJ)
+    vh_err_best(ii,JJ) = abs(vh_err(ii,JJ))
+  enddo ; enddo
 
   do itt=1,max_itts
     select case (itt)
@@ -2087,132 +2513,161 @@ subroutine meridional_flux_adjust(v, h_in, h_S, h_N, vhbt, vh_tot_0, dvhdv_tot_0
       case (3)  ; tol_eta = 1e-2 * CS%tol_eta
       case default ; tol_eta = CS%tol_eta
     end select
-    tol_vel = CS%tol_vel
 
-    do i=ish,ieh
-      if (vh_err(i) > 0.0) then ; dv_max(i) = dv(i)
-      elseif (vh_err(i) < 0.0) then ; dv_min(i) = dv(i)
-      else ; do_I(i) = .false. ; endif
-    enddo
+    do JJ=1,JJe ; do ii=1,iie
+      if (vh_err(ii,JJ) > 0.0) then ; dv_max(ii,JJ) = dv(ii,JJ)
+      elseif (vh_err(ii,JJ) < 0.0) then ; dv_min(ii,JJ) = dv(ii,JJ)
+      else ; do_ij(ii,JJ) = .false. ; endif
+    enddo ; enddo
+
     domore = .false.
-    do i=ish,ieh ; if (do_I(i)) then
-      if ((dt * min(G%IareaT(i,j),G%IareaT(i,j+1))*abs(vh_err(i)) > tol_eta) .or. &
-          (CS%better_iter .and. ((abs(vh_err(i)) > tol_vel * dvhdv_tot(i)) .or. &
-                                 (abs(vh_err(i)) > vh_err_best(i))) )) then
-        !   Use Newton's method, provided it stays bounded.  Otherwise bisect
-        ! the value with the appropriate bound.
-        ddv = -vh_err(i) / dvhdv_tot(i)
-        dv_prev = dv(i)
-        dv(i) = dv(i) + ddv
-        if (abs(ddv) < 1.0e-15*abs(dv(i))) then
-          do_I(i) = .false. ! ddv is small enough to quit.
-        elseif (ddv > 0.0) then
-          if (dv(i) >= dv_max(i)) then
-            dv(i) = 0.5*(dv_prev + dv_max(i))
-            if (dv_max(i) - dv_prev < 1.0e-15*abs(dv(i))) do_I(i) = .false.
+    do JJ=1,JJe ; do ii=1,iie
+      i = isb + ii - 1
+      J = JsbB + JJ - 1
+
+      if (do_ij(ii,JJ)) then
+        if ((dt * min(G%IareaT(i,j),G%IareaT(i,j+1))*abs(vh_err(ii,JJ)) > tol_eta) .or. &
+            (CS%better_iter .and. ((abs(vh_err(ii,JJ)) > tol_vel * dvhdv_tot(ii,JJ)) .or. &
+                                   (abs(vh_err(ii,JJ)) > vh_err_best(ii,JJ))) )) then
+          !   Use Newton's method, provided it stays bounded.  Otherwise bisect
+          ! the value with the appropriate bound.
+          ddv = -vh_err(ii,JJ) / dvhdv_tot(ii,JJ)
+          dv_prev = dv(ii,JJ)
+          dv(ii,JJ) = dv(ii,JJ) + ddv
+          if (abs(ddv) < 1.0e-15*abs(dv(ii,JJ))) then
+            do_ij(ii,JJ) = .false. ! ddv is small enough to quit.
+          elseif (ddv > 0.0) then
+            if (dv(ii,JJ) >= dv_max(ii,JJ)) then
+              dv(ii,JJ) = 0.5*(dv_prev + dv_max(ii,JJ))
+              if (dv_max(ii,JJ) - dv_prev < 1.0e-15*abs(dv(ii,JJ))) do_ij(ii,JJ) = .false.
+            endif
+          else ! dvv(i,J) < 0.0
+            if (dv(ii,JJ) <= dv_min(ii,JJ)) then
+              dv(ii,JJ) = 0.5*(dv_prev + dv_min(ii,JJ))
+              if (dv_prev - dv_min(ii,JJ) < 1.0e-15*abs(dv(ii,JJ))) do_ij(ii,JJ) = .false.
+            endif
           endif
-        else ! dvv(i) < 0.0
-          if (dv(i) <= dv_min(i)) then
-            dv(i) = 0.5*(dv_prev + dv_min(i))
-            if (dv_prev - dv_min(i) < 1.0e-15*abs(dv(i))) do_I(i) = .false.
-          endif
+          if (do_ij(ii,JJ)) domore = .true.
+        else
+          do_ij(ii,JJ) = .false.
         endif
-        if (do_I(i)) domore = .true.
-      else
-        do_I(i) = .false.
       endif
-    endif ; enddo
+    enddo ; enddo
+
     if (.not.domore) exit
 
-    if ((itt < max_itts) .or. present(vh_3d)) then ; do k=1,nz
-      do i=ish,ieh ; v_new(i) = v(i,J,k) + dv(i) * visc_rem(i,k) ; enddo
-      call merid_flux_layer(v_new, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), &
-                            vh_aux(:,k), dvhdv(:,k), visc_rem(:,k), &
-                            dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, por_face_areaV(:,:,k), &
-                            CS%h_marg_min, OBC)
-    enddo ; endif
+    do JJ=1,JJe ; do ii=1,iie
+      i = isb + ii - 1
+      J = JsbB + JJ - 1
+      vh_err(ii,JJ) = -vhbt(ii,JJ) ; dvhdv_tot(ii,JJ) = 0.0
+    enddo ; enddo
+    do k=1,nz
+      do JJ=1,JJe ; do ii=1,iie ; if (do_ij(ii,JJ)) then
+        i = isb + ii - 1
+        J = JsbB + JJ - 1
 
-    if (itt < max_itts) then
-      do i=ish,ieh
-        vh_err(i) = -vhbt(i) ; dvhdv_tot(i) = 0.0
-      enddo
-      do k=1,nz ; do i=ish,ieh
-        vh_err(i) = vh_err(i) + vh_aux(i,k)
-        dvhdv_tot(i) = dvhdv_tot(i) + dvhdv(i,k)
-      enddo ; enddo
-      do i=ish,ieh
-        vh_err_best(i) = min(vh_err_best(i), abs(vh_err(i)))
-      enddo
-    endif
+        v_new = v(i,J,k) + dv(ii,JJ) * visc_rem(ii,JJ,k)
+        call flux_elem(v_new, h_in(i,J,k), h_in(i,J+1,k), &
+            h_S(i,J,k), h_S(i,J+1,k), h_N(i,J,k), h_N(i,J+1,k), &
+            vh, dvhdv, visc_rem(ii,JJ,k), G%dx_Cv(i,J), &
+            G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, &
+            CS%vol_CFL, por_face_areaV(i,J,k), CS%h_marg_min)
+
+        if (local_open_BC) &
+          call flux_elem_OBC(v_new, h_in(i,J,k), h_in(i,J+1,k), &
+              vh, dvhdv, visc_rem(ii,JJ,k), &
+              por_face_areaV(i,J,k), G%dx_Cv(i,J), OBC, OBC%segnum_v(i,J), &
+              CS%h_marg_min)
+
+        if (present(vh_3d)) vh_3d(ii,JJ,k) = vh
+        vh_err(ii,JJ) = vh_err(ii,JJ) + vh
+        dvhdv_tot(ii,JJ) = dvhdv_tot(ii,JJ) + dvhdv
+      endif ; enddo ; enddo
+    enddo
+
+    do JJ=1,JJe ; do ii=1,iie
+      i = isb + ii - 1
+      J = JsbB + JJ - 1
+      vh_err_best(ii,JJ) = min(vh_err_best(ii,JJ), abs(vh_err(ii,JJ)))
+    enddo ; enddo
   enddo ! itt-loop
   ! If there are any faces which have not converged to within the tolerance,
   ! so-be-it, or else use a final upwind correction?
   ! This never seems to happen with 20 iterations as max_itt.
 
-  if (present(vh_3d)) then ; do k=1,nz ; do i=ish,ieh
-    vh_3d(i,J,k) = vh_aux(i,k)
-  enddo ; enddo ; endif
-
 end subroutine meridional_flux_adjust
+
 
 !> Sets of a structure that describes the meridional barotropic volume or mass fluxes as a
 !! function of barotropic flow to agree closely with the sum of the layer's transports.
 subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, &
                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                             visc_rem_max, j, ish, ieh, do_I, por_face_areaV)
+                             visc_rem_max, isb, ieb, JsbB, JebB, do_ij, &
+                             por_face_areaV, nii, nJJB)
+  integer,                                   intent(in) :: nii !< i block size for array calculations.
+  integer,                                   intent(in) :: nJJB !< J block size for array calculations.
   type(ocean_grid_type),                     intent(in)    :: G    !< Ocean's grid structure.
-  type(verticalGrid_type),                   intent(in)    :: GV   !< Ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)   :: v    !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_in !< Layer thickness used to calculate fluxes,
-                                                                   !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_S  !< South edge thickness in the reconstruction,
-                                                                   !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h_N  !< North edge thickness in the reconstruction,
-                                                                   !! [H ~> m or kg m-2].
+  type(verticalGrid_type),                   intent(in) :: GV !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                                             intent(in) :: v !< Meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h_in !< Layer thickness used to
+                                               !! calculate fluxes [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h_S  !< South edge thickness in the
+                                               !! reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h_N  !< North edge thickness in the
+                                               !! reconstruction [H ~> m or kg m-2].
   type(BT_cont_type),                        intent(inout) :: BT_cont !< A structure with elements
                        !! that describe the effective open face areas as a function of barotropic flow.
-  real, dimension(SZI_(G)),                  intent(in)    :: vh_tot_0    !< The summed transport
+  real, dimension(nii,nJJB),  intent(in) :: vh_tot_0    !< The summed transport
                        !! with 0 adjustment [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G)),                  intent(in)    :: dvhdv_tot_0 !< The partial derivative
+  real, dimension(nii,nJJB),  intent(in) :: dvhdv_tot_0 !< The partial derivative
                        !! of du_err with dv at 0 adjustment [H L ~> m2 or kg m-1].
-  real, dimension(SZI_(G)),                  intent(in)    :: dv_max_CFL !< Maximum acceptable value
-                                                                   !!  of dv [L T-1 ~> m s-1].
-  real, dimension(SZI_(G)),                  intent(in)    :: dv_min_CFL !< Minimum acceptable value
-                                                                   !!  of dv [L T-1 ~> m s-1].
-  real,                                      intent(in)    :: dt   !< Time increment [T ~> s].
-  type(unit_scale_type),                     intent(in)    :: US   !< A dimensional unit scaling type
-  type(continuity_PPM_CS),                   intent(in)    :: CS   !< This module's control structure.
-  real, dimension(SZI_(G),SZK_(GV)),         intent(in)    :: visc_rem !< Both the fraction of the
-                       !! momentum originally in a layer that remains after a time-step
-                       !! of viscosity, and the fraction of a time-step's worth of a barotropic
-                       !! acceleration that a layer experiences after viscosity is applied [nondim].
-                       !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
-  real, dimension(SZI_(G)),                  intent(in)    :: visc_rem_max !< Maximum allowable visc_rem [nondim]
-  integer,                                   intent(in)    :: j        !< Spatial index.
-  integer,                                   intent(in)    :: ish      !< Start of index range.
-  integer,                                   intent(in)    :: ieh      !< End of index range.
-  logical, dimension(SZI_(G)),               intent(in)    :: do_I     !< A logical flag indicating
-                       !! which I values to work on.
+  real, dimension(nii,nJJB),  intent(in) :: dv_max_CFL !< Maximum acceptable value
+                                                          !!  of dv [L T-1 ~> m s-1].
+  real, dimension(nii,nJJB),  intent(in) :: dv_min_CFL !< Minimum acceptable value
+                                                          !!  of dv [L T-1 ~> m s-1].
+  real,                                      intent(in) :: dt !< Time increment [T ~> s].
+  type(unit_scale_type),                     intent(in) :: US !< A dimensional unit scaling type
+  type(continuity_PPM_CS),                   intent(in) :: CS !< This module's control structure.
+  real, dimension(nii,nJJB,SZK_(GV)), &
+                           intent(in) :: visc_rem !< Both the fraction of the
+                     !! momentum originally in a layer that remains after a time-step
+                     !! of viscosity, and the fraction of a time-step's worth of a barotropic
+                     !! acceleration that a layer experiences after viscosity is applied [nondim].
+                     !! Visc_rem is between 0 (at the bottom) and 1 (far above the bottom).
+  real, dimension(nii,nJJB),  intent(in) :: visc_rem_max !< Maximum allowable
+                                                          !! visc_rem [nondim].
+  integer,                                   intent(in) :: JsbB !< Start of J index range.
+  integer,                                   intent(in) :: JebB !< End of J index range.
+  integer,                                   intent(in) :: isb  !< Start of i index range.
+  integer,                                   intent(in) :: ieb  !< End of i index range.
+  logical, dimension(nii,nJJB), intent(in) :: do_ij
+    !< A logical flag indicating which block points to work on.
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
-                                intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
+                          intent(in) :: por_face_areaV !< fractional open area of V-faces [nondim]
   ! Local variables
-  real, dimension(SZI_(G)) :: &
+  ! The block-sized work arrays below are dimensioned (nii,nJJB[,nz]).  In this meridional
+  ! routine their first (nii) block index is at the tracer-column (i) points, while the second
+  ! (nJJB) block index is staggered at the meridional velocity (v, C-grid J) points.
+  real, dimension(nii,nJJB) :: &
     dv0, &        ! The barotropic velocity increment that gives 0 transport [L T-1 ~> m s-1].
     dvL, dvR, &   ! The barotropic velocity increments that give the southerly
                   ! (dvL) and northerly (dvR) test velocities [L T-1 ~> m s-1].
-    zeros, &      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
     dv_CFL, &     ! The velocity increment that corresponds to CFL_min [L T-1 ~> m s-1].
-    v_L, v_R, &   ! The southerly (v_L), northerly (v_R), and zero-barotropic
-    v_0, &        ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
-    dvhdv_L, &    ! The effective layer marginal face areas with the southerly
-    dvhdv_R, &    ! (_L), northerly (_R), and zero-barotropic (_0) test
-    dvhdv_0, &    ! velocities [H L ~> m2 or kg m-1].
-    vh_L, vh_R, & ! The layer transports with the southerly (_L), northerly (_R)
-    vh_0, &       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
     FAmt_L, FAmt_R, & ! The summed effective marginal face areas for the 3
     FAmt_0, &     ! test velocities [H L ~> m2 or kg m-1].
     vhtot_L, &    ! The summed transport with the southerly (vhtot_L) and
     vhtot_R       ! and northerly (vhtot_R) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(nii,nJJB) :: &
+    zeros      ! An array of full of 0 transports [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real :: &
+    vh_L, vh_R, & ! The layer transports with the southerly (_L), northerly (_R)
+    vh_0, &       ! and zero-barotropic (_0) test velocities [H L2 T-1 ~> m3 s-1 or kg s-1].
+    dvhdv_L, &    ! The effective layer marginal face areas with the southerly
+    dvhdv_R, &    ! (_L), northerly (_R), and zero-barotropic (_0) test
+    dvhdv_0, &    ! velocities [H L ~> m2 or kg m-1].
+    v_L, v_R, &   ! The southerly (v_L), northerly (v_R), and zero-barotropic
+    v_0        ! transport (v_0) layer test velocities [L T-1 ~> m s-1].
   real :: FA_0    ! The effective face area with 0 barotropic transport [H L ~> m2 or kg m-1].
   real :: FA_avg  ! The average effective face area [H L ~> m2 or kg m-1], nominally given by
                   ! the realized transport divided by the barotropic velocity.
@@ -2226,112 +2681,158 @@ subroutine set_merid_BT_cont(v, h_in, h_S, h_N, BT_cont, vh_tot_0, dvhdv_tot_0, 
   real :: CFL_min ! A minimal increment in the CFL to try to ensure that the
                   ! flow is truly upwind [nondim]
   real :: Idt     ! The inverse of the time step [T-1 ~> s-1].
-  logical :: domore
-  integer :: i, k, nz
+  integer :: i, j, k, nz, ii, JJ, iie, JJe
 
   nz = GV%ke ; Idt = 1.0 / dt
+  iie = ieb - isb + 1 ; JJe = JebB - JsbB + 1
   min_visc_rem = 0.1 ; CFL_min = 1e-6
 
  ! Diagnose the zero-transport correction, dv0.
-  do i=ish,ieh ; zeros(i) = 0.0 ; enddo
+  do JJ=1,JJe ; do ii=1,iie
+    zeros(ii,JJ) = 0.0
+  enddo ; enddo
+
   call meridional_flux_adjust(v, h_in, h_S, h_N, zeros, vh_tot_0, dvhdv_tot_0, dv0, &
-                         dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
-                         j, ish, ieh, do_I, por_face_areaV)
+                              dv_max_CFL, dv_min_CFL, dt, G, GV, US, CS, visc_rem, &
+                              isb, ieb, JsbB, JebB, do_ij, por_face_areaV, &
+                              nii, nJJB)
 
   !   Determine the southerly- and northerly- fluxes.  Choose a sufficiently
   ! negative velocity correction for the northerly-flux, and a sufficiently
   ! positive correction for the southerly-flux.
-  domore = .false.
-  do i=ish,ieh ; if (do_I(i)) then
-    domore = .true.
-    dv_CFL(i) = (CFL_min * Idt) * G%dyCv(i,J)
-    dvR(i) = min(0.0,dv0(i) - dv_CFL(i))
-    dvL(i) = max(0.0,dv0(i) + dv_CFL(i))
-    FAmt_L(i) = 0.0 ; FAmt_R(i) = 0.0 ; FAmt_0(i) = 0.0
-    vhtot_L(i) = 0.0 ; vhtot_R(i) = 0.0
-  endif ; enddo
+  do JJ=1,JJe ; do ii=1,iie
+    i = isb + ii - 1
+    J = JsbB + JJ - 1
+    dv_CFL(ii,JJ) = (CFL_min * Idt) * G%dyCv(i,J)
+    dvR(ii,JJ) = min(0.0,dv0(ii,JJ) - dv_CFL(ii,JJ))
+    dvL(ii,JJ) = max(0.0,dv0(ii,JJ) + dv_CFL(ii,JJ))
+    FAmt_L(ii,JJ) = 0.0 ; FAmt_R(ii,JJ) = 0.0 ; FAmt_0(ii,JJ) = 0.0
+    vhtot_L(ii,JJ) = 0.0 ; vhtot_R(ii,JJ) = 0.0
+  enddo ; enddo
 
-  if (.not.domore) then
-    do k=1,nz ; do i=ish,ieh
-      BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
-      BT_cont%vBT_SS(i,J) = 0.0
-      BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
-      BT_cont%vBT_NN(i,J) = 0.0
-    enddo ; enddo
-    return
-  endif
-
-  do k=1,nz ; do i=ish,ieh ; if (do_I(i)) then
-    visc_rem_lim = max(visc_rem(i,k), min_visc_rem*visc_rem_max(i))
-    if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
-      if (v(i,J,k) + dvR(i)*visc_rem_lim > -dv_CFL(i)*visc_rem(i,k)) &
-        dvR(i) = -(v(i,J,k) + dv_CFL(i)*visc_rem(i,k)) / visc_rem_lim
-      if (v(i,J,k) + dvL(i)*visc_rem_lim < dv_CFL(i)*visc_rem(i,k)) &
-        dvL(i) = -(v(i,J,k) - dv_CFL(i)*visc_rem(i,k)) / visc_rem_lim
-    endif
-  endif ; enddo ; enddo
   do k=1,nz
-    do i=ish,ieh ; if (do_I(i)) then
-      v_L(i) = v(I,j,k) + dvL(i) * visc_rem(i,k)
-      v_R(i) = v(I,j,k) + dvR(i) * visc_rem(i,k)
-      v_0(i) = v(I,j,k) + dv0(i) * visc_rem(i,k)
-    endif ; enddo
-    call merid_flux_layer(v_0, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_0, dvhdv_0, &
-                          visc_rem(:,k), dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, &
-                          por_face_areaV(:,:,k), CS%h_marg_min)
-    call merid_flux_layer(v_L, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_L, dvhdv_L, &
-                          visc_rem(:,k), dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, &
-                          por_face_areaV(:,:,k), CS%h_marg_min)
-    call merid_flux_layer(v_R, h_in(:,:,k), h_S(:,:,k), h_N(:,:,k), vh_R, dvhdv_R, &
-                          visc_rem(:,k), dt, G, US, J, ish, ieh, do_I, CS%vol_CFL, &
-                          por_face_areaV(:,:,k), CS%h_marg_min)
-    do i=ish,ieh ; if (do_I(i)) then
-      FAmt_0(i) = FAmt_0(i) + dvhdv_0(i)
-      FAmt_L(i) = FAmt_L(i) + dvhdv_L(i)
-      FAmt_R(i) = FAmt_R(i) + dvhdv_R(i)
-      vhtot_L(i) = vhtot_L(i) + vh_L(i)
-      vhtot_R(i) = vhtot_R(i) + vh_R(i)
-    endif ; enddo
+    do JJ=1,JJe ; do ii=1,iie ; if (do_ij(ii,JJ)) then
+      i = isb + ii - 1
+      J = JsbB + JJ - 1
+
+      visc_rem_lim = max(visc_rem(ii,JJ,k), min_visc_rem*visc_rem_max(ii,JJ))
+      if (visc_rem_lim > 0.0) then ! This is almost always true for ocean points.
+        if (v(i,J,k) + dvR(ii,JJ)*visc_rem_lim > -dv_CFL(ii,JJ)*visc_rem(ii,JJ,k)) &
+          dvR(ii,JJ) = -(v(i,J,k) + dv_CFL(ii,JJ)*visc_rem(ii,JJ,k)) / visc_rem_lim
+        if (v(i,J,k) + dvL(ii,JJ)*visc_rem_lim < dv_CFL(ii,JJ)*visc_rem(ii,JJ,k)) &
+          dvL(ii,JJ) = -(v(i,J,k) - dv_CFL(ii,JJ)*visc_rem(ii,JJ,k)) / visc_rem_lim
+      endif
+    endif ; enddo ; enddo
   enddo
-  do i=ish,ieh ; if (do_I(i)) then
-    FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
-    if ((dvL(i) - dv0(i)) /= 0.0) &
-      FA_avg = vhtot_L(i) / (dvL(i) - dv0(i))
-    if (FA_avg > max(FA_0, FAmt_L(i))) then ; FA_avg = max(FA_0, FAmt_L(i))
-    elseif (FA_avg < min(FA_0, FAmt_L(i))) then ; FA_0 = FA_avg ; endif
-    BT_cont%FA_v_S0(i,J) = FA_0 ; BT_cont%FA_v_SS(i,J) = FAmt_L(i)
-    if (abs(FA_0-FAmt_L(i)) <= 1e-12*FA_0) then ; BT_cont%vBT_SS(i,J) = 0.0 ; else
-      BT_cont%vBT_SS(i,J) = (1.5 * (dvL(i) - dv0(i))) * &
-                   ((FAmt_L(i) - FA_avg) / (FAmt_L(i) - FA_0))
-    endif
 
-    FA_0 = FAmt_0(i) ; FA_avg = FAmt_0(i)
-    if ((dvR(i) - dv0(i)) /= 0.0) &
-      FA_avg = vhtot_R(i) / (dvR(i) - dv0(i))
-    if (FA_avg > max(FA_0, FAmt_R(i))) then ; FA_avg = max(FA_0, FAmt_R(i))
-    elseif (FA_avg < min(FA_0, FAmt_R(i))) then ; FA_0 = FA_avg ; endif
-    BT_cont%FA_v_N0(i,J) = FA_0 ; BT_cont%FA_v_NN(i,J) = FAmt_R(i)
-    if (abs(FAmt_R(i) - FA_0) <= 1e-12*FA_0) then ; BT_cont%vBT_NN(i,J) = 0.0 ; else
-      BT_cont%vBT_NN(i,J) = (1.5 * (dvR(i) - dv0(i))) * &
-                   ((FAmt_R(i) - FA_avg) / (FAmt_R(i) - FA_0))
-    endif
-  else
-    BT_cont%FA_v_S0(i,J) = 0.0 ; BT_cont%FA_v_SS(i,J) = 0.0
-    BT_cont%FA_v_N0(i,J) = 0.0 ; BT_cont%FA_v_NN(i,J) = 0.0
-    BT_cont%vBT_SS(i,J) = 0.0 ; BT_cont%vBT_NN(i,J) = 0.0
-  endif ; enddo
+  do k=1,nz
+    do JJ=1,JJe ; do ii=1,iie
+      i = isb + ii - 1
+      J = JsbB + JJ - 1
 
+      if (do_ij(ii,JJ)) then
+        v_L = v(i,J,k) + dvL(ii,JJ) * visc_rem(ii,JJ,k)
+        v_R = v(i,J,k) + dvR(ii,JJ) * visc_rem(ii,JJ,k)
+        v_0 = v(i,J,k) + dv0(ii,JJ) * visc_rem(ii,JJ,k)
+
+        call flux_elem(v_0, h_in(i,J,k), h_in(i,J+1,k), &
+            h_S(i,J,k), h_S(i,J+1,k), h_N(i,J,k), h_N(i,J+1,k), &
+            vh_0, dvhdv_0, visc_rem(ii,JJ,k), G%dx_Cv(i,J), &
+            G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, &
+            CS%vol_CFL, por_face_areaV(i,J,k), CS%h_marg_min)
+
+        call flux_elem(v_L, h_in(i,J,k), h_in(i,J+1,k), &
+            h_S(i,J,k), h_S(i,J+1,k), h_N(i,J,k), h_N(i,J+1,k), &
+            vh_L, dvhdv_L, visc_rem(ii,JJ,k), G%dx_Cv(i,J), &
+            G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, &
+            CS%vol_CFL, por_face_areaV(i,J,k), CS%h_marg_min)
+
+        call flux_elem(v_R, h_in(i,J,k), h_in(i,J+1,k), &
+            h_S(i,J,k), h_S(i,J+1,k), h_N(i,J,k), h_N(i,J+1,k), &
+            vh_R, dvhdv_R, visc_rem(ii,JJ,k), G%dx_Cv(i,J), &
+            G%IareaT(i,J), G%IareaT(i,J+1), G%IdyT(i,J), G%IdyT(i,J+1), dt, &
+            CS%vol_CFL, por_face_areaV(i,J,k), CS%h_marg_min)
+
+        ! XXX: Bracket duhdu to suppress FMA optimization after inlining.
+        FAmt_0(ii,JJ) = FAmt_0(ii,JJ) + (dvhdv_0)
+        FAmt_L(ii,JJ) = FAmt_L(ii,JJ) + (dvhdv_L)
+        FAmt_R(ii,JJ) = FAmt_R(ii,JJ) + (dvhdv_R)
+        vhtot_L(ii,JJ) = vhtot_L(ii,JJ) + vh_L
+        vhtot_R(ii,JJ) = vhtot_R(ii,JJ) + vh_R
+      endif
+    enddo ; enddo
+  enddo
+
+  do JJ=1,JJe ; do ii=1,iie
+    i = isb + ii - 1
+    J = JsbB + JJ - 1
+
+    if (do_ij(ii,JJ)) then
+      FA_0 = FAmt_0(ii,JJ)
+      FA_avg = FAmt_0(ii,JJ)
+
+      if (dvL(ii,JJ) - dv0(ii,JJ) /= 0.) &
+        FA_avg = vhtot_L(ii,JJ) / (dvL(ii,JJ) - dv0(ii,JJ))
+
+      if (FA_avg > max(FA_0, FAmt_L(ii,JJ))) then
+        FA_avg = max(FA_0, FAmt_L(ii,JJ))
+      elseif (FA_avg < min(FA_0, FAmt_L(ii,JJ))) then
+        FA_0 = FA_avg
+      endif
+
+      BT_cont%FA_v_S0(i,J) = FA_0
+      BT_cont%FA_v_SS(i,J) = FAmt_L(ii,JJ)
+
+      if (abs(FA_0-FAmt_L(ii,JJ)) <= 1e-12 * FA_0) then
+        BT_cont%vBT_SS(i,J) = 0.
+      else
+        BT_cont%vBT_SS(i,J) = (1.5 * (dvL(ii,JJ) - dv0(ii,JJ))) &
+            * ((FAmt_L(ii,JJ) - FA_avg) / (FAmt_L(ii,JJ) - FA_0))
+      endif
+
+      FA_0 = FAmt_0(ii,JJ)
+      FA_avg = FAmt_0(ii,JJ)
+
+      if (dvR(ii,JJ) - dv0(ii,JJ) /= 0.) &
+        FA_avg = vhtot_R(ii,JJ) / (dvR(ii,JJ) - dv0(ii,JJ))
+
+      if (FA_avg > max(FA_0, FAmt_R(ii,JJ))) then
+        FA_avg = max(FA_0, FAmt_R(ii,JJ))
+      elseif (FA_avg < min(FA_0, FAmt_R(ii,JJ))) then
+        FA_0 = FA_avg
+      endif
+
+      BT_cont%FA_v_N0(i,J) = FA_0 ; BT_cont%FA_v_NN(i,J) = FAmt_R(ii,JJ)
+
+      if (abs(FAmt_R(ii,JJ) - FA_0) <= 1e-12 * FA_0) then
+        BT_cont%vBT_NN(i,J) = 0.
+      else
+        BT_cont%vBT_NN(i,J) = (1.5 * (dvR(ii,JJ) - dv0(ii,JJ))) &
+            * ((FAmt_R(ii,JJ) - FA_avg) / (FAmt_R(ii,JJ) - FA_0))
+      endif
+    else
+      BT_cont%FA_v_S0(i,J) = 0.
+      BT_cont%FA_v_SS(i,J) = 0.
+      BT_cont%FA_v_N0(i,J) = 0.
+      BT_cont%FA_v_NN(i,J) = 0.
+      BT_cont%vBT_SS(i,J) = 0.
+      BT_cont%vBT_NN(i,J) = 0.
+    endif
+  enddo ; enddo
 end subroutine set_merid_BT_cont
 
+
 !> Calculates left/right edge values for PPM reconstruction.
-subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_2nd, OBC, k)
+subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, GV, LB, nkk, h_min, monotonic, simple_2nd, OBC)
   type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(out) :: h_W  !< West edge thickness in the reconstruction,
+  type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: h_W  !< West edge thickness in the reconstruction,
                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(out) :: h_E  !< East edge thickness in the reconstruction,
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: h_E  !< East edge thickness in the reconstruction,
                                                          !! [H ~> m or kg m-2].
   type(cont_loop_bounds_type),       intent(in)  :: LB   !< Active loop bounds structure.
+  integer,                           intent(in)  :: nkk  !< k block size for reconstruction calculations.
   real,                              intent(in)  :: h_min !< The minimum thickness
                     !! that can be obtained by a concave parabolic fit [H ~> m or kg m-2]
   logical,                           intent(in)  :: monotonic !< If true, use the
@@ -2341,16 +2842,18 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
                     !! arithmetic mean thicknesses as the default edge values
                     !! for a simple 2nd order scheme.
   type(ocean_OBC_type),              pointer     :: OBC !< Open boundaries control structure.
-  integer :: k      !< vertical grid index
+  integer :: k, kk  !< vertical grid and k-block indices
 
   ! Local variables with useful mnemonic names.
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes per grid point [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    slp ! The slopes per grid point in a k block [H ~> m or kg m-2]
   real, parameter :: oneSixth = 1./6.  ! [nondim]
   real :: h_ip1, h_im1 ! Neighboring thicknesses or sensibly extrapolated values [H ~> m or kg m-2]
   real :: dMx, dMn     ! The difference between the local thickness and the maximum (dMx) or
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
-  integer :: i, j, isl, iel, jsl, jel, n, stencil
+  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil
+  integer :: ksb, keb
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2359,7 +2862,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
     local_open_BC = OBC%open_u_BCs_exist_globally
   endif
 
-  isl = LB%ish-1 ; iel = LB%ieh+1 ; jsl = LB%jsh ; jel = LB%jeh
+  isl = LB%ish-1 ; iel = LB%ieh+1 ; jsl = LB%jsh ; jel = LB%jeh ; nz = GV%ke
 
   ! This is the stencil of the reconstruction, not the scheme overall.
   stencil = 2 ; if (simple_2nd) stencil = 1
@@ -2377,115 +2880,127 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
     call MOM_error(FATAL,mesg)
   endif
 
-  if (simple_2nd) then
-    do j=jsl,jel ; do i=isl,iel
-      h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j)
-      h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j)
-      h_W(i,j) = 0.5*( h_im1 + h_in(i,j) )
-      h_E(i,j) = 0.5*( h_ip1 + h_in(i,j) )
-    enddo ; enddo
-  else
-    do j=jsl,jel ; do i=isl-1,iel+1
-      if ((G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j)) == 0.0) then
-        slp(i,j) = 0.0
-      else
-        ! This uses a simple 2nd order slope.
-        slp(i,j) = 0.5 * (h_in(i+1,j) - h_in(i-1,j))
-        ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
-        dMx = max(h_in(i+1,j), h_in(i-1,j), h_in(i,j)) - h_in(i,j)
-        dMn = h_in(i,j) - min(h_in(i+1,j), h_in(i-1,j), h_in(i,j))
-        slp(i,j) = sign(1.,slp(i,j)) * min(abs(slp(i,j)), 2. * min(dMx, dMn))
-                ! * (G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j))
+  do ksb=1,nz,nkk
+    keb = min(ksb + nkk - 1, nz)
+
+    if (simple_2nd) then
+      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
+        h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
+        h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
+        h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) )
+        h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) )
+      enddo ; enddo ; enddo
+    else
+      do k=ksb,keb ; do j=jsl,jel ; do i=isl-1,iel+1
+        kk = k - ksb + 1
+
+        if ((G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j)) == 0.0) then
+          slp(i,j,kk) = 0.0
+        else
+          ! This uses a simple 2nd order slope.
+          slp(i,j,kk) = 0.5 * (h_in(i+1,j,k) - h_in(i-1,j,k))
+          ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
+          dMx = max(h_in(i+1,j,k), h_in(i-1,j,k), h_in(i,j,k)) - h_in(i,j,k)
+          dMn = h_in(i,j,k) - min(h_in(i+1,j,k), h_in(i-1,j,k), h_in(i,j,k))
+          slp(i,j,kk) = sign(1.,slp(i,j,kk)) * min(abs(slp(i,j,kk)), 2. * min(dMx, dMn))
+                  ! * (G%mask2dT(i-1,j) * G%mask2dT(i,j) * G%mask2dT(i+1,j))
+        endif
+      enddo ; enddo ; enddo
+
+      if (local_open_BC) then
+        do n=1, OBC%number_of_segments
+          segment => OBC%segment(n)
+          if (.not. segment%on_pe) cycle
+          if (segment%is_E_or_W) then
+            I=segment%HI%IsdB
+            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+              kk = k - ksb + 1
+
+              slp(i+1,j,kk) = 0.0
+              slp(i,j,kk) = 0.0
+            enddo ; enddo
+          endif
+        enddo
       endif
-    enddo ; enddo
+
+      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
+        kk = k - ksb + 1
+
+        ! Neighboring values should take into account any boundaries.  The 3
+        ! following sets of expressions are equivalent.
+      ! h_im1 = h_in(i-1,j,k) ; if (G%mask2dT(i-1,j) < 0.5) h_im1 = h_in(i,j)
+      ! h_ip1 = h_in(i+1,j,k) ; if (G%mask2dT(i+1,j) < 0.5) h_ip1 = h_in(i,j)
+        h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j,k) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j,k)
+        h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j,k) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j,k)
+        ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
+        h_W(i,j,k) = 0.5*( h_im1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i-1,j,kk) - slp(i,j,kk) )
+        h_E(i,j,k) = 0.5*( h_ip1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i,j,kk) - slp(i+1,j,kk) )
+      enddo ; enddo ; enddo
+    endif
 
     if (local_open_BC) then
       do n=1, OBC%number_of_segments
         segment => OBC%segment(n)
         if (.not. segment%on_pe) cycle
-        if (segment%is_E_or_W) then
+        if (segment%direction == OBC_DIRECTION_E) then
           I=segment%HI%IsdB
-          do j=segment%HI%jsd,segment%HI%jed
-            slp(i+1,j) = 0.0
-            slp(i,j) = 0.0
-          enddo
+          if (associated(segment%h_Reg)) then
+            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+              h_W(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_E(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_W(i,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_E(i,j,k) = segment%h_Reg%h_res(i,j,k)
+            enddo ; enddo
+          else
+            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+              h_W(i+1,j,k) = h_in(i,j,k)
+              h_E(i+1,j,k) = h_in(i,j,k)
+              h_W(i,j,k) = h_in(i,j,k)
+              h_E(i,j,k) = h_in(i,j,k)
+            enddo ; enddo
+          endif
+        elseif (segment%direction == OBC_DIRECTION_W) then
+          I=segment%HI%IsdB
+          if (associated(segment%h_Reg)) then
+            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+              h_W(i,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_E(i,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_W(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_E(i+1,j,k) = segment%h_Reg%h_res(i,j,k)
+            enddo ; enddo
+          else
+            do k=ksb,keb ; do j=segment%HI%jsd,segment%HI%jed
+              h_W(i,j,k) = h_in(i+1,j,k)
+              h_E(i,j,k) = h_in(i+1,j,k)
+              h_W(i+1,j,k) = h_in(i+1,j,k)
+              h_E(i+1,j,k) = h_in(i+1,j,k)
+            enddo ; enddo
+          endif
         endif
       enddo
     endif
 
-    do j=jsl,jel ; do i=isl,iel
-      ! Neighboring values should take into account any boundaries.  The 3
-      ! following sets of expressions are equivalent.
-    ! h_im1 = h_in(i-1,j,k) ; if (G%mask2dT(i-1,j) < 0.5) h_im1 = h_in(i,j)
-    ! h_ip1 = h_in(i+1,j,k) ; if (G%mask2dT(i+1,j) < 0.5) h_ip1 = h_in(i,j)
-      h_im1 = G%mask2dT(i-1,j) * h_in(i-1,j) + (1.0-G%mask2dT(i-1,j)) * h_in(i,j)
-      h_ip1 = G%mask2dT(i+1,j) * h_in(i+1,j) + (1.0-G%mask2dT(i+1,j)) * h_in(i,j)
-      ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
-      h_W(i,j) = 0.5*( h_im1 + h_in(i,j) ) + oneSixth*( slp(i-1,j) - slp(i,j) )
-      h_E(i,j) = 0.5*( h_ip1 + h_in(i,j) ) + oneSixth*( slp(i,j) - slp(i+1,j) )
-    enddo ; enddo
-  endif
-
-  if (local_open_BC) then
-    do n=1, OBC%number_of_segments
-      segment => OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (segment%direction == OBC_DIRECTION_E) then
-        I=segment%HI%IsdB
-        if (associated(segment%h_Reg)) then
-          do j=segment%HI%jsd,segment%HI%jed
-            h_W(i+1,j) = segment%h_Reg%h_res(i,j,k)
-            h_E(i+1,j) = segment%h_Reg%h_res(i,j,k)
-            h_W(i,j) = segment%h_Reg%h_res(i,j,k)
-            h_E(i,j) = segment%h_Reg%h_res(i,j,k)
-          enddo
-        else
-          do j=segment%HI%jsd,segment%HI%jed
-            h_W(i+1,j) = h_in(i,j)
-            h_E(i+1,j) = h_in(i,j)
-            h_W(i,j) = h_in(i,j)
-            h_E(i,j) = h_in(i,j)
-          enddo
-        endif
-      elseif (segment%direction == OBC_DIRECTION_W) then
-        I=segment%HI%IsdB
-        if (associated(segment%h_Reg)) then
-          do j=segment%HI%jsd,segment%HI%jed
-            h_W(i,j) = segment%h_Reg%h_res(i,j,k)
-            h_E(i,j) = segment%h_Reg%h_res(i,j,k)
-            h_W(i+1,j) = segment%h_Reg%h_res(i,j,k)
-            h_E(i+1,j) = segment%h_Reg%h_res(i,j,k)
-          enddo
-        else
-          do j=segment%HI%jsd,segment%HI%jed
-            h_W(i,j) = h_in(i+1,j)
-            h_E(i,j) = h_in(i+1,j)
-            h_W(i+1,j) = h_in(i+1,j)
-            h_E(i+1,j) = h_in(i+1,j)
-          enddo
-        endif
-      endif
-    enddo
-  endif
-
-  if (monotonic) then
-    call PPM_limit_CW84(h_in, h_W, h_E, G, isl, iel, jsl, jel)
-  else
-    call PPM_limit_pos(h_in, h_W, h_E, h_min, G, isl, iel, jsl, jel)
-  endif
-
-  return
+    if (monotonic) then
+      call PPM_limit_CW84(h_in, h_W, h_E, G, GV, isl, iel, jsl, jel, ksb, keb)
+    else
+      call PPM_limit_pos(h_in, h_W, h_E, h_min, G, GV, isl, iel, jsl, jel, ksb, keb)
+    endif
+  enddo
 end subroutine PPM_reconstruction_x
 
 !> Calculates left/right edge values for PPM reconstruction.
-subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_2nd, OBC, k)
+subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, GV, LB, nkk, h_min, monotonic, simple_2nd, OBC)
   type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(out) :: h_S  !< South edge thickness in the reconstruction,
+  type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: h_S  !< South edge thickness in the reconstruction,
                                                          !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(out) :: h_N  !< North edge thickness in the reconstruction,
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(out) :: h_N  !< North edge thickness in the reconstruction,
                                                          !! [H ~> m or kg m-2].
   type(cont_loop_bounds_type),       intent(in)  :: LB   !< Active loop bounds structure.
+  integer,                           intent(in)  :: nkk  !< k block size for reconstruction calculations.
   real,                              intent(in)  :: h_min !< The minimum thickness
                     !! that can be obtained by a concave parabolic fit [H ~> m or kg m-2]
   logical,                           intent(in)  :: monotonic !< If true, use the
@@ -2495,16 +3010,18 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
                     !! arithmetic mean thicknesses as the default edge values
                     !! for a simple 2nd order scheme.
   type(ocean_OBC_type),              pointer     :: OBC !< Open boundaries control structure.
-  integer :: k      !< vertical grid index
+  integer :: k, kk  !< vertical grid and k-block indices
 
   ! Local variables with useful mnemonic names.
-  real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes per grid point [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    slp ! The slopes per grid point in a k block [H ~> m or kg m-2]
   real, parameter :: oneSixth = 1./6.      ! [nondim]
   real :: h_jp1, h_jm1 ! Neighboring thicknesses or sensibly extrapolated values [H ~> m or kg m-2]
   real :: dMx, dMn     ! The difference between the local thickness and the maximum (dMx) or
                        ! minimum (dMn) of the surrounding values [H ~> m or kg m-2]
   character(len=256) :: mesg
-  integer :: i, j, isl, iel, jsl, jel, n, stencil
+  integer :: i, j, isl, iel, jsl, jel, nz, n, stencil
+  integer :: ksb, keb
   logical :: local_open_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -2513,7 +3030,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
     local_open_BC = OBC%open_v_BCs_exist_globally
   endif
 
-  isl = LB%ish ; iel = LB%ieh ; jsl = LB%jsh-1 ; jel = LB%jeh+1
+  isl = LB%ish ; iel = LB%ieh ; jsl = LB%jsh-1 ; jel = LB%jeh+1 ; nz = GV%ke
 
   ! This is the stencil of the reconstruction, not the scheme overall.
   stencil = 2 ; if (simple_2nd) stencil = 1
@@ -2531,161 +3048,178 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
     call MOM_error(FATAL,mesg)
   endif
 
-  if (simple_2nd) then
-    do j=jsl,jel ; do i=isl,iel
-      h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j)
-      h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j)
-      h_S(i,j) = 0.5*( h_jm1 + h_in(i,j) )
-      h_N(i,j) = 0.5*( h_jp1 + h_in(i,j) )
-    enddo ; enddo
-  else
-    do j=jsl-1,jel+1 ; do i=isl,iel
-      if ((G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1)) == 0.0) then
-        slp(i,j) = 0.0
-      else
-        ! This uses a simple 2nd order slope.
-        slp(i,j) = 0.5 * (h_in(i,j+1) - h_in(i,j-1))
-        ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
-        dMx = max(h_in(i,j+1), h_in(i,j-1), h_in(i,j)) - h_in(i,j)
-        dMn = h_in(i,j) - min(h_in(i,j+1), h_in(i,j-1), h_in(i,j))
-        slp(i,j) = sign(1.,slp(i,j)) * min(abs(slp(i,j)), 2. * min(dMx, dMn))
-                ! * (G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1))
+  do ksb=1,nz,nkk
+    keb = min(ksb + nkk - 1, nz)
+
+    if (simple_2nd) then
+      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
+        h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
+        h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
+        h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) )
+        h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) )
+      enddo ; enddo ; enddo
+    else
+      do k=ksb,keb ; do j=jsl-1,jel+1 ; do i=isl,iel
+        kk = k - ksb + 1
+
+        if ((G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1)) == 0.0) then
+          slp(i,j,kk) = 0.0
+        else
+          ! This uses a simple 2nd order slope.
+          slp(i,j,kk) = 0.5 * (h_in(i,j+1,k) - h_in(i,j-1,k))
+          ! Monotonic constraint, see Eq. B2 in Lin 1994, MWR (132)
+          dMx = max(h_in(i,j+1,k), h_in(i,j-1,k), h_in(i,j,k)) - h_in(i,j,k)
+          dMn = h_in(i,j,k) - min(h_in(i,j+1,k), h_in(i,j-1,k), h_in(i,j,k))
+          slp(i,j,kk) = sign(1.,slp(i,j,kk)) * min(abs(slp(i,j,kk)), 2. * min(dMx, dMn))
+                  ! * (G%mask2dT(i,j-1) * G%mask2dT(i,j) * G%mask2dT(i,j+1))
+        endif
+      enddo ; enddo ; enddo
+
+      if (local_open_BC) then
+        do n=1, OBC%number_of_segments
+          segment => OBC%segment(n)
+          if (.not. segment%on_pe) cycle
+          if (segment%is_N_or_S) then
+            J=segment%HI%JsdB
+            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+              kk = k - ksb + 1
+
+              slp(i,j+1,kk) = 0.0
+              slp(i,j,kk) = 0.0
+            enddo ; enddo
+          endif
+        enddo
       endif
-    enddo ; enddo
+
+      do k=ksb,keb ; do j=jsl,jel ; do i=isl,iel
+        kk = k - ksb + 1
+
+        ! Neighboring values should take into account any boundaries.  The 3
+        ! following sets of expressions are equivalent.
+        h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1,k) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j,k)
+        h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1,k) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j,k)
+        ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
+        h_S(i,j,k) = 0.5*( h_jm1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i,j-1,kk) - slp(i,j,kk) )
+        h_N(i,j,k) = 0.5*( h_jp1 + h_in(i,j,k) ) + &
+                     oneSixth*( slp(i,j,kk) - slp(i,j+1,kk) )
+      enddo ; enddo ; enddo
+    endif
 
     if (local_open_BC) then
       do n=1, OBC%number_of_segments
         segment => OBC%segment(n)
         if (.not. segment%on_pe) cycle
-        if (segment%is_N_or_S) then
+        if (segment%direction == OBC_DIRECTION_N) then
           J=segment%HI%JsdB
-          do i=segment%HI%isd,segment%HI%ied
-            slp(i,j+1) = 0.0
-            slp(i,j) = 0.0
-          enddo
+          if (associated(segment%h_Reg)) then
+            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+              h_S(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
+              h_N(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
+              h_S(i,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_N(i,j,k) = segment%h_Reg%h_res(i,j,k)
+            enddo ; enddo
+          else
+            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+              h_S(i,j+1,k) = h_in(i,j,k)
+              h_N(i,j+1,k) = h_in(i,j,k)
+              h_S(i,j,k) = h_in(i,j,k)
+              h_N(i,j,k) = h_in(i,j,k)
+            enddo ; enddo
+          endif
+        elseif (segment%direction == OBC_DIRECTION_S) then
+          J=segment%HI%JsdB
+          if (associated(segment%h_Reg)) then
+            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+              h_S(i,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_N(i,j,k) = segment%h_Reg%h_res(i,j,k)
+              h_S(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
+              h_N(i,j+1,k) = segment%h_Reg%h_res(i,j,k)
+            enddo ; enddo
+          else
+            do k=ksb,keb ; do i=segment%HI%isd,segment%HI%ied
+              h_S(i,j,k) = h_in(i,j+1,k)
+              h_N(i,j,k) = h_in(i,j+1,k)
+              h_S(i,j+1,k) = h_in(i,j+1,k)
+              h_N(i,j+1,k) = h_in(i,j+1,k)
+            enddo ; enddo
+          endif
         endif
       enddo
     endif
 
-    do j=jsl,jel ; do i=isl,iel
-      ! Neighboring values should take into account any boundaries.  The 3
-      ! following sets of expressions are equivalent.
-      h_jm1 = G%mask2dT(i,j-1) * h_in(i,j-1) + (1.0-G%mask2dT(i,j-1)) * h_in(i,j)
-      h_jp1 = G%mask2dT(i,j+1) * h_in(i,j+1) + (1.0-G%mask2dT(i,j+1)) * h_in(i,j)
-      ! Left/right values following Eq. B2 in Lin 1994, MWR (132)
-      h_S(i,j) = 0.5*( h_jm1 + h_in(i,j) ) + oneSixth*( slp(i,j-1) - slp(i,j) )
-      h_N(i,j) = 0.5*( h_jp1 + h_in(i,j) ) + oneSixth*( slp(i,j) - slp(i,j+1) )
-    enddo ; enddo
-  endif
-
-  if (local_open_BC) then
-    do n=1, OBC%number_of_segments
-      segment => OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (segment%direction == OBC_DIRECTION_N) then
-        J=segment%HI%JsdB
-        if (associated(segment%h_Reg)) then
-          do i=segment%HI%isd,segment%HI%ied
-            h_S(i,j+1) = segment%h_Reg%h_res(i,j,k)
-            h_N(i,j+1) = segment%h_Reg%h_res(i,j,k)
-            h_S(i,j) = segment%h_Reg%h_res(i,j,k)
-            h_N(i,j) = segment%h_Reg%h_res(i,j,k)
-          enddo
-        else
-          do i=segment%HI%isd,segment%HI%ied
-            h_S(i,j+1) = h_in(i,j)
-            h_N(i,j+1) = h_in(i,j)
-            h_S(i,j) = h_in(i,j)
-            h_N(i,j) = h_in(i,j)
-          enddo
-        endif
-      elseif (segment%direction == OBC_DIRECTION_S) then
-        J=segment%HI%JsdB
-        if (associated(segment%h_Reg)) then
-          do i=segment%HI%isd,segment%HI%ied
-            h_S(i,j) = segment%h_Reg%h_res(i,j,k)
-            h_N(i,j) = segment%h_Reg%h_res(i,j,k)
-            h_S(i,j+1) = segment%h_Reg%h_res(i,j,k)
-            h_N(i,j+1) = segment%h_Reg%h_res(i,j,k)
-          enddo
-        else
-          do i=segment%HI%isd,segment%HI%ied
-            h_S(i,j) = h_in(i,j+1)
-            h_N(i,j) = h_in(i,j+1)
-            h_S(i,j+1) = h_in(i,j+1)
-            h_N(i,j+1) = h_in(i,j+1)
-          enddo
-        endif
-      endif
-    enddo
-  endif
-
-  if (monotonic) then
-    call PPM_limit_CW84(h_in, h_S, h_N, G, isl, iel, jsl, jel)
-  else
-    call PPM_limit_pos(h_in, h_S, h_N, h_min, G, isl, iel, jsl, jel)
-  endif
-
-  return
+    if (monotonic) then
+      call PPM_limit_CW84(h_in, h_S, h_N, G, GV, isl, iel, jsl, jel, ksb, keb)
+    else
+      call PPM_limit_pos(h_in, h_S, h_N, h_min, G, GV, isl, iel, jsl, jel, ksb, keb)
+    endif
+  enddo
 end subroutine PPM_reconstruction_y
 
 !> This subroutine limits the left/right edge values of the PPM reconstruction
 !! to give a reconstruction that is positive-definite.  Here this is
 !! reinterpreted as giving a constant thickness if the mean thickness is less
 !! than h_min, with a minimum of h_min otherwise.
-subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
-  type(ocean_grid_type),             intent(in)  :: G    !< Ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in)  :: h_in !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(inout) :: h_L !< Left thickness in the reconstruction [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(inout) :: h_R !< Right thickness in the reconstruction [H ~> m or kg m-2].
-  real,                              intent(in)  :: h_min !< The minimum thickness
+subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, GV, iis, iie, jis, jie, ks, ke)
+  type(ocean_grid_type),             intent(in)    :: G    !< Ocean's grid structure.
+  type(verticalGrid_type),           intent(in)    :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                     intent(in)    :: h_in !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                     intent(inout) :: h_L !< Left thickness in the reconstruction [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                     intent(inout) :: h_R !< Right thickness in the reconstruction [H ~> m or kg m-2].
+  real,                              intent(in)    :: h_min !< The minimum thickness
                     !! that can be obtained by a concave parabolic fit [H ~> m or kg m-2]
-  integer,                           intent(in)  :: iis      !< Start of i index range.
-  integer,                           intent(in)  :: iie      !< End of i index range.
-  integer,                           intent(in)  :: jis      !< Start of j index range.
-  integer,                           intent(in)  :: jie      !< End of j index range.
+  integer,                           intent(in)    :: iis      !< Start of i index range.
+  integer,                           intent(in)    :: iie      !< End of i index range.
+  integer,                           intent(in)    :: jis      !< Start of j index range.
+  integer,                           intent(in)    :: jie      !< End of j index range.
+  integer,                           intent(in)    :: ks       !< Start of k index range.
+  integer,                           intent(in)    :: ke       !< End of k index range.
 
-! Local variables
   real    :: curv  ! The grid-normalized curvature of the three thicknesses  [H ~> m or kg m-2]
   real    :: dh    ! The difference between the edge thicknesses             [H ~> m or kg m-2]
   real    :: scale ! A scaling factor to reduce the curvature of the fit               [nondim]
-  integer :: i,j
+  integer :: i, j, k
 
-  do j=jis,jie ; do i=iis,iie
+  do k=ks,ke ; do j=jis,jie ; do i=iis,iie
     ! This limiter prevents undershooting minima within the domain with
     ! values less than h_min.
-    curv = 3.0*((h_L(i,j) + h_R(i,j)) - 2.0*h_in(i,j))
+    curv = 3.0*((h_L(i,j,k) + h_R(i,j,k)) - 2.0*h_in(i,j,k))
     if (curv > 0.0) then ! Only minima are limited.
-      dh = h_R(i,j) - h_L(i,j)
+      dh = h_R(i,j,k) - h_L(i,j,k)
       if (abs(dh) < curv) then ! The parabola's minimum is within the cell.
-        if (h_in(i,j) <= h_min) then
-          h_L(i,j) = h_in(i,j) ; h_R(i,j) = h_in(i,j)
-        elseif (12.0*curv*(h_in(i,j) - h_min) < (curv**2 + 3.0*dh**2)) then
+        if (h_in(i,j,k) <= h_min) then
+          h_L(i,j,k) = h_in(i,j,k) ; h_R(i,j,k) = h_in(i,j,k)
+        elseif (12.0*curv*(h_in(i,j,k) - h_min) < (curv**2 + 3.0*dh**2)) then
           ! The minimum value is h_in - (curv^2 + 3*dh^2)/(12*curv), and must
           ! be limited in this case.  0 < scale < 1.
-          scale = 12.0*curv*(h_in(i,j) - h_min) / (curv**2 + 3.0*dh**2)
-          h_L(i,j) = h_in(i,j) + scale*(h_L(i,j) - h_in(i,j))
-          h_R(i,j) = h_in(i,j) + scale*(h_R(i,j) - h_in(i,j))
+          scale = 12.0*curv*(h_in(i,j,k) - h_min) / (curv**2 + 3.0*dh**2)
+          h_L(i,j,k) = h_in(i,j,k) + scale*(h_L(i,j,k) - h_in(i,j,k))
+          h_R(i,j,k) = h_in(i,j,k) + scale*(h_R(i,j,k) - h_in(i,j,k))
         endif
       endif
     endif
-  enddo ; enddo
-
+  enddo ; enddo ; enddo
 end subroutine PPM_limit_pos
 
 !> This subroutine limits the left/right edge values of the PPM reconstruction
 !! according to the monotonic prescription of Colella and Woodward, 1984.
-subroutine PPM_limit_CW84(h_in, h_L, h_R, G, iis, iie, jis, jie)
+subroutine PPM_limit_CW84(h_in, h_L, h_R, G, GV, iis, iie, jis, jie, ks, ke)
   type(ocean_grid_type),             intent(in)  :: G     !< Ocean's grid structure.
-  real, dimension(SZI_(G),SZJ_(G)),  intent(in)  :: h_in  !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(inout) :: h_L !< Left thickness in the reconstruction,
+  type(verticalGrid_type),           intent(in)  :: GV   !< Ocean's vertical grid structure.
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(in)  :: h_in  !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(inout) :: h_L !< Left thickness in the reconstruction,
                                                           !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)),  intent(inout) :: h_R !< Right thickness in the reconstruction,
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  intent(inout) :: h_R !< Right thickness in the reconstruction,
                                                           !! [H ~> m or kg m-2].
   integer,                           intent(in)  :: iis   !< Start of i index range.
   integer,                           intent(in)  :: iie   !< End of i index range.
   integer,                           intent(in)  :: jis   !< Start of j index range.
   integer,                           intent(in)  :: jie   !< End of j index range.
+  integer,                           intent(in)  :: ks    !< Start of k index range.
+  integer,                           intent(in)  :: ke    !< End of k index range.
 
   ! Local variables
   real    :: h_i      ! A copy of the cell-average layer thickness                [H ~> m or kg m-2]
@@ -2693,29 +3227,27 @@ subroutine PPM_limit_CW84(h_in, h_L, h_R, G, iis, iie, jis, jie)
   real    :: RLdiff2  ! The squared difference between the input edge values   [H2 ~> m2 or kg2 m-4]
   real    :: RLmean   ! The average of the input edge thicknesses                 [H ~> m or kg m-2]
   real    :: FunFac   ! A curious product of the thickness slope and curvature [H2 ~> m2 or kg2 m-4]
-  integer :: i, j
+  integer :: i, j, k
 
-  do j=jis,jie ; do i=iis,iie
+  do k=ks,ke ; do j=jis,jie ; do i=iis,iie
     ! This limiter monotonizes the parabola following
     ! Colella and Woodward, 1984, Eq. 1.10
-    h_i = h_in(i,j)
-    if ( ( h_R(i,j) - h_i ) * ( h_i - h_L(i,j) ) <= 0. ) then
-      h_L(i,j) = h_i ; h_R(i,j) = h_i
+    h_i = h_in(i,j,k)
+    if ( ( h_R(i,j,k) - h_i ) * ( h_i - h_L(i,j,k) ) <= 0. ) then
+      h_L(i,j,k) = h_i ; h_R(i,j,k) = h_i
     else
-      RLdiff = h_R(i,j) - h_L(i,j)            ! Difference of edge values
-      RLmean = 0.5 * ( h_R(i,j) + h_L(i,j) )  ! Mean of edge values
+      RLdiff = h_R(i,j,k) - h_L(i,j,k)            ! Difference of edge values
+      RLmean = 0.5 * ( h_R(i,j,k) + h_L(i,j,k) )  ! Mean of edge values
       FunFac = 6. * RLdiff * ( h_i - RLmean ) ! Some funny factor
       RLdiff2 = RLdiff * RLdiff               ! Square of difference
-      if ( FunFac >  RLdiff2 ) h_L(i,j) = 3. * h_i - 2. * h_R(i,j)
-      if ( FunFac < -RLdiff2 ) h_R(i,j) = 3. * h_i - 2. * h_L(i,j)
+      if ( FunFac >  RLdiff2 ) h_L(i,j,k) = 3. * h_i - 2. * h_R(i,j,k)
+      if ( FunFac < -RLdiff2 ) h_R(i,j,k) = 3. * h_i - 2. * h_L(i,j,k)
     endif
-  enddo ; enddo
-
-  return
+  enddo ; enddo ; enddo
 end subroutine PPM_limit_CW84
 
 !> Return the maximum ratio of a/b or maxrat.
-function ratio_max(a, b, maxrat) result(ratio)
+pure function ratio_max(a, b, maxrat) result(ratio)
   real, intent(in) :: a       !< Numerator, in arbitrary units [A]
   real, intent(in) :: b       !< Denominator, in arbitrary units [B]
   real, intent(in) :: maxrat  !< Maximum value of ratio [A B-1]
@@ -2757,7 +3289,7 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
   endif
 
 ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
+  call log_version(param_file, mdl, version, "", log_to_all=.true., layout=.true.)
   call get_param(param_file, mdl, "MONOTONIC_CONTINUITY", CS%monotonic, &
                  "If true, CONTINUITY_PPM uses the Colella and Woodward "//&
                  "monotonic limiter.  The default (false) is to use a "//&
@@ -2817,6 +3349,27 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
                  "If true, the marginal thickness used and returned from continuity "//&
                  "is bounded from below by a sub-roundoff value.  Otherwise the "//&
                  "minimum is a large negative value to recreate previous answers.", default=.false.)
+  call get_param(param_file, mdl, "CONTINUITY_NIBLOCK", CS%niblock, &
+                 "The i-direction block size used in the mass and volume flux calculations. "//&
+                 "the default 0 setting is dynamic and fits the "//&
+                 "full computational i-domain length.", default=0, layoutParam=.true.)
+  call get_param(param_file, mdl, "CONTINUITY_NJBLOCK", CS%njblock, &
+                 "The j-direction block size used in the mass and volume flux calculations. "//&
+                 "the default 0 setting is dynamic and fits the "//&
+                 "full computational j-domain length.", default=1, layoutParam=.true.)
+  call get_param(param_file, mdl, "CONTINUITY_NKBLOCK", CS%nkblock, &
+                 "The k-direction block size used in PPM reconstruction edge value calculations. "//&
+                 "the default 0 setting is dynamic and fits the "//&
+                 "full vertical column.", default=1, layoutParam=.true.)
+  if (CS%niblock < 0) &
+    call MOM_error(FATAL, "CONTINUITY_NIBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%njblock < 0) &
+    call MOM_error(FATAL, "CONTINUITY_NJBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
+  if (CS%nkblock < 0) &
+    call MOM_error(FATAL, "CONTINUITY_NKBLOCK must be nonnegative; "//&
+                          "use 0 to select the default block size.")
   CS%diag => diag
 
   id_clock_reconstruct = cpu_clock_id('(Ocean continuity reconstruction)', grain=CLOCK_ROUTINE)
@@ -2842,7 +3395,6 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
       endif
     enddo
   endif
-
 end subroutine continuity_PPM_init
 
 !> continuity_PPM_stencil returns the continuity solver stencil size

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -123,6 +123,7 @@ type, public :: hor_visc_CS ; private
   logical :: res_scale_MEKE  !< If true, the viscosity contribution from MEKE is scaled by
                              !! the resolution function.
   logical :: use_GME         !< If true, use GME backscatter scheme.
+  integer :: nkblock         !< The k block size used in horizontal viscosity calculations
   integer :: answer_date     !< The vintage of the order of arithmetic and expressions in the
                              !! horizontal viscosity calculations.  Values below 20190101 recover
                              !! the answers from the end of 2018, while higher values use updated
@@ -273,8 +274,67 @@ contains
 !!   u(is-2:ie+2,js-2:je+2)
 !!   v(is-2:ie+2,js-2:je+2)
 !!   h(is-1:ie+1,js-1:je+1) or up to h(is-2:ie+2,js-2:je+2) with some Leith options.
-subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, GV, US, &
-                                CS, tv, dt, OBC, BT, TD, ADp, hu_cont, hv_cont, STOCH)
+subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, &
+    G, GV, US, CS, tv, dt, OBC, BT, TD, ADp, hu_cont, hv_cont, STOCH)
+  type(ocean_grid_type), intent(in) :: G
+      !< The ocean's grid structure
+  type(verticalGrid_type), intent(in) :: GV
+      !< The ocean's vertical grid structure
+  real, intent(in) :: u(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< The zonal velocity [L T-1 ~> m s-1]
+  real, intent(in) :: v(SZI_(G),SZJB_(G),SZK_(GV))
+      !< The meridional velocity [L T-1 ~> m s-1]
+  real, intent(inout) :: h(SZI_(G),SZJ_(G),SZK_(GV))
+      !< Layer thicknesses [H ~> m or kg m-2]
+  real, intent(in) :: uh(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< The zonal volume transport [H L2 T-1 ~> m3 s-1]
+  real, intent(in) :: vh(SZI_(G),SZJB_(G),SZK_(GV))
+      !< The meridional volume transport [H L2 T-1 ~> m3 s-1]
+  real, intent(out) :: diffu(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< Zonal acceleration due to horizontal viscosity [L T-2 ~> m s-2]
+  real, intent(out) :: diffv(SZI_(G),SZJB_(G),SZK_(GV))
+      !< Meridional acceleration due to horizontal viscosity [L T-2 ~> m s-2]
+  type(MEKE_type), intent(inout) :: MEKE
+      !< MEKE fields related to Mesoscale Eddy Kinetic Energy
+  type(VarMix_CS), intent(inout) :: VarMix
+      !< Variable mixing control structure
+  type(unit_scale_type), intent(in) :: US
+      !< A dimensional unit scaling type
+  type(hor_visc_CS), intent(inout) :: CS
+      !< Horizontal viscosity control structure
+  type(thermo_var_ptrs), intent(in) :: tv
+      !< A structure pointing to various thermodynamic variables
+  real, intent(in) :: dt
+      !< Time increment [T ~> s]
+  type(ocean_OBC_type), pointer, intent(in), optional :: OBC
+      !< Pointer to an open boundary condition type
+  type(barotropic_CS), intent(in), optional :: BT
+      !< Barotropic control structure
+  type(thickness_diffuse_CS), intent(in), optional :: TD
+      !< Thickness diffusion control structure
+  type(accel_diag_ptrs), optional, intent(in) :: ADp
+      !< Acceleration diagnostics
+  real, intent(inout), optional :: hu_cont(SZIB_(G),SZJ_(G),SZK_(GV))
+      !< Layer thickness at u-points [H ~> m or kg m-2]
+  real, intent(inout), optional :: hv_cont(SZI_(G),SZJB_(G),SZK_(GV))
+      !< Layer thickness at v-points [H ~> m or kg m-2]
+  type(stochastic_CS), intent(inout), optional :: STOCH
+      !< Stochastic control structure
+
+  integer :: nkk
+      ! The resolved k block size used in horizontal viscosity calculations
+
+  nkk = CS%nkblock
+  if (nkk == 0) nkk = GV%ke
+
+  call horizontal_viscosity_block(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, &
+      G, GV, US, CS, nkk, tv, dt, OBC, BT, TD, ADp, hu_cont, hv_cont, STOCH)
+end subroutine horizontal_viscosity
+
+
+!> Calculates the acceleration due to the horizontal viscosity using an explicit k-block size.
+subroutine horizontal_viscosity_block(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, GV, US, &
+                                CS, nkk, tv, dt, OBC, BT, TD, ADp, hu_cont, hv_cont, STOCH)
   type(ocean_grid_type),         intent(in)  :: G      !< The ocean's grid structure.
   type(verticalGrid_type),       intent(in)  :: GV     !< The ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
@@ -298,6 +358,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   type(VarMix_CS),               intent(inout) :: VarMix !< Variable mixing control structure
   type(unit_scale_type),         intent(in)    :: US   !< A dimensional unit scaling type
   type(hor_visc_CS),             intent(inout) :: CS   !< Horizontal viscosity control structure
+  integer,                       intent(in)    :: nkk  !< The effective k-block size [nondim]
   type(thermo_var_ptrs),         intent(in)    :: tv   !< A structure pointing to various
                                                        !! thermodynamic variables
   real,                          intent(in)    :: dt   !< Time increment [T ~> s]
@@ -312,54 +373,48 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   type(stochastic_CS), intent(inout), optional :: STOCH !< Stochastic control structure
 
   ! Local variables
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
+  real, dimension(SZIB_(G),SZJ_(G),nkk) :: &
     Del2u, &      ! The u-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
-    h_u, &        ! Thickness interpolated to u points [H ~> m or kg m-2].
-    vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
-    vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
-    div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJB_(G)) :: &
+    h_u           ! Thickness interpolated to u points [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJB_(G),nkk) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
-    h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
-    vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
-    vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
-    div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJ_(G)) :: &
-    dudx_bt, dvdy_bt, & ! components in the barotropic horizontal tension [T-1 ~> s-1]
-    div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
+    h_v           ! Thickness interpolated to v points [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJB_(G)) :: &
+    dudx_bt, dvdy_bt ! components in the barotropic horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
-    sh_xx_smooth, & ! horizontal tension from smoothed velocity including metric terms [T-1 ~> s-1]
-    sh_xx_bt, &   ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
-    str_xx,&      ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
+    sh_xx_smooth  ! horizontal tension from smoothed velocity including metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    sh_xx_bt      ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    str_xx, &     ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
-    str_xx_GME,&  ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
+    str_xx_GME, & ! smoothed diagonal term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
     bhstr_xx, &   ! A copy of str_xx that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     FrictWorkIntz, & ! depth integrated energy dissipated by lateral friction [R Z L2 T-3 ~> W m-2]
     FrictWorkIntz_bh, & ! depth integrated energy dissipated by biharmonic lateral friction [R Z L2 T-3 ~> W m-2]
     grad_vort_mag_h, & ! Magnitude of vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_vort_mag_h_2d, & ! Magnitude of 2d vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_div_mag_h, &     ! Magnitude of divergence gradient at h-points [L-1 T-1 ~> m-1 s-1]
-    dudx, dvdy, &    ! components in the horizontal tension [T-1 ~> s-1]
-    dudx_smooth, dvdy_smooth, & ! components in the horizontal tension from smoothed velocity [T-1 ~> s-1]
-    GME_effic_h, &  ! The filtered efficiency of the GME terms at h points [nondim]
-    m_leithy, &   ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
-    Ah_sq, &      ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
-    htot, &       ! The total thickness of all layers [H ~> m or kg m-2]
-    str_xx_BS      ! The diagonal term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
+    dudx, dvdy      ! components in the horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    GME_effic_h   ! The filtered efficiency of the GME terms at h points [nondim]
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    m_leithy      ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
   real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
-  real :: grad_vel_mag_bt_h ! Magnitude of the barotropic velocity gradient tensor squared at h-points [T-2 ~> s-2]
-  real :: boundary_mask_h ! A mask that zeroes out cells with at least one land edge [nondim]
 
-  real, dimension(SZIB_(G),SZJB_(G)) :: &
+  real, dimension(SZIB_(G),SZJB_(G),nkk) :: &
     dvdx, dudy, & ! components in the shearing strain [T-1 ~> s-1]
     dvdx_smooth, dudy_smooth, & ! components in the shearing strain from smoothed velocity [T-1 ~> s-1]
-    dDel2vdx, dDel2udy, & ! Components in the biharmonic equivalent of the shearing strain [L-2 T-1 ~> m-2 s-1]
-    dvdx_bt, dudy_bt,   & ! components in the barotropic shearing strain [T-1 ~> s-1]
+    dDel2vdx, dDel2udy ! Components in the biharmonic equivalent of the shearing strain [L-2 T-1 ~> m-2 s-1]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    dvdx_bt, dudy_bt   ! components in the barotropic shearing strain [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk) :: &
     sh_xy,  &     ! horizontal shearing strain (du/dy + dv/dx) including metric terms [T-1 ~> s-1]
-    sh_xy_smooth,  & ! horizontal shearing strain from smoothed velocity including metric terms [T-1 ~> s-1]
-    sh_xy_bt, &   ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
+    sh_xy_smooth  ! horizontal shearing strain from smoothed velocity including metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    sh_xy_bt      ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk) :: &
     str_xy, &     ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
     str_xy_GME, & ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
@@ -370,12 +425,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     grad_vort_mag_q_2d, & ! Magnitude of 2d vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     Del2vort_q, & ! Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
     grad_div_mag_q, &  ! Magnitude of divergence gradient at q-points [L-1 T-1 ~> m-1 s-1]
-    hq, &          ! harmonic mean of the harmonic means of the u- & v point thicknesses [H ~> m or kg m-2]
+    hq             ! harmonic mean of the harmonic means of the u- & v point thicknesses [H ~> m or kg m-2]
                    ! This form guarantees that hq/hu < 4.
-    GME_effic_q, & ! The filtered efficiency of the GME terms at q points [nondim]
-    str_xy_BS      ! The cross term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
-  real :: grad_vel_mag_bt_q ! Magnitude of the barotropic velocity gradient tensor squared at q-points [T-2 ~> s-2]
-  real :: boundary_mask_q ! A mask that zeroes out cells with at least one land edge [nondim]
+  real, dimension(SZIB_(G),SZJB_(G)) :: &
+    GME_effic_q   ! The filtered efficiency of the GME terms at q points [nondim]
 
   real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)) :: &
     Ah_q, &      ! biharmonic viscosity at corner points [L4 T-1 ~> m4 s-1]
@@ -418,7 +471,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     v_smooth         ! Meridional velocity, smoothed with a spatial low-pass filter [L T-1 ~> m s-1]
   real :: AhSm       ! Smagorinsky biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
-  real :: AhLthy     ! 2D Leith+E biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: Shear_mag_bc  ! Shear_mag value in backscatter [T-1 ~> s-1]
   real :: sh_xx_sq   ! Square of tension (sh_xx) [T-2 ~> s-2]
   real :: sh_xy_sq   ! Square of shearing strain (sh_xy) [T-2 ~> s-2]
@@ -426,8 +478,6 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real :: hu, hv     ! Thicknesses interpolated by arithmetic means to corner
                      ! points; these are first interpolated to u or v velocity
                      ! points where masks are applied [H ~> m or kg m-2].
-  real :: h_arith_q  ! The arithmetic mean total thickness at q points [H ~> m or kg m-2]
-  real :: I_GME_h0   ! The inverse of GME tapering scale [H-1 ~> m-1 or m2 kg-1]
   real :: h_neglect  ! thickness so small it can be lost in roundoff and so neglected [H ~> m or kg m-2]
   real :: h_neglect3 ! h_neglect^3 [H3 ~> m3 or kg3 m-6]
   real :: h_min      ! Minimum h at the 4 neighboring velocity points [H ~> m]
@@ -450,6 +500,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   real :: grad_vort_qg ! QG-based vorticity gradient magnitude [L-1 T-1 ~> m-1 s-1]
   real :: grid_Kh   ! Laplacian viscosity bound by grid [L2 T-1 ~> m2 s-1]
   real :: grid_Ah   ! Biharmonic viscosity bound by grid [L4 T-1 ~> m4 s-1]
+  real :: dudx_smooth, dvdy_smooth ! components in the horizontal tension from smoothed velocity [T-1 ~> s-1]
 
   logical :: rescale_Kh
   logical :: find_FrictWork
@@ -460,10 +511,15 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   logical :: skeb_use_frict
   logical :: use_cont_huv
   logical :: use_kh_struct
+  logical :: use_Leith    ! True if any Leith parameterizations are enabled
+  logical :: use_vort_xy  ! True if vort_xy must be computed
+  logical :: use_Smag     ! True if a Smagorinsky viscosity is enabled
   integer :: is_vort, ie_vort, js_vort, je_vort  ! Loop ranges for vorticity terms
   integer :: is_Kh, ie_Kh, js_Kh, je_Kh  ! Loop ranges for thickness point viscosities
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
-  integer :: i, j, k, n
+  integer :: i, j, k, kk, n
+  integer :: ksb, keb  ! Start and end domain index bounds of current block
+  integer :: kke       ! Block end index of current block
   real :: inv_PI3, inv_PI2, inv_PI6 ! Powers of the inverse of pi [nondim]
   real :: tmp
 
@@ -473,7 +529,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   ! NOTE: Several of these are declared with the memory extent of q-points, but the
   !   same arrays are also used at h-points to reduce the memory footprint of this
   !   module, so they should never be used in halo point or checksum calls.
-  real, dimension(SZIB_(G),SZJB_(G)) :: &
+  real, dimension(SZIB_(G),SZJB_(G),nkk) :: &
     Ah, &           ! biharmonic viscosity (h or q) [L4 T-1 ~> m4 s-1]
     Kh, &           ! Laplacian  viscosity (h or q) [L2 T-1 ~> m2 s-1]
     Kh_BS, &        ! Laplacian  antiviscosity [L2 T-1 ~> m2 s-1]
@@ -488,6 +544,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+
+  if (nkk < 0) call MOM_error(FATAL, "MOM_hor_visc: nkblock must be >= 0.")
 
   h_neglect  = GV%H_subroundoff
   !h_neglect3 = h_neglect**3
@@ -508,7 +566,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   skeb_use_frict = .false.
   if (present(STOCH)) skeb_use_frict = STOCH%skeb_use_frict
 
-  m_leithy(:,:) = 0.0 ! Initialize
+  if (CS%use_Leithy) m_leithy(:,:,:) = 0.0 ! Initialize
 
   if (present(OBC)) then ; if (associated(OBC)) then ; if (OBC%OBC_pe) then
     apply_OBC = OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally
@@ -574,93 +632,11 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   endif
 
   if (CS%use_GME) then
-
-    ! Initialize diagnostic arrays with zeros
-    GME_coeff_h(:,:,:) = 0.0
-    GME_coeff_q(:,:,:) = 0.0
-    str_xx_GME(:,:) = 0.0
-    str_xy_GME(:,:) = 0.0
-
-    ! Get barotropic velocities and their gradients
-    call barotropic_get_tav(BT, ubtav, vbtav, G, US)
-
-    call pass_vector(ubtav, vbtav, G%Domain)
-    call pass_var(h, G%domain, halo=2)
-
-    ! Calculate the barotropic horizontal tension
-    do j=js-2,je+2 ; do i=is-2,ie+2
-      dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j)) - &
-                                     (G%IdyCu(I-1,j) * ubtav(I-1,j)))
-      dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
-                                     (G%IdxCv(i,J-1) * vbtav(i,J-1)))
-    enddo ; enddo
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
-    enddo ; enddo
-
-    ! Components for the barotropic shearing strain
-    do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
-      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
-                                    - (vbtav(i,J)*G%IdyCv(i,J)))
-      dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1)*G%IdxCu(I,j+1)) &
-                                    - (ubtav(I,j)*G%IdxCu(I,j)))
-    enddo ; enddo
-
-    if (CS%no_slip) then
-      do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
-      enddo ; enddo
-    else
-      do J=js-2,je+1 ; do I=is-2,ie+1
-        sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
-      enddo ; enddo
-    endif
-
-    do j=js-2,je+2 ; do i=is-2,ie+2
-      htot(i,j) = 0.0
-    enddo ; enddo
-    do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
-      htot(i,j) = htot(i,j) + h(i,j,k)
-    enddo ; enddo ; enddo
-
-    I_GME_h0 = 1.0 / CS%GME_h0
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
-      grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
-            (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
-            (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
-      ! Probably the following test could be simplified to
-      ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
-      if (grad_vel_mag_bt_h > 0.0) then
-        GME_effic_h(i,j) = CS%GME_efficiency * G%mask2dT(I,J) * (MIN(htot(i,j) * I_GME_h0, 1.0)**2)
-      else
-        GME_effic_h(i,j) = 0.0
-      endif
-    enddo ; enddo
-
-    do J=js-2,je+1 ; do I=is-2,ie+1
-      boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
-      grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
-            (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1)) + (dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
-            (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1)) + (dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
-      ! Probably the following test could be simplified to
-      ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
-      if (grad_vel_mag_bt_q > 0.0) then
-        h_arith_q = 0.25 * ((htot(i,j) + htot(i+1,j+1)) + (htot(i+1,j) + htot(i,j+1)))
-        GME_effic_q(I,J) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
-      else
-        GME_effic_q(I,J) = 0.0
-      endif
-    enddo ; enddo
-
-    call thickness_diffuse_get_KH(TD, KH_u_GME, KH_v_GME, G, GV)
-
-    call pass_vector(KH_u_GME, KH_v_GME, G%domain, To_All+Scalar_Pair)
-
-    if (CS%debug) &
-      call uvchksum("GME KH[u,v]_GME", KH_u_GME, KH_v_GME, G%HI, haloshift=2, unscale=US%L_to_m**2*US%s_to_T)
-
-  endif ! use_GME
+    call hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, nkk, &
+                            dudx_bt, dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, &
+                            GME_effic_h, GME_effic_q, KH_u_GME, KH_v_GME, &
+                            GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
+  endif
 
   if (CS%use_Leithy) then
     ! Smooth the velocity. Right now it happens twice. In the future
@@ -698,94 +674,79 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! call pass_vector(slope_x, slope_y, G%Domain, halo=2)
   endif
 
-  !$OMP parallel do default(none) if (.not. CS%smooth_AH) &
-  !$OMP shared( &
-  !$OMP   CS, G, GV, US, OBC, VarMix, MEKE, u, v, h, uh, vh, &
-  !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
-  !$OMP   is_vort, ie_vort, js_vort, je_vort, &
-  !$OMP   is_Kh, ie_Kh, js_Kh, je_Kh, &
-  !$OMP   apply_OBC, apply_OBC_strain, rescale_Kh, find_FrictWork, use_kh_struct, skeb_use_frict, &
-  !$OMP   use_MEKE_Ku, use_MEKE_Au, u_smooth, v_smooth, use_cont_huv, slope_x, slope_y, dz, &
-  !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
-  !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
-  !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_bh, FrictWork_GME, &
-  !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont, STOCH, zc &
-  !$OMP ) &
-  !$OMP private( &
-  !$OMP   i, j, k, n, tmp, &
-  !$OMP   dudx, dudy, dvdx, dvdy, sh_xx, sh_xy, h_u, h_v, &
-  !$OMP   Del2u, Del2v, DY_dxBu, DX_dyBu, sh_xx_bt, sh_xy_bt, &
-  !$OMP   str_xx, str_xy, bhstr_xx, bhstr_xy, str_xx_GME, str_xy_GME, &
-  !$OMP   vort_xy, vort_xy_dx, vort_xy_dy, div_xx, div_xx_dx, div_xx_dy, &
-  !$OMP   grad_div_mag_h, grad_div_mag_q, grad_vort_mag_h, grad_vort_mag_q, &
-  !$OMP   grad_vort, grad_vort_qg, grad_vort_mag_h_2d, grad_vort_mag_q_2d, &
-  !$OMP   sh_xx_sq, sh_xy_sq, meke_res_fn, Shear_mag, Shear_mag_bc, vert_vort_mag, &
-  !$OMP   h_min, hrat_min, visc_bound_rem, Kh_max_here, &
-  !$OMP   grid_Ah, grid_Kh, d_Del2u, d_Del2v, d_str, &
-  !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
-  !$OMP   dDel2vdx, dDel2udy, Del2vort_q, Del2vort_h, KE, &
-  !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff, &
-  !$OMP   dudx_smooth, dudy_smooth, dvdx_smooth, dvdy_smooth, &
-  !$OMP   vort_xy_smooth, vort_xy_dx_smooth, vort_xy_dy_smooth, &
-  !$OMP   sh_xx_smooth, sh_xy_smooth, &
-  !$OMP   vert_vort_mag_smooth, m_leithy, Ah_sq, AhLthy, &
-  !$OMP   Kh_BS, str_xx_bs, str_xy_bs, bs_coeff_h, bs_coeff_q &
-  !$OMP ) &
-  !$OMP firstprivate( &
-  !$OMP   visc_limit_h, visc_limit_h_frac, visc_limit_h_flag, &
-  !$OMP   visc_limit_q, visc_limit_q_frac, visc_limit_q_flag &
-  !$OMP )
-  do k=1,nz
+  if (find_FrictWork .and. allocated(MEKE%mom_src)) then
+    do j=js,je ; do i=is,ie
+      MEKE%mom_src(i,j) = 0.
+    enddo ; enddo
+
+    if (allocated(MEKE%mom_src_bh)) then
+      do j=js,je ; do i=is,ie
+        MEKE%mom_src_bh(i,j) = 0.
+      enddo ; enddo
+    endif
+
+    if (allocated(MEKE%GME_snk)) then
+      do j=js,je ; do i=is,ie
+        MEKE%GME_snk(i,j) = 0.
+      enddo ; enddo
+    endif
+  endif
+
+  use_Leith = CS%Leith_Kh .or. CS%Leith_Ah .or. CS%use_Leithy
+  use_vort_xy = use_Leith .or. CS%id_vort_xy_q > 0 .or. CS%use_ZB2020
+  use_Smag = CS%Smagorinsky_Kh .or. CS%Smagorinsky_Ah
+
+  do ksb=1,nz,nkk
+    keb = min(ksb + nkk - 1, nz)
+    kke = keb - ksb + 1
 
     ! The following are the forms of the horizontal tension and horizontal
     ! shearing strain advocated by Smagorinsky (1993) and discussed in
     ! Griffies and Hallberg (2000).
 
-    ! NOTE: There is a ~1% speedup when the tension and shearing loops below
-    !   are fused (presumably due to shared access of Id[xy]C[uv]).  However,
-    !   this breaks the center/vertex index case convention, and also evaluates
-    !   the dudx and dvdy terms beyond their valid bounds.
-    ! TODO: Explore methods for retaining both the syntax and speedup.
-
     ! Calculate horizontal tension
-    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      dudx(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
-                                  (G%IdyCu(I-1,j) * u(I-1,j,k)))
-      dvdy(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
-                                  (G%IdxCv(i,J-1) * v(i,J-1,k)))
-      sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
-    enddo ; enddo
+    do kk=1,kke ; do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      k = ksb + kk - 1
+      dudx(i,j,kk) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u(I,j,k)) - &
+                                    (G%IdyCu(I-1,j) * u(I-1,j,k)))
+      dvdy(i,j,kk) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v(i,J,k)) - &
+                                    (G%IdxCv(i,J-1) * v(i,J-1,k)))
+      sh_xx(i,j,kk) = dudx(i,j,kk) - dvdy(i,j,kk)
+    enddo ; enddo ; enddo
 
     ! Components for the shearing strain
-    do J=js_vort,je_vort ; do I=is_vort,ie_vort
-      dvdx(I,J) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
-      dudy(I,J) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
-    enddo ; enddo
+    do kk=1,kke ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+      k = ksb + kk - 1
+      dvdx(I,J,kk) = CS%DY_dxBu(I,J)*((v(i+1,J,k)*G%IdyCv(i+1,J)) - (v(i,J,k)*G%IdyCv(i,J)))
+      dudy(I,J,kk) = CS%DX_dyBu(I,J)*((u(I,j+1,k)*G%IdxCu(I,j+1)) - (u(I,j,k)*G%IdxCu(I,j)))
+    enddo ; enddo ; enddo
 
     if (CS%use_Leithy) then
       ! Calculate horizontal tension from smoothed velocity
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        dudx_smooth(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = ksb + kk - 1
+        dudx_smooth = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * u_smooth(I,j,k)) - &
                                            (G%IdyCu(I-1,j) * u_smooth(I-1,j,k)))
-        dvdy_smooth(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
+        dvdy_smooth = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * v_smooth(i,J,k)) - &
                                            (G%IdxCv(i,J-1) * v_smooth(i,J-1,k)))
-        sh_xx_smooth(i,j) = dudx_smooth(i,j) - dvdy_smooth(i,j)
-      enddo ; enddo
+        sh_xx_smooth(i,j,kk) = dudx_smooth - dvdy_smooth
+      enddo ; enddo ; enddo
 
       ! Components for the shearing strain from smoothed velocity
-      do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-        dvdx_smooth(I,J) = CS%DY_dxBu(I,J) * &
+      do kk=1,kke ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+        k = ksb + kk - 1
+        dvdx_smooth(I,J,kk) = CS%DY_dxBu(I,J) * &
                          ((v_smooth(i+1,J,k)*G%IdyCv(i+1,J)) - (v_smooth(i,J,k)*G%IdyCv(i,J)))
-        dudy_smooth(I,J) = CS%DX_dyBu(I,J) * &
+        dudy_smooth(I,J,kk) = CS%DX_dyBu(I,J) * &
                          ((u_smooth(I,j+1,k)*G%IdxCu(I,j+1)) - (u_smooth(I,j,k)*G%IdxCu(I,j)))
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif ! use Leith+E
 
     if (CS%id_normstress > 0) then
-      do j=js,je ; do i=is,ie
-        NoSt(i,j,k) = sh_xx(i,j)
-      enddo ; enddo
+      do kk=1,kke ; do j=js,je ; do i=is,ie
+        k = ksb + kk - 1
+        NoSt(i,j,k) = sh_xx(i,j,kk)
+      enddo ; enddo ; enddo
     endif
 
     ! Interpolate the thicknesses to velocity points.
@@ -794,26 +755,32 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! even with OBCs if the accelerations are zeroed at OBC points, in which
     ! case the j-loop for h_u could collapse to j=js=1,je+1. -RWH
     if (use_cont_huv) then
-      do j=js-2,je+2 ; do I=Isq-1,Ieq+1
-        h_u(I,j) = hu_cont(I,j,k)
-      enddo ; enddo
-      do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J) = hv_cont(i,J,k)
-      enddo ; enddo
+      do kk=1,kke ; do j=js-2,je+2 ; do I=Isq-1,Ieq+1
+        k = ksb + kk - 1
+        h_u(I,j,kk) = hu_cont(I,j,k)
+      enddo ; enddo ; enddo
+      do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do i=is-2,ie+2
+        k = ksb + kk - 1
+        h_v(i,J,kk) = hv_cont(i,J,k)
+      enddo ; enddo ; enddo
     elseif (CS%use_land_mask) then
-      do j=js-2,je+2 ; do I=is-2,Ieq+1
-        h_u(I,j) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
-      enddo ; enddo
-      do J=js-2,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
-      enddo ; enddo
+      do kk=1,kke ; do j=js-2,je+2 ; do I=is-2,Ieq+1
+        k = ksb + kk - 1
+        h_u(I,j,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k))
+      enddo ; enddo ; enddo
+      do kk=1,kke ; do J=js-2,Jeq+1 ; do i=is-2,ie+2
+        k = ksb + kk - 1
+        h_v(i,J,kk) = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k))
+      enddo ; enddo ; enddo
     else
-      do j=js-2,je+2 ; do I=is-2,Ieq+1
-        h_u(I,j) = 0.5 * (h(i,j,k) + h(i+1,j,k))
-      enddo ; enddo
-      do J=js-2,Jeq+1 ; do i=is-2,ie+2
-        h_v(i,J) = 0.5 * (h(i,j,k) + h(i,j+1,k))
-      enddo ; enddo
+      do kk=1,kke ; do j=js-2,je+2 ; do I=is-2,Ieq+1
+        k = ksb + kk - 1
+        h_u(I,j,kk) = 0.5 * (h(i,j,k) + h(i+1,j,k))
+      enddo ; enddo ; enddo
+      do kk=1,kke ; do J=js-2,Jeq+1 ; do i=is-2,ie+2
+        k = ksb + kk - 1
+        h_v(i,J,kk) = 0.5 * (h(i,j,k) + h(i,j+1,k))
+      enddo ; enddo ; enddo
     endif
 
     ! Adjust contributions to shearing strain and interpolated values of
@@ -822,59 +789,63 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (apply_OBC_strain) then
         if (OBC%segment(n)%is_N_or_S .and. (J >= Js_vort) .and. (J <= Je_vort)) then
-          do I = max(OBC%segment(n)%HI%IsdB,Is_vort), min(OBC%segment(n)%HI%IedB,Ie_vort)
+          do kk=1,kke ; do I=max(OBC%segment(n)%HI%IsdB,Is_vort),min(OBC%segment(n)%HI%IedB,Ie_vort)
+            k = ksb + kk - 1
+
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
-                dvdx(I,J) = 0. ; dudy(I,J) = 0.
+                dvdx(I,J,kk) = 0. ; dudy(I,J,kk) = 0.
               case (OBC_STRAIN_FREESLIP)
-                dudy(I,J) = 0.
+                dudy(I,J,kk) = 0.
               case (OBC_STRAIN_COMPUTED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                  dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
+                  dudy(I,J,kk) = 2.0*CS%DX_dyBu(I,J)* &
                               (OBC%segment(n)%tangential_vel(I,J,k) - u(I,j,k))*G%IdxCu(I,j)
                 else
-                  dudy(I,J) = 2.0*CS%DX_dyBu(I,J)* &
+                  dudy(I,J,kk) = 2.0*CS%DX_dyBu(I,J)* &
                               (u(I,j+1,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdxCu(I,j+1)
                 endif
               case (OBC_STRAIN_SPECIFIED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
-                  dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
+                  dudy(I,J,kk) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j)*G%dxBu(I,J)
                 else
-                  dudy(I,J) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
+                  dudy(I,J,kk) = CS%DX_dyBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdxCu(I,j+1)*G%dxBu(I,J)
                 endif
             end select
             if (CS%use_Leithy) then
-              dvdx_smooth(I,J) = dvdx(I,J)
-              dudy_smooth(I,J) = dudy(I,J)
+              dvdx_smooth(I,J,kk) = dvdx(I,J,kk)
+              dudy_smooth(I,J,kk) = dudy(I,J,kk)
             endif
-          enddo
+          enddo ; enddo
         elseif (OBC%segment(n)%is_E_or_W .and. (I >= is_vort) .and. (I <= ie_vort)) then
-          do J = max(OBC%segment(n)%HI%JsdB,js_vort), min(OBC%segment(n)%HI%JedB,je_vort)
+          do kk=1,kke ; do J=max(OBC%segment(n)%HI%JsdB,js_vort),min(OBC%segment(n)%HI%JedB,je_vort)
+            k = ksb + kk - 1
+
             select case (OBC%strain_config)
               case (OBC_STRAIN_ZERO)
-                dvdx(I,J) = 0. ; dudy(I,J) = 0.
+                dvdx(I,J,kk) = 0. ; dudy(I,J,kk) = 0.
               case (OBC_STRAIN_FREESLIP)
-                dvdx(I,J) = 0.
+                dvdx(I,J,kk) = 0.
               case (OBC_STRAIN_COMPUTED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                  dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
+                  dvdx(I,J,kk) = 2.0*CS%DY_dxBu(I,J)* &
                               (OBC%segment(n)%tangential_vel(I,J,k) - v(i,J,k))*G%IdyCv(i,J)
                 else
-                  dvdx(I,J) = 2.0*CS%DY_dxBu(I,J)* &
+                  dvdx(I,J,kk) = 2.0*CS%DY_dxBu(I,J)* &
                               (v(i+1,J,k) - OBC%segment(n)%tangential_vel(I,J,k))*G%IdyCv(i+1,J)
                 endif
               case (OBC_STRAIN_SPECIFIED)
                 if (OBC%segment(n)%direction == OBC_DIRECTION_E) then
-                  dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
+                  dvdx(I,J,kk) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i,J)*G%dxBu(I,J)
                 else
-                  dvdx(I,J) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
+                  dvdx(I,J,kk) = CS%DY_dxBu(I,J)*OBC%segment(n)%tangential_grad(I,J,k)*G%IdyCv(i+1,J)*G%dxBu(I,J)
                 endif
             end select
             if (CS%use_Leithy) then
-              dvdx_smooth(I,J) = dvdx(I,J)
-              dudy_smooth(I,J) = dudy(I,J)
+              dvdx_smooth(I,J,kk) = dvdx(I,J,kk)
+              dudy_smooth(I,J,kk) = dudy(I,J,kk)
             endif
-          enddo
+          enddo ; enddo
         endif
       endif
 
@@ -884,27 +855,31 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
         ! are always zeroed out at OBC points, in which case the i-loop below
         ! becomes do i=is-1,ie+1. -RWH
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
-            h_v(i,J) = h(i,j,k)
-          enddo
+          do kk=1,kke ; do i=max(is-2,OBC%segment(n)%HI%isd),min(ie+2,OBC%segment(n)%HI%ied)
+            k = ksb + kk - 1
+            h_v(i,J,kk) = h(i,j,k)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-2) .and. (J <= Jeq+1)) then
-          do i = max(is-2,OBC%segment(n)%HI%isd), min(ie+2,OBC%segment(n)%HI%ied)
-            h_v(i,J) = h(i,j+1,k)
-          enddo
+          do kk=1,kke ; do i=max(is-2,OBC%segment(n)%HI%isd),min(ie+2,OBC%segment(n)%HI%ied)
+            k = ksb + kk - 1
+            h_v(i,J,kk) = h(i,j+1,k)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
-            h_u(I,j) = h(i,j,k)
-          enddo
+          do kk=1,kke ; do j=max(js-2,OBC%segment(n)%HI%jsd),min(je+2,OBC%segment(n)%HI%jed)
+            k = ksb + kk - 1
+            h_u(I,j,kk) = h(i,j,k)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-2) .and. (I <= Ieq+1)) then
-          do j = max(js-2,OBC%segment(n)%HI%jsd), min(je+2,OBC%segment(n)%HI%jed)
-            h_u(I,j) = h(i+1,j,k)
-          enddo
+          do kk=1,kke ; do j=max(js-2,OBC%segment(n)%HI%jsd),min(je+2,OBC%segment(n)%HI%jed)
+            k = ksb + kk - 1
+            h_u(I,j,kk) = h(i+1,j,k)
+          enddo ; enddo
         endif
       endif
     enddo ; endif
@@ -913,27 +888,27 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
       if (OBC%segment(n)%direction == OBC_DIRECTION_N) then
         if ((J >= js-2) .and. (J <= je)) then
-          do I = max(is-2,OBC%segment(n)%HI%IsdB), min(Ieq+1,OBC%segment(n)%HI%IedB)
-            h_u(I,j+1) = h_u(I,j)
-          enddo
+          do kk=1,kke ; do I=max(is-2,OBC%segment(n)%HI%IsdB),min(Ieq+1,OBC%segment(n)%HI%IedB)
+            h_u(I,j+1,kk) = h_u(I,j,kk)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_S) then
         if ((J >= js-1) .and. (J <= je+1)) then
-          do I = max(is-2,OBC%segment(n)%HI%isd), min(Ieq+1,OBC%segment(n)%HI%ied)
-            h_u(I,j) = h_u(I,j+1)
-          enddo
+          do kk=1,kke ; do I=max(is-2,OBC%segment(n)%HI%isd),min(Ieq+1,OBC%segment(n)%HI%ied)
+            h_u(I,j,kk) = h_u(I,j+1,kk)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_E) then
         if ((I >= is-2) .and. (I <= ie)) then
-          do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            h_v(i+1,J) = h_v(i,J)
-          enddo
+          do kk=1,kke ; do J=max(js-2,OBC%segment(n)%HI%jsd),min(Jeq+1,OBC%segment(n)%HI%jed)
+            h_v(i+1,J,kk) = h_v(i,J,kk)
+          enddo ; enddo
         endif
       elseif (OBC%segment(n)%direction == OBC_DIRECTION_W) then
         if ((I >= is-1) .and. (I <= ie+1)) then
-          do J = max(js-2,OBC%segment(n)%HI%jsd), min(Jeq+1,OBC%segment(n)%HI%jed)
-            h_v(i,J) = h_v(i+1,J)
-          enddo
+          do kk=1,kke ; do J=max(js-2,OBC%segment(n)%HI%jsd),min(Jeq+1,OBC%segment(n)%HI%jed)
+            h_v(i,J,kk) = h_v(i+1,J,kk)
+          enddo ; enddo
         endif
       endif
     enddo ; endif
@@ -941,234 +916,119 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
-      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-        sh_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) + dudy(I,J) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        k = ksb + kk - 1
+        sh_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
+      enddo ; enddo ; enddo
     else
-      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-        sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
-        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        k = ksb + kk - 1
+        sh_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) + dudy(I,J,kk) )
+        if (CS%id_shearstress > 0) ShSt(I,J,k) = sh_xy(I,J,kk)
+      enddo ; enddo ; enddo
     endif
 
     if (CS%use_Leithy) then
       ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
       ! dudy_smooth and dvdx_smooth do not (yet) include modifications at OBCs from above.
       if (CS%no_slip) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_smooth(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J) + dudy_smooth(I,J) )
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          sh_xy_smooth(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,kk) + dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_smooth(I,J) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J) + dudy_smooth(I,J) )
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          sh_xy_smooth(I,J,kk) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,kk) + dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       endif
     endif ! use Leith+E
 
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
-      do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        Del2u(I,j) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1))) + &
-                     CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j)) - (CS%dy2h(i,j)*sh_xx(i,j)))
-      enddo ; enddo
-      do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
-        Del2v(i,J) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J))) - &
-                     CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1)) - (CS%dx2h(i,j)*sh_xx(i,j)))
-      enddo ; enddo
+      do kk=1,kke ; do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
+        Del2u(I,j,kk) = CS%Idx2dyCu(I,j) * ((CS%dx2q(I,J)*sh_xy(I,J,kk)) - (CS%dx2q(I,J-1)*sh_xy(I,J-1,kk))) + &
+                     CS%Idxdy2u(I,j) * ((CS%dy2h(i+1,j)*sh_xx(i+1,j,kk)) - (CS%dy2h(i,j)*sh_xx(i,j,kk)))
+      enddo ; enddo ; enddo
+      do kk=1,kke ; do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
+        Del2v(i,J,kk) = CS%Idxdy2v(i,J) * ((CS%dy2q(I,J)*sh_xy(I,J,kk)) - (CS%dy2q(I-1,J)*sh_xy(I-1,J,kk))) - &
+                     CS%Idx2dyCv(i,J) * ((CS%dx2h(i,j+1)*sh_xx(i,j+1,kk)) - (CS%dx2h(i,j)*sh_xx(i,j,kk)))
+      enddo ; enddo ; enddo
       if (apply_OBC) then ; if (OBC%zero_biharmonic) then
         do n=1,OBC%number_of_segments
           I = OBC%segment(n)%HI%IsdB ; J = OBC%segment(n)%HI%JsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= Jsq-1) .and. (J <= Jeq+1)) then
-            do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
-              Del2v(i,J) = 0.
-            enddo
+            do kk=1,kke ; do I=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+              Del2v(i,J,kk) = 0.
+            enddo ; enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= Isq-1) .and. (I <= Ieq+1)) then
-            do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
-              Del2u(I,j) = 0.
-            enddo
+            do kk=1,kke ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+              Del2u(I,j,kk) = 0.
+            enddo ; enddo
           endif
         enddo
       endif ; endif
     endif
 
     ! Vorticity
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy) .or. (CS%id_vort_xy_q>0) .or. CS%use_ZB2020) then
+    if (use_vort_xy) then
       if (CS%no_slip) then
-        do J=js_vort,je_vort ; do I=is_vort,ie_vort
-          vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
-        enddo ; enddo
+        do kk=1,kke ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+          vort_xy(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
+        enddo ; enddo ; enddo
       else
         if (CS%use_circulation) then
-          do J=js_vort,je_vort ; do I=is_vort,ie_vort
-            vort_xy(I,J) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
-              ((v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J)))  &
-            - ((u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j)))  &
-             )
-          enddo ; enddo
+          do kk=1,kke ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+            k = ksb + kk - 1
+            vort_xy(I,J,kk) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
+                ((v(i+1,J,k)*G%dyCv(i+1,J)) - (v(i,J,k)*G%dyCv(i,J)))  &
+              - ((u(I,j+1,k)*G%dxCu(I,j+1)) - (u(I,j,k)*G%dxCu(I,j)))  &
+            )
+          enddo ; enddo ; enddo
         else
-          do J=js_vort,je_vort ; do I=is_vort,ie_vort
-            vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
-          enddo ; enddo
+          do kk=1,kke ; do J=js_vort,je_vort ; do I=is_vort,ie_vort
+            vort_xy(I,J,kk) = G%mask2dBu(I,J) * ( dvdx(I,J,kk) - dudy(I,J,kk) )
+          enddo ; enddo ; enddo
         endif
       endif
     endif
 
     if (CS%use_Leithy) then
       if (CS%no_slip) then
-        do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-          vort_xy_smooth(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J) - dudy_smooth(I,J) )
-        enddo ; enddo
+        do kk=1,kke ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+          vort_xy_smooth(I,J,kk) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J,kk) - dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       else
-        do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-          vort_xy_smooth(I,J) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J) - dudy_smooth(I,J) )
-        enddo ; enddo
+        do kk=1,kke ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+          vort_xy_smooth(I,J,kk) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J,kk) - dudy_smooth(I,J,kk) )
+        enddo ; enddo ; enddo
       endif
     endif
 
 
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
-
-      ! Vorticity gradient
-      do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
-        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        vort_xy_dx(i,J) = DY_dxBu * ((vort_xy(I,J) * G%IdyCu(I,j)) - (vort_xy(I-1,J) * G%IdyCu(I-1,j)))
-      enddo ; enddo
-
-      do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
-        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-        vort_xy_dy(I,j) = DX_dyBu * ((vort_xy(I,J) * G%IdxCv(i,J)) - (vort_xy(I,J-1) * G%IdxCv(i,J-1)))
-      enddo ; enddo
-
-      if (CS%use_Leithy) then
-        ! Gradient of smoothed vorticity
-        do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
-          DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-          vort_xy_dx_smooth(i,J) = DY_dxBu * &
-                      ((vort_xy_smooth(I,J) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J) * G%IdyCu(I-1,j)))
-        enddo ; enddo
-
-        do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
-          DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-          vort_xy_dy_smooth(I,j) = DX_dyBu * &
-                      ((vort_xy_smooth(I,J) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1) * G%IdxCv(i,J-1)))
-        enddo ; enddo
-      endif ! If Leithy
-
-      ! Laplacian of vorticity
-      ! if (CS%Leith_Ah .or. CS%use_Leithy) then
-      do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
-        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
-        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
-
-        Del2vort_q(I,J) = DY_dxBu * ((vort_xy_dx(i+1,J) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J) * G%IdyCv(i,J))) + &
-                          DX_dyBu * ((vort_xy_dy(I,j+1) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j) * G%IdyCu(I,j)))
-      enddo ; enddo
-      ! endif
-
-      if (CS%modified_Leith) then
-
-        ! Divergence
-        do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
-          div_xx(i,j) = dudx(i,j) + dvdy(i,j)
-        enddo ; enddo
-
-        ! Divergence gradient
-        do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
-        enddo ; enddo
-        do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
-        enddo ; enddo
-
-        ! Magnitude of divergence gradient
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j) = sqrt(((0.5*(div_xx_dx(I,j) + div_xx_dx(I-1,j)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J) + div_xx_dy(i,J-1)))**2))
-        enddo ; enddo
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J) = sqrt(((0.5*(div_xx_dx(I,j) + div_xx_dx(I,j+1)))**2) + &
-                                     ((0.5*(div_xx_dy(i,J) + div_xx_dy(i+1,J)))**2))
-        enddo ; enddo
-
-      else
-
-        do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
-          div_xx_dx(I,j) = 0.0
-        enddo ; enddo
-        do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
-          div_xx_dy(i,J) = 0.0
-        enddo ; enddo
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_div_mag_h(i,j) = 0.0
-        enddo ; enddo
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_div_mag_q(I,J) = 0.0
-        enddo ; enddo
-
-      endif ! CS%modified_Leith
-
-      ! Add in beta for the Leith viscosity
-      if (CS%use_beta_in_Leith) then
-        do J=js-2,Jeq+1 ; do i=is-1,ie+1
-          vort_xy_dx(i,J) = vort_xy_dx(i,J) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
-        enddo ; enddo
-        do j=js-1,je+1 ; do I=is-2,Ieq+1
-          vort_xy_dy(I,j) = vort_xy_dy(I,j) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
-        enddo ; enddo
-      endif ! CS%use_beta_in_Leith
-
-      if (CS%use_QG_Leith_visc) then
-
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          grad_vort_mag_h_2d(i,j) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I-1,j)))**2) )
-        enddo ; enddo
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          grad_vort_mag_q_2d(I,J) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2) + &
-                                         ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I,j+1)))**2) )
-        enddo ; enddo
-
-        ! This accumulates terms, some of which are in VarMix.
-        call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx, div_xx_dy, &
-                                     slope_x, slope_y, vort_xy_dx, vort_xy_dy)
-
-      endif
-
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        grad_vort_mag_h(i,j) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I-1,j)))**2) )
-      enddo ; enddo
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        grad_vort_mag_q(I,J) = SQRT(((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2) + &
-                                    ((0.5*(vort_xy_dy(I,j) + vort_xy_dy(I,j+1)))**2) )
-      enddo ; enddo
-
-      if (CS%use_Leithy) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          vert_vort_mag_smooth(i,j) = SQRT(((0.5*(vort_xy_dx_smooth(i,J) + &
-                                                  vort_xy_dx_smooth(i,J-1)))**2) + &
-                                           ((0.5*(vort_xy_dy_smooth(I,j) + &
-                                                  vort_xy_dy_smooth(I-1,j)))**2) )
-        enddo ; enddo
-      endif ! Leithy
-
+    if (use_Leith) then
+      call hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkk, ksb, kke, &
+                               is, ie, js, je, is_Kh, ie_Kh, js_Kh, je_Kh, Ieq, Jeq, &
+                               h, dz, slope_x, slope_y, dudx, dvdy, vort_xy, vort_xy_smooth, &
+                               grad_vort_mag_h, grad_vort_mag_h_2d, grad_div_mag_h, &
+                               grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, &
+                               vert_vort_mag_smooth, Del2vort_q)
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        sh_xx_sq = sh_xx(i,j)**2
-        sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1)**2) + (sh_xy(I,J)**2)) &
-                          + ((sh_xy(I-1,J)**2) + (sh_xy(I,J-1)**2)) )
-        Shear_mag(i,j) = sqrt(sh_xx_sq + sh_xy_sq)
-      enddo ; enddo
+      do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        sh_xx_sq = sh_xx(i,j,kk)**2
+        sh_xy_sq = 0.25 * ( ((sh_xy(I-1,J-1,kk)**2) + (sh_xy(I,J,kk)**2)) &
+                          + ((sh_xy(I-1,J,kk)**2) + (sh_xy(I,J-1,kk)**2)) )
+        Shear_mag(i,j,kk) = sqrt(sh_xx_sq + sh_xy_sq)
+      enddo ; enddo ; enddo
     endif
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        h_min = min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1))
-        hrat_min(i,j) = min(1.0, h_min / (h(i,j,k) + h_neglect))
-      enddo ; enddo
+      do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        k = ksb + kk - 1
+        h_min = min(h_u(I,j,kk), h_u(I-1,j,kk), h_v(i,J,kk), h_v(i,J-1,kk))
+        hrat_min(i,j,kk) = min(1.0, h_min / (h(i,j,k) + h_neglect))
+      enddo ; enddo ; enddo
     endif
 
     if (CS%Laplacian) then
@@ -1178,424 +1038,374 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%use_QG_Leith_visc) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            grad_vort = grad_vort_mag_h(i,j) + grad_div_mag_h(i,j)
-            grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j)
-            vert_vort_mag(i,j) = min(grad_vort, grad_vort_qg)
-          enddo ; enddo
+          do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            grad_vort = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
+            grad_vort_qg = 3. * grad_vort_mag_h_2d(i,j,kk)
+            vert_vort_mag(i,j,kk) = min(grad_vort, grad_vort_qg)
+          enddo ; enddo ; enddo
         else
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            vert_vort_mag(i,j) = grad_vort_mag_h(i,j) + grad_div_mag_h(i,j)
-          enddo ; enddo
+          do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            vert_vort_mag(i,j,kk) = grad_vort_mag_h(i,j,kk) + grad_div_mag_h(i,j,kk)
+          enddo ; enddo ; enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Kh(i,j) = CS%Kh_bg_xx(i,j)
-      enddo ; enddo
+      do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        Kh(i,j,kk) = CS%Kh_bg_xx(i,j)
+      enddo ; enddo ; enddo
 
       ! NOTE: The following do-block can be decomposed and vectorized after the
       !   stack size has been reduced.
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
         if (CS%add_LES_viscosity) then
           if (CS%Smagorinsky_Kh) &
-            Kh(i,j) = Kh(i,j) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j)
+            Kh(i,j,kk) = Kh(i,j,kk) + CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,kk)
           if (CS%Leith_Kh) &
-            Kh(i,j) = Kh(i,j) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3
+            Kh(i,j,kk) = Kh(i,j,kk) + CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,kk) * inv_PI3
         else
           if (CS%Smagorinsky_Kh) &
-            Kh(i,j) = max(Kh(i,j), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j))
+            Kh(i,j,kk) = max(Kh(i,j,kk), CS%Laplac2_const_xx(i,j) * Shear_mag(i,j,kk))
           if (CS%Leith_Kh) &
-            Kh(i,j) = max(Kh(i,j), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j) * inv_PI3)
+            Kh(i,j,kk) = max(Kh(i,j,kk), CS%Laplac3_const_xx(i,j) * vert_vort_mag(i,j,kk) * inv_PI3)
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = VarMix%Res_fn_h(i,j) * Kh(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Kh(i,j,kk) = VarMix%Res_fn_h(i,j) * Kh(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       ! Place a floor on the viscosity, if desired.
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Kh(i,j) = max(Kh(i,j), CS%Kh_bg_min)
-      enddo ; enddo
+      do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        Kh(i,j,kk) = max(Kh(i,j,kk), CS%Kh_bg_min)
+      enddo ; enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         ! *Add* the MEKE contribution (which might be negative)
         if (use_kh_struct) then
           if (CS%res_scale_MEKE) then
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
-            enddo ; enddo
+            do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              k = ksb + kk - 1
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j) * VarMix%BS_struct(i,j,k)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-            enddo ; enddo
+            do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              k = ksb + kk - 1
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+            enddo ; enddo ; enddo
           endif
         else
           if (CS%res_scale_MEKE) then
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
-            enddo ; enddo
+            do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j) * VarMix%Res_fn_h(i,j)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Kh(i,j) = Kh(i,j) + MEKE%Ku(i,j)
-            enddo ; enddo
+            do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              Kh(i,j,kk) = Kh(i,j,kk) + MEKE%Ku(i,j)
+            enddo ; enddo ; enddo
           endif
         endif
       endif
 
       if (CS%anisotropic) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
           ! *Add* the tension component of anisotropic viscosity
-          Kh(i,j) = Kh(i,j) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
-        enddo ; enddo
+          Kh(i,j,kk) = Kh(i,j,kk) + CS%Kh_aniso * (1. - CS%n1n2_h(i,j)**2)
+        enddo ; enddo ; enddo
       endif
 
       ! Newer method of bounding for stability
       if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          visc_bound_rem(i,j) = 1.0
-          Kh_max_here = hrat_min(i,j) * CS%Kh_Max_xx(i,j)
-          if (Kh(i,j) >= Kh_max_here) then
-            visc_bound_rem(i,j) = 0.0
-            Kh(i,j) = Kh_max_here
-          elseif ((Kh(i,j) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
-            visc_bound_rem(i,j) = 1.0 - Kh(i,j) / Kh_max_here
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          visc_bound_rem(i,j,kk) = 1.0
+          Kh_max_here = hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j)
+          if (Kh(i,j,kk) >= Kh_max_here) then
+            visc_bound_rem(i,j,kk) = 0.0
+            Kh(i,j,kk) = Kh_max_here
+          elseif ((Kh(i,j,kk) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
+            visc_bound_rem(i,j,kk) = 1.0 - Kh(i,j,kk) / Kh_max_here
           endif
-        enddo ; enddo
+        enddo ; enddo ; enddo
       elseif (CS%bound_Kh) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh(i,j) = min(Kh(i,j), hrat_min(i,j) * CS%Kh_Max_xx(i,j))
-        enddo ; enddo
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Kh(i,j,kk) = min(Kh(i,j,kk), hrat_min(i,j,kk) * CS%Kh_Max_xx(i,j))
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_Kh_h>0 .or. CS%debug) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh_h(i,j,k) = Kh(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = ksb + kk - 1
+          Kh_h(i,j,k) = Kh(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Kh>0) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
-          grid_Kh = max(Kh(i,j), CS%min_grid_Kh)
+          grid_Kh = max(Kh(i,j,kk), CS%min_grid_Kh)
           grid_Re_Kh(i,j,k) = (sqrt(KE) * sqrt(CS%grid_sp_h2(i,j))) / grid_Kh
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_div_xx_h>0) then
-        do j=js,je ; do i=is,ie
-          div_xx_h(i,j,k) = dudx(i,j) + dvdy(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
+          div_xx_h(i,j,k) = dudx(i,j,kk) + dvdy(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_sh_xx_h>0) then
-        do j=js,je ; do i=is,ie
-          sh_xx_h(i,j,k) = sh_xx(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
+          sh_xx_h(i,j,k) = sh_xx(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = -Kh(i,j) * sh_xx(i,j)
-      enddo ; enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j,kk) = -Kh(i,j,kk) * sh_xx(i,j,kk)
+      enddo ; enddo ; enddo
     else
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = 0.0
-      enddo ; enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j,kk) = 0.0
+      enddo ; enddo ; enddo
     endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         ! Shearing-strain averaged to h-points
-        local_strain = 0.25 * ( (sh_xy(I,J) + sh_xy(I-1,J-1)) + (sh_xy(I-1,J) + sh_xy(I,J-1)) )
+        local_strain = 0.25 * ( (sh_xy(I,J,kk) + sh_xy(I-1,J-1,kk)) + (sh_xy(I-1,J,kk) + sh_xy(I,J-1,kk)) )
         ! *Add* the shear-strain contribution to the xx-component of stress
-        str_xx(i,j) = str_xx(i,j) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
-      enddo ; enddo
+        str_xx(i,j,kk) = str_xx(i,j,kk) - CS%Kh_aniso * CS%n1n2_h(i,j) * CS%n1n1_m_n2n2_h(i,j) * local_strain
+      enddo ; enddo ; enddo
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at h points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xx.
-      do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-        Ah(i,j) = CS%Ah_bg_xx(i,j)
-      enddo ; enddo
+      do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        Ah(i,j,kk) = CS%Ah_bg_xx(i,j)
+      enddo ; enddo ; enddo
 
       if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              AhSm = Shear_mag(i,j) * (CS%Biharm_const_xx(i,j) &
-                  + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j))
-              Ah(i,j) = max(Ah(i,j), AhSm)
-            enddo ; enddo
+            do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              AhSm = Shear_mag(i,j,kk) * (CS%Biharm_const_xx(i,j) &
+                  + CS%Biharm_const2_xx(i,j) * Shear_mag(i,j,kk))
+              Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
+            enddo ; enddo ; enddo
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j)
-              Ah(i,j) = max(Ah(i,j), AhSm)
-            enddo ; enddo
+            do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+              AhSm = CS%Biharm_const_xx(i,j) * Shear_mag(i,j,kk)
+              Ah(i,j,kk) = max(Ah(i,j,kk), AhSm)
+            enddo ; enddo ; enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
-                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
+          do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                                 (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
             AhLth = CS%Biharm6_const_xx(i,j) * abs(Del2vort_h) * inv_PI6
-            Ah(i,j) = max(Ah(i,j), AhLth)
-          enddo ; enddo
+            Ah(i,j,kk) = max(Ah(i,j,kk), AhLth)
+          enddo ; enddo ; enddo
         endif
 
         if (CS%use_Leithy) then
-          ! Get m_leithy
-          if (CS%smooth_Ah) m_leithy(:,:) = 0.0 ! This is here to initialize domain edge halo values.
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
-                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
-            AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
-            if (AhLth <= CS%Ah_bg_xx(i,j)) then
-              m_leithy(i,j) = 0.0
-            else
-              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j)) < abs(vort_xy_smooth(i,j))) then
-                m_leithy(i,j) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j))**2
-              else
-                m_leithy(i,j) = CS%m_leithy_max(i,j)
-              endif
-            endif
-            if (CS%taper_leithy) then
-              ! Multiply m_leithy by taper function of depth
-              m_leithy(i,j) = m_leithy(i,j) * leithy_taper_function(CS, zc(i,j,k))
-            endif
-          enddo ; enddo
-
-          if (CS%smooth_Ah) then
-            ! Smooth m_leithy.  A single call smoothes twice.
-            call pass_var(m_leithy, G%Domain, halo=2)
-            call smooth_x9_h(CS, G, m_leithy, zero_land=.true.)
-            call pass_var(m_leithy, G%Domain)
-          endif
-          ! Get Ah
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
-                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
-            AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
-                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j)*vert_vort_mag_smooth(i,j)**2))
-            Ah(i,j) = max(CS%Ah_bg_xx(i,j), AhLthy)
-          enddo ; enddo
-          if (CS%smooth_Ah) then
-            ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
-            Ah_sq(:,:) = 0.0 ! This is here to initialize domain edge halo values.
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_sq(i,j) = Ah(i,j)**2
-            enddo ; enddo
-            call pass_var(Ah_sq, G%Domain, halo=2)
-            ! A single call smoothes twice.
-            call smooth_x9_h(CS, G, Ah_sq, zero_land=.false.)
-            call pass_var(Ah_sq, G%Domain)
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j))))
-              Ah(i,j)     = Ah_h(i,j,k)
-            enddo ; enddo
+          if (CS%taper_Leithy) then
+            call hor_visc_Leithy_Ah(G, GV, CS, nkk, ksb, kke, is_Kh, &
+                ie_Kh, js_Kh, je_Kh, inv_PI6, Del2vort_q, vert_vort_mag, &
+                vert_vort_mag_smooth, vort_xy_smooth, Ah, Ah_h, m_leithy, zc=zc)
           else
-            do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-              Ah_h(i,j,k) = Ah(i,j)
-            enddo ; enddo
+            call hor_visc_Leithy_Ah(G, GV, CS, nkk, ksb, kke, is_Kh, &
+                ie_Kh, js_Kh, je_Kh, inv_PI6, Del2vort_q, vert_vort_mag, &
+                vert_vort_mag_smooth, vort_xy_smooth, Ah, Ah_h, m_leithy)
           endif
         endif
-
       endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Ah(i,j) = Ah(i,j) + MEKE%Au(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          Ah(i,j,kk) = Ah(i,j,kk) + MEKE%Au(i,j)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = ksb + kk - 1
           KE = 0.125*(((u(I,j,k)+u(I-1,j,k))**2) + ((v(i,J,k)+v(i,J-1,k))**2))
-          Ah(i,j) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
-        enddo ; enddo
+          Ah(i,j,kk) = sqrt(KE) * CS%Re_Ah_const_xx(i,j)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Ah(i,j) = min(Ah(i,j), visc_bound_rem(i,j) * hrat_min(i,j) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Ah(i,j,kk) = min(Ah(i,j,kk), visc_bound_rem(i,j,kk) * hrat_min(i,j,kk) * CS%Ah_Max_xx(i,j))
+          enddo ; enddo ; enddo
         else
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            Ah(i,j) = min(Ah(i,j), hrat_min(i,j) * CS%Ah_Max_xx(i,j))
-          enddo ; enddo
+          do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            Ah(i,j,kk) = min(Ah(i,j,kk), hrat_min(i,j,kk) * CS%Ah_Max_xx(i,j))
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-          do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-            tmp = CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j)
+          do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+            k = ksb + kk - 1
+
+            tmp = CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xx_KS(i,j)
             visc_limit_h(i,j,k) = tmp
-            visc_limit_h_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xx_KS(i,j))
-            if (Ah(i,j) >= tmp) then
+            visc_limit_h_frac(i,j,k) = Ah(i,j,kk) / (CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xx_KS(i,j))
+            if (Ah(i,j,kk) >= tmp) then
               visc_limit_h_flag(i,j,k) = 1.
             endif
-          enddo ; enddo
+          enddo ; enddo ; enddo
       endif
 
       if ((CS%id_Ah_h>0) .or. CS%debug .or. CS%use_Leithy) then
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Ah_h(i,j,k) = Ah(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = ksb + kk - 1
+          Ah_h(i,j,k) = Ah(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%use_Leithy) then
         ! Compute Leith+E Kh after bounds have been applied to Ah
         ! and after it has been smoothed. Kh = -m_leithy * Ah
-        do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
-          Kh_BS(i,j) = -m_leithy(i,j) * Ah(i,j)
-          BS_coeff_h(i,j,k) = Kh_BS(i,j)
-        enddo ; enddo
+        do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+          k = ksb + kk - 1
+          Kh_BS(i,j,kk) = -m_leithy(i,j,kk) * Ah(i,j,kk)
+          BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_grid_Re_Ah > 0) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I-1,j,k))**2) + ((v(i,J,k) + v(i,J-1,k))**2))
-          grid_Ah = max(Ah(i,j), CS%min_grid_Ah)
+          grid_Ah = max(Ah(i,j,kk), CS%min_grid_Ah)
           grid_Re_Ah(i,j,k) = (sqrt(KE) * CS%grid_sp_h3(i,j)) / grid_Ah
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        d_del2u = (G%IdyCu(I,j) * Del2u(I,j)) - (G%IdyCu(I-1,j) * Del2u(I-1,j))
-        d_del2v = (G%IdxCv(i,J) * Del2v(i,J)) - (G%IdxCv(i,J-1) * Del2v(i,J-1))
-        d_str = Ah(i,j) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = ksb + kk - 1
 
-        str_xx(i,j) = str_xx(i,j) + d_str
+        d_del2u = (G%IdyCu(I,j) * Del2u(I,j,kk)) - (G%IdyCu(I-1,j) * Del2u(I-1,j,kk))
+        d_del2v = (G%IdxCv(i,J) * Del2v(i,J,kk)) - (G%IdxCv(i,J-1) * Del2v(i,J-1,kk))
+        d_str = Ah(i,j,kk) * ((CS%DY_dxT(i,j) * d_del2u) - (CS%DX_dyT(i,j) * d_del2v))
 
-        if (CS%use_Leithy) str_xx(i,j) = str_xx(i,j) - Kh_BS(i,j) * sh_xx_smooth(i,j)
+        str_xx(i,j,kk) = str_xx(i,j,kk) + d_str
+
+        if (CS%use_Leithy) str_xx(i,j,kk) = str_xx(i,j,kk) &
+            - Kh_BS(i,j,kk) * sh_xx_smooth(i,j,kk)
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+        bhstr_xx(i,j,kk) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo ; enddo
     endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        if (visc_limit_h_flag(i,j,k) > 0) then
-          Kh_BS(i,j) = 0.
-        else
-          if (use_kh_struct) then
-            Kh_BS(i,j) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
-          else
-            Kh_BS(i,j) = MEKE%Ku(i,j)
-          endif
-        endif
-      enddo ; enddo
-
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx_BS(i,j) = -Kh_BS(i,j) * sh_xx(i,j)
-      enddo ; enddo
-
-      if (CS%id_BS_coeff_h>0) then
-        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-          BS_coeff_h(i,j,k) = Kh_BS(i,j)
-        enddo ; enddo
-      endif
-
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = str_xx(i,j) + str_xx_BS(i,j)
-      enddo ; enddo
+      call hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkk, ksb, kke, &
+                                  Isq, Ieq, Jsq, Jeq, visc_limit_h_flag, sh_xx, str_xx, BS_coeff_h)
     endif ! Backscatter
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        dDel2vdx(I,J) = CS%DY_dxBu(I,J)*((Del2v(i+1,J)*G%IdyCv(i+1,J)) - (Del2v(i,J)*G%IdyCv(i,J)))
-        dDel2udy(I,J) = CS%DX_dyBu(I,J)*((Del2u(I,j+1)*G%IdxCu(I,j+1)) - (Del2u(I,j)*G%IdxCu(I,j)))
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        dDel2vdx(I,J,kk) = CS%DY_dxBu(I,J)*((Del2v(i+1,J,kk)*G%IdyCv(i+1,J)) - (Del2v(i,J,kk)*G%IdyCv(i,J)))
+        dDel2udy(I,J,kk) = CS%DX_dyBu(I,J)*((Del2u(I,j+1,kk)*G%IdxCu(I,j+1)) - (Del2u(I,j,kk)*G%IdxCu(I,j)))
+      enddo ; enddo ; enddo
       ! Adjust contributions to shearing strain on open boundaries.
       if (apply_OBC) then ; if ((OBC%strain_config == OBC_STRAIN_ZERO) .or. &
                                 (OBC%strain_config == OBC_STRAIN_FREESLIP)) then
         do n=1,OBC%number_of_segments
           J = OBC%segment(n)%HI%JsdB ; I = OBC%segment(n)%HI%IsdB
           if (OBC%segment(n)%is_N_or_S .and. (J >= js-1) .and. (J <= Jeq)) then
-            do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
+            do kk=1,kke ; do I=OBC%segment(n)%HI%IsdB,OBC%segment(n)%HI%IedB
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
-                dDel2vdx(I,J) = 0. ; dDel2udy(I,J) = 0.
+                dDel2vdx(I,J,kk) = 0. ; dDel2udy(I,J,kk) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
-                dDel2udy(I,J) = 0.
+                dDel2udy(I,J,kk) = 0.
               endif
-            enddo
+            enddo ; enddo
           elseif (OBC%segment(n)%is_E_or_W .and. (I >= is-1) .and. (I <= Ieq)) then
-            do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
+            do kk=1,kke ; do J=OBC%segment(n)%HI%JsdB,OBC%segment(n)%HI%JedB
               if (OBC%strain_config == OBC_STRAIN_ZERO) then
-                dDel2vdx(I,J) = 0. ; dDel2udy(I,J) = 0.
+                dDel2vdx(I,J,kk) = 0. ; dDel2udy(I,J,kk) = 0.
               elseif (OBC%strain_config == OBC_STRAIN_FREESLIP) then
-                dDel2vdx(I,J) = 0.
+                dDel2vdx(I,J,kk) = 0.
               endif
-            enddo
+            enddo ; enddo
           endif
         enddo
       endif ; endif
     endif
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        sh_xy_sq = sh_xy(I,J)**2
-        sh_xx_sq = 0.25 * ( ((sh_xx(i,j)**2) + (sh_xx(i+1,j+1)**2)) &
-                          + ((sh_xx(i,j+1)**2) + (sh_xx(i+1,j)**2)) )
-        Shear_mag(I,J) = sqrt(sh_xy_sq + sh_xx_sq)
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        sh_xy_sq = sh_xy(I,J,kk)**2
+        sh_xx_sq = 0.25 * ( ((sh_xx(i,j,kk)**2) + (sh_xx(i+1,j+1,kk)**2)) &
+                          + ((sh_xx(i,j+1,kk)**2) + (sh_xx(i+1,j,kk)**2)) )
+        Shear_mag(I,J,kk) = sqrt(sh_xy_sq + sh_xx_sq)
+      enddo ; enddo ; enddo
     endif
 
-    do J=js-1,Jeq ; do I=is-1,Ieq
-      h2uq = 4.0 * (h_u(I,j) * h_u(I,j+1))
-      h2vq = 4.0 * (h_v(i,J) * h_v(i+1,J))
-      hq(I,J) = (2.0 * (h2uq * h2vq)) &
-          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j) + h_u(I,j+1)) + (h_v(i,J) + h_v(i+1,J))))
-    enddo ; enddo
+    do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+      h2uq = 4.0 * (h_u(I,j,kk) * h_u(I,j+1,kk))
+      h2vq = 4.0 * (h_v(i,J,kk) * h_v(i+1,J,kk))
+      hq(I,J,kk) = (2.0 * (h2uq * h2vq)) &
+          / (h_neglect3 + (h2uq + h2vq) * ((h_u(I,j,kk) + h_u(I,j+1,kk)) + (h_v(i,J,kk) + h_v(i+1,J,kk))))
+    enddo ; enddo ; enddo
 
     if (CS%bound_Ah .or. CS%bound_Kh) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        h_min = min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J))
-        hrat_min(I,J) = min(1.0, h_min / (hq(I,J) + h_neglect))
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        h_min = min(h_u(I,j,kk), h_u(I,j+1,kk), h_v(i,J,kk), h_v(i+1,J,kk))
+        hrat_min(I,J,kk) = min(1.0, h_min / (hq(I,J,kk) + h_neglect))
+      enddo ; enddo ; enddo
 
     endif
 
     if (CS%no_slip) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
         if (CS%no_slip .and. (G%mask2dBu(I,J) < 0.5)) then
           if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) + &
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) > 0.0) then
             ! This is a coastal vorticity point, so modify hq and hrat_min.
 
-            hu = G%mask2dCu(I,j) * h_u(I,j) + G%mask2dCu(I,j+1) * h_u(I,j+1)
-            hv = G%mask2dCv(i,J) * h_v(i,J) + G%mask2dCv(i+1,J) * h_v(i+1,J)
+            hu = G%mask2dCu(I,j) * h_u(I,j,kk) + G%mask2dCu(I,j+1) * h_u(I,j+1,kk)
+            hv = G%mask2dCv(i,J) * h_v(i,J,kk) + G%mask2dCv(i+1,J) * h_v(i+1,J,kk)
             if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
                 (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
               ! Only one of hu and hv is nonzero, so just add them.
-              hq(I,J) = hu + hv
-              hrat_min(I,J) = 1.0
+              hq(I,J,kk) = hu + hv
+              hrat_min(I,J,kk) = 1.0
             else
               ! Both hu and hv are nonzero, so take the harmonic mean.
-              hq(I,J) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
-              hrat_min(I,J) = min(1.0, min(hu, hv) / (hq(I,J) + h_neglect) )
+              hq(I,J,kk) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
+              hrat_min(I,J,kk) = min(1.0, min(hu, hv) / (hq(I,J,kk) + h_neglect) )
             endif
           endif
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
     endif
 
     ! Pass the velocity gradients and thickness to ZB2020
     if (CS%use_ZB2020) then
-      call ZB2020_copy_gradient_and_thickness(sh_xx, sh_xy, vort_xy, hq, G, GV, CS%ZB2020, k)
+      do kk=1,kke
+        k = ksb + kk - 1
+        call ZB2020_copy_gradient_and_thickness(sh_xx(:,:,kk), sh_xy(:,:,kk), vort_xy(:,:,kk), hq(:,:,kk), &
+                                                 G, GV, CS%ZB2020, k)
+      enddo
     endif
 
     if (CS%Laplacian) then
@@ -1605,354 +1415,349 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
 
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            grad_vort = grad_vort_mag_q(I,J) + grad_div_mag_q(I,J)
-            grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J)
-            vert_vort_mag(I,J) = min(grad_vort, grad_vort_qg)
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            grad_vort = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
+            grad_vort_qg = 3. * grad_vort_mag_q_2d(I,J,kk)
+            vert_vort_mag(I,J,kk) = min(grad_vort, grad_vort_qg)
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            vert_vort_mag(I,J) = grad_vort_mag_q(I,J) + grad_div_mag_q(I,J)
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            vert_vort_mag(I,J,kk) = grad_vort_mag_q(I,J,kk) + grad_div_mag_q(I,J,kk)
+          enddo ; enddo ; enddo
         endif
       endif
 
       ! Static (pre-computed) background viscosity
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J) = CS%Kh_bg_xy(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        Kh(I,J,kk) = CS%Kh_bg_xy(I,J)
+      enddo ; enddo ; enddo
 
       if (CS%Smagorinsky_Kh) then
         if (CS%add_LES_viscosity) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = Kh(I,J) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J)
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = Kh(I,J,kk) + CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,kk)
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = max(Kh(I,J), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J) )
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = max(Kh(I,J,kk), CS%Laplac2_const_xy(I,J) * Shear_mag(I,J,kk) )
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%Leith_Kh) then
         if (CS%add_LES_viscosity) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = Kh(I,J) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3 ! Is this right? -AJA
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = Kh(I,J,kk) + CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,kk) * inv_PI3 ! Is this right? -AJA
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = max(Kh(I,J), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J) * inv_PI3)
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = max(Kh(I,J,kk), CS%Laplac3_const_xy(I,J) * vert_vort_mag(I,J,kk) * inv_PI3)
+          enddo ; enddo ; enddo
         endif
       endif
 
       ! All viscosity contributions above are subject to resolution scaling
 
       if (rescale_Kh) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh(I,J) = VarMix%Res_fn_q(I,J) * Kh(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          Kh(I,J,kk) = VarMix%Res_fn_q(I,J) * Kh(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        Kh(I,J) = max(Kh(I,J), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        Kh(I,J,kk) = max(Kh(I,J,kk), CS%Kh_bg_min) ! Place a floor on the viscosity, if desired.
+      enddo ; enddo ; enddo
 
       if (use_MEKE_Ku .and. .not. CS%EY24_EBT_BS) then
         if (use_kh_struct) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            k = ksb + kk - 1
+
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
-            Kh(I,J) = Kh(I,J) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+            Kh(I,J,kk) = Kh(I,J,kk) + 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
                                        (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
                                        ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
                                        (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) ) * meke_res_fn
-          enddo ; enddo
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
             meke_res_fn = 1.
             if (CS%res_scale_MEKE) meke_res_fn = VarMix%Res_fn_q(I,J)
 
-            Kh(I,J) = Kh(I,J) + 0.25 * ( &
+            Kh(I,J,kk) = Kh(I,J,kk) + 0.25 * ( &
                 (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
                                        (MEKE%Ku(i+1,j) + &
                                         MEKE%Ku(i,j+1)) ) * meke_res_fn
-          enddo ; enddo
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%anisotropic) then
         ! *Add* the shear component of anisotropic viscosity
-        do J=js-1,Jeq ; do I=is-1,Ieq
-            Kh(I,J) = Kh(I,J) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Kh(I,J,kk) = Kh(I,J,kk) + CS%Kh_aniso * CS%n1n2_q(I,J)**2
+        enddo ; enddo ; enddo
       endif
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
         ! Newer method of bounding for stability
         if ((CS%bound_Kh) .and. (CS%bound_Ah)) then
-          visc_bound_rem(I,J) = 1.0
-          Kh_max_here = hrat_min(I,J) * CS%Kh_Max_xy(I,J)
-          if (Kh(I,J) >= Kh_max_here) then
-            visc_bound_rem(I,J) = 0.0
-            Kh(I,J) = Kh_max_here
-          elseif ((Kh(I,J) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
-            visc_bound_rem(I,J) = 1.0 - Kh(I,J) / Kh_max_here
+          visc_bound_rem(I,J,kk) = 1.0
+          Kh_max_here = hrat_min(I,J,kk) * CS%Kh_Max_xy(I,J)
+          if (Kh(I,J,kk) >= Kh_max_here) then
+            visc_bound_rem(I,J,kk) = 0.0
+            Kh(I,J,kk) = Kh_max_here
+          elseif ((Kh(I,J,kk) > 0.0) .or. (CS%backscatter_underbound .and. (Kh_max_here > 0.0))) then
+            visc_bound_rem(I,J,kk) = 1.0 - Kh(I,J,kk) / Kh_max_here
           endif
         elseif (CS%bound_Kh) then
-          Kh(I,J) = min(Kh(I,J), hrat_min(I,J) * CS%Kh_Max_xy(I,J))
+          Kh(I,J,kk) = min(Kh(I,J,kk), hrat_min(I,J,kk) * CS%Kh_Max_xy(I,J))
         endif
-      enddo ; enddo
+      enddo ; enddo ; enddo
 
       if (CS%use_Leithy) then
         ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh_BS(I,J) = 0.25 * ((BS_coeff_h(i,j  ,k) + BS_coeff_h(i+1,j+1,k)) + &
-                               (BS_coeff_h(i,j+1,k) + BS_coeff_h(i+1,j  ,k)))
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
+          Kh_BS(I,J,kk) = 0.25 * ((BS_coeff_h(i,j,k) + BS_coeff_h(i+1,j+1,k)) &
+              + (BS_coeff_h(i,j+1,k) + BS_coeff_h(i+1,j,k)))
+        enddo ; enddo ; enddo
 
         if (CS%id_BS_coeff_q > 0) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            BS_coeff_q(I,J,k) = Kh_BS(I,J)
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            k = ksb + kk - 1
+            BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%id_Kh_q > 0 .or. CS%debug) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Kh_q(I,J,k) = Kh(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
+          Kh_q(I,J,k) = Kh(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_vort_xy_q > 0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          vort_xy_q(I,J,k) = vort_xy(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
+          vort_xy_q(I,J,k) = vort_xy(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_sh_xy_q > 0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          sh_xy_q(I,J,k) = sh_xy(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
+          sh_xy_q(I,J,k) = sh_xy(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        str_xy(I,J,kk) = -Kh(I,J,kk) * sh_xy(I,J,kk)
+      enddo ; enddo ; enddo
 
       if (CS%use_Leithy) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = str_xy(I,J) - Kh_BS(I,J) * sh_xy_smooth(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = str_xy(I,J,kk) - Kh_BS(I,J,kk) * sh_xy_smooth(I,J,kk)
+        enddo ; enddo ; enddo
       endif
     else
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J) = 0.
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        str_xy(I,J,kk) = 0.
+      enddo ; enddo ; enddo
     endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
         ! Horizontal-tension averaged to q-points
-        local_strain = 0.25 * ( (sh_xx(i,j) + sh_xx(i+1,j+1)) + (sh_xx(i+1,j) + sh_xx(i,j+1)) )
+        local_strain = 0.25 * ( (sh_xx(i,j,kk) + sh_xx(i+1,j+1,kk)) + (sh_xx(i+1,j,kk) + sh_xx(i,j+1,kk)) )
         ! *Add* the tension contribution to the xy-component of stress
-        str_xy(I,J) = str_xy(I,J) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
-      enddo ; enddo
+        str_xy(I,J,kk) = str_xy(I,J,kk) - CS%Kh_aniso * CS%n1n2_q(I,J) * CS%n1n1_m_n2n2_q(I,J) * local_strain
+      enddo ; enddo ; enddo
     endif
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
       ! largest value from several parameterizations. Also get the
       ! biharmonic component of str_xy.
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        Ah(I,J) = CS%Ah_bg_xy(I,J)
-      enddo ; enddo
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        Ah(I,J,kk) = CS%Ah_bg_xy(I,J)
+      enddo ; enddo ; enddo
 
       if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
-            do J=js-1,Jeq ; do I=is-1,Ieq
-              AhSm = Shear_mag(I,J) * (CS%Biharm_const_xy(I,J) &
-                  + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J))
-              Ah(I,J) = max(Ah(I,J), AhSm)
-            enddo ; enddo
+            do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+              AhSm = Shear_mag(I,J,kk) * (CS%Biharm_const_xy(I,J) &
+                  + CS%Biharm_const2_xy(I,J) * Shear_mag(I,J,kk))
+              Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
+            enddo ; enddo ; enddo
           else
-            do J=js-1,Jeq ; do I=is-1,Ieq
-              AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J)
-              Ah(I,J) = max(Ah(I,J), AhSm)
-            enddo ; enddo
+            do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+              AhSm = CS%Biharm_const_xy(I,J) * Shear_mag(I,J,kk)
+              Ah(I,J,kk) = max(Ah(I,J,kk), AhSm)
+            enddo ; enddo ; enddo
           endif
         endif
 
         if (CS%Leith_Ah) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J)) * inv_PI6
-            Ah(I,J) = max(Ah(I,J), AhLth)
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            AhLth = CS%Biharm6_const_xy(I,J) * abs(Del2vort_q(I,J,kk)) * inv_PI6
+            Ah(I,J,kk) = max(Ah(I,J,kk), AhLth)
+          enddo ; enddo ; enddo
         endif
       endif ! Smagorinsky_Ah or Leith_Ah
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah(I,J) = Ah(I,J) + 0.25 * ( &
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          Ah(I,J,kk) = Ah(I,J,kk) + 0.25 * ( &
               (MEKE%Au(i,j) + MEKE%Au(i+1,j+1)) + (MEKE%Au(i+1,j) + MEKE%Au(i,j+1)) )
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
       if (CS%Re_Ah > 0.0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
           KE = 0.125 * (((u(I,j,k) + u(I,j+1,k))**2) + ((v(i,J,k) + v(i+1,J,k))**2))
-          Ah(I,J) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
-        enddo ; enddo
+          Ah(I,J,kk) = sqrt(KE) * CS%Re_Ah_const_xy(I,J)
+        enddo ; enddo ; enddo
       endif
 
       if (CS%bound_Ah) then
         if (CS%bound_Kh) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Ah(I,J) = min(Ah(I,J), visc_bound_rem(I,J) * hrat_min(I,J) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Ah(I,J,kk) = min(Ah(I,J,kk), visc_bound_rem(I,J,kk) * hrat_min(I,J,kk) * CS%Ah_Max_xy(I,J))
+          enddo ; enddo ; enddo
         else
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            Ah(I,J) = min(Ah(I,J), hrat_min(I,J) * CS%Ah_Max_xy(I,J))
-          enddo ; enddo
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            Ah(I,J,kk) = min(Ah(I,J,kk), hrat_min(I,J,kk) * CS%Ah_Max_xy(I,J))
+          enddo ; enddo ; enddo
         endif
       endif
 
       if (CS%EY24_EBT_BS) then
-          do J=js-1,Jeq ; do I=is-1,Ieq
-            tmp = CS%KS_coef *hrat_min(I,J) * CS%Ah_Max_xy_KS(I,J)
+          do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+            k = ksb + kk - 1
+
+            tmp = CS%KS_coef * hrat_min(I,J,kk) * CS%Ah_Max_xy_KS(I,J)
             visc_limit_q(I,J,k) = tmp
-            visc_limit_q_frac(i,j,k) = Ah(i,j) / (CS%KS_coef * hrat_min(i,j) * CS%Ah_Max_xy_KS(i,j))
-            if (Ah(I,J) >= tmp) then
+            visc_limit_q_frac(i,j,k) = Ah(i,j,kk) / (CS%KS_coef * hrat_min(i,j,kk) * CS%Ah_Max_xy_KS(i,j))
+            if (Ah(I,J,kk) >= tmp) then
               visc_limit_q_flag(I,J,k) = 1.
             endif
-          enddo ; enddo
+          enddo ; enddo ; enddo
       endif
 
       ! Leith+E doesn't recompute Ah at q points, it just interpolates it from h to q points
       if (CS%use_Leithy) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah(I,J) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
+          Ah(I,J,kk) = 0.25 * ((Ah_h(i,j,k) + Ah_h(i+1,j+1,k)) + (Ah_h(i,j+1,k) + Ah_h(i+1,j,k)))
+        enddo ; enddo ; enddo
       endif
 
       if (CS%id_Ah_q>0 .or. CS%debug) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          Ah_q(I,J,k) = Ah(I,J)
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          k = ksb + kk - 1
+          Ah_q(I,J,k) = Ah(I,J,kk)
+        enddo ; enddo ; enddo
       endif
 
       ! Again, need to initialize str_xy as if its biharmonic
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        d_str = Ah(I,J) * (dDel2vdx(I,J) + dDel2udy(I,J))
+      do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+        d_str = Ah(I,J,kk) * (dDel2vdx(I,J,kk) + dDel2udy(I,J,kk))
 
-        str_xy(I,J) = str_xy(I,J) + d_str
+        str_xy(I,J,kk) = str_xy(I,J,kk) + d_str
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
-        bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-      enddo ; enddo
+        bhstr_xy(I,J,kk) = d_str * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+      enddo ; enddo ; enddo
     endif ! Get Ah at q points and biharmonic part of str_xy
 
     ! Backscatter using MEKE
     if (CS%EY24_EBT_BS) then
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        if (visc_limit_q_flag(I,J,k) > 0) then
-          Kh_BS(I,J) = 0.
-        else
-          if (use_kh_struct) then
-            Kh_BS(I,J) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
-                                 (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
-                                ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
-                                 (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
-          else
-            Kh_BS(I,J) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
-                                (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
-          endif
-        endif
-      enddo ; enddo
-
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy_BS(I,J) = -Kh_BS(I,J) * (sh_xy(I,J))
-      enddo ; enddo
-
-      if (CS%id_BS_coeff_q>0) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          BS_coeff_q(I,J,k) = Kh_BS(I,J)
-        enddo ; enddo
-      endif
-
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J) = str_xy(I,J) + str_xy_BS(I,J)
-      enddo ; enddo
+      call hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, nkk, ksb, kke, &
+                                   is, js, Ieq, Jeq, visc_limit_q_flag, sh_xy, str_xy, BS_coeff_q)
     endif ! Backscatter
 
     if (CS%use_GME) then
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      do kk=1,kke ; do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+        k = ksb + kk - 1
+
         GME_coeff = GME_effic_h(i,j) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I-1,j,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i,J-1,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
-        str_xx_GME(i,j) = GME_coeff * sh_xx_bt(i,j)
-      enddo ; enddo
+        str_xx_GME(i,j,kk) = GME_coeff * sh_xx_bt(i,j)
+      enddo ; enddo ; enddo
 
       ! The wider halo here is to permit one pass of smoothing without a halo update.
-      do J=js-2,je+1 ; do I=is-2,ie+1
+      do kk=1,kke ; do J=js-2,je+1 ; do I=is-2,ie+1
+        k = ksb + kk - 1
+
         GME_coeff = GME_effic_q(I,J) * 0.25 * &
             ((KH_u_GME(I,j,k)+KH_u_GME(I,j+1,k)) + (KH_v_GME(i,J,k)+KH_v_GME(i+1,J,k)))
         GME_coeff = MIN(GME_coeff, CS%GME_limiter)
 
         if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
-        str_xy_GME(I,J) = GME_coeff * sh_xy_bt(I,J)
-      enddo ; enddo
+        str_xy_GME(I,J,kk) = GME_coeff * sh_xy_bt(I,J)
+      enddo ; enddo ; enddo
 
       ! Applying GME diagonal term.  This is linear and the arguments can be rescaled.
-      call smooth_GME(CS, G, GME_flux_h=str_xx_GME)
-      call smooth_GME(CS, G, GME_flux_q=str_xy_GME)
+      ! smooth_GME is an impure host routine, so str_xx_GME/str_xy_GME must be brought back
+      do kk=1,kke
+        call smooth_GME(CS, G, GME_flux_h=str_xx_GME(:,:,kk))
+        call smooth_GME(CS, G, GME_flux_q=str_xy_GME(:,:,kk))
+      enddo
 
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = (str_xx(i,j) + str_xx_GME(i,j)) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = ksb + kk - 1
+        str_xx(i,j,kk) = (str_xx(i,j,kk) + str_xx_GME(i,j,kk)) * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo ; enddo
 
       ! This adds in GME and changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = (str_xy(I,J,kk) + str_xy_GME(I,J,kk)) * (hq(I,J,kk) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = (str_xy(I,J,kk) + str_xy_GME(I,J,kk)) * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       endif
 
     else ! .not. use_GME
       ! This changes the units of str_xx from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
-      do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-        str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
-      enddo ; enddo
+      do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        k = ksb + kk - 1
+        str_xx(i,j,kk) = str_xx(i,j,kk) * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo ; enddo
 
       ! This changes the units of str_xy from [L2 T-2 ~> m2 s-2] to [H L2 T-2 ~> m3 s-2 or kg s-2].
       if (CS%no_slip) then
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = str_xy(I,J,kk) * (hq(I,J,kk) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       else
-        do J=js-1,Jeq ; do I=is-1,Ieq
-          str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-        enddo ; enddo
+        do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J,kk) = str_xy(I,J,kk) * (hq(I,J,kk) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        enddo ; enddo ; enddo
       endif
     endif ! use_GME
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
-    do j=js,je ; do I=Isq,Ieq
-      diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1)) - (CS%dx2q(I,J)*str_xy(I,J))) + &
-                       G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j)) - (CS%dy2h(i+1,j)*str_xx(i+1,j)))) * &
-                     G%IareaCu(I,j)) / (h_u(I,j) + h_neglect)
-    enddo ; enddo
+    do kk=1,kke ; do j=js,je ; do I=Isq,Ieq
+      k = ksb + kk - 1
+      diffu(I,j,k) = ((G%IdxCu(I,j)*((CS%dx2q(I,J-1)*str_xy(I,J-1,kk)) - (CS%dx2q(I,J)*str_xy(I,J,kk))) + &
+                       G%IdyCu(I,j)*((CS%dy2h(i,j)*str_xx(i,j,kk)) - (CS%dy2h(i+1,j)*str_xx(i+1,j,kk)))) * &
+                     G%IareaCu(I,j)) / (h_u(I,j,kk) + h_neglect)
+    enddo ; enddo ; enddo
 
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done
@@ -1960,19 +1765,21 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_E_or_W) then
           I = OBC%segment(n)%HI%IsdB
-          do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+          do kk=1,kke ; do j=OBC%segment(n)%HI%jsd,OBC%segment(n)%HI%jed
+            k = ksb + kk - 1
             diffu(I,j,k) = 0.
-          enddo
+          enddo ; enddo
         endif
       enddo
     endif
 
     ! Evaluate 1/h y.Div(h Grad u) or the biharmonic equivalent.
-    do J=Jsq,Jeq ; do i=is,ie
-      diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J)) - (CS%dy2q(I,J)*str_xy(I,J))) - &
-                       G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j)) - (CS%dx2h(i,j+1)*str_xx(i,j+1)))) * &
-                     G%IareaCv(i,J)) / (h_v(i,J) + h_neglect)
-    enddo ; enddo
+    do kk=1,kke ; do J=Jsq,Jeq ; do i=is,ie
+      k = ksb + kk - 1
+      diffv(i,J,k) = ((G%IdyCv(i,J)*((CS%dy2q(I-1,J)*str_xy(I-1,J,kk)) - (CS%dy2q(I,J)*str_xy(I,J,kk))) - &
+                       G%IdxCv(i,J)*((CS%dx2h(i,j)*str_xx(i,j,kk)) - (CS%dx2h(i,j+1)*str_xx(i,j+1,kk)))) * &
+                     G%IareaCv(i,J)) / (h_v(i,J,kk) + h_neglect)
+    enddo ; enddo ; enddo
 
     if (apply_OBC) then
       ! This is not the right boundary condition. If all the masking of tendencies are done
@@ -1980,9 +1787,10 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       do n=1,OBC%number_of_segments
         if (OBC%segment(n)%is_N_or_S) then
           J = OBC%segment(n)%HI%JsdB
-          do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+          do kk=1,kke ; do i=OBC%segment(n)%HI%isd,OBC%segment(n)%HI%ied
+            k = ksb + kk - 1
             diffv(i,J,k) = 0.
-          enddo
+          enddo ; enddo
         endif
       enddo
     endif
@@ -1991,60 +1799,63 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * ( &
-                  ((str_xx(i,j) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-                 - (str_xx(i,j) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy(I,J) *                                  &
+                  ((str_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+                 - (str_xx(i,j,kk) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+              + 0.25*(( (str_xy(I,J,kk) *                                  &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy(I-1,J-1) *                              &
+                      + (str_xy(I-1,J-1,kk) *                              &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy(I-1,J) *                                &
+                    + ( (str_xy(I-1,J,kk) *                                &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy(I,J-1) *                                &
+                      + (str_xy(I,J-1,kk) *                                &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           FrictWork(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx(i,j)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) ) ) &
-           - (str_xx(i,j)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
-          + (0.25*(((str_xy(I,J)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
-                +(str_xy(I-1,J-1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
-               +((str_xy(I-1,J)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
-                +(str_xy(I,J-1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
+            ((str_xx(i,j,kk)*CS%dy2h(i,j) * ( &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
+           - (str_xx(i,j,kk)*CS%dx2h(i,j) * ( &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
+          + (0.25*(((str_xy(I,J,kk)*(                                     &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
+                +(str_xy(I-1,J-1,kk)*(                                 &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
+               +((str_xy(I-1,J,kk)*(                                   &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
+                +(str_xy(I,J-1,kk)*(                                   &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
 
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
 
       if (CS%EY24_EBT_BS) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           FrictWork(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork(i,j,k)
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
     endif
 
@@ -2053,148 +1864,145 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           FrictWork_bh(i,j,k) = GV%H_to_RZ * ( &
-                  ((bhstr_xx(i,j) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
-                 - (bhstr_xx(i,j) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
-              + 0.25*(( (bhstr_xy(I,J) *                              &
+                  ((bhstr_xx(i,j,kk) * (u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))  &
+                 - (bhstr_xx(i,j,kk) * (v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))) &
+              + 0.25*(( (bhstr_xy(I,J,kk) *                              &
                        (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                       + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                    + (bhstr_xy(I-1,J-1) *                            &
+                    + (bhstr_xy(I-1,J-1,kk) *                            &
                        (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                       + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                  + ( (bhstr_xy(I-1,J) *                              &
+                  + ( (bhstr_xy(I-1,J,kk) *                              &
                        (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                       + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                    + (bhstr_xy(I,J-1) *                              &
+                    + (bhstr_xy(I,J-1,kk) *                              &
                        (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                       + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
-        do j=js,je ; do i=is,ie
-          ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
+        ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           FrictWork_bh(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((bhstr_xx(i,j)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) ) ) &
-           - (bhstr_xx(i,j)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
-          + (0.25*(((bhstr_xy(I,J)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
-                +(bhstr_xy(I-1,J-1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
-               +((bhstr_xy(I-1,J)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
-                +(bhstr_xy(I,J-1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
-        enddo ; enddo
+            ((bhstr_xx(i,j,kk)*CS%dy2h(i,j) * ( &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
+           - (bhstr_xx(i,j,kk)*CS%dx2h(i,j) * ( &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
+          + (0.25*(((bhstr_xy(I,J,kk)*(                                     &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
+                +(bhstr_xy(I-1,J-1,kk)*(                                 &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
+               +((bhstr_xy(I-1,J,kk)*(                                   &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
+                +(bhstr_xy(I,J-1,kk)*(                                   &
+                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
+                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
+                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
+        enddo ; enddo ; enddo
       endif
 
       if (CS%EY24_EBT_BS) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           FrictWork_bh(i,j,k) = (1. - visc_limit_h_flag(i,j,k)) * FrictWork_bh(i,j,k)
-        enddo ; enddo
+        enddo ; enddo ; enddo
       endif
     endif
 
     if (CS%use_GME) then
-      if (CS%FrictWork_bug) then ; do j=js,je ; do i=is,ie
-      ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
-      ! This is the old formulation that includes energy diffusion
+      if (CS%FrictWork_bug) then ; do kk=1,kke ; do j=js,je ; do i=is,ie
+        ! Diagnose   str_xx_GME*d_x u - str_yy_GME*d_y v + str_xy_GME*(d_y u + d_x v)
+        ! This is the old formulation that includes energy diffusion
+        k = ksb + kk - 1
         FrictWork_GME(i,j,k) = GV%H_to_RZ * ( &
-                ((str_xx_GME(i,j)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
-               - (str_xx_GME(i,j)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
-              + 0.25*(( (str_xy_GME(I,J) *                              &
+                ((str_xx_GME(i,j,kk)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j))    &
+               - (str_xx_GME(i,j,kk)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j)))   &
+              + 0.25*(( (str_xy_GME(I,J,kk) *                              &
                          (((u(I,j+1,k)-u(I,j,k))*G%IdyBu(I,J))          &
                         + ((v(i+1,J,k)-v(i,J,k))*G%IdxBu(I,J))))        &
-                      + (str_xy_GME(I-1,J-1) *                          &
+                      + (str_xy_GME(I-1,J-1,kk) *                          &
                          (((u(I-1,j,k)-u(I-1,j-1,k))*G%IdyBu(I-1,J-1))  &
                         + ((v(i,J-1,k)-v(i-1,J-1,k))*G%IdxBu(I-1,J-1)))) ) &
-                    + ( (str_xy_GME(I-1,J) *                            &
+                    + ( (str_xy_GME(I-1,J,kk) *                            &
                          (((u(I-1,j+1,k)-u(I-1,j,k))*G%IdyBu(I-1,J))    &
                         + ((v(i,J,k)-v(i-1,J,k))*G%IdxBu(I-1,J))))      &
-                      + (str_xy_GME(I,J-1) *                            &
+                      + (str_xy_GME(I,J-1,kk) *                            &
                          (((u(I,j,k)-u(I,j-1,k))*G%IdyBu(I,J-1))        &
                         + ((v(i+1,J-1,k)-v(i,J-1,k))*G%IdxBu(I,J-1)))) ) ) )
-        enddo ; enddo
-      else ; do j=js,je ; do i=is,ie
+        enddo ; enddo ; enddo
+      else ; do kk=1,kke ; do j=js,je ; do i=is,ie
+        k = ksb + kk - 1
         FrictWork_GME(i,j,k) = GV%H_to_RZ * G%IareaT(i,j) * ( &
-            ((str_xx_GME(i,j)*CS%dy2h(i,j) * ( &
-                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) ) ) &
-           - (str_xx_GME(i,j)*CS%dx2h(i,j) * ( &
-                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) ) )) &
-       + (0.25*(((str_xy_GME(I,J)*(                                     &
-                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1)+h_neglect)) &
-                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect))))            &
-                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J)+h_neglect)) &
-                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)))) ))          &
-                +(str_xy_GME(I-1,J-1)*(                                 &
-                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect)) &
-                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1)+h_neglect))))    &
-                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)) &
-                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1)+h_neglect)))) )) ) &
-               +((str_xy_GME(I-1,J)*(                                   &
-                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1)+h_neglect)) &
-                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j)+h_neglect))))      &
-                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J)+h_neglect)) &
-                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J)+h_neglect)))) ))        &
-                +(str_xy_GME(I,J-1)*(                                   &
-                     (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j)+h_neglect)) &
-                                    - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1)+h_neglect))))          &
-                   + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1)+h_neglect)) &
-                                    - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1)+h_neglect)))) )) ) )) )
-      enddo ; enddo ; endif
+            ((str_xx_GME(i,j,kk)*CS%dy2h(i,j) * ( &
+                  (uh(I,j,k)*G%dxCu(I,j)*G%IdyCu(I,j)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                - (uh(I-1,j,k)*G%dxCu(I-1,j)*G%IdyCu(I-1,j)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) ) ) &
+           - (str_xx_GME(i,j,kk)*CS%dx2h(i,j) * ( &
+                  (vh(i,J,k)*G%dyCv(i,J)*G%IdxCv(i,J)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                - (vh(i,J-1,k)*G%dyCv(i,J-1)*G%IdxCv(i,J-1)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) ) )) &
+       + (0.25*(((str_xy_GME(I,J,kk)*(                                     &
+                     (CS%dx2q(I,J)*((uh(I,j+1,k)*G%IareaCu(I,j+1)/(h_u(I,j+1,kk)+h_neglect)) &
+                                  - (uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect))))            &
+                   + (CS%dy2q(I,J)*((vh(i+1,J,k)*G%IareaCv(i+1,J)/(h_v(i+1,J,kk)+h_neglect)) &
+                                  - (vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)))) ))          &
+                +(str_xy_GME(I-1,J-1,kk)*(                                 &
+                     (CS%dx2q(I-1,J-1)*((uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect)) &
+                                      - (uh(I-1,j-1,k)*G%IareaCu(I-1,j-1)/(h_u(I-1,j-1,kk)+h_neglect))))    &
+                   + (CS%dy2q(I-1,J-1)*((vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)) &
+                                      - (vh(i-1,J-1,k)*G%IareaCv(i-1,J-1)/(h_v(i-1,J-1,kk)+h_neglect)))) )) ) &
+               +((str_xy_GME(I-1,J,kk)*(                                   &
+                     (CS%dx2q(I-1,J)*((uh(I-1,j+1,k)*G%IareaCu(I-1,j+1)/(h_u(I-1,j+1,kk)+h_neglect)) &
+                                    - (uh(I-1,j,k)*G%IareaCu(I-1,j)/(h_u(I-1,j,kk)+h_neglect))))      &
+                   + (CS%dy2q(I-1,J)*((vh(i,J,k)*G%IareaCv(i,J)/(h_v(i,J,kk)+h_neglect)) &
+                                    - (vh(i-1,J,k)*G%IareaCv(i-1,J)/(h_v(i-1,J,kk)+h_neglect)))) ))        &
+                +(str_xy_GME(I,J-1,kk)*(                                   &
+                      (CS%dx2q(I,J-1)*((uh(I,j,k)*G%IareaCu(I,j)/(h_u(I,j,kk)+h_neglect)) &
+                                     - (uh(I,j-1,k)*G%IareaCu(I,j-1)/(h_u(I,j-1,kk)+h_neglect))))          &
+                    + (CS%dy2q(I,J-1)*((vh(i+1,J-1,k)*G%IareaCv(i+1,J-1)/(h_v(i+1,J-1,kk)+h_neglect)) &
+                                     - (vh(i,J-1,k)*G%IareaCv(i,J-1)/(h_v(i,J-1,kk)+h_neglect)))) )) ) )) )
+      enddo ; enddo ; enddo ; endif
+      if (find_FrictWork .and. allocated(MEKE%mom_src) .and. allocated(MEKE%GME_snk)) then
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
+          MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
+        enddo ; enddo ; enddo
+      endif
     endif
 
-    if (skeb_use_frict) then ; do j=js,je ; do i=is,ie
+    if (skeb_use_frict) then ; do kk=1,kke ; do j=js,je ; do i=is,ie
+      k = ksb + kk - 1
       ! Note that the sign convention is FrictWork < 0 means energy dissipation.
       STOCH%skeb_diss(i,j,k) = STOCH%skeb_diss(i,j,k) - STOCH%skeb_frict_coef * &
                                FrictWork(i,j,k) / (GV%H_to_RZ * (h(i,j,k) + h_neglect))
-    enddo ; enddo ; endif
+    enddo ; enddo ; enddo ; endif
 
     ! Make a similar calculation as for FrictWork above but accumulating into
     ! the vertically integrated MEKE source term, and adjusting for any
     ! energy loss seen as a reduction in the (biharmonic) frictional source term.
     if (find_FrictWork .and. allocated(MEKE%mom_src)) then
-      if (k==1) then
-        do j=js,je ; do i=is,ie
-          MEKE%mom_src(i,j) = 0.
-        enddo ; enddo
-
-        if (allocated(MEKE%mom_src_bh)) then
-          do j=js,je ; do i=is,ie
-            MEKE%mom_src_bh(i,j) = 0.
-          enddo ; enddo
-        endif
-
-        if (allocated(MEKE%GME_snk)) then
-          do j=js,je ; do i=is,ie
-            MEKE%GME_snk(i,j) = 0.
-          enddo ; enddo
-        endif
-      endif
       if (MEKE%backscatter_Ro_c /= 0.) then
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
+
           FatH = 0.25*( (abs(G%CoriolisBu(I-1,J-1)) + abs(G%CoriolisBu(I,J))) + &
                         (abs(G%CoriolisBu(I-1,J)) + abs(G%CoriolisBu(I,J-1))) )
-          Shear_mag_bc = sqrt(sh_xx(i,j) * sh_xx(i,j) + &
-            0.25*(((sh_xy(I-1,J-1)*sh_xy(I-1,J-1)) + (sh_xy(I,J)*sh_xy(I,J))) + &
-                  ((sh_xy(I-1,J)*sh_xy(I-1,J)) + (sh_xy(I,J-1)*sh_xy(I,J-1)))))
+          Shear_mag_bc = sqrt(sh_xx(i,j,kk) * sh_xx(i,j,kk) + &
+            0.25*(((sh_xy(I-1,J-1,kk)*sh_xy(I-1,J-1,kk)) + (sh_xy(I,J,kk)*sh_xy(I,J,kk))) + &
+                  ((sh_xy(I-1,J,kk)*sh_xy(I-1,J,kk)) + (sh_xy(I,J-1,kk)*sh_xy(I,J-1,kk)))))
           if ((CS%answer_date > 20190101) .and. (CS%answer_date < 20241201)) then
             FatH = (US%s_to_T*FatH)**MEKE%backscatter_Ro_pow ! f^n
             ! Note the hard-coded dimensional constant in the following line that can not
@@ -2218,26 +2026,22 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           if (allocated(MEKE%mom_src_bh)) &
             MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) &
                 + (FrictWork_bh(i,j,k) - RoScl * FrictWork_bh(i,j,k))
-        enddo ; enddo
+        enddo ; enddo ; enddo
       else
-        do j=js,je ; do i=is,ie
+        do kk=1,kke ; do j=js,je ; do i=is,ie
+          k = ksb + kk - 1
           MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
-        enddo ; enddo
+        enddo ; enddo ; enddo
 
         if (allocated(MEKE%mom_src_bh)) then
-          do j=js,je ; do i=is,ie
+          do kk=1,kke ; do j=js,je ; do i=is,ie
+            k = ksb + kk - 1
             MEKE%mom_src_bh(i,j) = MEKE%mom_src_bh(i,j) + FrictWork_bh(i,j,k)
-          enddo ; enddo
+          enddo ; enddo ; enddo
         endif
-      endif ! MEKE%backscatter_Ro_c
-
-      if (CS%use_GME .and. allocated(MEKE%GME_snk)) then
-        do j=js,je ; do i=is,ie
-          MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
-        enddo ; enddo
       endif
-    endif ! find_FrictWork and associated(mom_src)
-  enddo ! end of k loop
+    endif
+  enddo
 
   ! Offer fields for diagnostic averaging.
   if (CS%id_normstress > 0) call post_data(CS%id_normstress, NoSt, CS%diag)
@@ -2290,24 +2094,25 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
     endif
   endif
 
+
   if (CS%id_FrictWorkIntz > 0) then
     do j=js,je
-      do i=is,ie ; FrictWorkIntz(i,j) = FrictWork(i,j,1) ; enddo
+      do i=is,ie ; FrictWorkIntz(i,j,1) = FrictWork(i,j,1) ; enddo
       do k=2,nz ; do i=is,ie
-        FrictWorkIntz(i,j) = FrictWorkIntz(i,j) + FrictWork(i,j,k)
+        FrictWorkIntz(i,j,1) = FrictWorkIntz(i,j,1) + FrictWork(i,j,k)
       enddo ; enddo
     enddo
-    call post_data(CS%id_FrictWorkIntz, FrictWorkIntz, CS%diag)
+    call post_data(CS%id_FrictWorkIntz, FrictWorkIntz(:,:,1), CS%diag)
   endif
 
   if (CS%id_FrictWorkIntz_bh > 0) then
     do j=js,je
-      do i=is,ie ; FrictWorkIntz_bh(i,j) = FrictWork_bh(i,j,1) ; enddo
+      do i=is,ie ; FrictWorkIntz_bh(i,j,1) = FrictWork_bh(i,j,1) ; enddo
       do k=2,nz ; do i=is,ie
-        FrictWorkIntz_bh(i,j) = FrictWorkIntz_bh(i,j) + FrictWork_bh(i,j,k)
+        FrictWorkIntz_bh(i,j,1) = FrictWorkIntz_bh(i,j,1) + FrictWork_bh(i,j,k)
       enddo ; enddo
     enddo
-    call post_data(CS%id_FrictWorkIntz_bh, FrictWorkIntz_bh, CS%diag)
+    call post_data(CS%id_FrictWorkIntz_bh, FrictWorkIntz_bh(:,:,1), CS%diag)
   endif
 
   if (present(ADp)) then
@@ -2339,9 +2144,637 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
                                CS%dx2h, CS%dy2h, CS%dx2q, CS%dy2q)
   endif
 
-  if (allocated(zc)) deallocate(zc)
+  if (allocated(zc)) then
+    deallocate(zc)
+  endif
+end subroutine horizontal_viscosity_block
 
-end subroutine horizontal_viscosity
+!> Calculates the magnitude of the vorticity and divergence gradients, and the
+!! Laplacian of vorticity, that are used within horizontal_viscosity by the Leith,
+!! modified Leith, Leith+E, and QG Leith viscosity schemes. The caller must only
+!! invoke this routine when CS%Leith_Kh, CS%Leith_Ah, or CS%use_Leithy is true.
+subroutine hor_visc_Leith_grad(G, GV, US, CS, VarMix, nkk, ksb, kke, is, ie, &
+    js, je, is_Kh, ie_Kh, js_Kh, je_Kh, Ieq, Jeq, h, dz, slope_x, slope_y, &
+    dudx, dvdy, vort_xy, vort_xy_smooth, grad_vort_mag_h, grad_vort_mag_h_2d, &
+    grad_div_mag_h, grad_vort_mag_q, grad_vort_mag_q_2d, grad_div_mag_q, &
+    vert_vort_mag_smooth, Del2vort_q)
+  type(ocean_grid_type),         intent(in)    :: G      !< The ocean's grid structure.
+  type(verticalGrid_type),       intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),         intent(in)    :: US     !< A dimensional unit scaling type
+  type(hor_visc_CS),             intent(in)    :: CS     !< Horizontal viscosity control structure
+  type(VarMix_CS),               intent(inout) :: VarMix !< Variable mixing control structure
+  integer,                       intent(in)    :: nkk !< The k-block size used to size the following arrays [nondim]
+  integer,                       intent(in)    :: ksb    !< The first domain k-index of the current k-block
+  integer,                       intent(in)    :: kke    !< The in-block k-index upper bound of the current k-block
+  integer,                       intent(in)    :: is     !< Start i-loop index for the h-point viscosities
+  integer,                       intent(in)    :: ie     !< End i-loop index for the h-point viscosities
+  integer,                       intent(in)    :: js     !< Start j-loop index for the h-point viscosities
+  integer,                       intent(in)    :: je     !< End j-loop index for the h-point viscosities
+  integer,                       intent(in)    :: is_Kh  !< Start i-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: ie_Kh  !< End i-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: js_Kh  !< Start j-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: je_Kh  !< End j-loop index for the thickness point viscosities
+  integer,                       intent(in)    :: Ieq    !< The last i-index at q-points
+  integer,                       intent(in)    :: Jeq    !< The last j-index at q-points
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                  intent(in)    :: h      !< Layer thicknesses [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                  intent(in)    :: dz     !< Height change across layers [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), &
+                                  intent(inout) :: slope_x !< Isopycnal slope in i-direction [Z L-1 ~> nondim]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), &
+                                  intent(inout) :: slope_y !< Isopycnal slope in j-direction [Z L-1 ~> nondim]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                                  intent(in)    :: dudx   !< x-derivative of the horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                                  intent(in)    :: dvdy   !< y-derivative of the horizontal tension [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(in)    :: vort_xy !< Vertical vorticity (dv/dx - du/dy) including
+                                                       !! metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(in)    :: vort_xy_smooth !< Vertical vorticity including metric
+                                                       !! terms, smoothed [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                                  intent(out)   :: grad_vort_mag_h !< Magnitude of vorticity gradient at
+                                                       !! h-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                                  intent(out)   :: grad_vort_mag_h_2d !< Magnitude of 2d vorticity gradient
+                                                       !! at h-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                                  intent(out)   :: grad_div_mag_h !< Magnitude of divergence gradient at
+                                                       !! h-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(out)   :: grad_vort_mag_q !< Magnitude of vorticity gradient at
+                                                       !! q-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(out)   :: grad_vort_mag_q_2d !< Magnitude of 2d vorticity gradient
+                                                       !! at q-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(out)   :: grad_div_mag_q !< Magnitude of divergence gradient at
+                                                       !! q-points [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(out)   :: vert_vort_mag_smooth !< Magnitude of gradient of smoothed
+                                                       !! vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(out)   :: Del2vort_q !< Laplacian of vorticity at q-points
+                                                       !! [L-2 T-1 ~> m-2 s-1]
+
+  real, dimension(SZI_(G),SZJB_(G),nkk) :: &
+    vort_xy_dx, &        ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
+    vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
+    div_xx_dy            ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJ_(G),nkk) :: &
+    vort_xy_dy, &        ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
+    vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
+    div_xx_dx            ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    div_xx               ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
+  real :: DY_dxBu ! Ratio of meridional over zonal grid spacing at vertices [nondim]
+  real :: DX_dyBu ! Ratio of zonal over meridional grid spacing at vertices [nondim]
+  integer :: i, j, k, kk
+
+  ! Vorticity gradient
+  do kk=1,kke ; do J=js-2,je_Kh ; do i=is_Kh-1,ie_Kh+1
+    DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+    vort_xy_dx(i,J,kk) = DY_dxBu * ((vort_xy(I,J,kk) * G%IdyCu(I,j)) - (vort_xy(I-1,J,kk) * G%IdyCu(I-1,j)))
+  enddo ; enddo ; enddo
+
+  do kk=1,kke ; do j=js_Kh-1,je_Kh+1 ; do I=is-2,ie_Kh
+    DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+    vort_xy_dy(I,j,kk) = DX_dyBu * ((vort_xy(I,J,kk) * G%IdxCv(i,J)) - (vort_xy(I,J-1,kk) * G%IdxCv(i,J-1)))
+  enddo ; enddo ; enddo
+
+  if (CS%use_Leithy) then
+    ! Gradient of smoothed vorticity
+    do kk=1,kke ; do J=js_Kh-1,je_Kh ; do i=is_Kh,ie_Kh
+      DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+      vort_xy_dx_smooth(i,J,kk) = DY_dxBu * &
+                  ((vort_xy_smooth(I,J,kk) * G%IdyCu(I,j)) - (vort_xy_smooth(I-1,J,kk) * G%IdyCu(I-1,j)))
+    enddo ; enddo ; enddo
+
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do I=is_Kh-1,ie_Kh
+      DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+      vort_xy_dy_smooth(I,j,kk) = DX_dyBu * &
+                  ((vort_xy_smooth(I,J,kk) * G%IdxCv(i,J)) - (vort_xy_smooth(I,J-1,kk) * G%IdxCv(i,J-1)))
+    enddo ; enddo ; enddo
+  endif
+
+  ! Laplacian of vorticity
+  ! if (CS%Leith_Ah .or. CS%use_Leithy) then
+  do kk=1,kke ; do J=js_Kh-1,je_Kh ; do I=is_Kh-1,ie_Kh
+    DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+    DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+
+    Del2vort_q(I,J,kk) = DY_dxBu * ((vort_xy_dx(i+1,J,kk) * G%IdyCv(i+1,J)) - (vort_xy_dx(i,J,kk) * G%IdyCv(i,J))) + &
+                      DX_dyBu * ((vort_xy_dy(I,j+1,kk) * G%IdyCu(I,j+1)) - (vort_xy_dy(I,j,kk) * G%IdyCu(I,j)))
+  enddo ; enddo ; enddo
+  ! endif
+
+  if (CS%modified_Leith) then
+    ! Divergence
+    do kk=1,kke ; do j=js_Kh-1,je_Kh+1 ; do i=is_Kh-1,ie_Kh+1
+      div_xx(i,j,kk) = dudx(i,j,kk) + dvdy(i,j,kk)
+    enddo ; enddo ; enddo
+
+    ! Divergence gradient
+    do kk=1,kke ; do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
+      div_xx_dx(I,j,kk) = G%IdxCu(I,j)*(div_xx(i+1,j,kk) - div_xx(i,j,kk))
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
+      div_xx_dy(i,J,kk) = G%IdyCv(i,J)*(div_xx(i,j+1,kk) - div_xx(i,j,kk))
+    enddo ; enddo ; enddo
+
+    ! Magnitude of divergence gradient
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      grad_div_mag_h(i,j,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I-1,j,kk)))**2) + &
+                                 ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i,J-1,kk)))**2))
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+      grad_div_mag_q(I,J,kk) = sqrt(((0.5*(div_xx_dx(I,j,kk) + div_xx_dx(I,j+1,kk)))**2) + &
+                                 ((0.5*(div_xx_dy(i,J,kk) + div_xx_dy(i+1,J,kk)))**2))
+    enddo ; enddo ; enddo
+  else
+    do kk=1,kke ; do j=js-1,je+1 ; do I=is_Kh-1,ie_Kh
+      div_xx_dx(I,j,kk) = 0.0
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do J=js_Kh-1,je_Kh ; do i=is-1,ie+1
+      div_xx_dy(i,J,kk) = 0.0
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      grad_div_mag_h(i,j,kk) = 0.0
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+      grad_div_mag_q(I,J,kk) = 0.0
+    enddo ; enddo ; enddo
+  endif
+
+  ! Add in beta for the Leith viscosity
+  if (CS%use_beta_in_Leith) then
+    do kk=1,kke ; do J=js-2,Jeq+1 ; do i=is-1,ie+1
+      vort_xy_dx(i,J,kk) = vort_xy_dx(i,J,kk) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do j=js-1,je+1 ; do I=is-2,Ieq+1
+      vort_xy_dy(I,j,kk) = vort_xy_dy(I,j,kk) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
+    enddo ; enddo ; enddo
+  endif
+
+  if (CS%use_QG_Leith_visc) then
+
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      grad_vort_mag_h_2d(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
+                                     ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
+    enddo ; enddo ; enddo
+    do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+      grad_vort_mag_q_2d(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
+                                     ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
+    enddo ; enddo ; enddo
+
+    ! This accumulates terms, some of which are in VarMix.
+    do kk=1,kke
+      k = ksb + kk - 1
+      call calc_QG_Leith_viscosity(VarMix, G, GV, US, h, dz, k, div_xx_dx(:,:,kk), div_xx_dy(:,:,kk), &
+                                   slope_x, slope_y, vort_xy_dx(:,:,kk), vort_xy_dy(:,:,kk))
+    enddo
+  endif
+
+  do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+    grad_vort_mag_h(i,j,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i,J-1,kk)))**2) + &
+                                ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I-1,j,kk)))**2) )
+  enddo ; enddo ; enddo
+  do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+    grad_vort_mag_q(I,J,kk) = SQRT(((0.5*(vort_xy_dx(i,J,kk) + vort_xy_dx(i+1,J,kk)))**2) + &
+                                ((0.5*(vort_xy_dy(I,j,kk) + vort_xy_dy(I,j+1,kk)))**2) )
+  enddo ; enddo ; enddo
+
+  if (CS%use_Leithy) then
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      vert_vort_mag_smooth(i,j,kk) = SQRT(((0.5*(vort_xy_dx_smooth(i,J,kk) + &
+                                              vort_xy_dx_smooth(i,J-1,kk)))**2) + &
+                                       ((0.5*(vort_xy_dy_smooth(I,j,kk) + &
+                                              vort_xy_dy_smooth(I-1,j,kk)))**2) )
+    enddo ; enddo ; enddo
+  endif
+end subroutine hor_visc_Leith_grad
+
+!> Adds the MEKE-based (EY24_EBT_BS) backscatter contribution to the diagonal term of
+!! the stress tensor at h-points. The caller must only invoke this routine when
+!! CS%EY24_EBT_BS is true.
+subroutine hor_visc_backscatter_h(G, CS, MEKE, VarMix, use_kh_struct, nkk, &
+    ksb, kke, Isq, Ieq, Jsq, Jeq, visc_limit_h_flag, sh_xx, str_xx, BS_coeff_h)
+  type(ocean_grid_type), intent(in)    :: G   !< The ocean's grid structure.
+  type(hor_visc_CS),     intent(in)    :: CS  !< Horizontal viscosity control structure
+  type(MEKE_type),       intent(in)    :: MEKE !< MEKE fields related to Mesoscale Eddy Kinetic Energy.
+  type(VarMix_CS),       intent(in)    :: VarMix !< Variable mixing control structure
+  logical,               intent(in)    :: use_kh_struct !< If true, shape the backscatter coefficient
+                                                 !! with VarMix%BS_struct
+  integer,               intent(in)    :: nkk !< The k-block size used to size the following arrays [nondim]
+  integer,               intent(in)    :: ksb  !< The first domain k-index of the current k-block
+  integer,               intent(in)    :: kke  !< The in-block k-index upper bound of the current k-block
+  integer,               intent(in)    :: Isq !< Start i-loop index for the stress tensor at h-points
+  integer,               intent(in)    :: Ieq !< End i-loop index for the stress tensor at h-points
+  integer,               intent(in)    :: Jsq !< Start j-loop index for the stress tensor at h-points
+  integer,               intent(in)    :: Jeq !< End j-loop index for the stress tensor at h-points
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(in)    :: visc_limit_h_flag !< determines whether backscatter is shut off [nondim]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                         intent(in)    :: sh_xx !< horizontal tension (du/dx - dv/dy) including
+                                                 !! metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                         intent(inout) :: str_xx !< The diagonal term in the stress tensor
+                                                 !! [H L2 T-2 ~> m3 s-2 or kg s-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                         intent(inout) :: BS_coeff_h !< A diagnostic array of the backscatter
+                                                 !! coefficient [L2 T-1 ~> m2 s-1]
+
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: &
+    Kh_BS, &     ! Laplacian antiviscosity [L2 T-1 ~> m2 s-1]
+    str_xx_BS    ! The diagonal term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
+  integer :: i, j, k, kk
+
+  do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    k = ksb + kk - 1
+
+    if (visc_limit_h_flag(i,j,k) > 0) then
+      Kh_BS(i,j,kk) = 0.
+    else
+      if (use_kh_struct) then
+        Kh_BS(i,j,kk) = MEKE%Ku(i,j) * VarMix%BS_struct(i,j,k)
+      else
+        Kh_BS(i,j,kk) = MEKE%Ku(i,j)
+      endif
+    endif
+  enddo ; enddo ; enddo
+
+  do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    str_xx_BS(i,j,kk) = -Kh_BS(i,j,kk) * sh_xx(i,j,kk)
+  enddo ; enddo ; enddo
+
+  if (CS%id_BS_coeff_h>0) then
+    do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      k = ksb + kk - 1
+      BS_coeff_h(i,j,k) = Kh_BS(i,j,kk)
+    enddo ; enddo ; enddo
+  endif
+
+  do kk=1,kke ; do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    str_xx(i,j,kk) = str_xx(i,j,kk) + str_xx_BS(i,j,kk)
+  enddo ; enddo ; enddo
+end subroutine hor_visc_backscatter_h
+
+
+!> Adds the MEKE-based (EY24_EBT_BS) backscatter contribution to the cross term of
+!! the stress tensor at q-points. The caller must only invoke this routine when
+!! CS%EY24_EBT_BS is true.
+subroutine hor_visc_backscatter_q(G, GV, CS, MEKE, VarMix, use_kh_struct, &
+    nkk, ksb, kke, is, js, Ieq, Jeq, visc_limit_q_flag, sh_xy, str_xy, BS_coeff_q)
+  type(ocean_grid_type),   intent(in)    :: G   !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< The ocean's vertical grid structure.
+  type(hor_visc_CS),       intent(in)    :: CS  !< Horizontal viscosity control structure
+  type(MEKE_type),         intent(in)    :: MEKE !< MEKE fields related to Mesoscale Eddy Kinetic Energy.
+  type(VarMix_CS),         intent(in)    :: VarMix !< Variable mixing control structure
+  logical,                 intent(in)    :: use_kh_struct !< If true, shape the backscatter coefficient
+                                                 !! with VarMix%BS_struct
+  integer,                 intent(in)    :: nkk !< The k-block size used to size the following arrays [nondim]
+  integer,                 intent(in)    :: ksb  !< The first domain k-index of the current k-block
+  integer,                 intent(in)    :: kke  !< The in-block k-index upper bound of the current k-block
+  integer,                 intent(in)    :: is  !< Start i-loop index for the q-point stress tensor
+  integer,                 intent(in)    :: js  !< Start j-loop index for the q-point stress tensor
+  integer,                 intent(in)    :: Ieq !< End i-loop index for the q-point stress tensor
+  integer,                 intent(in)    :: Jeq !< End j-loop index for the q-point stress tensor
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
+                           intent(in)    :: visc_limit_q_flag !< determines whether backscatter is shut off [nondim]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(in)    :: sh_xy !< horizontal shearing strain (du/dy + dv/dx) including
+                                                 !! metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(inout) :: str_xy !< The cross term in the stress tensor
+                                                 !! [H L2 T-2 ~> m3 s-2 or kg s-2]
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
+                           intent(inout) :: BS_coeff_q !< A diagnostic array of the backscatter
+                                                 !! coefficient [L2 T-1 ~> m2 s-1]
+
+  real, dimension(SZIB_(G),SZJB_(G),nkk) :: &
+    Kh_BS, &     ! Laplacian antiviscosity [L2 T-1 ~> m2 s-1]
+    str_xy_BS    ! The cross term in the stress tensor due to backscatter [H L2 T-2 ~> m3 s-2 or kg s-2]
+  integer :: i, j, k, kk
+
+  do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+    k = ksb + kk - 1
+
+    if (visc_limit_q_flag(I,J,k) > 0) then
+      Kh_BS(I,J,kk) = 0.
+    else
+      if (use_kh_struct) then
+        Kh_BS(I,J,kk) = 0.25*( ((MEKE%Ku(i,j)*VarMix%BS_struct(i,j,k)) + &
+                             (MEKE%Ku(i+1,j+1)*VarMix%BS_struct(i+1,j+1,k))) + &
+                            ((MEKE%Ku(i+1,j)*VarMix%BS_struct(i+1,j,k)) + &
+                             (MEKE%Ku(i,j+1)*VarMix%BS_struct(i,j+1,k))) )
+      else
+        Kh_BS(I,J,kk) = 0.25*( (MEKE%Ku(i,j) + MEKE%Ku(i+1,j+1)) + &
+                            (MEKE%Ku(i+1,j) + MEKE%Ku(i,j+1)) )
+      endif
+    endif
+  enddo ; enddo ; enddo
+
+  do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+    str_xy_BS(I,J,kk) = -Kh_BS(I,J,kk) * (sh_xy(I,J,kk))
+  enddo ; enddo ; enddo
+
+  if (CS%id_BS_coeff_q>0) then
+    do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+      k = ksb + kk - 1
+      BS_coeff_q(I,J,k) = Kh_BS(I,J,kk)
+    enddo ; enddo ; enddo
+  endif
+
+  do kk=1,kke ; do J=js-1,Jeq ; do I=is-1,Ieq
+    str_xy(I,J,kk) = str_xy(I,J,kk) + str_xy_BS(I,J,kk)
+  enddo ; enddo ; enddo
+end subroutine hor_visc_backscatter_q
+
+
+!> Computes the Leith+E antisymmetric-viscosity ratio m_leithy, and updates the
+!! biharmonic viscosity Ah (and Ah_h) to include the Leith+E contribution, optionally
+!! smoothing m_leithy and Ah in the process. The caller must only invoke this
+!! routine when CS%use_Leithy is true.
+subroutine hor_visc_Leithy_Ah(G, GV, CS, nkk, ksb, kke, is_Kh, ie_Kh, &
+    js_Kh, je_Kh, inv_PI6, Del2vort_q, vert_vort_mag, vert_vort_mag_smooth, &
+    vort_xy_smooth, Ah, Ah_h, m_leithy, zc)
+  type(ocean_grid_type),   intent(in)    :: G   !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< The ocean's vertical grid structure.
+  type(hor_visc_CS),       intent(in)    :: CS  !< Horizontal viscosity control structure
+  integer,                 intent(in)    :: nkk !< The k-block size used to size the following arrays [nondim]
+  integer,                 intent(in)    :: ksb  !< The first domain k-index of the current k-block
+  integer,                 intent(in)    :: kke  !< The in-block k-index upper bound of the current k-block
+  integer,                 intent(in)    :: is_Kh !< Start i-loop index for the thickness point viscosities
+  integer,                 intent(in)    :: ie_Kh !< End i-loop index for the thickness point viscosities
+  integer,                 intent(in)    :: js_Kh !< Start j-loop index for the thickness point viscosities
+  integer,                 intent(in)    :: je_Kh !< End j-loop index for the thickness point viscosities
+  real,                    intent(in)    :: inv_PI6 !< The inverse of pi to the sixth power [nondim]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(in)    :: Del2vort_q !< Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(in)    :: vert_vort_mag !< Magnitude of the vertical vorticity
+                                                 !! gradient (h or q) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(in)    :: vert_vort_mag_smooth !< Magnitude of gradient of smoothed
+                                                 !! vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(in)    :: vort_xy_smooth !< Vertical vorticity including metric
+                                                 !! terms, smoothed [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                           intent(inout) :: Ah  !< biharmonic viscosity (h or q) [L4 T-1 ~> m4 s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(inout) :: Ah_h !< biharmonic viscosity at thickness points [L4 T-1 ~> m4 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                           intent(out)   :: m_leithy !< Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in), optional :: zc
+      !< Depth at center of h cell [Z ~> m]
+
+  real, dimension(SZI_(G),SZJ_(G),nkk) :: Ah_sq
+      ! The square of the biharmonic viscosity [L8 T-2 ~> m8 s-2]
+  real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
+  real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
+  real :: AhLthy     ! 2D Leith+E biharmonic viscosity [L4 T-1 ~> m4 s-1]
+  integer :: i, j, k, kk
+
+  ! Get m_leithy
+  if (CS%smooth_Ah) then
+    do kk=1,kke
+      m_leithy(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
+    enddo
+  endif
+
+  do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+    Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                         (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
+    AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
+    if (AhLth <= CS%Ah_bg_xx(i,j)) then
+      m_leithy(i,j,kk) = 0.0
+    else
+      if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j,kk)) < abs(vort_xy_smooth(i,j,kk))) then
+        m_leithy(i,j,kk) = CS%c_K * (vert_vort_mag(i,j,kk) / vort_xy_smooth(i,j,kk))**2
+      else
+        m_leithy(i,j,kk) = CS%m_leithy_max(i,j)
+      endif
+    endif
+  enddo ; enddo ; enddo
+
+  if (CS%taper_leithy) then
+    ! Multiply m_leithy by taper function of depth
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      k = ksb + kk - 1
+      m_leithy(i,j,kk) = m_leithy(i,j,kk) * leithy_taper_function(CS, zc(i,j,k))
+    enddo ; enddo ; enddo
+  endif
+
+  if (CS%smooth_Ah) then
+    do kk=1,kke
+      ! Smooth m_leithy.  A single call smoothes twice.
+      call pass_var(m_leithy(:,:,kk), G%Domain, halo=2)
+      call smooth_x9_h(CS, G, m_leithy(:,:,kk), zero_land=.true.)
+      call pass_var(m_leithy(:,:,kk), G%Domain)
+    enddo
+  endif
+
+  ! Get Ah
+  do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+    Del2vort_h = 0.25 * ((Del2vort_q(I,J,kk) + Del2vort_q(I-1,J-1,kk)) + &
+                         (Del2vort_q(I-1,J,kk) + Del2vort_q(I,J-1,kk)))
+    AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
+            sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j,kk)*vert_vort_mag_smooth(i,j,kk)**2))
+    Ah(i,j,kk) = max(CS%Ah_bg_xx(i,j), AhLthy)
+  enddo ; enddo ; enddo
+  if (CS%smooth_Ah) then
+    ! Smooth Ah before applying upper bound.  Square Ah, then smooth, then take its square root.
+    do kk=1,kke
+      Ah_sq(:,:,kk) = 0.0 ! This is here to initialize domain edge halo values.
+    enddo
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      Ah_sq(i,j,kk) = Ah(i,j,kk)**2
+    enddo ; enddo ; enddo
+    do kk=1,kke
+      call pass_var(Ah_sq(:,:,kk), G%Domain, halo=2)
+      ! A single call smoothes twice.
+      call smooth_x9_h(CS, G, Ah_sq(:,:,kk), zero_land=.false.)
+      call pass_var(Ah_sq(:,:,kk), G%Domain)
+    enddo
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      k = ksb + kk - 1
+      Ah_h(i,j,k) = max(CS%Ah_bg_xx(i,j), sqrt(max(0., Ah_sq(i,j,kk))))
+      Ah(i,j,kk) = Ah_h(i,j,k)
+    enddo ; enddo ; enddo
+  else
+    do kk=1,kke ; do j=js_Kh,je_Kh ; do i=is_Kh,ie_Kh
+      k = ksb + kk - 1
+      Ah_h(i,j,k) = Ah(i,j,kk)
+    enddo ; enddo ; enddo
+  endif
+end subroutine hor_visc_Leithy_Ah
+
+
+!> Calculates the barotropic tension and shearing strain fields and the GME
+!! efficiency and isopycnal height diffusivity fields that are used within
+!! horizontal_viscosity when GME (CS%use_GME) is active. The caller must
+!! only invoke this routine when CS%use_GME is true.
+subroutine hor_visc_GME_setup(G, GV, US, CS, h, BT, TD, nkk, dudx_bt, &
+    dvdy_bt, dvdx_bt, dudy_bt, sh_xx_bt, sh_xy_bt, GME_effic_h, GME_effic_q, &
+    KH_u_GME, KH_v_GME, GME_coeff_h, GME_coeff_q, str_xx_GME, str_xy_GME)
+  type(ocean_grid_type),         intent(in)    :: G      !< The ocean's grid structure.
+  type(verticalGrid_type),       intent(in)    :: GV     !< The ocean's vertical grid structure.
+  type(unit_scale_type),         intent(in)    :: US     !< A dimensional unit scaling type
+  type(hor_visc_CS),             intent(inout) :: CS     !< Horizontal viscosity control structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                  intent(inout) :: h      !< Layer thicknesses [H ~> m or kg m-2].
+  type(barotropic_CS),           optional, intent(in) :: BT !< Barotropic control structure
+  type(thickness_diffuse_CS),    optional, intent(in) :: TD !< Thickness diffusion control structure
+  integer,                       intent(in)    :: nkk !< The k-block size used to size the following arrays [nondim]
+  real, dimension(SZI_(G),SZJB_(G)), &
+                                  intent(out)   :: dudx_bt !< x-component in the barotropic
+                                                       !! horizontal tension [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJB_(G)), &
+                                  intent(out)   :: dvdy_bt !< y-component in the barotropic
+                                                       !! horizontal tension [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: dvdx_bt !< x-component in the barotropic
+                                                       !! shearing strain [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: dudy_bt !< y-component in the barotropic
+                                                       !! shearing strain [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                                  intent(out)   :: sh_xx_bt !< Barotropic horizontal tension
+                                                       !! (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: sh_xy_bt !< Barotropic horizontal shearing strain
+                                                       !! (du/dy + dv/dx) including metric terms [T-1 ~> s-1]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                                  intent(out)   :: GME_effic_h !< The filtered efficiency of the
+                                                       !! GME terms at h points [nondim]
+  real, dimension(SZIB_(G),SZJB_(G)), &
+                                  intent(out)   :: GME_effic_q !< The filtered efficiency of the
+                                                       !! GME terms at q points [nondim]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), &
+                                  intent(out)   :: KH_u_GME !< Isopycnal height diffusivities in
+                                                       !! u-columns [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), &
+                                  intent(out)   :: KH_v_GME !< Isopycnal height diffusivities in
+                                                       !! v-columns [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
+                                  intent(out)   :: GME_coeff_h !< GME coefficient at h-points
+                                                       !! [L2 T-1 ~> m2 s-1]
+  real, dimension(SZIB_(G),SZJB_(G),SZK_(GV)), &
+                                  intent(out)   :: GME_coeff_q !< GME coeff. at q-points [L2 T-1 ~> m2 s-1]
+  real, dimension(SZI_(G),SZJ_(G),nkk), &
+                                  intent(out)   :: str_xx_GME !< Smoothed diagonal term in the
+                                                       !! stress tensor from GME [L2 T-2 ~> m2 s-2]
+  real, dimension(SZIB_(G),SZJB_(G),nkk), &
+                                  intent(out)   :: str_xy_GME !< Smoothed cross term in the
+                                                       !! stress tensor from GME [L2 T-2 ~> m2 s-2]
+
+  real, dimension(SZIB_(G),SZJ_(G)) :: &
+    ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G)) :: &
+    vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+    htot          ! The total thickness of all layers [H ~> m or kg m-2]
+  real :: grad_vel_mag_bt_h ! Magnitude of the barotropic velocity gradient tensor squared at h-points [T-2 ~> s-2]
+  real :: boundary_mask_h ! A mask that zeroes out cells with at least one land edge [nondim]
+  real :: grad_vel_mag_bt_q ! Magnitude of the barotropic velocity gradient tensor squared at q-points [T-2 ~> s-2]
+  real :: boundary_mask_q ! A mask that zeroes out cells with at least one land edge [nondim]
+  real :: h_arith_q  ! The arithmetic mean total thickness at q points [H ~> m or kg m-2]
+  real :: I_GME_h0   ! The inverse of GME tapering scale [H-1 ~> m-1 or m2 kg-1]
+  integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+
+  is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+
+  ! Initialize diagnostic arrays with zeros
+  GME_coeff_h(:,:,:) = 0.0
+  GME_coeff_q(:,:,:) = 0.0
+  str_xx_GME(:,:,:) = 0.0
+  str_xy_GME(:,:,:) = 0.0
+
+  ! Get barotropic velocities and their gradients
+  call barotropic_get_tav(BT, ubtav, vbtav, G, US)
+
+  call pass_vector(ubtav, vbtav, G%Domain)
+  call pass_var(h, G%domain, halo=2)
+
+  ! Calculate the barotropic horizontal tension
+  do j=js-2,je+2 ; do i=is-2,ie+2
+    dudx_bt(i,j) = CS%DY_dxT(i,j)*((G%IdyCu(I,j) * ubtav(I,j)) - &
+                                   (G%IdyCu(I-1,j) * ubtav(I-1,j)))
+    dvdy_bt(i,j) = CS%DX_dyT(i,j)*((G%IdxCv(i,J) * vbtav(i,J)) - &
+                                   (G%IdxCv(i,J-1) * vbtav(i,J-1)))
+  enddo ; enddo
+  do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
+  enddo ; enddo
+
+  ! Components for the barotropic shearing strain
+  do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+    dvdx_bt(I,J) = CS%DY_dxBu(I,J)*((vbtav(i+1,J)*G%IdyCv(i+1,J)) &
+                                  - (vbtav(i,J)*G%IdyCv(i,J)))
+    dudy_bt(I,J) = CS%DX_dyBu(I,J)*((ubtav(I,j+1)*G%IdxCu(I,j+1)) &
+                                  - (ubtav(I,j)*G%IdxCu(I,j)))
+  enddo ; enddo
+
+  if (CS%no_slip) then
+    do J=js-2,je+1 ; do I=is-2,ie+1
+      sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+    enddo ; enddo
+  else
+    do J=js-2,je+1 ; do I=is-2,ie+1
+      sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+    enddo ; enddo
+  endif
+
+  do j=js-2,je+2 ; do i=is-2,ie+2
+    htot(i,j) = 0.0
+  enddo ; enddo
+  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+    htot(i,j) = htot(i,j) + h(i,j,k)
+  enddo ; enddo ; enddo
+
+  I_GME_h0 = 1.0 / CS%GME_h0
+  do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+    boundary_mask_h = (G%mask2dCu(I,j) * G%mask2dCu(I-1,j)) * (G%mask2dCv(i,J) * G%mask2dCv(i,J-1))
+    grad_vel_mag_bt_h = G%mask2dT(I,J) * boundary_mask_h * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
+          (0.25*((dvdx_bt(I,J)+dvdx_bt(I-1,J-1)) + (dvdx_bt(I,J-1)+dvdx_bt(I-1,J))))**2 + &
+          (0.25*((dudy_bt(I,J)+dudy_bt(I-1,J-1)) + (dudy_bt(I,J-1)+dudy_bt(I-1,J))))**2)
+    ! Probably the following test could be simplified to
+    ! if (boundary_mask_h * G%mask2dT(I,J) > 0.0) then
+    if (grad_vel_mag_bt_h > 0.0) then
+      GME_effic_h(i,j) = CS%GME_efficiency * G%mask2dT(I,J) * (MIN(htot(i,j) * I_GME_h0, 1.0)**2)
+    else
+      GME_effic_h(i,j) = 0.0
+    endif
+  enddo ; enddo
+
+  do J=js-2,je+1 ; do I=is-2,ie+1
+    boundary_mask_q = (G%mask2dCv(i,J) * G%mask2dCv(i+1,J)) * (G%mask2dCu(I,j) * G%mask2dCu(I,j+1))
+    grad_vel_mag_bt_q = G%mask2dBu(I,J) * boundary_mask_q * (dvdx_bt(I,J)**2 + dudy_bt(I,J)**2 + &
+          (0.25*((dudx_bt(i,j)+dudx_bt(i+1,j+1)) + (dudx_bt(i,j+1)+dudx_bt(i+1,j))))**2 + &
+          (0.25*((dvdy_bt(i,j)+dvdy_bt(i+1,j+1)) + (dvdy_bt(i,j+1)+dvdy_bt(i+1,j))))**2)
+    ! Probably the following test could be simplified to
+    ! if (boundary_mask_q * G%mask2dBu(I,J) > 0.0) then
+    if (grad_vel_mag_bt_q > 0.0) then
+      h_arith_q = 0.25 * ((htot(i,j) + htot(i+1,j+1)) + (htot(i+1,j) + htot(i,j+1)))
+      GME_effic_q(I,J) = CS%GME_efficiency * G%mask2dBu(I,J) * (MIN(h_arith_q * I_GME_h0, 1.0)**2)
+    else
+      GME_effic_q(I,J) = 0.0
+    endif
+  enddo ; enddo
+
+  call thickness_diffuse_get_KH(TD, KH_u_GME, KH_v_GME, G, GV)
+
+  call pass_vector(KH_u_GME, KH_v_GME, G%domain, To_All+Scalar_Pair)
+
+  if (CS%debug) &
+    call uvchksum("GME KH[u,v]_GME", KH_u_GME, KH_v_GME, G%HI, haloshift=2, unscale=US%L_to_m**2*US%s_to_T)
+
+end subroutine hor_visc_GME_setup
+
 
 !> Allocates space for and calculates static variables used by horizontal_viscosity.
 !! hor_visc_init calculates and stores the values of a number of metric functions that
@@ -2425,6 +2858,12 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   CS%diag => diag
   ! Read parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
+
+  call get_param(param_file, mdl, "HORVISC_NKBLOCK", CS%nkblock, &
+                 "The k-direction block size used in horizontal viscosity calculations. "//&
+                 "The default 0 setting dynamically uses the full vertical column.", &
+                 default=0, layoutParam=.true.)
+  if (CS%nkblock < 0) call MOM_error(FATAL, "HORVISC_NKBLOCK must be >= 0.")
 
   call get_param(param_file, mdl, "USE_CIRCULATION_IN_HORVISC", CS%use_circulation, &
                  "Use circulation theorem to compute vorticity in horvisc module (for ZB20 or Leith)", &
@@ -3341,9 +3780,9 @@ end subroutine hor_visc_init
 
 !> leithy_taper_function returns 1 if zc is shallower than leithy_depth; 0 if deeper than
 !! leithy_depth+leithy_width; and an interpolating cubic spline in between.
-function leithy_taper_function(CS, zc)
+pure function leithy_taper_function(CS, zc)
   type(hor_visc_CS), intent(in) :: CS      !< Control structure for horizontal viscosity
-  real,              intent(in) :: zc      !< depth of h-cell centersi [Z ~> m]
+  real,              intent(in) :: zc      !< depth of h-cell centers [Z ~> m]
   real :: leithy_taper_function            ! Taper function evaluated at zc [nondim]
 
   ! Local variables


### PR DESCRIPTION
This patch introduces a block-implementation of the continuity solver,
where blocks refer to outer loops over smaller n-dimensional "block"
subdomains.  This allows for smaller local arrays which can be adjusted
in size to match multiple cacheing architectures.

The term "block" is used to distinguish from the "domain" of MPI
decomposition and "tile" of cube sphere decomposition.

Solver inputs and outputs (velocity, external fields, etc) are retained
as full arrays and referenced with the original indices `(i,j,k)`.
Local arrays are blocks and referenced

Two independent blocking methods are applied here:

* Reconstruction uses k-blocks which adjust the vertical size of arrays.
  CPUs would be expected to use single-layer blocks, and GPUs would use
  the whole domian.

* The flux calculations and corrections use ij-blocks, which may in some
  cases resemble the existing ik-slices of the original code.  Again,
  CPUs would use i-aligned blocks and the GPU would use the whole
  domain.

Structurally, the main difference is that operations in i-rows of
`(zonal|meridional)_flux_layer` have been replaced by scalar functions
`flux_elem` and `flux_elem_OBC`, which accept points and
nearest-neighbors as arguments.

Blocks are currently defined by the `N[IJK]BLOCK_CONTINUITY" parameters.
Default values are set to (64,1,1) in order to optimize CPU performance.
If set to 0, then the block axis fills the whole domain.

Impacts on CPU performance are minor, and also model dependent.  Timings
are based on the `ifx` compiler using the following flags
```
ifx -O3 -fp-model source -qno-opt-dynamic-align
```
Separate testing using `-march=core-avx-i` produced slower results but
otherwise similar trends.

For a double-gyre 128x128x100 grid with 32x32 domains over 64 cores we
see the timings below.

dev/gfdl
```
(Ocean continuity reconstruction)   0.539956    0.612690    0.573847
(Ocean continuity update)           0.339540    0.373796    0.357862
(Ocean continuity correction)       2.266883    2.907985    2.723116
(Ocean continuity equation)         3.948385    3.972371    3.961390
```
This PR
```
(Ocean continuity reconstruction)   0.548973    0.581059    0.566920
(Ocean continuity update)           0.308963    0.352395    0.332855
(Ocean continuity correction)       2.195137    3.050991    2.851677
(Ocean continuity equation)         4.027751    4.052390    4.039474
```
Slowdown is about 2%.

The slowdown is somewhat compiler-specific: ifx seem overly aggressive
to vectorize the PR code, whereas dev/gfdl is never vectorized.  If I
explicitly disable vectorization with a directive, then the timings are
faster than dev/gfdl.
```
(Ocean continuity reconstruction)   0.531258    0.585222    0.560212
(Ocean continuity update)           0.306300    0.354434    0.334293
(Ocean continuity correction)       2.100923    2.871680    2.640728
(Ocean continuity equation)         3.855074    3.881029    3.868398
```
This becomes a 2% speedup.

For a 256x256 domain,

dev/gfdl
```
(Ocean continuity reconstruction)   0.965205    1.013317    0.996596
(Ocean continuity update)           0.634148    0.650063    0.641865
(Ocean continuity correction)       3.373112    4.191397    3.970682
(Ocean continuity equation)         5.862792    5.873180    5.868280
```
this PR (standard vectorized bytecode)
```
(Ocean continuity reconstruction)   0.958195    1.008051    0.992341
(Ocean continuity update)           0.603837    0.616610    0.610089
(Ocean continuity correction)       3.061607    4.031595    3.845603
(Ocean continuity equation)         5.696905    5.708243    5.701259
```
Speedup is about 3%.

----

Notes:

* Parentheses are used to disable FMAs in a few locations:
  ```
  +        ! XXX: Bracket duhdu to suppress FMA optimization
  +        FAmt_0(ii,jj) = FAmt_0(ii,jj) + (duhdu_0)
  +        FAmt_L(ii,jj) = FAmt_L(ii,jj) + (duhdu_L)
  +        FAmt_R(ii,jj) = FAmt_R(ii,jj) + (duhdu_R)
  ```
  At some point, we may want to restore these.

* Legacy OpenMP thread directives have been removed.  After discussions
  with many groups, we decided that these are not being used by anyone.

----

Ed Yang (@edoyango) is the sole author of this work, motivated by work of Pranay Reddy Kommera of NVIDIA, and was first implemented in the MOM6 GPU development branch.  Marshall Ward ported this to the CPU-based dev/gfdl branch, and resolved some minor code conflicts (and also wrote this commit log).