### PR TITLE
+Add #override_unset support to MOM_file_parser

### DIFF
--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -272,6 +272,8 @@ subroutine close_param_file(CS, quiet_close, component)
   character(len=40)  :: mdl   ! This module's name.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
+  integer :: last_unused_line(CS%nfiles) ! The last line in each file that is flagged as unused
+                                         ! upon entry to this routine
   integer :: i, n, num_unused
 
   if (present(quiet_close)) then ; if (quiet_close) then
@@ -332,11 +334,13 @@ subroutine close_param_file(CS, quiet_close, component)
   endif
 
   num_unused = 0
-  do i = 1, CS%nfiles
-    if (is_root_pe() .and. (CS%report_unused .or. &
-                            CS%unused_params_fatal)) then
-      ! Check for unused lines.
-      do n=1,CS%param_data(i)%num_lines
+  if (is_root_pe() .and. (CS%report_unused .or. CS%unused_params_fatal)) then
+    ! Set line_used to true for lines that match parameters with override absent lines.
+    call label_absented_lines_as_used(CS, last_unused_line)
+
+    ! Check for unused lines.
+    do i = 1, CS%nfiles
+      do n=1,last_unused_line(i)
         if (.not.CS%param_data(i)%line_used(n)) then
           num_unused = num_unused + 1
           if (CS%report_unused) &
@@ -344,8 +348,10 @@ subroutine close_param_file(CS, quiet_close, component)
                             " : "//trim(CS%param_data(i)%fln(n)%line))
         endif
       enddo
-    endif
+    enddo
+  endif
 
