### PR TITLE
Remove unused OBC_registry_type

### DIFF
--- a/src/core/MOM_boundary_update.F90
+++ b/src/core/MOM_boundary_update.F90
@@ -14,8 +14,6 @@ use MOM_dyn_horgrid,           only : dyn_horgrid_type
 use MOM_open_boundary,         only : ocean_obc_type, chksum_OBC_segments
 use MOM_open_boundary,         only : read_OBC_dynamics_data, read_OBC_tracer_data
 use MOM_open_boundary,         only : update_OBC_dynamics_data, update_OBC_tracer_data
-use MOM_open_boundary,         only : OBC_registry_type, file_OBC_CS
-use MOM_open_boundary,         only : register_file_OBC, file_OBC_end
 use MOM_unit_scaling,          only : unit_scale_type
 use MOM_tracer_registry,       only : tracer_registry_type
 use MOM_variables,             only : thermo_var_ptrs
@@ -39,7 +37,6 @@ public update_OBC_data
 
 !> The control structure for the MOM_boundary_update module
 type, public :: update_OBC_CS ; private
-  logical :: use_files = .false.        !< If true, use external files for the open boundary.
   logical :: use_Kelvin = .false.       !< If true, use the Kelvin wave open boundary.
   logical :: use_tidal_bay = .false.    !< If true, use the tidal_bay open boundary.
   logical :: use_shelfwave = .false.    !< If true, use the shelfwave open boundary.
@@ -50,7 +47,6 @@ type, public :: update_OBC_CS ; private
   integer :: nk_OBC_debug = 0           !< The number of layers of OBC segment data to write out
                                         !! in full when DEBUG_OBCS is true.
   !>@{ Pointers to the control structures for named OBC specifications
-  type(file_OBC_CS), pointer :: file_OBC_CSp => NULL()
   type(Kelvin_OBC_CS), pointer :: Kelvin_OBC_CSp => NULL()
   type(tidal_bay_OBC_CS) :: tidal_bay_OBC
   type(shelfwave_OBC_CS), pointer :: shelfwave_OBC_CSp => NULL()
@@ -97,9 +93,6 @@ subroutine call_OBC_register(G, GV, US, param_file, CS, OBC, tr_Reg)
   call get_param(param_file, mdl, "OBC_VALUE_UPDATE_BUG", CS%value_update_bug, &
                  "If true, recover a bug that OBC segment data does not update if all segments "//&
                  "use 'value' and none uses 'file'.", default=enable_bugs)
-  call get_param(param_file, mdl, "USE_FILE_OBC", CS%use_files, &
-                 "If true, use external files for the open boundary.", &
-                 default=.false.)
   call get_param(param_file, mdl, "USE_TIDAL_BAY_OBC", CS%use_tidal_bay, &
                  "If true, use the tidal_bay open boundary.", &
                  default=.false.)
@@ -133,10 +126,6 @@ subroutine call_OBC_register(G, GV, US, param_file, CS, OBC, tr_Reg)
                  "when DEBUG_OBCS is true.", &
                  default=0, debuggingParam=.true., do_not_log=.not.CS%debug_OBCs)
 
-  if (CS%use_files) CS%use_files = &
-    register_file_OBC(param_file, CS%file_OBC_CSp, US, &
-               OBC%OBC_Reg)
-
   if (trim(config) == "DOME") then
     call register_DOME_OBC(param_file, US, OBC, tr_Reg)
 !  elseif (trim(config) == "tidal_bay") then
@@ -146,17 +135,13 @@ subroutine call_OBC_register(G, GV, US, param_file, CS, OBC, tr_Reg)
   endif
 
   if (CS%use_tidal_bay) CS%use_tidal_bay = &
-    register_tidal_bay_OBC(param_file, CS%tidal_bay_OBC, US, &
-               OBC%OBC_Reg)
+    register_tidal_bay_OBC(param_file, CS%tidal_bay_OBC, US)
   if (CS%use_Kelvin) CS%use_Kelvin = &
