### PR TITLE
Fix dl bug in MOM_diag_mediator.F90 

### DIFF
--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1956,7 +1956,7 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
     call post_xy_average(diag_cs, diag, locfield)
   endif
 
-  if ((diag%conversion_factor /= 0.) .and. (diag%conversion_factor /= 1.) .and. dl<2) &
+  if ((diag%conversion_factor /= 0.) .and. (diag%conversion_factor /= 1.) .and. dlfac<2) &
     deallocate( locfield )
 
 end subroutine post_data_3d_low


### PR DESCRIPTION
@jessluo was running with an intel debug compile and had an error with `dl` in the diag manager. The downscaled diagnostics were not being used in that run. 

It looks like `dl` should have been changed to `dlfac` in PR #1115 and is now uninitialized which is why the debug compile caught this bug.

