### PR TITLE
Read OBC tracer data with updated thickness

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1569,13 +1569,16 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
                        CS%tv, CS%t_dyn_rel_adv, CS%use_uh_particles)
   endif
 
+  ! Tracer-step OBC path: active when DT_OBC_SEG_UPDATE_OBGC is ignored (i.e. DT_OBC_SEG_UPDATE_OBGC = DT_TRACER)
+  ! or when the bug fix is enabled (OBC_TRACER_DZ_BUG=F). OBC_TRACER_DZ_BUG controls whether dz is recomputed
+  ! from the current layer thicknesses before reading.
   if (associated(CS%OBC)) then
-    if (CS%OBC%ignore_dt_obc_bgc) then
-      ! If DT_OBC_SEG_UPDATE_OBGC is ignored by the flag, all tracers are read and updated at the
-      ! beginning of every tracer step.  Note that the thickness used here to remap source data is
-      ! not recalculated, therefore not updated by the last dynamic step, to be consistent with
-      ! old answer.
-      call read_OBC_tracer_data(G, GV, US, CS%OBC, Time_local)
+    if (CS%OBC%ignore_dt_obc_bgc .or. (.not. CS%OBC%tracer_dz_bug)) then
+      if (CS%OBC%tracer_dz_bug) then
+        call read_OBC_tracer_data(G, GV, US, CS%OBC, Time_local)
+      else
+        call read_OBC_tracer_data(G, GV, US, CS%OBC, Time_local, h=h, tv=CS%tv)
+      endif
       call update_OBC_tracer_data(CS%OBC)
     endif
   endif

--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -190,7 +190,7 @@ subroutine update_OBC_data(OBC, G, GV, US, tv, h, CS, Time)
     ! Update tracers: this is the old incorrect path. See step_MOM_tracer_dyn for the locked path.
     ! If DT_OBC_SEG_UPDATE_OBGC is used (not recommended), BGC has its own update schedule, which
     ! may happen in between tracer steps.
-    if ((.not. OBC%ignore_dt_obc_bgc) .and. OBC%any_needs_IO_for_data) then
+    if ((.not. OBC%ignore_dt_obc_bgc) .and. OBC%any_needs_IO_for_data .and. OBC%tracer_dz_bug) then
       call read_OBC_tracer_data(G, GV, US, OBC, Time, include_bgc=OBC%update_OBC_seg_data)
       call update_OBC_tracer_data(OBC, include_bgc=OBC%update_OBC_seg_data)
     endif

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -488,6 +488,9 @@ type, public :: ocean_OBC_type
                                 !! while BGC follows its own update schedule, which may not reproduce
                                 !! across restarts.  Once DT_OBC_SEG_UPDATE_OBGC is deprecated, only
                                 !! the "true" path will be needed.
+  logical :: tracer_dz_bug      !< If true, recover a bug that OBC tracer segment data is read
+                                !! without recomputing segment layer thicknesses using the current
+                                !! layer thicknesses and thermodynamic state.
 end type ocean_OBC_type
 
 !> Control structure for open boundaries that read from files.
@@ -772,6 +775,10 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  "update schedule, which may not reproduce across restarts. Once "//&
                  "DT_OBC_SEG_UPDATE_OBGC is deprecated, only the 'true' path will be needed.", &
                  default=.false.)
+  call get_param(param_file, mdl, "OBC_TRACER_DZ_BUG", OBC%tracer_dz_bug, &
+                 "If true, recover a bug that OBC tracer segment data is read without "//&
+                 "recomputing segment layer thicknesses from the current layer thicknesses "//&
+                 "and thermodynamic state.", default=enable_bugs)
   call get_param(param_file, mdl, "REENTRANT_X", reentrant_x, default=.true.)
   call get_param(param_file, mdl, "REENTRANT_Y", reentrant_y, default=.false.)
 
@@ -6854,6 +6861,7 @@ subroutine rotate_OBC_config(OBC_in, G_in, OBC, G, turns)
   OBC%exterior_OBC_bug = OBC_in%exterior_OBC_bug
   OBC%hor_index_bug = OBC_in%hor_index_bug
   OBC%ignore_dt_obc_bgc = OBC_in%ignore_dt_obc_bgc
+  OBC%tracer_dz_bug = OBC_in%tracer_dz_bug
   OBC%n_tide_constituents = OBC_in%n_tide_constituents
   OBC%add_tide_constituents = OBC_in%add_tide_constituents
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4702,21 +4702,92 @@ end subroutine read_OBC_field_data
 !> Read OBC segment data for the dynamical fields, with field indices
 !! m=1..NUM_PHYS_FIELDS-2 (U, V, gradients, SSH, and tidal constituents).
 subroutine read_OBC_dynamics_data(G, GV, US, OBC, tv, h, Time)
