### PR TITLE
ICE_SMB_TIME_VARYING (for ice sheet solo driver)

### DIFF
--- a/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
@@ -59,10 +59,12 @@ program Shelf_main
   use MOM_write_cputime,   only : write_cputime, MOM_write_cputime_init
   use MOM_write_cputime,   only : write_cputime_start_clock, write_cputime_CS
   use MOM_forcing_type,    only : forcing
-  use MOM_ice_shelf_initialize, only : initialize_ice_SMB
+  use MOM_ice_shelf, only : initialize_ice_SMB
 
   use MOM_ice_shelf, only : initialize_ice_shelf, ice_shelf_end, ice_shelf_CS
-  use MOM_ice_shelf, only : ice_shelf_save_restart, solo_step_ice_shelf
+  use MOM_ice_shelf, only : ice_shelf_save_restart, solo_step_ice_shelf, update_ice_SMB
+  use MOM_interp_infra, only : time_interp_extern_init
+
 
   implicit none
 
@@ -171,6 +173,8 @@ program Shelf_main
   call write_cputime_start_clock(write_CPU_CSp)
 
   call MOM_infra_init() ; call io_infra_init()
+
+  call time_interp_extern_init()
 
   ! These clocks are on the global pelist.
   initClock = cpu_clock_id( 'Initialization' )
@@ -295,7 +299,7 @@ program Shelf_main
   call initialize_ice_shelf(param_file, ocn_grid, Time, ice_shelf_CSp, diag, &
                             Start_time, dirs%output_directory, fluxes_in=fluxes, solo_ice_sheet_in=.true.)
 
-  call initialize_ice_SMB(fluxes%shelf_sfc_mass_flux, ocn_grid, US, param_file)
+  call initialize_ice_SMB(ice_shelf_CSp, fluxes%shelf_sfc_mass_flux, ocn_grid, US, param_file)
 
   ! This is the end of the code that is the counterpart of MOM_initialization.
   call callTree_waypoint("End of ice shelf initialization.")
@@ -402,7 +406,7 @@ program Shelf_main
   ns = 1 ; ns_ice = 1
   do while ((ns < nmax) .and. (Time < Time_end))
     call callTree_enter("Main loop, Shelf_driver.F90", ns)
-
+    call update_ice_SMB(ice_shelf_CSp, ocn_grid, fluxes%shelf_sfc_mass_flux, Time)
     ! This call steps the model over a time time_step.
     Time1 = Master_Time ; Time = Master_Time
     call solo_step_ice_shelf(ice_shelf_CSp, Time_step_shelf, ns_ice, Time, fluxes_in=fluxes)

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -83,6 +83,8 @@ public ice_shelf_save_restart, solo_step_ice_shelf, add_shelf_forces
 public initialize_ice_shelf_fluxes, initialize_ice_shelf_forces
 public ice_sheet_calving_to_ocean_sfc
 public adjust_ice_sheet_frazil
+public initialize_ice_SMB
+public update_ice_smb
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -233,6 +235,10 @@ type, public :: ice_shelf_CS ; private
              id_Gr_t_area = -1, id_Gr_g_area = -1, id_Gr_f_area = -1
   !>@}
 
+  type(external_field) :: smb_file
+  !< Handle for reading the time interpolated smb from a file
+  logical :: time_varying_smb
+  !< logical flag set true if reading time-varying smb
   type(external_field) :: mass_handle
     !< Handle for reading the time interpolated ice shelf mass from a file
   type(external_field) :: area_handle
@@ -2655,6 +2661,24 @@ subroutine update_shelf_mass(G, US, CS, ISS, Time)
 
 end subroutine update_shelf_mass
 
+!>Update ice smb
+subroutine update_ice_SMB(CS, G, SMB, Time)
+  type(ice_shelf_CS), pointer :: CS
+  type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
+  real, dimension(SZDI_(G),SZDJ_(G)), &
+       intent(inout) :: SMB !< Ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
+  type(time_type), intent(in) :: Time
+
+
+  if (CS%time_varying_smb) then
+     call time_interp_external(CS%smb_file, Time, SMB)
+  endif
+
+  return
+
+end subroutine update_ice_SMB
+
+
 !> Save the ice shelf restart file
 subroutine ice_shelf_query(CS, G, frac_shelf_h, mass_shelf, data_override_shelf_fluxes)
   type(ice_shelf_CS),         pointer    :: CS !< ice shelf control structure
