### PR TITLE
(*)Set 5 BUG param defaults via ENABLE_BUGS_BY_DEFAULT

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2887,7 +2887,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "If true, recover a bug that the BGC OBC segment update schedule is "//&
                  "referenced to the start of the current run rather than the overall start "//&
                  "time, which can lead to restart reproducibility failures.", &
-                 default=.true., do_not_log=.not.associated(OBC_in))
+                 default=enable_bugs, do_not_log=.not.associated(OBC_in))
 
   ! Copy the grid metrics and bathymetry to the ocean_grid_type
   call copy_dyngrid_to_MOM_grid(dG_in, G_in, US)

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5749,7 +5749,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
   call get_param(param_file, mdl, "DTBT_RESTART_BUG", dtbt_restart_bug, &
                  "If true, recover a bug where the barotropic timestep DTBT read from a "//&
                  "restart file is immediately overridden by a recalculation on the "//&
-                 "first dynamics step.", default=.true.)
+                 "first dynamics step.", default=enable_bugs)
   call get_param(param_file, mdl, "TIDES", use_tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
   if (use_tides .and. present(HA_CSp)) CS%HA_CSp => HA_CSp

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -77,6 +77,8 @@ subroutine call_OBC_register(G, GV, US, param_file, CS, OBC, tr_Reg)
 
   ! Local variables
   logical :: debug
+  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
+                          ! recreate the bugs, or if false bugs are only used if actively selected.
   character(len=200) :: config
   character(len=40)  :: mdl = "MOM_boundary_update" ! This module's name.
   ! This include declares and sets the variable "version".
@@ -89,9 +91,11 @@ subroutine call_OBC_register(G, GV, US, param_file, CS, OBC, tr_Reg)
 
   call log_version(param_file, mdl, version, "")
 
+  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
+                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(param_file, mdl, "OBC_VALUE_UPDATE_BUG", CS%value_update_bug, &
                  "If true, recover a bug that OBC segment data does not update if all segments "//&
-                 "use 'value' and none uses 'file'.", default=.true.)
+                 "use 'value' and none uses 'file'.", default=enable_bugs)
   call get_param(param_file, mdl, "USE_FILE_OBC", CS%use_files, &
                  "If true, use external files for the open boundary.", &
                  default=.false.)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -755,7 +755,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "specified for the reservoir concentrations.", default=enable_bugs, do_not_log=.true.)
   call get_param(param_file, mdl, "OBC_TEMP_SALT_NEEDED_BUG", OBC%ts_needed_bug, &
                  "If true, recover a bug that OBC temperature and salinity can be ignored "//&
-                 "even if they are registered tracers in the rest of the model.", default=.true.)
+                 "even if they are registered tracers in the rest of the model.", default=enable_bugs)
   call get_param(param_file, mdl, "REENTRANT_X", reentrant_x, default=.true.)
   call get_param(param_file, mdl, "REENTRANT_Y", reentrant_y, default=.false.)
 

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1569,6 +1569,8 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   logical :: showCallTree
   logical :: read_TideAmp, debug
   logical :: global_indexing
+  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
+                          ! recreate the bugs, or if false bugs are only used if actively selected.
   character(len=240) :: Tideamp_file  ! Input file names
   character(len=80)  :: tideamp_var ! Input file variable names
   real    :: utide  ! A tidal velocity [L T-1 ~> m s-1]
@@ -1877,9 +1879,11 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   call get_param(param_file, mdl, "ICE_SHELF_RC", CS%Rc, &
                  "Critical flux Richardson number for ice melt ", &
                  units="nondim", default=0.20)
+  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
+                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(param_file, mdl, "ICE_SHELF_USTAR_FROM_VEL_BUGFIX", CS%ustar_from_vel_bugfix, &
                  "Bug fix for ice-area weighting of squared ocean velocities "//&
-                 "used to calculate friction velocity under ice shelves", default=.false.)
+                 "used to calculate friction velocity under ice shelves", default=.not.enable_bugs)
   call get_param(param_file, mdl, "ICE_SHELF_BUOYANCY_FLUX_ITT_BUGFIX", CS%buoy_flux_itt_bugfix, &
                  "Bug fix of buoyancy iteration", default=.true., old_name="ICE_SHELF_BUOYANCY_FLUX_ITT_BUG")
   call get_param(param_file, mdl, "ICE_SHELF_SALT_FLUX_ITT_BUGFIX", CS%salt_flux_itt_bugfix, &


### PR DESCRIPTION
  Changed the default values of 4 recently added _BUG parameters (`OBC_BGC_TIME_REF_BUG`, `DTBT_RESTART_BUG`, `OBC_TEMP_SALT_NEEDED_BUG` and `OBC_VALUE_UPDATE_BUG`) from True to to use the value of `ENABLE_BUGS_BY_DEFAULT`. Also changed the default for `ICE_SHELF_USTAR_FROM_VEL_BUGFIX` from False to the opposite of `ENABLE_BUGS_BY_DEFAULT`.  This will change answers if `ENABLE_BUGS_BY_DEFAULT` is set to false, but all answers are bitwise identical otherwise.