### PR TITLE
write_energy: Conditional file opening 

### DIFF
--- a/src/diagnostics/MOM_harmonic_analysis.F90
+++ b/src/diagnostics/MOM_harmonic_analysis.F90
@@ -11,7 +11,7 @@ use MOM_time_manager,  only : operator(+), operator(-), operator(<), operator(>)
 use MOM_grid,          only : ocean_grid_type
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_file_parser,   only : param_file_type, get_param
-use MOM_io,            only : file_exists, open_ASCII_file, READONLY_FILE, close_file
+use MOM_io,            only : file_exists, READONLY_FILE, close_file
 use MOM_io,            only : MOM_infra_file, vardesc, MOM_field
 use MOM_io,            only : var_desc, create_MOM_file, SINGLE_FILE, MOM_write_field
 use MOM_error_handler, only : MOM_mesg, MOM_error, NOTE

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -319,8 +319,12 @@ subroutine MOM_sum_output_end(CS)
       deallocate(CS%lH)
     endif
 
-    inquire(unit=CS%fileenergy_ascii, opened=is_open)
-    if (is_open) call close_file(CS%fileenergy_ascii)
+    if (is_root_PE()) then
+      is_open = .false.
+      if (CS%fileenergy_ascii /= -1) &
+        inquire(unit=CS%fileenergy_ascii, opened=is_open)
+      if (is_open) call close_file(CS%fileenergy_ascii)
+    endif
 
     deallocate(CS)
   endif
@@ -625,7 +629,9 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     !  Reopen or create a text output file, with an explanatory header line.
     if (is_root_pe()) then
       if (day > CS%Start_time) then
-        inquire(unit=CS%fileenergy_ascii, opened=is_open)
+        is_open = .false.
+        if (CS%fileenergy_ascii /= -1) &
+          inquire(unit=CS%fileenergy_ascii, opened=is_open)
         if (.not. is_open) &
           call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=APPEND_FILE)
       else

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -15,7 +15,7 @@ use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,  only : forcing
 use MOM_grid,          only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
-use MOM_io,            only : create_MOM_file, reopen_MOM_file
+use MOM_io,            only : create_MOM_file, reopen_MOM_file, close_file
 use MOM_io,            only : MOM_infra_file, MOM_netcdf_file, MOM_field
 use MOM_io,            only : file_exists, slasher, vardesc, var_desc, MOM_write_field
 use MOM_io,            only : field_size, read_variable, read_attribute, open_ASCII_file, stdout
@@ -137,7 +137,8 @@ type, public :: sum_output_CS ; private
   integer :: previous_calls = 0 !< The number of times write_energy has been called.
   integer :: prev_n = 0         !< The value of n from the last call.
   type(MOM_netcdf_file) :: fileenergy_nc !< The file handle for the netCDF version of the energy file.
-  integer :: fileenergy_ascii   !< The unit number of the ascii version of the energy file.
+  integer :: fileenergy_ascii = -1
+    !< The unit number of the ascii version of the energy file.
   type(MOM_field), dimension(NUM_FIELDS+MAX_FIELDS_) :: &
              fields             !< fieldtype variables for the output fields.
   character(len=200) :: energyfile  !< The name of the energy file with path.
@@ -306,13 +307,20 @@ end subroutine MOM_sum_output_init
 
 !> MOM_sum_output_end deallocates memory used by the MOM_sum_output module.
 subroutine MOM_sum_output_end(CS)
-  type(Sum_output_CS), pointer :: CS  !< The control structure returned by a
-                                      !! previous call to MOM_sum_output_init.
+  type(Sum_output_CS), pointer :: CS
+    !< Control structure returned by a previous call to MOM_sum_output_init.
+
+  logical :: is_open
+    ! True if CS%fileenergy_ascii is open
+
   if (associated(CS)) then
     if (CS%do_APE_calc) then
       deallocate(CS%DL%depth, CS%DL%area, CS%DL%vol_below)
       deallocate(CS%lH)
     endif
+
+    inquire(unit=CS%fileenergy_ascii, opened=is_open)
+    if (is_open) call close_file(CS%fileenergy_ascii)
 
     deallocate(CS)
   endif
@@ -477,6 +485,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     Tr_units             ! The units for each of the tracers
   integer :: nTr_stocks  ! The total number of tracers in all registered tracer packages
   integer :: iyear, imonth, iday, ihour, iminute, isecond, itick ! For call to get_date()
+  logical :: is_open     ! True if the CS%fileenergy_ascii has been opened
 
  ! A description for output of each of the fields.
   type(vardesc) :: vars(NUM_FIELDS+MAX_FIELDS_)
@@ -616,7 +625,9 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     !  Reopen or create a text output file, with an explanatory header line.
     if (is_root_pe()) then
       if (day > CS%Start_time) then
-        call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=APPEND_FILE)
+        inquire(unit=CS%fileenergy_ascii, opened=is_open)
+        if (.not. is_open) &
+          call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=APPEND_FILE)
       else
         call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=WRITEONLY_FILE)
         if (abs(CS%timeunit - 86400.0) < 1.0) then

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -19,7 +19,7 @@ use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : read_param, get_param, log_param, log_version, param_file_type
 use MOM_grid, only : MOM_grid_init, ocean_grid_type
 use MOM_io, only : file_exists, slasher, MOM_read_data
