### PR TITLE
Hot fix for tar --one-top-level work around

### DIFF
--- a/.gitlab/mom6-ci-run-gnu-restarts-script.sh
+++ b/.gitlab/mom6-ci-run-gnu-restarts-script.sh
@@ -41,7 +41,8 @@ time make -f tools/MRS/Makefile.restart gnu_ocean_only -s -j RESTART_STAGE=02
 time make -f tools/MRS/Makefile.restart gnu_ice_ocean_SIS2 -s -j RESTART_STAGE=02
 time make -f tools/MRS/Makefile.restart gnu_ocean_only -s -j RESTART_STAGE=12
 time make -f tools/MRS/Makefile.restart gnu_ice_ocean_SIS2 -s -j RESTART_STAGE=12
-tar cf - `find [oilc]*/ -path "*/??.ignore/*" -name "ocean.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/gnu_restarts -xf -
+mkdir -p results/gnu_restarts
+tar cf - `find [oilc]*/ -path "*/??.ignore/*" -name "ocean.stats.*[a-z][a-z][a-z]"` | tar --directory=results/gnu_restarts -xf -
 check_for_core_files
 find [oilc]* -name "*.ignore" -type d -prune -exec rm -rf {} \;
 section_end

--- a/.gitlab/mom6-ci-run-gnu-script.sh
+++ b/.gitlab/mom6-ci-run-gnu-script.sh
@@ -36,8 +36,10 @@ set -v
 # Run symmetric gnu regressions
 section_start gnu_all_sym "Running symmetric gnu"
 time make -f tools/MRS/Makefile.run gnu_all -s -j
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/gnu_all_sym -xf -
-tar cf - `find [oicl]* -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --one-top-level=results/gnu_params -xf -
+mkdir -p results/gnu_all_sym
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/gnu_all_sym -xf -
+mkdir -p results/gnu_params
+tar cf - `find [oicl]* -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --directory=results/gnu_params -xf -
 check_for_core_files
 section_end
 
@@ -45,28 +47,32 @@ section_end
 section_start gnu_all_nonsym "Running nonsymmetric gnu"
 time make -f tools/MRS/Makefile.run ocean_only/circle_obcs/ocean.stats.gnu
 time make -f tools/MRS/Makefile.run gnu_all -s -j MEMORY=dynamic_nonsymmetric
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/gnu_all_nonsym -xf -
+mkdir -p results/gnu_all_nonsym
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/gnu_all_nonsym -xf -
 check_for_core_files
 section_end
 
 # Run symmetric gnu regressions with alternate layout
 section_start gnu_all_layout "Running symmetric gnu with alternate layouts"
 time make -f tools/MRS/Makefile.run gnu_all -s -j LAYOUT=alt
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/gnu_all_layout -xf -
+mkdir -p results/gnu_all_layout
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/gnu_all_layout -xf -
 check_for_core_files
 section_end
 
 # Run symmetric gnu regressions with debug executable
 section_start gnu_ocean_only_debug "Running symmetric gnu_ocean_only with debug executable"
 time make -f tools/MRS/Makefile.run gnu_ocean_only -s -j MODE=debug
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/gnu_ocean_only_debug -xf -
+mkdir -p results/gnu_ocean_only_debug
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/gnu_ocean_only_debug -xf -
 check_for_core_files
 section_end
 
 # Run symmetric static gnu regressions
 section_start gnu_all_static "Running symmetric gnu with static executable"
 time make -f tools/MRS/Makefile.run gnu_static_ocean_only MEMORY=static -s -j
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/gnu_all_static -xf -
+mkdir -p results/gnu_all_static
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/gnu_all_static -xf -
 check_for_core_files
 section_end
 

--- a/.gitlab/mom6-ci-run-intel-script.sh
+++ b/.gitlab/mom6-ci-run-intel-script.sh
@@ -36,8 +36,10 @@ set -v
 # Run symmetric intel regressions
 section_start intel_all_sym "Running symmetric intel"
 time make -f tools/MRS/Makefile.run intel_all -s -j
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/intel_all_sym -xf -
-tar cf - `find [oicl]* -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --one-top-level=results/intel_params -xf -
+mkdir -p results/intel_all_sym
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/intel_all_sym -xf -
+mkdir -p results/intel_params
+tar cf - `find [oicl]* -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --directory=results/intel_params -xf -
 check_for_core_files
 section_end
 
@@ -45,14 +47,16 @@ section_end
 section_start intel_all_nonsym "Running nonsymmetric intel"
 time make -f tools/MRS/Makefile.run ocean_only/circle_obcs/ocean.stats.intel -s
 time make -f tools/MRS/Makefile.run intel_all -s -j MEMORY=dynamic_nonsymmetric
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/intel_all_nonsym -xf -
+mkdir -p results/intel_all_nonsym
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/intel_all_nonsym -xf -
 check_for_core_files
 section_end
 
 # Run symmetric intel regressions with alternate layout
 section_start intel_all_layout "Running symmetric intel with alternate layouts"
 time make -f tools/MRS/Makefile.run intel_all -s -j LAYOUT=alt
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/intel_all_layout -xf -
+mkdir -p results/intel_all_layout
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/intel_all_layout -xf -
 check_for_core_files
 section_end
 

--- a/.gitlab/mom6-ci-run-pgi-script.sh
+++ b/.gitlab/mom6-ci-run-pgi-script.sh
@@ -36,8 +36,10 @@ set -v
 # Run symmetric pgi regressions
 section_start pgi_all_sym "Running symmetric pgi"
 time make -f tools/MRS/Makefile.run pgi_all -s -j
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/pgi_all_sym -xf -
-tar cf - `find [oicl]* -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --one-top-level=results/pgi_params -xf -
+mkdir -p results/pgi_all_sym
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/pgi_all_sym -xf -
+mkdir -p results/pgi_params
+tar cf - `find [oicl]* -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --directory=results/pgi_params -xf -
 check_for_core_files
 section_end
 
@@ -45,14 +47,16 @@ section_end
 section_start pgi_all_nonsym "Running nonsymmetric pgi"
 time make -f tools/MRS/Makefile.run ocean_only/circle_obcs/ocean.stats.pgi -s
 time make -f tools/MRS/Makefile.run pgi_all -s -j MEMORY=dynamic_nonsymmetric
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/pgi_all_nonsym -xf -
+mkdir -p results/pgi_all_nonsym
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/pgi_all_nonsym -xf -
 check_for_core_files
 section_end
 
 # Run symmetric pgi regressions with alternate layout
 section_start pgi_all_layout "Running symmetric pgi with alternate layouts"
 time make -f tools/MRS/Makefile.run gnu_all -s -j LAYOUT=alt
-tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/pgi_all_layout -xf -
+mkdir -p results/pgi_all_layout
+tar cf - `find [oicl]* -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/pgi_all_layout -xf -
 check_for_core_files
 section_end
 

