### PR TITLE
visc: enable cuberoot in find_L_open_convex

### DIFF
--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -119,10 +119,14 @@ type, public :: set_visc_CS ; private
                             !! non-commuting conversion of mean tideamp to mean ustar**3 [nondim]
   logical :: concave_trigonometric_L  !< If true, use trigonometric expressions to determine the
                             !! fractional open interface lengths for concave topography.
-  integer :: answer_date    !< The vintage of the order of arithmetic and expressions in the set
-                            !! viscosity calculations.  Values below 20190101 recover the answers
-                            !! from the end of 2018, while higher values use updated and more robust
-                            !! forms of the same expressions.
+  integer :: answer_date    !< The vintage of the order of arithmetic and expressions
+                            !! in the set viscosity calculations.  Values below
+                            !! 20190101 recover the answers from the end of 2018,
+                            !! while higher values use updated and more robust forms
+                            !! of the same expressions.  Values below 20260704 use
+                            !! the non-reproducible power operator in place of
+                            !! cuberoot() when finding the open distances with
+                            !! CHANNEL_DRAG.
   logical :: debug          !< If true, write verbose checksums for debugging purposes.
   logical :: BBL_use_tidal_bg !< If true, use a tidal background amplitude for the bottom velocity
                             !! when computing the bottom stress.
@@ -1795,11 +1799,11 @@ subroutine find_L_open_convex(vol_below, D_vel, Dp, Dm, L, GV, US, CS)
       L(K) = 1.0
     elseif (vol_below(K) <= Vol_direct) then
       ! Both edges of the cell are bounded by walls.
-      ! if (CS%answer_date < 20240101)) then
+      if (CS%answer_date < 20260704) then
         L(K) = (-0.25*C24_crv*vol_below(K))**C1_3
-      ! else
-      !   L(K) = cuberoot(-0.25*C24_crv*vol_below(K))
-      ! endif
+      else
+        L(K) = cuberoot(-0.25*C24_crv*vol_below(K))
+      endif
     else
       ! x_R is at 1/2 but x_L is in the interior & L is found by iteratively solving
       !   vol_below(K) = 0.5*L^2*(slope + crv/3*(3-4L))
@@ -3012,10 +3016,16 @@ subroutine set_visc_init(Time, G, GV, US, param_file, diag, visc, CS, restart_CS
                  "This sets the default value for the various _ANSWER_DATE parameters.", &
                  default=99991231)
   call get_param(param_file, mdl, "SET_VISC_ANSWER_DATE", CS%answer_date, &
-                 "The vintage of the order of arithmetic and expressions in the set viscosity "//&
-                 "calculations.  Values below 20190101 recover the answers from the end of 2018, "//&
-                 "while higher values use updated and more robust forms of the same expressions.", &
-                 default=default_answer_date, do_not_log=.not.GV%Boussinesq)
+                 "The vintage of the order of arithmetic and expressions " // &
+                 "in the set viscosity calculations.  Values below " // &
+                 "20190101 recover the answers from the end of 2018, " // &
+                 "while higher values use updated and more robust forms " // &
+                 "of the same expressions.  Values below 20260704 use " // &
+                 "the non-reproducible power operator in place of " // &
+                 "cuberoot() when finding the open distances with " // &
+                 "CHANNEL_DRAG.", &
+                 default=min(20260703,default_answer_date), &
+                 do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) CS%answer_date = max(CS%answer_date, 20230701)
   call get_param(param_file, mdl, "BOTTOMDRAGLAW", CS%bottomdraglaw, &
                  "If true, the bottom stress is calculated with a drag "//&


### PR DESCRIPTION
This patch uncomments the existing cuberoot() replacement of **C1_3 in find_L_open_convex().

This is required to improve CPU-GPU reproducibility.

The default answer date was changed from eternal (year 9999) to 20260703, and the cuberoot is enabled on 20260704.