### PR TITLE
Revisit handling of merge conflicts between main and dev/gfdl

### DIFF
--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1655,8 +1655,8 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, &
       handles%id_seaice_bc_flux = register_diag_field('ocean_model', 'SEAICE_BLACK_CARBON_FLUX_CPL', &
           diag%axesT1, Time, 'SEAICE_BLACK_CARBON_FLUX from cpl', 'kg m-2 s', &
           conversion=US%RZ_T_to_kg_m2s)
-    end if
-  end if
+    endif
+  endif
   handles%id_psurf = register_diag_field('ocean_model', 'p_surf', diag%axesT1, Time, &
         'Pressure at ice-ocean or atmosphere-ocean interface', &
         'Pa', conversion=US%RL2_T2_to_Pa, cmor_field_name='pso', &

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -789,9 +789,9 @@ function auto_determine_io_layout(idiv, jdiv, nio) result(best_io_layout)
       if (ratio_diff < min_ratio_diff) then
         min_ratio_diff = ratio_diff
         best_io_layout = [io_layout(1), io_layout(2)]
-      end if
-    end if
-  end do
+      endif
+    endif
+  enddo
 
 end function auto_determine_io_layout
 

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -330,7 +330,8 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
   if (CS%MLE_MLD_decay_time>0.) then
     if (CS%debug) then
       call hchksum(CS%MLD_filtered, 'mixed_layer_restrat: MLD_filtered', G%HI, haloshift=1, unscale=GV%H_to_mks)
-      call hchksum(h_MLD, 'mixed_layer_restrat: MLD in', G%HI, haloshift=1, unscale=GV%H_to_mks)
+      if (CS%MLE_density_diff <= 0.) &
+        call hchksum(h_MLD, 'mixed_layer_restrat: MLD in', G%HI, haloshift=1, unscale=GV%H_to_mks)
     endif
     aFac = CS%MLE_MLD_decay_time / ( dt + CS%MLE_MLD_decay_time )
     bFac = dt / ( dt + CS%MLE_MLD_decay_time )
@@ -1781,16 +1782,16 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
              "parameter a micron away from the equator.", &
              units="m2 s-2", default=1.0e-24, scale=US%m_to_Z**2*US%T_to_s**2)
     call get_param(param_file, mdl, "WAVE_ENHANCED_USTAR", CS%wave_enhanced_ustar, &
-             "If true, enhance ustar using surface waves, following Eq. 28 in Bodner23. " //&
-             "Use a Langmuir number if provided. Otherwise, assumes equilibrium "// &
+             "If true, enhance ustar using surface waves, following Eq. 28 in Bodner23. "//&
+             "Use a Langmuir number if provided. Otherwise, assumes equilibrium "//&
              "surface waves (La-2=11.).", default=.false.)
     call get_param(param_file, mdl, "TAIL_DH", CS%MLE_tail_dh, &
              "Fraction by which to extend the mixed-layer restratification "//&
              "depth used for a smoother stream function at the base of "//&
              "the mixed-layer.", units="nondim", default=0.0)
     call get_param(param_file, mdl, "USE_CR_GRID", CS%Cr_grid, &
-             "If true, read in a spatially varying Cr field." //&
-             "If CR = 0 (default), this field is scaled by 1.0." //&
+             "If true, read in a spatially varying Cr field. "//&
+             "If CR = 0 (default), this field is scaled by 1.0. "//&
              "If CR>0., this field works as a mask and is scaled by CR.", default=.false.)
     call get_param(param_file, mdl, "USE_MLD_GRID", CS%MLD_grid, &
              "If true, read in a spatially varying MLD_decaying_Tfilt field.", default=.false.)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3325,7 +3325,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
     call extract_tracer_flow_member(tracer_flow_CSp, use_MARBL_tracers=use_MARBL_tracers)
     if (use_MARBL_tracers) &
       allocate(CS%prediabatic_T(SZI_(G),SZJ_(G), SZK_(G)), CS%prediabatic_S(SZI_(G),SZJ_(G), SZK_(G)))
-  end if
+  endif
   if (associated(sponge_CSp))      CS%sponge_CSp      => sponge_CSp
   if (associated(ALE_sponge_CSp))  CS%ALE_sponge_CSp  => ALE_sponge_CSp
   if (associated(oda_incupd_CSp))  CS%oda_incupd_CSp  => oda_incupd_CSp

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -996,17 +996,17 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
     call MOM_error(NOTE, 'Enforcing consistency across autotroph tracer initial conditions')
     do j=G%jsc, G%jec ; do i=G%isc, G%iec
       ! Copy tracer data into flat array
