### PR TITLE
Hor_visc: FrictWork_bh compute condition.

### DIFF
--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2048,7 +2048,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
       endif
     endif
 
-    if (CS%id_FrictWork_bh>0 .or. CS%id_FrictWorkIntz_bh > 0 .or. allocated(MEKE%mom_src_bh)) then
+    if (CS%id_FrictWork_bh>0 .or. CS%id_FrictWorkIntz_bh > 0 .or. allocated(MEKE%mom_src_bh) &
+        .or. (allocated(MEKE%mom_src) .and. MEKE%backscatter_Ro_c /= 0.)) then
       if (CS%FrictWork_bug) then
         ! Diagnose   bhstr_xx*d_x u - bhstr_yy*d_y v + bhstr_xy*(d_y u + d_x v)
         ! This is the old formulation that includes energy diffusion !cyc


### PR DESCRIPTION
FrictWork_bh is currently only computed when id_FrictWork_bh or id_FrictWorkIntz_bh are enabled, or if MEKE%mom_src_bh is allocated. However, MEKE%mom_src accumulation uses FrictWork_bh whenever MEKE%backscatter_Ro_c /= 0.

If mom_src is allocated but mom_src_bh is not (e.g., MEKE_bhFrCoeff < 0), FrictWork_bh can be uninitialized here.

Assisted-by: Copilot