### PR TITLE
Fix spaces after commas on declaration lines

### DIFF
--- a/src/ALE/Recon1d_type.F90
+++ b/src/ALE/Recon1d_type.F90
@@ -269,7 +269,7 @@ subroutine remap_to_sub_grid(this, h0, u0, n1, h_sub, &
   real :: dh0_eff ! Running sum of source cell thickness [H]
   integer :: i0_last_thick_cell, n0
 ! real :: u0_min(this%n), u0_max(this%n) ! Min/max of u0 for each source cell [A]
-! real :: ul,ur ! Left/right edge values [A]
+! real :: ul, ur ! Left/right edge values [A]
 
   n0 = this%n
 

--- a/src/ALE/coord_hycom.F90
+++ b/src/ALE/coord_hycom.F90
@@ -86,7 +86,7 @@ subroutine init_3d_coord_hycom(CS, G, nk, coordinateResolution, target_density, 
   real, dimension(SZI_(G),SZJ_(G),nk+1), intent(in) :: target_density !< Interface target densities [R ~> kg m-3]
   type(interp_CS_type), intent(in) :: interp_CS !< Controls for interpolation
   ! Local variables
-  integer   :: i,j,k
+  integer   :: i, j, k
 
   if (associated(CS)) call MOM_error(FATAL, "init_3d_coord_hycom: CS already associated!")
 
@@ -302,7 +302,7 @@ subroutine build_hycom1_target_anomaly(CS, remapCS, eqn_of_state, nz, ix, jy, de
   real,        optional, intent(in)  :: h_neglect_edge !< A negligibly small width for the purpose of
                                                 !! edge value calculation [H ~> m or kg m-2]
   ! Local variables
-  integer   :: degree,k
+  integer   :: degree, k
   real, dimension(nz)   :: rho_col ! Layer densities in a column [R ~> kg m-3]
   real, dimension(nz,2) :: ppoly_E ! Polynomial edge values [R ~> kg m-3]
   real, dimension(nz,2) :: ppoly_S ! Polynomial edge slopes [R H-1]

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -302,7 +302,7 @@ type, public :: MOM_control_struct ; private
                                      !! number of dynamics steps in nstep_tot
   logical :: debug                   !< If true, write verbose checksums for debugging purposes.
   logical :: debug_OBCs              !< If true, write verbose OBC values for debugging purposes.
-  integer :: ntrunc                  !< number u,v truncations since last call to write_energy
+  integer :: ntrunc                  !< number u, v truncations since last call to write_energy
 
   integer :: cont_stencil            !< The stencil for thickness from the continuity solver.
   integer :: dyn_h_stencil           !< The stencil for thickness for the dynamics based on
@@ -596,7 +596,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
 
   logical :: do_advection    ! If true, do tracer advection.
   logical :: do_diabatic     ! If true, do diabatic update.
-  logical :: thermo_does_span_coupling ! If true,thermodynamic (diabatic) forcing spans
+  logical :: thermo_does_span_coupling ! If true, thermodynamic (diabatic) forcing spans
                                        ! multiple coupling timesteps.
   logical :: tradv_does_span_coupling  ! If true, tracer advection spans
                                        ! multiple coupling timesteps.

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -244,7 +244,7 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
   real :: Heff3, Heff4  ! Temporary effective H at U or V points [H ~> m or kg m-2].
   real :: h_tiny        ! A very small thickness [H ~> m or kg m-2].
   real :: UHeff, VHeff  ! More temporary variables [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real :: QUHeff,QVHeff ! More temporary variables [H L2 T-2 ~> m3 s-2 or kg s-2].
+  real :: QUHeff, QVHeff ! More temporary variables [H L2 T-2 ~> m3 s-2 or kg s-2].
   integer :: i, j, k, n, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: Is_q, Ie_q, Js_q, Je_q  ! The scheme-dependent range of values at which vorticity is set.
   logical :: Stokes_VF

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -6502,7 +6502,7 @@ subroutine barotropic_get_tav(CS, ubtav, vbtav, G, US)
                                                             !! over a baroclinic timestep [L T-1 ~> m s-1]
   type(unit_scale_type),             intent(in)    :: US    !< A dimensional unit scaling type
   ! Local variables
-  integer :: i,j
+  integer :: i, j
 
   do j=G%jsc,G%jec ; do I=G%isc-1,G%iec
     ubtav(I,j) = CS%ubtav(I,j)

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2649,7 +2649,7 @@ subroutine PPM_limit_pos(h_in, h_L, h_R, h_min, G, iis, iie, jis, jie)
   real    :: curv  ! The grid-normalized curvature of the three thicknesses  [H ~> m or kg m-2]
   real    :: dh    ! The difference between the edge thicknesses             [H ~> m or kg m-2]
   real    :: scale ! A scaling factor to reduce the curvature of the fit               [nondim]
-  integer :: i,j
+  integer :: i, j
 
   do j=jis,jie ; do i=iis,iie
     ! This limiter prevents undershooting minima within the domain with

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4011,7 +4011,7 @@ subroutine gradient_at_q_points(G, GV, segment, uvel, vvel)
   type(OBC_segment_type), intent(inout) :: segment !< OBC segment structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(in)    :: uvel !< zonal velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(in)    :: vvel !< meridional velocity [L T-1 ~> m s-1]
-  integer :: i,j,k
+  integer :: i, j, k
 
   if (.not. segment%on_pe) return
 

--- a/src/core/MOM_stoch_eos.F90
+++ b/src/core/MOM_stoch_eos.F90
@@ -67,7 +67,7 @@ logical function MOM_stoch_eos_init(Time, G, GV, US, param_file, diag, CS, resta
   ! local variables
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  integer :: i,j
+  integer :: i, j
 
   MOM_stoch_eos_init = .false.
 

--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -763,7 +763,7 @@ subroutine adjust_area_mean_to_zero(array, G, scaling, unit_scale, unscale)
   real :: scalefac  ! A scaling factor for the variable [a A-1 ~> 1]
   real :: areaIntPosVals, areaIntNegVals ! The global area integral of the positive and negative values [m2 a]
   real :: posScale, negScale ! The scaling factor to apply to positive or negative values [nondim]
-  integer :: i,j
+  integer :: i, j
 
   scalefac = 1.0
   if (present(unscale)) then ; scalefac = unscale

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1782,7 +1782,7 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
                                                 !! in internally scaled arbitrary units [A ~> a]
   type(diag_ctrl),   intent(in) :: diag_CS !< Structure used to regulate diagnostic output
   logical, optional, intent(in) :: is_static !< If true, this is a static field that is always offered.
-  real,    optional,target, intent(in) :: mask(:,:,:) !< If present, use this real array as the data mask [nondim]
+  real, optional, target, intent(in) :: mask(:,:,:) !< If present, use this real array as the data mask [nondim]
 
   ! Local variables
   real, dimension(:,:,:), pointer :: locfield ! The field being offered in arbitrary unscaled units [a]
@@ -4500,7 +4500,7 @@ subroutine downsample_diag_field_3d(locfield, locfield_dsamp, dl, diag_cs, diag,
   integer, intent(inout) :: iev            !< i-end index for diagnostics
   integer, intent(inout) :: jsv            !< j-start index for diagnostics
   integer, intent(inout) :: jev            !< j-end index for diagnostics
-  real,    optional,target, intent(in) :: mask(:,:,:) !< If present, use this real array as the data mask [nondim]
+  real, optional, target, intent(in) :: mask(:,:,:) !< If present, use this real array as the data mask [nondim]
   ! Local variables
   real, dimension(:,:,:), pointer :: locmask ! A pointer to the mask [nondim]
   integer :: f1, f2, isv_o, jsv_o
@@ -4539,7 +4539,7 @@ subroutine downsample_diag_field_2d(locfield, locfield_dsamp, dl, diag_cs, diag,
   integer, intent(inout) :: iev            !< i-end index for diagnostics
   integer, intent(inout) :: jsv            !< j-start index for diagnostics
   integer, intent(inout) :: jev            !< j-end index for diagnostics
-  real,    optional,target, intent(in) :: mask(:,:) !< If present, use this real array as the data mask [nondim].
+  real, optional, target, intent(in) :: mask(:,:) !< If present, use this real array as the data mask [nondim].
   ! Local variables
   real, dimension(:,:), pointer :: locmask ! A pointer to the mask [nondim]
   integer :: f1, f2, isv_o, jsv_o

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -704,7 +704,7 @@ subroutine determine_land_blocks(mask, nx, ny, idiv, jdiv, ibuf, jbuf, num_maske
   integer, dimension(idiv) :: iend     !< The ending index of each division along x axis
   integer, dimension(jdiv) :: jbegin   !< The starting index of each division along y axis
   integer, dimension(jdiv) :: jend     !< The ending index of each division along y axis
-  integer :: i, j, ib, ie, jb,je
+  integer :: i, j, ib, ie, jb, je
 
   call compute_extent(1, nx, idiv, ibegin, iend)
   call compute_extent(1, ny, jdiv, jbegin, jend)

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -103,7 +103,7 @@ subroutine random_2d_01(CS, HI, rand)
   type(hor_index_type), intent(in)    :: HI !< Horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), intent(out) :: rand !< Random numbers between 0 and 1 [nondim]
   ! Local variables
-  integer :: i,j
+  integer :: i, j
 
   do j = HI%jsd,HI%jed
     do i = HI%isd,HI%ied
@@ -120,7 +120,7 @@ subroutine random_2d_norm(CS, HI, rand)
   type(hor_index_type), intent(in)    :: HI !< Horizontal index structure
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), intent(out) :: rand !< Random numbers between 0 and 1 [nondim]
   ! Local variables
-  integer :: i,j,n
+  integer :: i, j, n
 
   do j = HI%jsd,HI%jed
     do i = HI%isd,HI%ied
@@ -156,7 +156,7 @@ subroutine random_2d_constructor(CS, HI, Time, seed)
   type(time_type),      intent(in)    :: Time !< Current model time
   integer,              intent(in)    :: seed !< Seed for PRNG
   ! Local variables
-  integer :: i,j,sseed,tseed
+  integer :: i, j, sseed, tseed
 
   if (.not. allocated(CS%stream2d)) allocate( CS%stream2d(HI%isd:HI%ied,HI%jsd:HI%jed) )
 
@@ -177,9 +177,9 @@ end subroutine random_2d_constructor
 integer function seed_from_time(Time)
   type(time_type), intent(in)    :: Time !< Current model time
   ! Local variables
-  integer :: yr,mo,dy,hr,mn,sc,s1,s2
+  integer :: yr, mo, dy, hr, mn, sc, s1, s2
 
-  call get_date(Time,yr,mo,dy,hr,mn,sc)
+  call get_date(Time, yr, mo, dy, hr, mn, sc)
   s1 = sc + 61*(mn + 61*hr) + 379 ! Range 379 .. 89620
   ! Fun fact: 2147483647 is the eighth Mersenne prime.
   ! This is not the reason for using 2147483647 here. It is the

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1020,7 +1020,7 @@ subroutine adjust_ice_sheet_frazil(sfc_state_in, fluxes_in, CS)
                                                  !! the ice-shelf state
   type(surface), pointer :: sfc_state => NULL()
   type(forcing), pointer :: fluxes => NULL()
-  integer :: i,j,is,ie,js,je
+  integer :: i, j, is, ie, js, je
 
   G => CS%grid ; ISS => CS%ISS
 

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -518,7 +518,7 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
                           ! in through open boundaries [C ~> degC]
   !This include declares and sets the variable "version".
 # include "version_variable.h"
-  character(len=200) :: IC_file,filename,inputdir
+  character(len=200) :: IC_file, filename, inputdir
   character(len=40)  :: var_name
   character(len=40)  :: mdl = "MOM_ice_shelf_dyn"  ! This module's name.
   logical :: shelf_mass_is_dynamic, override_shelf_movement, active_shelf_dynamics
@@ -1196,7 +1196,7 @@ subroutine volume_above_floatation(CS, G, ISS, vaf, hemisphere)
   integer :: IS_ID ! local copy of hemisphere
   real, dimension(SZI_(G),SZJ_(G))  :: vaf_cell !< cell-wise volume above floatation [Z L2 ~> m3]
   integer, dimension(SZI_(G),SZJ_(G))  :: mask ! a mask for active cells depending on hemisphere indicated
-  integer :: is,ie,js,je,i,j
+  integer :: is, ie, js, je, i, j
 
   if (CS%GL_couple) &
     call MOM_error(FATAL, "MOM_ice_shelf_dyn, volume above floatation calculation assumes GL_couple=.FALSE..")
@@ -1339,7 +1339,7 @@ subroutine ice_visc_diag(CS,G,ice_visc)
   type(ocean_grid_type),  intent(in) :: G  !< The grid structure used by the ice shelf.
   real, dimension(SZDI_(G),SZDJ_(G)), intent(out)  :: ice_visc !< area-averaged vertically integrated ice viscosity
                                                                !! [R L2 Z T-1 ~> Pa s m]
-  integer :: i,j
+  integer :: i, j
 
   ice_visc(:,:)=0.0
   if (CS%visc_qps==4) then
@@ -1635,7 +1635,7 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, US, u_shlf, v_shlf, taudx, taudy, i
   logical :: converged ! Indicates nonlinear convergence
   logical :: calc_Au_for_convergence ! Used for convergence criteria than need a CG_action
   character(len=160) :: mesg  ! The text of an error message
-  integer :: conv_flag, i, j, k,l, iter, nodefloat
+  integer :: conv_flag, i, j, k, l, iter, nodefloat
   integer :: Isdq, Iedq, Jsdq, Jedq, isd, ied, jsd, jed
   integer :: Iscq, Iecq, Jscq, Jecq, isc, iec, jsc, jec
   real    :: err_max, err_tempu, err_tempv, err_init ! Errors in [R L3 Z T-2 ~> kg m s-2] or [L T-1 ~> m s-1]
@@ -3323,7 +3323,7 @@ subroutine calve_to_mask(G, h_shelf, area_shelf_h, hmask, calve_mask)
   real, dimension(SZDI_(G),SZDJ_(G)), intent(in)    :: calve_mask !< A mask that indicates where the ice
                                                              !! shelf can exist, and where it will calve.
 
-  integer                        :: i,j
+  integer :: i, j
 
   do j=G%jsc,G%jec ; do i=G%isc,G%iec
     if ((calve_mask(i,j) == 0.0) .and. (hmask(i,j) /= 0.0)) then
@@ -4407,7 +4407,7 @@ subroutine IS_dynamics_post_data_2(CS, ISS, G)
   real, dimension(SZDI_(G),SZDJ_(G),3) :: dev_stress ! deviatoric stress components xx,yy, and xy [R L Z T-2 ~> Pa]
   real, dimension(SZDI_(G),SZDJ_(G),2) :: p_dev_stress ! horizontal principal deviatoric stress [R L Z T-2 ~> Pa]
   real, dimension(SZDI_(G),SZDJ_(G))  :: ice_visc ! area-averaged ice viscosity [R L2 T-1 ~> Pa s]
-  real :: p1,p2 ! Used to calculate strain-rate principal components [T-1 ~> s-1]
+  real :: p1, p2 ! Used to calculate strain-rate principal components [T-1 ~> s-1]
   integer :: i, j
 
   !Allocate the gradient basis functions for 1 cell-centered quadrature point per cell
@@ -4844,7 +4844,7 @@ subroutine change_in_draft(CS, G, h_shelf0, h_shelf1, ddraft)
                           intent(in)    :: h_shelf1 !< the current thickness of the ice shelf [Z ~> m].
   real, dimension(SZDI_(G),SZDJ_(G)), &
                           intent(inout)    :: ddraft !< the change in shelf draft thickness
-  real :: b0,b1
+  real :: b0, b1
   integer :: i, j, isc, iec, jsc, jec
   real    :: OD
 
@@ -4909,7 +4909,7 @@ subroutine bilinear_shape_functions (X, Y, Phi, area)
 ! ... will all cells have the same shape and dimension?
 
   real, dimension(4) :: xquad, yquad ! [nondim]
-  real :: a,b,c,d  ! Various lengths [L ~> m]
+  real :: a, b, c, d ! Various lengths [L ~> m]
   real :: xexp, yexp ! [nondim]
   integer :: node, qpoint, xnode, ynode
 

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -109,7 +109,7 @@ subroutine initialize_ice_thickness_from_file(h_shelf, area_shelf_h, hmask, melt
 
   !  This subroutine reads ice thickness and area from a file and puts it into
   !  h_shelf [Z ~> m] and area_shelf_h [L2 ~> m2] (and dimensionless) and updates hmask
-  character(len=200) :: filename,thickness_file,inputdir ! Strings for file/path
+  character(len=200) :: filename, thickness_file, inputdir ! Strings for file/path
   character(len=200) :: thickness_varname, area_varname, hmask_varname, melt_mask_varname  ! Variable name in file
   character(len=40)  :: mdl = "initialize_ice_thickness_from_file" ! This subroutine's name.
   integer :: i, j, isc, jsc, iec, jec
@@ -327,7 +327,7 @@ subroutine initialize_ice_shelf_boundary_channel(u_face_mask_bdry, v_face_mask_b
   type(param_file_type), intent(in)    :: PF !< A structure to parse for run-time parameters
 
   character(len=40)  :: mdl = "initialize_ice_shelf_boundary_channel" ! This subroutine's name.
-  integer :: i, j, isd, jsd, giec, gjec, gisc, gjsc,gisd,gjsd, isc, jsc, iec, jec, ied, jed
+  integer :: i, j, isd, jsd, giec, gjec, gisc, gjsc, gisd, gjsd, isc, jsc, iec, jec, ied, jed
   real    :: input_thick ! The input ice shelf thickness [Z ~> m]
   real    :: input_vel  ! The input ice velocity at the upstream boundary [L T-1 ~> m s-1]
   real    :: lenlat, len_stress, westlon, lenlon, southlat ! The input positions of the channel boundarises
@@ -426,7 +426,7 @@ subroutine initialize_ice_flow_from_file(bed_elev,u_shelf, v_shelf,float_cond,&
 
   !  This subroutine reads ice thickness and area from a file and puts it into
   !  h_shelf [Z ~> m] and area_shelf_h [L2 ~> m2] (and dimensionless) and updates hmask
-  character(len=200) :: filename,vel_file,inputdir,bed_topo_file ! Strings for file/path
+  character(len=200) :: filename, vel_file, inputdir, bed_topo_file ! Strings for file/path
   character(len=200) :: ushelf_varname, vshelf_varname, &
                         floatfr_varname, bed_varname  ! Variable name in file
   character(len=40)  :: mdl = "initialize_ice_velocity_from_file" ! This subroutine's name.

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -446,7 +446,7 @@ subroutine set_coord_from_file(Rlay, g_prime, GV, US, param_file)
   integer :: k, nz
   character(len=40)  :: mdl = "set_coord_from_file" ! This subroutine's name.
   character(len=40)  :: coord_var
-  character(len=200) :: filename,coord_file,inputdir ! Strings for file/path
+  character(len=200) :: filename, coord_file, inputdir ! Strings for file/path
   nz = GV%ke
 
   call callTree_enter(trim(mdl)//"(), MOM_coord_initialization.F90")

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -101,7 +101,7 @@ subroutine MOM_calculate_grad_Coriolis(dF_dx, dF_dy, G, US)
   type(unit_scale_type),    optional, intent(in)    :: US !< A dimensional unit scaling type
   ! Local variables
   character(len=40)  :: mdl = "MOM_calculate_grad_Coriolis" ! This subroutine's name.
-  integer :: i,j
+  integer :: i, j
   real :: f1, f2 ! Average of adjacent Coriolis parameters [T-1 ~> s-1]
 
   call callTree_enter(trim(mdl)//"(), MOM_shared_initialization.F90")
@@ -132,7 +132,7 @@ function diagnoseMaximumDepth(D, G)
                            intent(in) :: D !< Ocean bottom depth in [m] or [Z ~> m]
   real :: diagnoseMaximumDepth             !< The global maximum ocean bottom depth in [m] or [Z ~> m]
   ! Local variables
-  integer :: i,j
+  integer :: i, j
   diagnoseMaximumDepth = D(G%isc,G%jsc)
   do j=G%jsc, G%jec ; do i=G%isc, G%iec
     diagnoseMaximumDepth = max(diagnoseMaximumDepth,D(i,j))

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -125,7 +125,7 @@ type, public :: ODA_CS ; private
   logical :: do_bias_adjustment !< If true, use spatio-temporally varying climatological tendency
                                 !! adjustment for Temperature and Salinity
   real :: bias_adjustment_multiplier !< A scaling for the bias adjustment [nondim]
-  integer :: assim_method !< Method: NO_ASSIM,EAKF_ASSIM or OI_ASSIM
+  integer :: assim_method !< Method: NO_ASSIM, EAKF_ASSIM or OI_ASSIM
   integer :: ensemble_size !< Size of the ensemble
   integer :: ensemble_id = 0 !< id of the current ensemble member
   integer, pointer, dimension(:,:) :: ensemble_pelist !< PE list for ensemble members
@@ -578,7 +578,7 @@ subroutine get_bias_correction_tracer(Time, US, CS)
   real, allocatable, dimension(:), target :: z_edges_in ! Cell edge depths for input data [Z ~> m]
   real :: missing_value ! A value indicating that there is no valid input data at this point [CU ~> conc]
   integer, dimension(3) :: fld_sz
-  integer :: i,j,k
+  integer :: i, j, k
 
 
   call cpu_clock_begin(id_clock_bias_adjustment)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -2572,7 +2572,7 @@ subroutine thickness_diffuse_get_KH(CS, KH_u_GME, KH_v_GME, G, GV)
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: KH_v_GME !< Isopycnal height
                                                    !! diffusivities at v-faces [L2 T-1 ~> m2 s-1]
   ! Local variables
-  integer :: i,j,k
+  integer :: i, j, k
 
   do k=1,GV%ke+1 ; do j = G%jsc, G%jec ; do I = G%isc-1, G%iec
     KH_u_GME(I,j,k) = CS%KH_u_GME(I,j,k)

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1827,7 +1827,7 @@ subroutine KPP_get_BLD(CS, BLD, G, US, m_to_BLD_units)
                                                        !! to the desired units for BLD [various]
   ! Local variables
   real :: scale  ! A dimensional rescaling factor in [nondim] or other units.
-  integer :: i,j
+  integer :: i, j
 
   scale = 1.0 ; if (present(m_to_BLD_units)) scale = US%Z_to_m*m_to_BLD_units
 
@@ -1847,7 +1847,7 @@ subroutine KPP_get_Lam2(CS, Lam2, G, US)
   real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: Lam2 !< (Langmuir Number)^-2 [nondim]
 
   ! Local variables
-  integer :: i,j ! Horizontal indices
+  integer :: i, j ! Horizontal indices
 
   !$OMP parallel do default(none) shared(Lam2, CS, G)
   do j = G%jsc, G%jec ; do i = G%isc, G%iec

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -354,7 +354,7 @@ subroutine get_input_TKE(G, TKE_itidal_input, nFreq, CS)
                                                          !! [H Z2 T-3 ~> m3 s-3 or W m-2].
   type(int_tide_input_CS),   target       :: CS !< A pointer that is set to point to the control
                                                  !! structure for the internal tide input module.
-  integer :: i,j,fr
+  integer :: i, j, fr
 
   do fr=1,nFreq ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
     TKE_itidal_input(i,j,fr) = CS%TKE_itidal_input(i,j,fr)
@@ -370,7 +370,7 @@ subroutine get_barotropic_tidal_vel(G, vel_btTide, nFreq, CS)
                          intent(out) :: vel_btTide !< Barotropic velocity read from file [L T-1 ~> m s-1].
   type(int_tide_input_CS),   target       :: CS !< A pointer that is set to point to the control
                                                  !! structure for the internal tide input module.
-  integer :: i,j,fr
+  integer :: i, j, fr
 
   do fr=1,nFreq ; do j=G%jsd,G%jed ; do i=G%isd,G%ied
     vel_btTide(i,j,fr) = CS%tideamp(i,j,fr)

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -1390,7 +1390,7 @@ subroutine init_ohlmann_table(optics)
   !! in log-space that any increment in Table 1a
   integer, parameter :: nval_lut=401
   real :: chl, log10chl_lut, w1, w2
-  integer :: n,m,mm1,err
+  integer :: n, m, mm1, err
 
   allocate(optics%a1_lut(nval_lut),optics%b1_lut(nval_lut),&
        &   optics%a2_lut(nval_lut),optics%b2_lut(nval_lut),&

--- a/src/tracer/MOM_tracer_diabatic.F90
+++ b/src/tracer/MOM_tracer_diabatic.F90
@@ -46,9 +46,9 @@ subroutine tracer_vertdiff(h_old, ea, eb, dt, tr, G, GV, &
                                                                      !! convert_flux_in is .false.
   real, dimension(SZI_(G),SZJ_(G)), optional,intent(inout) :: btm_reservoir !< amount of tracer in a bottom reservoir
                                                                      !! [CU R Z ~> CU kg m-2]
-  real,                             optional,intent(in)    :: sink_rate !< rate at which the tracer sinks
+  real,                            optional, intent(in)    :: sink_rate !< rate at which the tracer sinks
                                                                      !! [Z T-1 ~> m s-1]
-  logical,                          optional,intent(in)    :: convert_flux_in !< True if the specified sfc_flux needs
+  logical,                         optional, intent(in)    :: convert_flux_in !< True if the specified sfc_flux needs
                                                                      !! to be integrated in time
 
   ! local variables
@@ -243,9 +243,9 @@ subroutine tracer_vertdiff_Eulerian(h_old, ent, dt, tr, G, GV, &
                                                                      !! convert_flux_in is .false.
   real, dimension(SZI_(G),SZJ_(G)), optional,intent(inout) :: btm_reservoir !< amount of tracer in a bottom reservoir
                                                                      !! [CU R Z ~> CU kg m-2]
-  real,                             optional,intent(in)    :: sink_rate !< rate at which the tracer sinks
+  real,                            optional, intent(in)    :: sink_rate !< rate at which the tracer sinks
                                                                      !! [Z T-1 ~> m s-1]
-  logical,                          optional,intent(in)    :: convert_flux_in !< True if the specified sfc_flux needs
+  logical,                         optional, intent(in)    :: convert_flux_in !< True if the specified sfc_flux needs
                                                                      !! to be integrated in time
 
   ! local variables


### PR DESCRIPTION
  Added a space following commas on 47 variable declaration lines in 23 files, to follow the guidance on syntax in the MOM6 style guide.  Only white space is changed and all answers are bitwise identical.