-    register_Kelvin_OBC(param_file, CS%Kelvin_OBC_CSp, US, &
-               OBC%OBC_Reg)
+    register_Kelvin_OBC(param_file, CS%Kelvin_OBC_CSp, US)
   if (CS%use_shelfwave) CS%use_shelfwave = &
-    register_shelfwave_OBC(param_file, CS%shelfwave_OBC_CSp, G, US, &
-               OBC%OBC_Reg)
+    register_shelfwave_OBC(param_file, CS%shelfwave_OBC_CSp, G, US)
   if (CS%use_dyed_channel) CS%use_dyed_channel = &
-    register_dyed_channel_OBC(param_file, CS%dyed_channel_OBC_CSp, US, &
-               OBC%OBC_Reg)
+    register_dyed_channel_OBC(param_file, CS%dyed_channel_OBC_CSp, US)
 
 end subroutine call_OBC_register
 
@@ -204,7 +189,6 @@ end subroutine update_OBC_data
 subroutine OBC_register_end(CS)
   type(update_OBC_CS),       pointer    :: CS !< Control structure for OBCs
 
-  if (CS%use_files) call file_OBC_end(CS%file_OBC_CSp)
   if (CS%use_Kelvin) call Kelvin_OBC_end(CS%Kelvin_OBC_CSp)
 
   if (associated(CS)) deallocate(CS)

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -58,8 +58,6 @@ public open_boundary_test_extern_uv
 public open_boundary_test_extern_h
 public open_boundary_zero_normal_flow
 public parse_segment_str
-public register_OBC, OBC_registry_init
-public register_file_OBC, file_OBC_end
 public segment_tracer_registry_init
 public segment_tracer_registry_end
 public segment_thickness_reservoir_init
@@ -424,7 +422,6 @@ type, public :: ocean_OBC_type
                                                       !! z-space data on segments
   type(remapping_CS), pointer :: remap_h_CS => NULL() !< ALE remapping control structure for
                                                       !! thickness-based fields on segments
-  type(OBC_registry_type), pointer :: OBC_Reg => NULL()  !< Registry type for boundaries
   real, allocatable :: rx_normal(:,:,:)     !< Array storage for normal phase speed for EW radiation OBCs
                                             !! in units of grid points per timestep [nondim]
   real, allocatable :: ry_normal(:,:,:)     !< Array storage for normal phase speed for NS radiation OBCs
@@ -492,25 +489,6 @@ type, public :: ocean_OBC_type
                                 !! without recomputing segment layer thicknesses using the current
                                 !! layer thicknesses and thermodynamic state.
 end type ocean_OBC_type
-
-!> Control structure for open boundaries that read from files.
-!! Probably lots to update here.
-type, public :: file_OBC_CS ; private
-  logical :: OBC_file_used = .false.     !< Placeholder for now to avoid an empty type.
-end type file_OBC_CS
-
-!> Type to carry something (what??) for the OBC registry.
-type, public :: OBC_struct_type
-  character(len=32)               :: name             !< OBC name used for error messages
-end type OBC_struct_type
-
-!> Type to carry basic OBC information needed for updating values.
-type, public :: OBC_registry_type
-  integer               :: nobc = 0          !< number of registered open boundary types.
-  type(OBC_struct_type) :: OB(MAX_FIELDS_)   !< array of registered boundary types.
-  logical               :: locked = .false.  !< New OBC types may be registered if locked=.false.
-                                             !! When locked=.true.,no more boundaries can be registered.
-end type OBC_registry_type
 
 !> Type to carry OBC information needed for setting segments for OBGC tracers
 type, private :: external_tracers_segments_props
