### PR TITLE
*Negative h_marg_min without CONT_USE_H_MARG_MIN

### DIFF
--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2815,8 +2815,8 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
                  "Otherwise use the transport averaged areas.", default=.true.)
   call get_param(param_file, mdl, "CONT_USE_H_MARG_MIN", use_h_marg_min, &
                  "If true, the marginal thickness used and returned from continuity "//&
-                 "is bounded from below by a sub-roundoff value. Otherwise the "//&
-                 "minimum is 0.", default=.false.)
+                 "is bounded from below by a sub-roundoff value.  Otherwise the "//&
+                 "minimum is a large negative value to recreate previous answers.", default=.false.)
   CS%diag => diag
 
   id_clock_reconstruct = cpu_clock_id('(Ocean continuity reconstruction)', grain=CLOCK_ROUTINE)
@@ -2826,7 +2826,8 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
   if (use_h_marg_min) then
     CS%h_marg_min = GV%H_subroundoff
   else
-    CS%h_marg_min = 0.
+    ! The light-year here means there is effectively no floor on negative marginal thicknesses.
+    CS%h_marg_min = -1.0e16*GV%m_to_H  ! Negative 1.057 light years
   endif
 
   if (local_open_BC) then


### PR DESCRIPTION
  Set `h_marg_min` to about -1 lightyear when `CONT_USE_H_MARG_MIN = False`, to recover the existing answers from the main branch of MOM6.  Before `CONT_USE_H_MARG_MIN` was added, there was no floor on the marginal thicknesses, but the time that this parameter was added in NOAA-GFDL/MOM6/pull/996 in December, 2025, a physically sensible floor of 0 was added for the marginal thicknesses for the continuity transports when it was not true.  The marginal thicknesses is the thickness at a particular velocity in the sub-gridscale reconstruction that is integrated to get the time-integrated transport. However, there appear to be some cases where setting this floor to 0 changes answers from those with the main branch of MOM6.  At this time we do not know how these negative marginal thicknesses might arise; perhaps they arise from CFL values that exceed 1 while iterating to reconcile the baroclinic and barotropic transports.  However, resetting the floor to a huge negative value essentially ensures that no floor is applied, and empirically the answers from the main branch are recovered.