@@ -3050,6 +3074,62 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     endif
   endif
 end subroutine process_and_post_scalar_data
+
+!> Initialize ice surface mass balance field that is held constant over time
+subroutine initialize_ice_SMB(CS, SMB, G, US, PF)
+  type(ice_shelf_CS), pointer  :: CS
+  type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
+  real, dimension(SZDI_(G),SZDJ_(G)), &
+                         intent(inout) :: SMB !< Ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
+  type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
+  type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
+
+  real :: SMB_val  ! Constant ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
+  character(len=40)  :: mdl = "initialize_ice_SMB" ! This subroutine's name.
+  character(len=200) :: config
+  character(len=200) :: varname
+  character(len=200) :: inputdir, filename, SMB_file
+  logical :: smb_file_has_time
+
+  call get_param(PF, mdl, "ICE_SMB_CONFIG", config, &
+                 "This specifies how the initial ice surface mass balance parameter is specified. "//&
+                 "Valid values are: CONSTANT and FILE.", &
+                 default="CONSTANT")
+
+  if (trim(config)=="CONSTANT") then
+    call get_param(PF, mdl, "SMB", SMB_val, &
+                 "Surface mass balance.", units="kg m-2 s-1", default=0.0, scale=US%kg_m2s_to_RZ_T)
+
+    SMB(:,:) = SMB_val
+
+  elseif (trim(config)=="FILE") then
+    call MOM_mesg("  MOM_ice_shelf.F90, initialize_ice_shelf: reading SMB parameter")
+    call get_param(PF, mdl, "INPUTDIR", inputdir, default=".")
+    inputdir = slasher(inputdir)
+
+    call get_param(PF, mdl, "ICE_SMB_FILE", SMB_file, &
+                 "The file from which the ice surface mass balance is read.", &
+                 default="ice_SMB.nc")
+    filename = trim(inputdir)//trim(SMB_file)
+    call log_param(PF, mdl, "INPUTDIR/ICE_SMB_FILE", filename)
+    call get_param(PF, mdl, "ICE_SMB_VARNAME", varname, &
+                   "The variable to use as surface mass balance.", &
+                   default="SMB")
+    call get_param(PF, mdl, "ICE_SMB_TIME_VARYING", SMB_file_has_time, &
+                 "The file from which the ice surface mass balance is read has a time axis.", &
+                 default=.false.)
+    call log_param(PF, mdl, "ICE_SMB_TIME_VARYING", SMB_file_has_time)
+    if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
+       " initialize_ice_SMV_from_file: Unable to open "//trim(filename))
+    if (SMB_file_has_time) then
+       CS%smb_file = init_external_field(filename, varname, MOM_domain=G%Domain,correct_leap_year_inconsistency=.true.)
+       CS%time_varying_smb = .true.
+    else
+       call MOM_read_data(filename,trim(varname), SMB, G%Domain, scale=US%kg_m2s_to_RZ_T)
+       CS%time_varying_smb = .false.
+    endif
+  endif
+end subroutine initialize_ice_SMB
 
 !> \namespace mom_ice_shelf
 !!

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -2672,6 +2672,7 @@ subroutine update_ice_SMB(CS, G, SMB, Time)
 
   if (CS%time_varying_smb) then
      call time_interp_external(CS%smb_file, Time, SMB)
+     if (CS%debug) call hchksum(SMB, "updatte_ice_SMB", CS%Grid_in%HI, haloshift=0)
   endif
 
   return
@@ -2825,7 +2826,6 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
     call change_thickness_using_precip(CS, ISS, G, US, fluxes_in, time_step, Time)
     if (CS%smb_diag) dh_adott_sum(is:ie,js:je) = dh_adott_sum(is:ie,js:je) + &
                                              (ISS%h_shelf(is:ie,js:je) - dh_adott(is:ie,js:je))
-
     remaining_time = remaining_time - time_step
 
     ! If the last mini-timestep is a day or less, we cannot expect velocities to change by much.
@@ -2849,6 +2849,7 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
   if (CS%id_h_shelf > 0)      call post_data(CS%id_h_shelf      ,ISS%h_shelf     ,CS%diag)
   if (CS%id_dhdt_shelf > 0)   call post_data(CS%id_dhdt_shelf   ,ISS%dhdt_shelf  ,CS%diag)
   if (CS%id_h_mask > 0)       call post_data(CS%id_h_mask       ,ISS%hmask       ,CS%diag)