+  do i = 1, CS%nfiles
     if (is_root_pe()) close(CS%iounit(i))
     call MOM_mesg("close_param_file: "// trim(CS%filename(i))//" has been closed successfully.", 5)
     CS%iounit(i) = -1
@@ -443,7 +449,7 @@ subroutine populate_param_data(iounit, filename, param_data)
           line = removeComments(line)
           if ((len_trim(line) > 1000) .and. is_root_PE()) then
             call MOM_error(WARNING, "MOM_file_parser: Consider using continuation to split up "//&
-                                    "the excessivley long parameter input line "//trim(line))
+                                    "the excessively long parameter input line "//trim(line))
           endif
           line = simplifyWhiteSpace(line(:len_trim(line)))
           num_lines = num_lines + 1
@@ -1003,7 +1009,7 @@ function max_input_line_length(CS, pf_num) result(max_len)
         contBufSize = contBufSize + last - 1
         continuedLine = .true.
         if (count==CS%param_data(ipf)%num_lines .and. is_root_pe()) &
-           call MOM_error(FATAL, "MOM_file_parser : the last line of the file ends in a"// &
+          call MOM_error(FATAL, "MOM_file_parser : the last line of the file ends in a"// &
                  " continuation character but there are no more lines to read. "// &
                  " Line: '"//trim(CS%param_data(ipf)%fln(count)%line(:last))//"'"// &
                  " in file "//trim(filename)//".")
@@ -1039,12 +1045,14 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
   character(len=CS%max_line_len) :: val_str, lname, origLine
   character(len=CS%max_line_len) :: line, continuationBuffer
   character(len=240) :: blockName
-  character(len=FILENAME_LENGTH) :: filename
+  character(len=FILENAME_LENGTH) :: filename, absent_filename
   integer            :: is, id, isd, isu, ise, iso, ipf
   integer            :: last, last1, ival, oval, max_vals, count, contBufSize
+  integer            :: start_line_num
   character(len=52)  :: set
-  logical            :: found_override, found_equals
-  logical            :: found_define, found_undef
+  logical            :: found_override, found_absent, found_equals ! True for patterns found on a line
+  logical            :: found_define, found_undef   ! True for patterns found on a line
+  logical            :: has_been_absented       ! True if an #override absent has been found for varname
   logical            :: force_cycle, defined_in_line, continuedLine
   logical            :: variableKindIsLogical, valueIsSame
   logical            :: inWrongBlock, fullPathParameter
@@ -1061,7 +1069,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
   ! return variables indicating whether this variable is defined and the string
   ! that contains the value of this variable.
   found = .false.
-  oval = 0 ; ival = 0
+  oval = 0 ; ival = 0 ; has_been_absented = .false.
   max_vals = SIZE(value_string)
   do is=1,max_vals ; value_string(is) = " " ; enddo
 
@@ -1075,6 +1083,14 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       line = CS%param_data(ipf)%fln(count)%line
       last = len_trim(line)
 
+      ! Record whether a line has been used only for the starting line of a continuation block,
+      ! and do not flag any continuation lines as unused.
+      if (.not.continuedLine) then
+        start_line_num = count
+      else
+        CS%param_data(ipf)%line_used(count) = .true.
+      endif
+
       last1 = max(1,last)
       ! Check if line ends in continuation character (either & or \)
       ! Note achar(92) is a backslash
@@ -1083,12 +1099,12 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         contBufSize=contBufSize + len_trim(line)-1
         continuedLine = .true.
         if (count==CS%param_data(ipf)%num_lines .and. is_root_pe()) &
-           call MOM_error(FATAL, "MOM_file_parser : the last line"// &
+          call MOM_error(FATAL, "MOM_file_parser : the last line"// &
                  " of the file ends in a continuation character but"// &
                  " there are no more lines to read. "// &
                  " Line: '"//trim(line(:last))//"'"//&
                  " in file "//trim(filename)//".")
-        cycle ! cycle inorder to append the next line of the file
+        cycle ! cycle in order to append the next line of the file
       elseif (continuedLine) then
         ! If we reached this point then this is the end of line continuation
         continuationBuffer(contBufSize+1:contBufSize+len_trim(line))=line(:last)
@@ -1102,17 +1118,21 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       origLine = trim(line) ! Keep original for error messages
 
       ! Check for '#override' at start of line
-      found_override = .false. ; found_define = .false. ; found_undef = .false.
-      iso = index(line(:last), "#override " )! ; if (is > 0) found_override = .true.
-      if (iso>1) call MOM_error(FATAL, "MOM_file_parser : #override was found "// &
+      found_override = .false. ; found_define = .false. ; found_undef = .false. ; found_absent = .false.
+      iso = index(line(:last), "#override " )! ; if (iso > 0) found_override = .true.
+      if (iso > 1) call MOM_error(FATAL, "MOM_file_parser : #override was found "// &
                  " but was not the first keyword."// &
-                 " Line: '"//trim(line(:last))//"'"//&
-                 " in file "//trim(filename)//".")
-      if (iso==1) then
+                 " Line: '"//trim(line(:last))//"' in file "//trim(filename)//".")
+      if (iso == 1) then
         found_override = .true.
-        if (index(line(:last), "#override define ")==1) found_define = .true.
-        if (index(line(:last), "#override undef ")==1) found_undef = .true.
-        line = trim(adjustl(line(iso+10:last))) ; last = len_trim(line)
+        if (index(line(:last), "#override absent ") == 1) then
+          found_absent = .true.
+          line = trim(adjustl(line(18:last))) ; last = len_trim(line)
+        else
+          if (index(line(:last), "#override define ") == 1) found_define = .true.
+          if (index(line(:last), "#override undef ") == 1) found_undef = .true.
+          line = trim(adjustl(line(iso+10:last))) ; last = len_trim(line)
+        endif
       endif
 
       ! Newer form of parameter block, block%, %block or block%param or
@@ -1129,10 +1149,10 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
             call MOM_error(FATAL, 'get_variable_line: A named close for a parameter'// &
             ' block is required but found "%". Block="'//trim(blockName)//'"' )
         blockName = popBlockLevel(blockName)
-        call flag_line_as_read(CS%param_data(ipf)%line_used,count)
+        CS%param_data(ipf)%line_used(start_line_num) = .true.
       elseif (iso==last) then ! This is a new block if % is last character
         blockName = pushBlockLevel(blockName, line(:iso-1))
-        call flag_line_as_read(CS%param_data(ipf)%line_used,count)
+        CS%param_data(ipf)%line_used(start_line_num) = .true.
       else ! This is of the form block%parameter = ... (full path parameter)
         iso=index(line(:last),'%',.true.)
         ! Check that the parameter block names on the line matches the state set by the caller
@@ -1167,29 +1187,44 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       isd = index(line(:last), "define" )! ; if (isd > 0) found_define = .true.
       isu = index(line(:last), "undef" )! ; if (isu > 0) found_undef = .true.
       ise = index(line(:last), " = " ) ; if (ise > 1) found_equals = .true.
-      if (index(line(:last), "#define ")==1) found_define = .true.
-      if (index(line(:last), "#undef ")==1) found_undef = .true.
+      if (index(line(:last), "#define ") == 1) found_define = .true.
+      if (index(line(:last), "#undef ") == 1) found_undef = .true.
+
+      ! Handle the case when '#override absent' is at the start of the line
+      if (found_absent) then
+        ! Set a flag to discard any other values specified for this parameter.
+        has_been_absented = .true.
+        absent_filename = filename
+        CS%param_data(ipf)%line_used(start_line_num) = .true.
+        if (oval > 0) call MOM_error(FATAL, 'MOM_file_parser : Both an #override assignment and an '//&
+                '#override absent line occur for the parameter "'//trim(varname)//'", with the latter occurring '//&
+                'in line "'//trim(CS%param_data(ipf)%fln(count)%line) // '" in file "' //&
+                trim(filename) // '".')
+        cycle
+      endif
+      if (found_override .and. has_been_absented) then
+        call MOM_error(FATAL, 'MOM_file_parser : An #override was found for the parameter "'//&
+              trim(varname) //'" on line "'//trim(CS%param_data(ipf)%fln(count)%line)// '" in file "' //&
+              trim(filename) // '", but it had a previous #override absent in file "'//trim(absent_filename)//'".')
+      endif
 
       ! Check for missing, mutually exclusive or incomplete keywords
       if (.not. (found_define .or. found_undef .or. found_equals)) then
         if (found_override) then
-          call MOM_error(FATAL, "MOM_file_parser : override was found " // &
-              " without a define or undef." // &
-              " Line: '" // trim(line(:last)) // "'" // &
-              " in file " // trim(filename) // ".")
+          call MOM_error(FATAL, 'MOM_file_parser : An #override was found for "' //&
+              trim(varname) // '" without a define, undef or assignment. ' //&
+              'Line: "' // trim(line(:last)) // '" in file "' // trim(filename) // '".')
         else
-          call MOM_error(FATAL, "MOM_file_parser : the parameter name '" // &
-              trim(varname) // "' was found without define or undef." // &
-              " Line: '" // trim(line(:last)) // "'" // &
-              " in file " // trim(filename) // ".")
+          call MOM_error(FATAL, 'MOM_file_parser : The parameter "' // &
+              trim(varname) // '" was found without a define, undef or assignment. '//&
+              'Line: "' // trim(line(:last)) // '" in file "' // trim(filename) // '".')
         endif
       endif
 
       if (found_equals .and. (found_define .or. found_undef)) &
-             call MOM_error(FATAL, &
-               "MOM_file_parser : Both 'a=b' and 'undef/define' syntax occur."// &
-               " Line: '"//trim(line(:last))//"'"//&
-               " in file "//trim(filename)//".")
+        call MOM_error(FATAL, &
+              'MOM_file_parser : Both "PARAM = val" and "undef/define PARAM" syntax occur on '// &
+              'line: "' // trim(line(:last)) // '" in file "' // trim(filename) // '".')
 
       ! Interpret the line and collect values, if any
       ! NOTE: At least one of these must be true
@@ -1235,7 +1270,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       endif
 
       ! This line has now been used.
-      call flag_line_as_read(CS%param_data(ipf)%line_used,count)
+      CS%param_data(ipf)%line_used(start_line_num) = .true.
 
       ! Detect inconsistencies
       force_cycle = .false.
@@ -1313,14 +1348,194 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
 
   enddo paramfile_loop
 
+  if (has_been_absented) then
+    if (found) call MOM_error(WARNING, 'MOM_file_parser : the value of the parameter "'//&
+          trim(varname) // '" was set but discarded due to an #override absent line in "'//&
+          trim(absent_filename) //'".')
+    found = .false.
+    do is=1,max_vals ; value_string(is) = " " ; enddo
+  endif
+
 end subroutine get_variable_line
 
-!> Record that a line has been used to set a parameter
-subroutine flag_line_as_read(line_used, count)
-  logical, dimension(:), pointer    :: line_used !< A structure indicating which lines have been read
-  integer,               intent(in) :: count !< The parameter on this line number has been read
-  line_used(count) = .true.
-end subroutine flag_line_as_read
+!> Set line_used to true for lines that match parameters with \#override absent lines and
+!! return an array with the last unused line in each of the input files.
+subroutine label_absented_lines_as_used(CS, last_unused_line)
+  type(param_file_type),         intent(inout) :: CS   !< The control structure for the file_parser module,
+                                                       !! it is also a structure to parse for run-time parameters
+  integer, dimension(CS%nfiles), intent(out)   :: last_unused_line !< The last line in each file that
+                                                       !! is flagged as unused, or 0 if there are no
+                                                       !! unused lines in a file.
+  ! Local variables
+  character(len=CS%max_line_len) :: line
+  character(len=240) :: blockName, param_block, varname
+  integer :: iso, is_absent, last, varlen
+  integer :: n, pfn, ipf, last_unused_before
+  logical :: seek_absent_in_file(CS%nfiles)
+
+  do ipf = 1, CS%nfiles
+    ! Check for unused lines in each file and record the last one.
+    last_unused_line(ipf) = 0
+    do n = CS%param_data(ipf)%num_lines, 1, -1
+      if (.not.CS%param_data(ipf)%line_used(n)) then
+        last_unused_line(ipf) = n
+        exit
+      endif
+    enddo
+  enddo
+
+  ! Because #override absent can impact settings from earlier files in the list, we need to look
+  ! for #override absent lines in files that come after the first absent line.
+  seek_absent_in_file(1) = (last_unused_line(1) > 0)
+  do ipf = 2, CS%nfiles
+    seek_absent_in_file(ipf) = (seek_absent_in_file(ipf-1) .or. (last_unused_line(ipf) > 0))
+  enddo
+
+  ! Look for any #override absent lines that could lead to lines being relabeled as used.
+  do ipf = 1, CS%nfiles
+    blockName = ''  ! This resets the block stack.
+    do n = 1, CS%param_data(ipf)%num_lines
+
+      line = adjustl(CS%param_data(ipf)%fln(n)%line)
+      last = len_trim(line)
+
+      ! Parse the block structure
+      iso = index(line(:last), '%')
+      if (iso == 1) then ! % is first character means this is a close
+        blockName = popBlockLevel(blockName)
+      elseif (iso == last) then ! This is a new block if % is last character
+        blockName = pushBlockLevel(blockName, line(:iso-1))
+      endif
+
+      ! Find all lines with #override absent varname
+      is_absent = index(line(:last), "#override absent " )
+      if (is_absent > 1) call MOM_error(FATAL, &
+                 "MOM_file_parser : #override absent was found but was not the "//&
+                 'first keyword in "'//trim(CS%filename(ipf))//'" : "'// trim(CS%param_data(ipf)%fln(n)%line)//'".' )
+      if (is_absent == 1) then
+        CS%param_data(ipf)%line_used(n) = .true.
+        line = trim(adjustl(line(18:last)//" ")) ; last = len_trim(line)
+
+        iso = index(line(:last), '%', .true.)
+        if (iso > 0) then
+          ! Parse the block and name for full path parameters
+          if (iso == 1) then
+            call MOM_error(FATAL, "close_param_file: A parameter block can not be closed on "//&
+                  'an #override absent line, as is done in "'//trim(CS%filename(ipf))//'" : "'// &
+                  trim(CS%param_data(ipf)%fln(n)%line)//'".' )
+          elseif (iso == last) then
+            call MOM_error(FATAL, "close_param_file: A parameter block can not be opened on "//&
+                  'an #override absent line, as is done in "'//trim(CS%filename(ipf))//'" : "'// &
+                  trim(CS%param_data(ipf)%fln(n)%line)//'".' )
+          else
+            ! This is a line with the form param_block%param, where param_block is the full block
+            ! name and blockName is ignored.  Store this block name and strip it out of line.
+            param_block = trim(line(:iso-1))
+            line = trim(adjustl(line(iso+1:last))) ; last = len_trim(line)
+          endif
+        else
+          param_block = blockName
+        endif
+
+        varlen = index(line,' ') ; if (varlen == 0) varlen = last
+        varname = line(:varlen)
+
+        ! This set of calls sets line_used to true for any lines that match this name.
+        do pfn = 1, CS%nfiles
+          if (last_unused_line(pfn) > 0) &
+            call label_param_lines_as_used(CS, varname, param_block, pfn, last_unused_line(pfn))
+        enddo
+
+      endif  ! End of block handling a line with #override absent
+    enddo
+  enddo
+
+  ! Update the determination of the last unused line.
+  do ipf = 1, CS%nfiles
+    last_unused_before = last_unused_line(ipf)
+    ! Check again for unused lines in each file and record the last one.
+    last_unused_line(ipf) = 0
+    do n = last_unused_before, 1, -1
+      if (.not.CS%param_data(ipf)%line_used(n)) then
+        last_unused_line(ipf) = n
+        exit
+      endif
+    enddo
+  enddo
+
+end subroutine label_absented_lines_as_used
+
+!> This subroutine sets the lines in the param_file_type that refer to
+!! a named parameter as though they had been used.
+subroutine label_param_lines_as_used(CS, varname, set_block_Name, ipf, max_line)
+  type(param_file_type), intent(inout) :: CS      !< The control structure for the file_parser module,
+                                                  !! it is also a structure to parse for run-time parameters
+  character(len=*),      intent(in)    :: varname !< The case-sensitive name of the parameter to set as used
+  character(len=*),      intent(in)    :: set_block_Name !< The case-sensitive block name of the parameter
+  integer,               intent(in)    :: ipf     !< The index of the parameter file to examine
+  integer,               intent(in)    :: max_line !< The last line in the file to work upon.
+
+  ! Local variables
+  character(len=CS%max_line_len) :: line
+  character(len=240) :: blockName  ! The current block name that applies to all lines.
+  character(len=240) :: line_block ! The block name for the current line.
+  character(len=FILENAME_LENGTH) :: filename
+  integer :: n, iso, last
+
+  filename = CS%filename(ipf)
+  blockName = ''
+
+  ! Scan through each line of the file that might have an unused line that would be set at used
+  do n = 1, min(CS%param_data(ipf)%num_lines, max_line)
+    line = CS%param_data(ipf)%fln(n)%line
+    last = len_trim(line)
+
+    ! Deal with lines changing the block level via block% or %block
+    ! Error handling of the block lines in the files occured already in get_variable_line.
+    iso = index(line(:last), '%')
+    if (iso==1) then ! % is first character means this is a close
+      blockName = popBlockLevel(blockName)
+    elseif (iso==last) then ! This is a new block if % is last character
+      blockName = pushBlockLevel(blockName, line(:iso-1))
+    endif
+
+    if (CS%param_data(ipf)%line_used(n)) cycle
+    ! Continuation and block level setting lines have already been recorded as having been used.
+
+    ! Check for '#override' at the start of a line and strip it out.
+    iso = index(line(:last), "#override " )
+    if (iso > 1) call MOM_error(FATAL, "MOM_file_parser : #override was found but was not "//&
+                 " the first keyword.  Line: '"//trim(line(:last))//"' in file "//trim(filename)//".")
+    if (iso == 1) then
+      line = trim(adjustl(line(11:last))) ; last = len_trim(line)
+    endif
+
+    iso = index(line(:last), '%', .true.)
+    if (iso > 0) then
+      ! This is a parameter in the form block%parameter = ... (full path parameter)
+      line_block = trim(line(:iso-1))
+      ! Strip out the block, so that line starts with the parameter name
+      line = trim(adjustl(line(iso+1:last))) ; last = len_trim(line)
+    else
+      line_block = blockName
+    endif
+
+    ! Only interpret this line if its block matches the block indicated by set_block_Name
+    if ((len_trim(line_block)>0) .or. (len_trim(set_block_Name)>0)) then
+      if (trim(set_block_Name) /= trim(line_block)) cycle
+    endif
+
+    ! Eliminate anything that follows an equals sign so that only the variable name is checked.
+    iso = index(line(:last), '=')
+    if (iso > 0) last = iso - 1
+
+    ! Determine whether or not this line mentions the named parameter
+    if (index(" "//line(:last)//" ", " "//trim(varname)//" ") > 0) &
+      CS%param_data(ipf)%line_used(n) = .true.
+  enddo
+
+end subroutine label_param_lines_as_used
+
 
 !> Returns true if an override warning has been issued for the variable varName
 function overrideWarningHasBeenIssued(chain, varName)
@@ -1650,10 +1865,10 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
 
   if (ticks == 0) then
     write(mesg, '("  ",a," ",a," (Time): ",i0,":",i0)') trim(modulename), &
-       trim(varname), days, secs
+          trim(varname), days, secs
   else
     write(mesg, '("  ",a," ",a," (Time): ",i0,":",i0,":",i0)') trim(modulename), &
-       trim(varname), days, secs, ticks
+          trim(varname), days, secs, ticks
   endif
   if (is_root_pe()) then
     if (CS%log_open) write(CS%stdlog,'(a)') trim(mesg)
@@ -2423,9 +2638,9 @@ end function popBlockLevel
 !!
 !!  By Robert Hallberg and Alistair Adcroft, updated 9/2013.
 !!
-!!    The subroutines here parse a set of input files for the value
+!!    The subroutines here parse a set of input files for the value of
 !!  a named parameter and sets that parameter at run time.  Currently
-!!  these files use use one of several formats:
+!!  these files use one of several formats:
 !!    \#define VAR      ! To set the logical VAR to true.
 !!    VAR = True        ! To set the logical VAR to true.
 !!    \#undef VAR       ! To set the logical VAR to false.
@@ -2434,6 +2649,7 @@ end function popBlockLevel
 !!    VAR = 999         ! To set the real or integer VAR to 999.
 !!    \#override VAR = 888 ! To override a previously set value.
 !!    VAR = 1.1, 2.2, 3.3  ! To set an array of real values.
+!!    \#override absent VAR ! To ignore the presence of another line setting VAR.
   ! Note that in the comments above, dOxygen translates \# to # .
 !!
 !!  In addition, when set by the get_param interface, the values of

--- a/src/framework/testing/MOM_file_parser_tests.F90
+++ b/src/framework/testing/MOM_file_parser_tests.F90
@@ -719,6 +719,22 @@ subroutine test_read_param_unused_fatal
 end subroutine test_read_param_unused_fatal
 
 
+subroutine test_read_param_unused_fatal_absent
+  type(param_file_type) :: param
+  type(string) :: lines(3)
+
+  lines = [ &
+      string('FATAL_UNUSED_PARAMS = True'), &
+      string(sample_param_name // ' = 1'), &
+      string('#override absent '//sample_param_name) &
+  ]
+  call create_test_file(param_filename, lines)
+
+  call open_param_file(param_filename, param)
+  call close_param_file(param)
+end subroutine test_read_param_unused_fatal_absent
+
+
 subroutine test_read_param_replace_tabs
   type(param_file_type) :: param
   integer :: sample
@@ -775,6 +791,27 @@ subroutine test_read_param_multiline_param
 
   call assert(sample == sample_result, 'Incorrect result')
 end subroutine test_read_param_multiline_param
+
+
+subroutine test_read_param_multiline_param_fatal_unused
+  type(param_file_type) :: param
+  integer :: sample
+  type(string) :: lines(3)
+  integer, parameter :: sample_result = 1
+
+  lines = [ &
+      string('FATAL_UNUSED_PARAMS = True'), &
+      string(sample_param_name // ' = &'), &
+      string('  1') &
+  ]
+  call create_test_file(param_filename, lines)
+
+  call open_param_file(param_filename, param)
+  call read_param(param, sample_param_name, sample)
+  call close_param_file(param)
+
+  call assert(sample == sample_result, 'Incorrect result')
+end subroutine test_read_param_multiline_param_fatal_unused
 
 
 subroutine test_read_param_multiline_param_unclosed
@@ -918,6 +955,25 @@ subroutine test_read_param_override_twice
   call read_param(param, sample_param_name, sample)
   ! FATAL; return to program
 end subroutine test_read_param_override_twice
+
+
+subroutine test_read_param_override_twice_absent
+  type(param_file_type) :: param
+  integer :: sample
+  type(string) :: lines(3)
+  integer, parameter :: sample_result = 4
+
+  lines = [ &
+      string(sample_param_name // ' = 1'), &
+      string('#override ' // sample_param_name // ' = 2'), &
+      string('#override absent '//sample_param_name) &
+  ]
+  call create_test_file(param_filename, lines)
+
+  call open_param_file(param_filename, param)
+  call read_param(param, sample_param_name, sample)
+  ! FATAL; return to program
+end subroutine test_read_param_override_twice_absent
 
 
 subroutine test_read_param_override_repeat
@@ -1079,6 +1135,42 @@ subroutine test_read_param_block
 
   call assert(sample == sample_result, 'Incorrect value')
 end subroutine test_read_param_block
+
+
+subroutine test_read_param_block_absent
+  type(param_file_type) :: param
+  integer :: sample
+  logical :: param_was_set
+  type(string) :: lines(10)
+  integer, parameter :: sample_result = 123
+
+  ! Test that all 4 combinations of block formats for
+  ! setting parameters and absenting them work.
+  lines = [ &
+      string('ABC%SAMPLE_PARAMETER_1 = 1'), &
+      string('ABC%'), &
+      string('ABC%SAMPLE_PARAMETER_2 = 2'), &
+      string('SAMPLE_PARAMETER_3 = 3'), &
+      string('SAMPLE_PARAMETER_4 = 4'), &
+      string('#override absent ABC%SAMPLE_PARAMETER_1'), &
+      string('#override absent SAMPLE_PARAMETER_2'), &
+      string('#override absent SAMPLE_PARAMETER_3'), &
+      string('%ABC'), &
+      string('#override absent ABC%SAMPLE_PARAMETER_4') &
+  ]
+  call create_test_file(param_filename, lines)
+
+  sample = sample_result
+  call open_param_file(param_filename, param)
+  call openParameterBlock(param, 'ABC')
+  call read_param(param, 'SAMPLE_PARAMETER_2', sample, set=param_was_set)
+  call closeParameterBlock(param)
+  call clearParameterBlock(param)
+  call close_param_file(param)
+
+  call assert(.not.param_was_set, 'Parameter should be absent')
+  call assert(sample == sample_result, 'Absent parameter changed value')
+end subroutine test_read_param_block_absent
 
 
 ! TODO: This test fails due to an implementation issue.
@@ -1764,7 +1856,10 @@ subroutine run_file_parser_tests
   call suite%add(test_read_param_time_unit, "test_read_param_time_unit")
 
   call suite%add(test_read_param_unused_fatal, &
-    "test_read_param_unused_fatal", fatal=.true.)
+      "test_read_param_unused_fatal", fatal=.true.)
+
+  call suite%add(test_read_param_unused_fatal_absent, &
+      "test_read_param_unused_fatal_absent")
 
   call suite%add(test_read_param_multiline_comment, &
       "test_read_param_multiline_comment")
@@ -1774,6 +1869,9 @@ subroutine run_file_parser_tests
 
   call suite%add(test_read_param_multiline_param, &
       "test_read_param_multiline_param")
+
+  call suite%add(test_read_param_multiline_param_fatal_unused, &
+      "test_read_param_multiline_param_fatal_unused")
 
   call suite%add(test_read_param_multiline_param_unclosed, &
       "test_read_param_multiline_param_unclosed", fatal=.true.)
@@ -1797,6 +1895,9 @@ subroutine run_file_parser_tests
 
   call suite%add(test_read_param_override_twice, &
       "test_read_param_override_twice", fatal=.true.)
+
+  call suite%add(test_read_param_override_twice_absent, &
+      "test_read_param_override_twice_absent", fatal=.true.)
 
   call suite%add(test_read_param_override_repeat, &
       "test_read_param_override_repeat", fatal=.true.)
@@ -1823,6 +1924,8 @@ subroutine run_file_parser_tests
       "test_read_param_assign_in_define", fatal=.true.)
 
   call suite%add(test_read_param_block, "test_read_param_block")
+
+  call suite%add(test_read_param_block_absent, "test_read_param_block_absent")
 
   ! FIXME: Test does not pass
   !call suite%add(test_read_param_block_stack, "test_read_param_block_stack")


### PR DESCRIPTION
  Added the ability to use an `#override_unset` line to counteract previous lines setting a parameter in the MOM file parser.  This will open the way for the use of `FATAL_UNUSED_PARAMS` with override files, for which changes in top-level parameters may mean that subsidiary parameters are no longer being read. It is a fatal error to have both `#override` and
`#override_unset` lines for the same parameter.

  This commit also addresses a problem with the previous version, in which lines that are continued were being marked as unused even they were actually used. The current version of the code will flag the start of an unused set of lines, but does not flag the continuation lines as unused when they are actually used. To see the error in previous versions of the code, set `FATAL_UNUSED_PARAMS = True` and add lines like:
```
  #override LAYOUT = 1, &
                     2
```
to an input file.  This should be perfectly acceptable and reasonable, but it leads incorrectly to a fatal error.

  This commit adds the new internal subroutines `label_unset_lines_as_used()` and `label_param_lines_as_used()` that reparse the input file and label all parameters with `#override_unset lines` as though they had been used.  It also eliminates the tiny primordial subroutine `flag_line_as_read()`, which was replaced with simple single-line assignments that are actually shorter than the previous subroutine call.

  This new capability is tested with 3 new tests that were added to MOM_file_parser_tests that demonstrate its usefulness for running successfully with `FATAL_UNUSED_PARAMS`, and that it works as intended for re-assigning parameter values, including in various flavors of parameter blocks.

  All answers that worked previously are bitwise identical, but some cases that would have previously encountered an unnecessary fatal error will no longer do so.