--- a/.gitlab/pipeline-ci-tool.sh
+++ b/.gitlab/pipeline-ci-tool.sh
@@ -230,8 +230,10 @@ mrs-run-sub-suite () {
   fi
   set -e
   time make -f tools/MRS/Makefile.run $1_$2 MEMORY=$3 MODE=$4 LAYOUT=$5 -s -j
-  tar cf - `find $EXP_GROUPS -name "*.stats.*[a-z][a-z][a-z]"` | tar --one-top-level=results/$1-$2-$3-$4-$5-stats -xf -
-  tar cf - `find $EXP_GROUPS -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --one-top-level=results/$1-$2-$3-$4-$5-params -xf -
+  mkdir -p results/$1-$2-$3-$4-$5-stats
+  tar cf - `find $EXP_GROUPS -name "*.stats.*[a-z][a-z][a-z]"` | tar --directory=results/$1-$2-$3-$4-$5-stats -xf -
+  mkdir -p results/$1-$2-$3-$4-$5-params
+  tar cf - `find $EXP_GROUPS -name "*_parameter_doc.*" -o -name "*available_diags*"` | tar --directory=results/$1-$2-$3-$4-$5-params -xf -
   check-for-core-files $EXP_GROUPS
   section-end mrs-run-sub-suite-$1-$2-$3-$4-$5
 }


### PR DESCRIPTION
A new version of tar appeared on Gaea which uses the openat2() system call which incorrectly raises a EXDEV signal in several situations. This patch replaces --one-top-level with explicit directory creation.

This is a hot fix because the CI stopped working after the Gaea upgrade.