### PR TITLE
Fix unit scaling for ref_h_mld in pRef_MLD calculation

### DIFF
--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -103,7 +103,7 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   hRef_MLD(:) = ref_h_mld
-  pRef_MLD(:) = GV%H_to_RZ*GV%g_Earth*ref_h_mld
+  pRef_MLD(:) = (GV%H_to_RZ*GV%g_Earth)*(GV%Z_to_H*ref_h_mld)
   z_ref_diag(:,:) = 0.
 
   EOSdom(:) = EOS_domain(G%HI)


### PR DESCRIPTION
I took a peek down the rabbit hole of the dimensional consistency tests in MOM6 as they relate to COBALT. COBALT answers changed when I changed `H_RESCALE_POWER`. With some help from Sonnet 5, I tracked this down to the mixed layer depth calculation in `diagnoseMLDbyDensityDifference`, which is used in the calculation of photoacclimation in COBALT.

The configurable reference depth `HREF_FOR_MLD` used for MLD calculations is given a scale of `US%m_to_Z`, which makes sense. ocean_BGC has its own reference depth `PHA_MLD_HREF` which also uses this scaling.

https://github.com/NOAA-GFDL/MOM6/blob/fa457667bc417b465a40d8a6e8e4bcba64cf9d3a/src/parameterizations/vertical/MOM_diabatic_driver.F90#L3556-L3558

The issue is that `diagnoseMLDbyDensityDifference` converts this using `H_to_RZ`:

https://github.com/NOAA-GFDL/MOM6/blob/fa457667bc417b465a40d8a6e8e4bcba64cf9d3a/src/diagnostics/MOM_diagnose_MLD.F90#L106

If I've understood the units scaling correctly, the right way to do it is what this PR changes it to:
```fortran
pRef_MLD(:) = (GV%H_to_RZ*GV%g_Earth)*(GV%Z_to_H*ref_h_mld)
```

This shouldn't change actual answers in MOM6, but if the H or Z rescaling factors were changed AND a non-default was set for `HREF_FOR_MLD` (default is 0.0) it will change diagnostics like MLD_003. It changes answers in COBALT when H or Z rescaling factors are changed because `diagnoseMLDbyDensityDifference` is used for photoacclimation calculation, which affects phytoplankton growth and then everything else in the BGC. 