-      do k=1,GV%ke; do m=1, CS%ntr
+      do k=1,GV%ke ; do m=1, CS%ntr
         MARBL_instances%tracers(m,k) = CS%tracer_data(m)%tr(i,j,k)
-      end do ; end do
+      enddo ; enddo
       ! call consistency enforcement
       call MARBL_instances%autotroph_tracer_consistency_enforce()
       ! Copy tracer data out of flat array
-      do k=1,GV%ke; do m=1, CS%ntr
+      do k=1,GV%ke ; do m=1, CS%ntr
         CS%tracer_data(m)%tr(i,j,k) = MARBL_instances%tracers(m,k)
-      end do ; end do
-    end do ; end do
-  end if
+      enddo ; enddo
+    enddo ; enddo
+  endif
 
   ! Initialize total chlorophyll to get SW Pen correct (if it wasn't initialized from restart file)
   if ((CS%total_Chl_ind > 0) .and. &

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -391,7 +391,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, visc, CS, p_surf)
     if (associated(visc%h_ML)) then
       CS%hbl(:,:) = visc%h_ML(:,:)
     else
-      call MOM_error(FATAL, "hor_bnd_diffusion requires that visc%h_ML is associated.")
+      call MOM_error(FATAL, "neutral_diffusion requires that visc%h_ML is associated.")
     endif
     call pass_var(CS%hbl, G%Domain, halo=1)
 

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -539,11 +539,13 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
             I = segment%HI%IsdB
             do m = 1,segment%tr_Reg%ntseg ! replace tracers with OBC values
               ntr_id = segment%tr_reg%Tr(m)%ntr_index
-              if (segment%direction == OBC_DIRECTION_W) then
-                T_tmp(i,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-              else
-                T_tmp(i+1,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-              endif
+              if (advect_this_tracer(ntr_id)) then
+                if (segment%direction == OBC_DIRECTION_W) then
+                  T_tmp(i,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
+                else
+                  T_tmp(i+1,ntr_id) = segment%tr_Reg%Tr(m)%tres(i,j,k)
+                endif
+              endif ! advect_this_tracer
             enddo
             do m = 1,ntr ! Apply update tracer values for slope calculation
               if (advect_this_tracer(m)) then
@@ -681,7 +683,9 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
               ! should the reservoir evolve for this case Kate ?? - Nope
                 do m=1,segment%tr_Reg%ntseg
                   ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                  flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
+                  if (advect_this_tracer(ntr_id)) then
+                    flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
+                  endif ! advect_this_tracer
                 enddo
               endif
             endif
@@ -703,7 +707,9 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
               uhh(I) = uhr(I,j,k)
               do m=1,segment%tr_Reg%ntseg
                 ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
+                if (advect_this_tracer(ntr_id)) then
+                  flux_x(I,j,ntr_id) = uhh(I)*segment%tr_Reg%Tr(m)%tres(I,j,k)
+                endif ! advect_this_tracer
               enddo
             endif
           endif
@@ -761,9 +767,9 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
 
         ! diagnostics
         if (flux_type == 0) then
-          if (associated(Tr(m)%ad_x)) then ; do I=is-1,ie ; if (do_i(i,j) .or. do_i(i+1,j)) then
+          if (associated(Tr(m)%ad_x)) then ; do I=is-1,ie
             Tr(m)%ad_x(I,j,k) = Tr(m)%ad_x(I,j,k) + flux_x(I,j,m)*Idt
-          endif ; enddo ; endif
+          enddo ; endif
 
           ! diagnose convergence of flux_x (do not use the Ihnew(i) part of the logic).
           ! division by areaT to get into W/m2 for heat and kg/(s*m2) for salt.
@@ -774,13 +780,13 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
             endif ; enddo
           endif
         elseif (flux_type == 1) then
-          if (associated(Tr(m)%ad_x_resolved)) then ; do I=is-1,ie ; if (do_i(i,j) .or. do_i(i+1,j)) then
+          if (associated(Tr(m)%ad_x_resolved)) then ; do I=is-1,ie
             Tr(m)%ad_x_resolved(I,j,k) = Tr(m)%ad_x_resolved(I,j,k) + flux_x(I,j,m)*Idt
-          endif ; enddo ; endif
+          enddo ; endif
         elseif (flux_type == 2) then
-          if (associated(Tr(m)%ad_x_param)) then ; do I=is-1,ie ; if (do_i(i,j) .or. do_i(i+1,j)) then
+          if (associated(Tr(m)%ad_x_param)) then ; do I=is-1,ie
             Tr(m)%ad_x_param(I,j,k) = Tr(m)%ad_x_param(I,j,k) + flux_x(I,j,m)*Idt
-          endif ; enddo ; endif
+          enddo ; endif
         endif ! the case of flux_type not equal 0, 1, or 2 is caught in advect_tracer above.
       endif ! advect_this_tracer
     enddo
@@ -802,13 +808,14 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
     !$OMP ordered
     do m=1,ntr ; if (associated(Tr(m)%ad2d_x)) then
       do j=js,je ; if (domore_u_initial(j,k)) then
-        do I=is-1,ie ; if (do_i(i,j) .or. do_i(i+1,j)) then
+        do I=is-1,ie
           Tr(m)%ad2d_x(I,j) = Tr(m)%ad2d_x(I,j) + flux_x(I,j,m)*Idt
-        endif ; enddo
+        enddo
       endif ; enddo
     endif ; enddo ! End of m-loop.
     !$OMP end ordered
   endif
+
 end subroutine advect_x
 
 !> This subroutine does 1-d flux-form advection using a monotonic piecewise
@@ -960,11 +967,13 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
             J = segment%HI%JsdB
             do m = 1,segment%tr_Reg%ntseg ! replace tracers with OBC values
               ntr_id = segment%tr_reg%Tr(m)%ntr_index
-              if (segment%direction == OBC_DIRECTION_S) then
-                T_tmp(i,ntr_id,j) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-              else
-                T_tmp(i,ntr_id,j+1) = segment%tr_Reg%Tr(m)%tres(i,j,k)
-              endif
+              if (advect_this_tracer(ntr_id)) then
+                if (segment%direction == OBC_DIRECTION_S) then
+                  T_tmp(i,ntr_id,j) = segment%tr_Reg%Tr(m)%tres(i,j,k)
+                else
+                  T_tmp(i,ntr_id,j+1) = segment%tr_Reg%Tr(m)%tres(i,j,k)
+                endif
+              endif ! advect_this_tracer
             enddo
             do m = 1,ntr ! Apply update tracer values for slope calculation
               if (advect_this_tracer(m)) then
@@ -1104,7 +1113,9 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                   vhh(i,J) = vhr(i,J,k)
                   do m=1,segment%tr_Reg%ntseg
                     ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                    flux_y(i,ntr_id,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%tres(i,J,k)
+                    if (advect_this_tracer(ntr_id)) then
+                      flux_y(i,ntr_id,J) = vhh(i,J)*OBC%segment(n)%tr_Reg%Tr(m)%tres(i,J,k)
+                    endif ! advect_this_tracer
                   enddo
                 endif
               enddo
@@ -1126,7 +1137,9 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                 vhh(i,J) = vhr(i,J,k)
                 do m=1,segment%tr_Reg%ntseg
                   ntr_id = segment%tr_reg%Tr(m)%ntr_index
-                  flux_y(i,ntr_id,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%tres(i,J,k)
+                  if (advect_this_tracer(ntr_id)) then
+                    flux_y(i,ntr_id,J) = vhh(i,J)*segment%tr_Reg%Tr(m)%tres(i,J,k)
+                  endif ! advect_this_tracer
                 enddo
               endif
             enddo
@@ -1212,17 +1225,17 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
     !$OMP ordered
     do m=1,ntr ; if (associated(Tr(m)%ad_y)) then
       do J=js-1,je ; if (domore_v_initial(J)) then
-        do i=is,ie ; if (do_i(i,j) .or. do_i(i,j+1)) then
+        do i=is,ie
           Tr(m)%ad_y(i,J,k) = Tr(m)%ad_y(i,J,k) + flux_y(i,m,J)*Idt
-        endif ; enddo
+        enddo
       endif ; enddo
     endif ; enddo ! End of m-loop.
 
     do m=1,ntr ; if (associated(Tr(m)%ad2d_y)) then
       do J=js-1,je ; if (domore_v_initial(J)) then
-        do i=is,ie ; if (do_i(i,j) .or. do_i(i,j+1)) then
+        do i=is,ie
           Tr(m)%ad2d_y(i,J) = Tr(m)%ad2d_y(i,J) + flux_y(i,m,J)*Idt
-        endif ; enddo
+        enddo
       endif ; enddo
     endif ; enddo ! End of m-loop.
     !$OMP end ordered
@@ -1230,9 +1243,9 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
     !$OMP ordered
     do m=1,ntr ; if (associated(Tr(m)%ad_y_resolved)) then
       do J=js-1,je ; if (domore_v_initial(J)) then
-        do i=is,ie ; if (do_i(i,j) .or. do_i(i,j+1)) then
+        do i=is,ie
           Tr(m)%ad_y_resolved(i,J,k) = Tr(m)%ad_y_resolved(i,J,k) + flux_y(i,m,J)*Idt
-        endif ; enddo
+        enddo
       endif ; enddo
     endif ; enddo ! End of m-loop.
     !$OMP end ordered
@@ -1240,13 +1253,14 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
     !$OMP ordered
     do m=1,ntr ; if (associated(Tr(m)%ad_y_param)) then
       do J=js-1,je ; if (domore_v_initial(J)) then
-        do i=is,ie ; if (do_i(i,j) .or. do_i(i,j+1)) then
+        do i=is,ie
           Tr(m)%ad_y_param(i,J,k) = Tr(m)%ad_y_param(i,J,k) + flux_y(i,m,J)*Idt
-        endif ; enddo
+        enddo
       endif ; enddo
     endif ; enddo ! End of m-loop.
     !$OMP end ordered
   endif ! the case of flux_type not equal 0, 1, or 2 is caught in advect_tracer above.
+
 end subroutine advect_y
 
 !> Initialize lateral tracer advection module


### PR DESCRIPTION
  This PR corrects some inconsistencies arising from merging parallel changes on the dev/ncar and dev/gfdl branches of the MOM_tracer_advect.F90 code in #1151, and it fixes a handful of minor problems that were detected while reexamining merging the changes introduced via github.com/mom-ocean/MOM6/pull/1700 with the code already on dev/gfdl.

  It reconciles the changes introduced with the `flux_type` argument to `advect_tracer()` with separate changes that modified the treatment of tracer properties in reservoirs and the use of unnecessary masking in the calculation of the tracer fluxes.  Specifically, it restores `advect_this_tracer` tests that were accidentally dropped from the open boundary condition tracer fluxes reconciling changes coming in via dev/ncar and dev/gfdl, and it does not use masking via tests for `do_i` that in some cases was using uninitialized logical values in the halo regions of these arrays.

  The `advect_this_tracer` tests were introduced with the separate use of `advect_tracer()` for resolved and parameterized tracer transports as a part of (github.com/NCAR/MOM6/pull/352).  The elimination of the use of the `OBC_inflow_conc` elements occurred in (github.com/NOAA-GFDL/MOM6/pull/1117).  The elimination of the use of the `do_i` masks when calculating fluxes occurred in (github.com/NOAA-GFDL/MOM6/pull/1110) and addressed the issue at (github.com/NOAA-GFDL/MOM6/issues/952).

  It corrects a fatal error message in `neutral_diffusion_calc_coeffs()` that had been copied over verbatim from `hor_bnd_diffusion()`.

  It corrects the spacing in the multi-line parameter documentation message for `USE_CR_GRID`.  Without this change separate statements clarifying the meaning this parameter were combined without any space between them.  Also added a logical test before a checksum call for `h_MLD` in `mixedlayer_restrat_OM4()` to avoid a possible segmentation fault due to a checksum call using an unassociated pointer in some cases with `DEBUG = True`.  (This potential segmentation fault might never have actually been encountered.)

  Separately, it corrects the syntax of some enddo and endif statements in recently added code in `register_forcing_type_diags()`, `auto_determine_io_layout()`, `diabatic_driver_init()` and `initialize_MARBL_tracers()` to match the syntax documented in the MOM6 style guide and that is already in use elsewhere in these modules. These changes have come in to the main branch via dev/ncar, and hence were not included in similar changes in (github.com/NOAA-GFDL/MOM6/pull/1075).

  The commits in this PR will change the output in some MOM_parameter_doc files, but all answers are bitwise identical.