+  if (CS%id_shelf_sfc_mass_flux > 0) call post_data(CS%id_shelf_sfc_mass_flux, fluxes_in%shelf_sfc_mass_flux, CS%diag)
   call process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Ifull_time_step, dh_adott, dh_adott*0.0)
   call disable_averaging(CS%diag)
 

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -24,7 +24,7 @@ public initialize_ice_flow_from_file
 public initialize_ice_shelf_boundary_from_file
 public initialize_ice_C_basal_friction
 public initialize_ice_AGlen
-public initialize_ice_SMB
+
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
 ! their mks counterparts with notation like "a velocity [Z T-1 ~> m s-1]".  If the units
@@ -440,7 +440,7 @@ subroutine initialize_ice_flow_from_file(bed_elev,u_shelf, v_shelf,float_cond,&
                  default="ice_shelf_vel.nc")
 
   filename = trim(inputdir)//trim(vel_file)
-  call log_param(PF, mdl, "INPUTDIR/THICKNESS_FILE", filename)
+  call log_param(PF, mdl, "INPUTDIR/ICE_VELOCITY_FILE", filename)
   call get_param(PF, mdl, "ICE_U_VEL_VARNAME", ushelf_varname, &
                  "The name of the u velocity variable in ICE_VELOCITY_FILE.", &
                  default="u_shelf")
@@ -676,49 +676,4 @@ subroutine initialize_ice_AGlen(AGlen, ice_viscosity_compute, G, US, PF)
   endif
 end subroutine initialize_ice_AGlen
 
-!> Initialize ice surface mass balance field that is held constant over time
-subroutine initialize_ice_SMB(SMB, G, US, PF)
-  type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
-  real, dimension(SZDI_(G),SZDJ_(G)), &
-                         intent(inout) :: SMB !< Ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
-  type(unit_scale_type), intent(in)    :: US !< A structure containing unit conversion factors
-  type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
-
-  real :: SMB_val  ! Constant ice surface mass balance parameter, often in [R Z T-1 ~> kg m-2 s-1]
-  character(len=40)  :: mdl = "initialize_ice_SMB" ! This subroutine's name.
-  character(len=200) :: config
-  character(len=200) :: varname
-  character(len=200) :: inputdir, filename, SMB_file
-
-  call get_param(PF, mdl, "ICE_SMB_CONFIG", config, &
-                 "This specifies how the initial ice surface mass balance parameter is specified. "//&
-                 "Valid values are: CONSTANT and FILE.", &
-                 default="CONSTANT")
-
-  if (trim(config)=="CONSTANT") then
-    call get_param(PF, mdl, "SMB", SMB_val, &
-                 "Surface mass balance.", units="kg m-2 s-1", default=0.0, scale=US%kg_m2s_to_RZ_T)
-
-    SMB(:,:) = SMB_val
-
-  elseif (trim(config)=="FILE") then
-    call MOM_mesg("  MOM_ice_shelf.F90, initialize_ice_shelf: reading SMB parameter")
-    call get_param(PF, mdl, "INPUTDIR", inputdir, default=".")
-    inputdir = slasher(inputdir)
-
-    call get_param(PF, mdl, "ICE_SMB_FILE", SMB_file, &
-                 "The file from which the ice surface mass balance is read.", &
-                 default="ice_SMB.nc")
-    filename = trim(inputdir)//trim(SMB_file)
-    call log_param(PF, mdl, "INPUTDIR/ICE_SMB_FILE", filename)
-    call get_param(PF, mdl, "ICE_SMB_VARNAME", varname, &
-                   "The variable to use as surface mass balance.", &
-                   default="SMB")
-
-    if (.not.file_exists(filename, G%Domain)) call MOM_error(FATAL, &
-       " initialize_ice_SMV_from_file: Unable to open "//trim(filename))
-    call MOM_read_data(filename,trim(varname), SMB, G%Domain, scale=US%kg_m2s_to_RZ_T)
-
-  endif
-end subroutine initialize_ice_SMB
 end module MOM_ice_shelf_initialize


### PR DESCRIPTION
These changes are introduced for the ice sheet solo driver and enable the specification of time-varying surface mass input. Setting MOM_parameter: ICE_SMB_TIME_VARYING = True enables this option.