-  type(ocean_grid_type),                     intent(in) :: G    !< Ocean grid structure
-  type(verticalGrid_type),                   intent(in) :: GV   !< Ocean vertical grid structure
-  type(unit_scale_type),                     intent(in) :: US   !< A dimensional unit scaling type
-  type(ocean_OBC_type),                      pointer    :: OBC  !< Open boundary structure
-  type(thermo_var_ptrs),                     intent(in) :: tv   !< Thermodynamics structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h    !< Thickness [H ~> m or kg m-2]
-  type(time_type),                           intent(in) :: Time !< Model time
+  type(ocean_grid_type),   intent(in) :: G    !< Ocean grid structure
+  type(verticalGrid_type), intent(in) :: GV   !< Ocean vertical grid structure
+  type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
+  type(ocean_OBC_type),    pointer    :: OBC  !< Open boundary structure
+  type(thermo_var_ptrs),   intent(in) :: tv   !< Thermodynamics structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in) :: h    !< Thickness [H ~> m or kg m-2]
+  type(time_type),         intent(in) :: Time !< Model time
 
   ! Local variables
-  integer :: i, j, k, n, m
+  integer :: n, m
   type(OBC_segment_type), pointer :: segment => NULL()
-  real :: dz(SZI_(G),SZJ_(G),SZK_(GV))  ! Distance between the interfaces around a layer [Z ~> m]
 
   if (.not. associated(OBC)) return
   if (OBC%user_BCs_set_globally) return
+
+  call update_OBC_segment_dz(G, GV, US, OBC, h, tv)
+
+  do n=1,OBC%number_of_segments
+    segment => OBC%segment(n)
+
+    if (.not. segment%on_pe) cycle ! continue to next segment if not in data domain
+
+    do m=1, NUM_PHYS_FIELDS-2
+      call read_OBC_field_data(G, GV, US, OBC, segment, m, Time)
+    enddo ! end dynamical field loop
+  enddo ! end segment loop
+end subroutine read_OBC_dynamics_data
+
+!> Read OBC segment data for tracer fields, with field indices
+!! m=NUM_PHYS_FIELDS-1..segment%num_fields (T, S, and BGC tracers).
+!! If optional arguments h and tv are not given, it is assumed that segment%dz has been calculated
+!! by a prior call to read_OBC_dynamics_data.  Otherwise, segment%dz is recalculated with h and tv.
+!! The optional argument include_bgc (default .true.) allows BGC fields to be read
+!! independently.
+subroutine read_OBC_tracer_data(G, GV, US, OBC, Time, h, tv, include_bgc)
+  type(ocean_grid_type),            intent(in) :: G    !< Ocean grid structure
+  type(verticalGrid_type),          intent(in) :: GV   !< Ocean vertical grid structure
+  type(unit_scale_type),            intent(in) :: US   !< A dimensional unit scaling type
+  type(ocean_OBC_type),             pointer    :: OBC  !< Open boundary structure
+  type(time_type),                  intent(in) :: Time !< Model time
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                          optional, intent(in) :: h  !< Thickness for recomputing dz [H ~> m or kg m-2]
+  type(thermo_var_ptrs),  optional, intent(in) :: tv !< Thermodynamics structure for recomputing dz
+  logical,                optional, intent(in) :: include_bgc       !< Read BGC tracers
+
+  ! Local variables
+  logical :: do_bgc ! If true, read BGC tracer fields
+  integer :: n, m
+  type(OBC_segment_type), pointer :: segment => NULL()
+
+  if (.not. associated(OBC)) return
+  if (OBC%user_BCs_set_globally) return
+
+  do_bgc = .true. ; if (present(include_bgc)) do_bgc = include_bgc
+
+  if (present(h) .and. present(tv)) &
+    call update_OBC_segment_dz(G, GV, US, OBC, h, tv)
+
+  do n=1,OBC%number_of_segments
+    segment => OBC%segment(n)
+    if (.not. segment%on_pe) cycle ! continue to next segment if not in data domain
+
+    do m=NUM_PHYS_FIELDS-1, segment%num_fields
+      if (.not. allocated(segment%field(m)%buffer_dst)) cycle
+      if (segment%field(m)%bgc_tracer .and. (.not. do_bgc)) cycle
+      call read_OBC_field_data(G, GV, US, OBC, segment, m, Time)
+    enddo ! end tracer field loop
+  enddo ! end segment loop
+end subroutine read_OBC_tracer_data
+
+!> Compute segment%dz and segment%dZtot at all OBC segments from the current layer thicknesses.
+!! These arrays are the target vertical grid used for remapping OBC data to the model grid.
+subroutine update_OBC_segment_dz(G, GV, US, OBC, h, tv)
+  type(ocean_grid_type),   intent(in) :: G   !< Ocean grid structure
+  type(verticalGrid_type), intent(in) :: GV  !< Ocean vertical grid structure
+  type(unit_scale_type),   intent(in) :: US  !< A dimensional unit scaling type
+  type(ocean_OBC_type),    pointer    :: OBC !< Open boundary structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in) :: h   !< Thickness [H ~> m or kg m-2]
+  type(thermo_var_ptrs),   intent(in) :: tv  !< Thermodynamics structure
+
+  ! Local variables
+  integer :: i, j, k, n
+  type(OBC_segment_type), pointer :: segment => NULL()
+  real :: dz(SZI_(G),SZJ_(G),SZK_(GV))  ! Distance between interfaces around a layer [Z ~> m]
 
   dz(:,:,:) = 0.0
   call thickness_to_dz(h, tv, dz, G, GV, US)