@@ -5136,87 +5114,6 @@ subroutine update_OBC_ramp(Time, OBC, US, activate)
   write(msg(1:12),'(es12.3)') OBC%ramp_value
   call MOM_error(NOTE, "MOM_open_boundary: update_OBC_ramp set OBC ramp to "//trim(msg))
 end subroutine update_OBC_ramp
-
-!> register open boundary objects for boundary updates.
-subroutine register_OBC(name, param_file, Reg)
-  character(len=32),     intent(in)  :: name        !< OBC name used for error messages
-  type(param_file_type), intent(in)  :: param_file  !< file to parse for  model parameter values
-  type(OBC_registry_type), pointer   :: Reg         !< pointer to the tracer registry
-  integer :: nobc
-  character(len=256) :: mesg    ! Message for error messages.
-
-  if (.not. associated(Reg)) call OBC_registry_init(param_file, Reg)
-
-  if (Reg%nobc>=MAX_FIELDS_) then
-    write(mesg, '("Increase MAX_FIELDS_ in MOM_memory.h to at least ",I0," to allow for &
-        &all the open boundaries being registered via register_OBC.")') Reg%nobc+1
-    call MOM_error(FATAL,"MOM register_OBC: "//mesg)
-  endif
-  Reg%nobc = Reg%nobc + 1
-  nobc     = Reg%nobc
-
-  Reg%OB(nobc)%name = name
-
-  if (Reg%locked) call MOM_error(FATAL, &
-      "MOM register_OBC was called for OBC "//trim(Reg%OB(nobc)%name)//&
-      " with a locked OBC registry.")
-
-end subroutine register_OBC
-
-!> This routine include declares and sets the variable "version".
-subroutine OBC_registry_init(param_file, Reg)
-  type(param_file_type),   intent(in) :: param_file !< open file to parse for model parameters
-  type(OBC_registry_type), pointer    :: Reg        !< pointer to OBC registry
-
-  integer, save :: init_calls = 0
-
-# include "version_variable.h"
-  character(len=256) :: mesg    ! Message for error messages.
-
-  if (.not.associated(Reg)) then ; allocate(Reg)
-  else ; return ; endif
-
-  ! Read all relevant parameters and write them to the model log.
-! call log_version(param_file, mdl, version, "")
-
-  init_calls = init_calls + 1
-  if (init_calls > 1) then
-    write(mesg,'("OBC_registry_init called ",I0," times with different registry pointers.")') init_calls
-    if (is_root_pe()) call MOM_error(WARNING,"MOM_open_boundary: "//trim(mesg))
-  endif
-
-end subroutine OBC_registry_init
-
-!> Add file to OBC registry.
-function register_file_OBC(param_file, CS, US, OBC_Reg)
-  type(param_file_type),    intent(in) :: param_file !< parameter file.
-  type(file_OBC_CS),        pointer    :: CS         !< file control structure.
-  type(unit_scale_type),    intent(in) :: US         !< A dimensional unit scaling type
-  type(OBC_registry_type),  pointer    :: OBC_Reg    !< OBC registry.
-  logical                              :: register_file_OBC
-  character(len=32)  :: casename = "OBC file"        !< This case's name.
-
-  if (associated(CS)) then
-    call MOM_error(WARNING, "register_file_OBC called with an "// &
-                            "associated control structure.")
-    return
-  endif
-  allocate(CS)
-
-  ! Register the file for boundary updates.
-  call register_OBC(casename, param_file, OBC_Reg)
-  register_file_OBC = .true.
-
-end function register_file_OBC
-
-!> Clean up the file OBC from registry.
-subroutine file_OBC_end(CS)
-  type(file_OBC_CS), pointer    :: CS   !< OBC file control structure.
-
-  if (associated(CS)) then
-    deallocate(CS)
-  endif
-end subroutine file_OBC_end
 
 !> Initialize the segment tracer registry.
 subroutine segment_tracer_registry_init(param_file, segment)

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -14,9 +14,8 @@ use MOM_error_handler,  only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
 use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE
-use MOM_open_boundary,  only : OBC_segment_type, register_OBC, rotate_OBC_segment_direction
+use MOM_open_boundary,  only : OBC_segment_type, rotate_OBC_segment_direction
 use MOM_open_boundary,  only : OBC_DIRECTION_N, OBC_DIRECTION_E, OBC_DIRECTION_S, OBC_DIRECTION_W
-use MOM_open_boundary,  only : OBC_registry_type
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
 use MOM_time_manager,   only : time_type, time_to_real
@@ -59,17 +58,15 @@ end type Kelvin_OBC_CS
 contains
 
 !> Add Kelvin wave to OBC registry.
-logical function register_Kelvin_OBC(param_file, CS, US, OBC_Reg)
+logical function register_Kelvin_OBC(param_file, CS, US)
   type(param_file_type),    intent(in) :: param_file !< parameter file.
   type(Kelvin_OBC_CS),      pointer    :: CS         !< Kelvin wave control structure.
   type(unit_scale_type),    intent(in) :: US         !< A dimensional unit scaling type
-  type(OBC_registry_type),  pointer    :: OBC_Reg    !< OBC registry.
 
   ! Local variables
   logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
                           ! recreate the bugs, or if false bugs are only used if actively selected.
   character(len=40)  :: mdl = "register_Kelvin_OBC"  !< This subroutine's name.
-  character(len=32)  :: casename = "Kelvin wave"     !< This case's name.
   character(len=200) :: config
 
   if (associated(CS)) then
@@ -132,8 +129,6 @@ logical function register_Kelvin_OBC(param_file, CS, US, OBC_Reg)
                  "If true, retain several horizontal indexing bugs that were in the original "//&
                  "version of Kelvin_set_OBC_data.", default=enable_bugs)
 
-  ! Register the Kelvin open boundary.
-  call register_OBC(casename, param_file, OBC_Reg)
   register_Kelvin_OBC = .true.
 
   ! TODO: Revisit and correct the internal Kelvin wave test case.

--- a/src/user/dyed_channel_initialization.F90
+++ b/src/user/dyed_channel_initialization.F90
@@ -13,7 +13,6 @@ use MOM_grid,            only : ocean_grid_type
 use MOM_open_boundary,   only : ocean_OBC_type, OBC_NONE
 use MOM_open_boundary,   only : OBC_DIRECTION_W, OBC_DIRECTION_N, OBC_DIRECTION_S, OBC_DIRECTION_E
 use MOM_open_boundary,   only : OBC_segment_type, register_segment_tracer
-use MOM_open_boundary,   only : OBC_registry_type, register_OBC
 use MOM_time_manager,    only : time_type, time_to_real
 use MOM_tracer_registry, only : tracer_registry_type, tracer_name_lookup
 use MOM_tracer_registry, only : tracer_type
@@ -44,16 +43,14 @@ integer :: ntr = 0 !< Number of dye tracers
 contains
 
 !> Add dyed channel to OBC registry.
-logical function register_dyed_channel_OBC(param_file, CS, US, OBC_Reg)
+logical function register_dyed_channel_OBC(param_file, CS, US)
   type(param_file_type),     intent(in) :: param_file !< parameter file.
   type(dyed_channel_OBC_CS), pointer    :: CS         !< Dyed channel control structure.
   type(unit_scale_type),     intent(in) :: US         !< A dimensional unit scaling type
-  type(OBC_registry_type),   pointer    :: OBC_Reg    !< OBC registry.
 
   ! Local variables
   logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
                           ! recreate the bugs, or if false bugs are only used if actively selected.
-  character(len=32)  :: casename = "dyed channel"     ! This case's name.
   character(len=40)  :: mdl = "register_dyed_channel_OBC" ! This subroutine's name.
 
   if (associated(CS)) then
@@ -79,8 +76,6 @@ logical function register_dyed_channel_OBC(param_file, CS, US, OBC_Reg)
                  "(if Boussienesq) or 1 kg m-2 layer thickness instead of the actual thickness.", &
                  default=enable_bugs)
 
-  ! Register the open boundaries.
-  call register_OBC(casename, param_file, OBC_Reg)
   register_dyed_channel_OBC = .true.
 
 end function register_dyed_channel_OBC

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -11,8 +11,7 @@ use MOM_error_handler,  only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
 use MOM_open_boundary,  only : ocean_OBC_type, OBC_NONE, OBC_DIRECTION_W
-use MOM_open_boundary,  only : OBC_segment_type, register_OBC
-use MOM_open_boundary,  only : OBC_registry_type, rotate_OBC_segment_direction
+use MOM_open_boundary,  only : OBC_segment_type, rotate_OBC_segment_direction
 use MOM_time_manager,   only : time_type, time_to_real
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
@@ -42,12 +41,11 @@ end type shelfwave_OBC_CS
 contains
 
 !> Add shelfwave to OBC registry.
-function register_shelfwave_OBC(param_file, CS, G, US, OBC_Reg)
+function register_shelfwave_OBC(param_file, CS, G, US)
   type(param_file_type),    intent(in) :: param_file !< parameter file.
   type(shelfwave_OBC_CS),   pointer    :: CS         !< shelfwave control structure.
   type(ocean_grid_type),    intent(in) :: G          !< The ocean's grid structure.
   type(unit_scale_type),    intent(in) :: US         !< A dimensional unit scaling type
-  type(OBC_registry_type),  pointer    :: OBC_Reg    !< Open boundary condition registry.
   logical                              :: register_shelfwave_OBC
 
   ! Local variables
@@ -68,8 +66,6 @@ function register_shelfwave_OBC(param_file, CS, G, US, OBC_Reg)
   endif
   allocate(CS)
 
-  ! Register the tracer for horizontal advection & diffusion.
-  call register_OBC(casename, param_file, OBC_Reg)
   call get_param(param_file, mdl, "F_0", f0, &
                  default=0.0, units="s-1", scale=US%T_to_s, do_not_log=.true.)
   call get_param(param_file, mdl,"SHELFWAVE_X_WAVELENGTH", Lx, &

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -12,8 +12,7 @@ use MOM_error_handler,  only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,    only : get_param, log_version, param_file_type
 use MOM_grid,           only : ocean_grid_type
 use MOM_open_boundary,  only : ocean_OBC_type
-use MOM_open_boundary,  only : OBC_segment_type, register_OBC
-use MOM_open_boundary,  only : OBC_registry_type
+use MOM_open_boundary,  only : OBC_segment_type
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_verticalGrid,   only : verticalGrid_type
 use MOM_time_manager,   only : time_type, time_to_real
@@ -36,13 +35,11 @@ end type tidal_bay_OBC_CS
 contains
 
 !> Add tidal bay to OBC registry.
-function register_tidal_bay_OBC(param_file, CS, US, OBC_Reg)
+function register_tidal_bay_OBC(param_file, CS, US)
   type(param_file_type),    intent(in) :: param_file !< parameter file.
   type(tidal_bay_OBC_CS),   intent(inout) :: CS      !< tidal bay control structure.
   type(unit_scale_type),    intent(in) :: US         !< A dimensional unit scaling type
-  type(OBC_registry_type),  pointer    :: OBC_Reg    !< OBC registry.
   logical                              :: register_tidal_bay_OBC
-  character(len=32)  :: casename = "tidal bay"       !< This case's name.
   character(len=40)  :: mdl = "tidal_bay_initialization" ! This module's name.
 
   call get_param(param_file, mdl, "TIDAL_BAY_FLOW", CS%tide_flow, &
@@ -56,8 +53,6 @@ function register_tidal_bay_OBC(param_file, CS, US, OBC_Reg)
                  "tidal bay configuration.", &
                  units="m", default=0.1, scale=US%m_to_Z)
 
-  ! Register the open boundaries.
-  call register_OBC(casename, param_file, OBC_Reg)
   register_tidal_bay_OBC = .true.
 
 end function register_tidal_bay_OBC


### PR DESCRIPTION
Remove `OBC_registry_type`, `OBC_struct_type`, `register_OBC, OBC_registry_init`, `register_file_OBC, file_OBC_CS`, and `file_OBC_end` from MOM_open_boundary.F90, along with the `OBC_Reg` field from `ocean_OBC_type`.

This structure seems never used. The registry accumulated names into a list that nothing ever read back. The locked flag was never set, log_version was commented out, and the OBC_struct_type Doxygen comment read "carry something (what??)". `register_DOME_OBC` never used the registry at all.

The `OBC_Reg` argument is removed from `register_Kelvin_OBC`, `register_shelfwave_OBC`, `register_tidal_bay_OBC`, and `register_dyed_channel_OBC`. The `file_OBC_CS` placeholder type (single unused logical field) and its register/end pair are removed; `USE_FILE_OBC` parameter is removed.

There is no answer change.