### PR TITLE
GitHub Actions: Update action versions

### DIFF
--- a/.github/workflows/verify-linux.yml
+++ b/.github/workflows/verify-linux.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Check white space (non-blocking)
       run: |
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -67,7 +67,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-symmetric.tar .testing/build/symmetric/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-symmetric-artifact
           path: mom6-symmetric.tar
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -93,7 +93,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-asymmetric.tar .testing/build/asymmetric/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-asymmetric-artifact
           path: mom6-asymmetric.tar
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -119,7 +119,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-repro.tar .testing/build/repro/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-repro-artifact
           path: mom6-repro.tar
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -145,7 +145,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-openmp.tar .testing/build/openmp/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-openmp-artifact
           path: mom6-openmp.tar
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -177,7 +177,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-target.tar .testing/build/target/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-target-artifact
           path: mom6-target.tar
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -210,7 +210,7 @@ jobs:
           .testing/build/opt/MOM6 \
           .testing/build/timing/time_*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-opt-artifact
           path: mom6-opt.tar
@@ -221,7 +221,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -252,7 +252,7 @@ jobs:
           .testing/build/opt_target/MOM6 \
           .testing/build/target_codebase/.testing/build/timing/time_*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-opt-target-artifact
           path: mom6-opt-target.tar
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -289,7 +289,7 @@ jobs:
           .testing/build/unit/test_* \
           .testing/build/unit/*.gcno
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-coverage-artifact
           path: mom6-coverage.tar
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup/
 
@@ -321,17 +321,17 @@ jobs:
       - build-asymmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download asymmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-asymmetric-artifact
 
@@ -352,12 +352,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -375,12 +375,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -398,12 +398,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -421,12 +421,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -454,12 +454,12 @@ jobs:
           - {id: r, desc: "density"}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -479,17 +479,17 @@ jobs:
       - build-openmp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download OpenMP MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-openmp-artifact
 
@@ -512,17 +512,17 @@ jobs:
       - build-repro
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download DEBUG MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download REPRO MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-repro-artifact
 
@@ -546,17 +546,17 @@ jobs:
       - build-target
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download target MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-target-artifact
 
@@ -578,12 +578,12 @@ jobs:
     needs: build-coverage
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download unit coverage tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-coverage-artifact
 
@@ -622,12 +622,12 @@ jobs:
       - build-opt
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
       - name: Download timing tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-opt-artifact
 
@@ -652,7 +652,7 @@ jobs:
       - build-opt-target
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/ubuntu-setup
 
@@ -667,12 +667,12 @@ jobs:
           build/target_codebase
 
       - name: Download optimized MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-opt-artifact
 
       - name: Download optimized target MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-opt-target-artifact
 
@@ -733,7 +733,7 @@ jobs:
       - run-coverage
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             mom6-asymmetric-artifact
@@ -761,7 +761,7 @@ jobs:
       - run-timings
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             mom6-symmetric-artifact
@@ -785,7 +785,7 @@ jobs:
       - compare-timings
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             mom6-symmetric-artifact

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup/
 
@@ -35,7 +35,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-symmetric.tar .testing/build/symmetric/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-symmetric-artifact
           path: mom6-symmetric.tar
@@ -45,7 +45,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup/
 
@@ -61,7 +61,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-asymmetric.tar .testing/build/asymmetric/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-asymmetric-artifact
           path: mom6-asymmetric.tar
@@ -71,7 +71,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup/
 
@@ -87,7 +87,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-repro.tar .testing/build/repro/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-repro-artifact
           path: mom6-repro.tar
@@ -97,7 +97,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup/
 
@@ -113,7 +113,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-openmp.tar .testing/build/openmp/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-openmp-artifact
           path: mom6-openmp.tar
@@ -124,7 +124,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup/
 
@@ -145,7 +145,7 @@ jobs:
       - name: Prepare artifact
         run: tar -cf mom6-target.tar .testing/build/target/MOM6
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mom6-target-artifact
           path: mom6-target.tar
@@ -160,17 +160,17 @@ jobs:
       - build-asymmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download asymmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-asymmetric-artifact
 
@@ -191,12 +191,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -214,12 +214,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -237,12 +237,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -260,12 +260,12 @@ jobs:
     needs: build-symmetric
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -293,12 +293,12 @@ jobs:
           - {id: r, desc: "density"}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
@@ -318,17 +318,17 @@ jobs:
       - build-openmp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download OpenMP MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-openmp-artifact
 
@@ -351,17 +351,17 @@ jobs:
       - build-repro
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download DEBUG MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download REPRO MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-repro-artifact
 
@@ -385,17 +385,17 @@ jobs:
       - build-target
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/macos-setup
 
       - name: Download symmetric MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-symmetric-artifact
 
       - name: Download target MOM6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mom6-target-artifact
 
@@ -424,7 +424,7 @@ jobs:
       - test-repro
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             mom6-asymmetric-artifact
@@ -451,7 +451,7 @@ jobs:
       - test-repro
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             mom6-symmetric-artifact
@@ -474,7 +474,7 @@ jobs:
       - test-regression
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             mom6-symmetric-artifact


### PR DESCRIPTION
This should eliminate the Node 20 warnings in the Actions CI.

This only affect GitHub Actions so does not need regression testing.