-use MOM_io, only : open_ASCII_file, get_filename_appendix
+use MOM_io, only : open_ASCII_file, close_file, get_filename_appendix
 use MOM_io, only : APPEND_FILE, WRITEONLY_FILE
 use MOM_restart, only : register_restart_field, MOM_restart_CS
 use MOM_time_manager, only : time_type, get_time, set_time, time_type_to_real, operator(>)
@@ -265,7 +265,8 @@ type, public :: ice_shelf_dyn_CS ; private
   type(time_type) :: Start_time !< The start time of the simulation.
                                 ! Start_time is set in MOM_initialization.F90
   integer :: prev_IS_energy_calls = 0 !< The number of times write_ice_shelf_energy has been called.
-  integer :: IS_fileenergy_ascii   !< The unit number of the ascii version of the energy file.
+  integer :: IS_fileenergy_ascii = -1
+    !< The unit number of the ascii version of the energy file.
   character(len=200) :: IS_energyfile  !< The name of the ice sheet energy file with path.
 
   ! ids for outputting intermediate thickness in advection subroutine (debugging)
@@ -1341,6 +1342,8 @@ subroutine write_ice_shelf_energy(CS, G, US, mass, area, day, time_step)
   character(len=32)  :: mesg_intro, time_units, day_str, n_str, date_str
   integer :: start_of_day, num_days
   real    :: reday  ! Time in units given by CS%Timeunit, but often [days]
+  logical :: is_open
+    ! True if CS%fileenergy_ascii is open
 
   ! write_energy_time is the next integral multiple of energysavedays.
   if (present(time_step)) then
@@ -1405,7 +1408,9 @@ subroutine write_ice_shelf_energy(CS, G, US, mass, area, day, time_step)
 
   if (is_root_pe()) then  ! Only the root PE actually writes anything.
     if (day > CS%Start_time) then
-      call open_ASCII_file(CS%IS_fileenergy_ascii, trim(CS%IS_energyfile), action=APPEND_FILE)
+      inquire(unit=CS%IS_fileenergy_ascii, opened=is_open)
+      if (.not. is_open) &
+        call open_ASCII_file(CS%IS_fileenergy_ascii, trim(CS%IS_energyfile), action=APPEND_FILE)
     else
       call open_ASCII_file(CS%IS_fileenergy_ascii, trim(CS%IS_energyfile), action=WRITEONLY_FILE)
       if (abs(CS%timeunit - 86400.0) < 1.0) then
@@ -5222,7 +5227,11 @@ end subroutine interpolate_H_to_B
 
 !> Deallocates all memory associated with the ice shelf dynamics module
 subroutine ice_shelf_dyn_end(CS)
-  type(ice_shelf_dyn_CS), pointer   :: CS !< A pointer to the ice shelf dynamics control structure
+  type(ice_shelf_dyn_CS), pointer :: CS
+    !< A pointer to the ice shelf dynamics control structure
+
+  logical :: is_open
+    ! True if CS%fileenergy_ascii is open
 
   if (.not.associated(CS)) return
 
@@ -5250,6 +5259,9 @@ subroutine ice_shelf_dyn_end(CS)
   if (associated(CS%Phi)) deallocate(CS%Phi)
   if (associated(CS%Phisub)) deallocate(CS%Phisub)
   if (associated(CS%PhiC)) deallocate(CS%PhiC)
+
+  inquire(unit=CS%IS_fileenergy_ascii, opened=is_open)
+  if (is_open) call close_file(CS%IS_fileenergy_ascii)
 
   deallocate(CS)
 

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -1408,7 +1408,9 @@ subroutine write_ice_shelf_energy(CS, G, US, mass, area, day, time_step)
 
   if (is_root_pe()) then  ! Only the root PE actually writes anything.
     if (day > CS%Start_time) then
-      inquire(unit=CS%IS_fileenergy_ascii, opened=is_open)
+      is_open = .false.
+      if (CS%IS_fileenergy_ascii /= -1) &
+        inquire(unit=CS%IS_fileenergy_ascii, opened=is_open)
       if (.not. is_open) &
         call open_ASCII_file(CS%IS_fileenergy_ascii, trim(CS%IS_energyfile), action=APPEND_FILE)
     else
@@ -5260,7 +5262,9 @@ subroutine ice_shelf_dyn_end(CS)
   if (associated(CS%Phisub)) deallocate(CS%Phisub)
   if (associated(CS%PhiC)) deallocate(CS%PhiC)
 
-  inquire(unit=CS%IS_fileenergy_ascii, opened=is_open)
+  is_open = .false.
+  if (CS%IS_fileenergy_ascii /= -1) &
+    inquire(unit=CS%IS_fileenergy_ascii, opened=is_open)
   if (is_open) call close_file(CS%IS_fileenergy_ascii)
 
   deallocate(CS)


### PR DESCRIPTION
When `MOM_io` switched to using `newunit=` in its `open()` calls, it replaced
a static arbitrary file handle with an automatically generated handle.
This caused a new file to be created after every call.

In `write_energy` and its ice shelf analogue, the new handles had the same
file name, so it would have gone undetected in many cases.  In ice shelf
development, this was detected because it exceed the open file limit in
the OS.

This patch now queries if the file has already been opened.  Only then
does it open the file for appending.

This check is not applied at `Start_date`, since we presumably would not
call these functions twice on the initial timestep.  But maybe that
possibility should be considered?

Minor changes:

* the handle is now initialized to -1; `newunit` will never assign this
  value in a standards-compliant compiler

* The files are now closed in the termination functions.  Previously we
  relied on runtime and OS cleanup.

* An unused `open_ASCII_file` import was removed.