@@ -4724,8 +4795,7 @@ subroutine read_OBC_dynamics_data(G, GV, US, OBC, tv, h, Time)
 
   do n=1,OBC%number_of_segments
     segment => OBC%segment(n)
-
-    if (.not. segment%on_pe) cycle ! continue to next segment if not in data domain
+    if (.not. segment%on_pe) cycle
 
     ! dZtot may extend one point past the end of the segment on the current PE for use at vorticity points
     segment%dZtot(:,:) = 0.0
@@ -4742,48 +4812,8 @@ subroutine read_OBC_dynamics_data(G, GV, US, OBC, tv, h, Time)
         segment%dZtot(i,J) = segment%dZtot(i,J) + segment%dz(i,J,k)
       enddo ; enddo
     endif
-
-    do m=1, NUM_PHYS_FIELDS-2
-      call read_OBC_field_data(G, GV, US, OBC, segment, m, Time)
-    enddo ! end dynamical field loop
   enddo ! end segment loop
-end subroutine read_OBC_dynamics_data
-
-!> Read OBC segment data for tracer fields, with field indices
-!! m=NUM_PHYS_FIELDS-1..segment%num_fields (T, S, and BGC tracers).
-!! Assumes segment%dz has been populated by a prior call to read_OBC_dynamics_data at the current
-!! time step. The optional argument include_bgc (default .true.) allows BGC fields to be read
-!! independently.
-subroutine read_OBC_tracer_data(G, GV, US, OBC, Time, include_bgc)
-  type(ocean_grid_type),   intent(in) :: G    !< Ocean grid structure
-  type(verticalGrid_type), intent(in) :: GV   !< Ocean vertical grid structure
-  type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
-  type(ocean_OBC_type),    pointer    :: OBC  !< Open boundary structure
-  type(time_type),         intent(in) :: Time !< Model time
-  logical, optional,       intent(in) :: include_bgc       !< Read BGC tracers
-
-  ! Local variables
-  logical :: do_bgc ! If true, read BGC tracer fields
-  integer :: n, m
-  type(OBC_segment_type), pointer :: segment => NULL()
-
-  if (.not. associated(OBC)) return
-  if (OBC%user_BCs_set_globally) return
-
-  do_bgc = .true. ; if (present(include_bgc)) do_bgc = include_bgc
-
-  do n=1,OBC%number_of_segments
-    segment => OBC%segment(n)
-
-    if (.not. segment%on_pe) cycle ! continue to next segment if not in data domain
-
-    do m=NUM_PHYS_FIELDS-1, segment%num_fields
-      if (.not. allocated(segment%field(m)%buffer_dst)) cycle
-      if (segment%field(m)%bgc_tracer .and. (.not. do_bgc)) cycle
-      call read_OBC_field_data(G, GV, US, OBC, segment, m, Time)
-    enddo ! end tracer field loop
-  enddo ! end segment loop
-end subroutine read_OBC_tracer_data
+end subroutine update_OBC_segment_dz
 
 !> Update OBC segment dynamical fields: normal/tangential velocity, gradient, SSH, and
 !! the thickness reservoir.


### PR DESCRIPTION
This PR follows #1130. A new runtime parameter `OBC_TRACER_DZ_BUG` is introduced. When it is false, external OBC tracer data is read using the up-to-date thickness for vertical remapping. This should be more consistent with the thickness used by tracer advection elsewhere. When the flag is on, OBC becomes modestly slower (additional dz calculation every tracer advection step) but probably more accurate.

4db554d1f6256ece577093ac72f5e25379ff4832 splits out segment%dz calculation from read_OBC_dynamics_data, so that read_OBC_tracer_data can also update dz independently.
1ece00d2f6e442869dac9f67a1f74c03c38d5911 adds a runtime flag OBC_TRACER_DZ_BUG to allow OBC tracer read use the updated thickness.

This is no answer change.