### PR TITLE
MOM_file_parser white space follows MOM6 style

### DIFF
--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -193,7 +193,7 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir, ens
   endif
 
   if (Netcdf_file) &
-    call MOM_error(FATAL,"open_param_file: NetCDF files are not yet supported.")
+    call MOM_error(FATAL, "open_param_file: NetCDF files are not yet supported.")
 
   if (is_root_pe()) then
     open(newunit=iounit, file=trim(filename), access='SEQUENTIAL', &
@@ -219,17 +219,17 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir, ens
   ! Increment the maximum line length, but always report values in blocks of 4 characters.
   CS%max_line_len = max(CS%max_line_len, 4 + 4*(max_input_line_length(CS, i) - 1) / 4)
 
-  call read_param(CS,"SEND_LOG_TO_STDOUT",CS%log_to_stdout)
-  call read_param(CS,"REPORT_UNUSED_PARAMS",CS%report_unused)
-  call read_param(CS,"FATAL_UNUSED_PARAMS",CS%unused_params_fatal)
+  call read_param(CS, "SEND_LOG_TO_STDOUT", CS%log_to_stdout)
+  call read_param(CS, "REPORT_UNUSED_PARAMS", CS%report_unused)
+  call read_param(CS, "FATAL_UNUSED_PARAMS", CS%unused_params_fatal)
   CS%doc_file = "MOM_parameter_doc"
   if (present(ensemble_num)) then
     ! append instance suffix to doc_file
-    write(ensemble_suffix,'(A,I0.4)') '_', ensemble_num
+    write(ensemble_suffix, '(A,I0.4)') '_', ensemble_num
     CS%doc_file = trim(CS%doc_file)//ensemble_suffix
   endif
   if (present(component)) CS%doc_file = trim(component)//"_parameter_doc"
-  call read_param(CS,"DOCUMENT_FILE", CS%doc_file)
+  call read_param(CS, "DOCUMENT_FILE", CS%doc_file)
   if (.not.may_check) then
     CS%report_unused = .false.
     CS%unused_params_fatal = .false.
@@ -399,7 +399,7 @@ subroutine populate_param_data(iounit, filename, param_data)
       read(iounit, '(a)', end=8) line
       line = replaceTabs(line)
       if (inMultiLineComment) then
-        if (closeMultiLineComment(line)) inMultiLineComment=.false.
+        if (closeMultiLineComment(line)) inMultiLineComment = .false.
       else
         if (lastNonCommentNonBlank(line)>0) then
           line = removeComments(line)
@@ -407,7 +407,7 @@ subroutine populate_param_data(iounit, filename, param_data)
           num_lines = num_lines + 1
           total_chars = total_chars + len_trim(line)
         endif
-        if (openMultiLineComment(line)) inMultiLineComment=.true.
+        if (openMultiLineComment(line)) inMultiLineComment = .true.
       endif
     enddo ! while (.true.)
  8  continue ! get here when read() reaches EOF
@@ -443,7 +443,7 @@ subroutine populate_param_data(iounit, filename, param_data)
       read(iounit, '(a)', end=18) line
       line = replaceTabs(line)
       if (inMultiLineComment) then
-        if (closeMultiLineComment(line)) inMultiLineComment=.false.
+        if (closeMultiLineComment(line)) inMultiLineComment = .false.
       else
         if (lastNonCommentNonBlank(line)>0) then
           line = removeComments(line)
@@ -458,7 +458,7 @@ subroutine populate_param_data(iounit, filename, param_data)
           do ch=1,llen ; char_buf(rsc+ch)(1:1) = line(ch:ch) ; enddo
           rsc = rsc + llen
         endif
-        if (openMultiLineComment(line)) inMultiLineComment=.true.
+        if (openMultiLineComment(line)) inMultiLineComment = .true.
       endif
     enddo ! while (.true.)
 18  continue ! get here when read() reaches EOF
@@ -499,11 +499,11 @@ function openMultiLineComment(string)
   integer :: icom, last
 
   openMultiLineComment = .false.
-  last = lastNonCommentIndex(string)+1
+  last = lastNonCommentIndex(string) + 1
   icom = index(string(last:), "/*")
   if (icom > 0) then
-    openMultiLineComment=.true.
-    last = last+icom+1
+    openMultiLineComment = .true.
+    last = last + icom + 1
   endif
   icom = index(string(last:), "*/") ; if (icom > 0) openMultiLineComment=.false.
 end function openMultiLineComment
@@ -514,7 +514,7 @@ function closeMultiLineComment(string)
   logical                      :: closeMultiLineComment
 ! True if a */ appears on this line
   closeMultiLineComment = .false.
-  if (index(string, "*/")>0) closeMultiLineComment=.true.
+  if (index(string, "*/")>0) closeMultiLineComment = .true.
 end function closeMultiLineComment
 
 !> Find position of last character before any comments, As marked by "!", "//", or "/*"
@@ -551,9 +551,9 @@ function replaceTabs(string)
 
   do i=1, len(string)
     if (string(i:i)==achar(9)) then
-      replaceTabs(i:i)=" "
+      replaceTabs(i:i) = " "
     else
-      replaceTabs(i:i)=string(i:i)
+      replaceTabs(i:i) = string(i:i)
     endif
   enddo
 end function replaceTabs
@@ -565,9 +565,9 @@ function removeComments(string)
 
   integer :: last
 
-  removeComments=repeat(" ",len(string))
+  removeComments = repeat(" ", len(string))
   last = lastNonCommentNonBlank(string)
-  removeComments(:last)=adjustl(string(:last)) ! Copy only the non-comment part of string
+  removeComments(:last) = adjustl(string(:last)) ! Copy only the non-comment part of string
 end function removeComments
 
 !> Constructs a string with all repeated white space replaced with single blanks
@@ -582,39 +582,39 @@ function simplifyWhiteSpace(string)
   character(len=1) :: quoteChar=" "
 
   nonBlank  = .false. ; insideString = .false. ! NOTE: For some reason this line is needed??
-  i=0
-  simplifyWhiteSpace=repeat(" ",len(string)+16)
+  i = 0
+  simplifyWhiteSpace = repeat(" ", len(string)+16)
   do j=1,len_trim(string)
     if (insideString) then ! Do not change formatting inside strings
-      i=i+1
-      simplifyWhiteSpace(i:i)=string(j:j)
+      i = i + 1
+      simplifyWhiteSpace(i:i) = string(j:j)
       if (string(j:j)==quoteChar) insideString=.false. ! End of string
     else ! The following is outside of string delimiters
       if (string(j:j)==" " .or. string(j:j)==achar(9)) then ! Space or tab
         if (nonBlank) then ! Only copy a blank if the preceding character was non-blank
-          i=i+1
-          simplifyWhiteSpace(i:i)=" " ! Not string(j:j) so that tabs are replace by blanks
-          nonBlank=.false.
+          i = i + 1
+          simplifyWhiteSpace(i:i) = " " ! Not string(j:j) so that tabs are replace by blanks
+          nonBlank = .false.
         endif
       elseif (string(j:j)=='"' .or. string(j:j)=="'") then ! Start a sting
-        i=i+1
-        simplifyWhiteSpace(i:i)=string(j:j)
-        insideString=.true.
-        quoteChar=string(j:j) ! Keep copy of starting quote
-        nonBlank=.true.       ! For exit from string
+        i = i + 1
+        simplifyWhiteSpace(i:i) = string(j:j)
+        insideString = .true.
+        quoteChar = string(j:j) ! Keep copy of starting quote
+        nonBlank = .true.       ! For exit from string
       elseif (string(j:j)=='=') then
         ! Insert spaces if this character is "=" so that line contains " = "
         if (nonBlank) then
-          i=i+1
-          simplifyWhiteSpace(i:i)=" "
+          i = i + 1
+          simplifyWhiteSpace(i:i) = " "
         endif
-        i=i+2
-        simplifyWhiteSpace(i-1:i)=string(j:j)//" "
-        nonBlank=.false.
+        i = i + 2
+        simplifyWhiteSpace(i-1:i) = string(j:j)//" "
+        nonBlank = .false.
       else ! All other characters
-        i=i+1
-        simplifyWhiteSpace(i:i)=string(j:j)
-        nonBlank=.true.
+        i = i + 1
+        simplifyWhiteSpace(i:i) = string(j:j)
+        nonBlank = .true.
       endif
     endif ! if (insideString)
   enddo ! j
@@ -642,22 +642,22 @@ subroutine read_param_int(CS, varname, value, fail_if_missing, set)
 
   call get_variable_line(CS, varname, found, defined, value_string)
   if (found .and. defined .and. (LEN_TRIM(value_string(1)) > 0)) then
-    read(value_string(1),*,err = 1001) value
+    read(value_string(1), *, err=1001) value
     if (present(set)) set = .true.
   else
     if (present(fail_if_missing)) then ; if (fail_if_missing) then
       if (.not.found) then
-        call MOM_error(FATAL,'read_param_int: Unable to find variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_int: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
       else
-        call MOM_error(FATAL,'read_param_int: Variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_int: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
     endif ; endif
     if (present(set)) set = .false.
   endif
   return
- 1001 call MOM_error(FATAL,'read_param_int: read error for integer variable '//trim(varname)// &
+ 1001 call MOM_error(FATAL, 'read_param_int: read error for integer variable '//trim(varname)// &
                              ' parsing "'//trim(value_string(1))//'"')
 end subroutine read_param_int
 
@@ -679,22 +679,22 @@ subroutine read_param_int_array(CS, varname, value, fail_if_missing, set)
   call get_variable_line(CS, varname, found, defined, value_string)
   if (found .and. defined .and. (LEN_TRIM(value_string(1)) > 0)) then
     if (present(set)) set = .true.
-    read(value_string(1),*,end=991,err=1002) value
+    read(value_string(1), *, end=991, err=1002) value
  991 return
   else
     if (present(fail_if_missing)) then ; if (fail_if_missing) then
       if (.not.found) then
-        call MOM_error(FATAL,'read_param_int_array: Unable to find variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_int_array: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
       else
-        call MOM_error(FATAL,'read_param_int_array: Variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_int_array: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
     endif ; endif
     if (present(set)) set = .false.
   endif
   return
- 1002 call MOM_error(FATAL,'read_param_int_array: read error for integer array '//trim(varname)// &
+ 1002 call MOM_error(FATAL, 'read_param_int_array: read error for integer array '//trim(varname)// &
                              ' parsing "'//trim(value_string(1))//'"')
 end subroutine read_param_int_array
 
@@ -718,23 +718,23 @@ subroutine read_param_real(CS, varname, value, fail_if_missing, scale, set)
 
   call get_variable_line(CS, varname, found, defined, value_string)
   if (found .and. defined .and. (LEN_TRIM(value_string(1)) > 0)) then
-    read(value_string(1),*,err=1003) value
+    read(value_string(1), *, err=1003) value
     if (present(scale)) value = scale*value
     if (present(set)) set = .true.
   else
     if (present(fail_if_missing)) then ; if (fail_if_missing) then
       if (.not.found) then
-        call MOM_error(FATAL,'read_param_real: Unable to find variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_real: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
       else
-        call MOM_error(FATAL,'read_param_real: Variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_real: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
     endif ; endif
     if (present(set)) set = .false.
   endif
   return
- 1003 call MOM_error(FATAL,'read_param_real: read error for real variable '//trim(varname)// &
+ 1003 call MOM_error(FATAL, 'read_param_real: read error for real variable '//trim(varname)// &
                              ' parsing "'//trim(value_string(1))//'"')
 end subroutine read_param_real
 
@@ -758,24 +758,24 @@ subroutine read_param_real_array(CS, varname, value, fail_if_missing, scale, set
 
   call get_variable_line(CS, varname, found, defined, value_string)
   if (found .and. defined .and. (LEN_TRIM(value_string(1)) > 0)) then
-    read(value_string(1),*,end=991,err=1004) value
+    read(value_string(1), *, end=991, err=1004) value
 991 continue
     if (present(scale)) value(:) = scale*value(:)
     if (present(set)) set = .true.
   else
     if (present(fail_if_missing)) then ; if (fail_if_missing) then
       if (.not.found) then
-        call MOM_error(FATAL,'read_param_real_array: Unable to find variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_real_array: Unable to find variable '//trim(varname)// &
                              ' in any input files.')
       else
-        call MOM_error(FATAL,'read_param_real_array: Variable '//trim(varname)// &
+        call MOM_error(FATAL, 'read_param_real_array: Variable '//trim(varname)// &
                              ' found but not set in input files.')
       endif
     endif ; endif
     if (present(set)) set = .false.
   endif
   return
- 1004 call MOM_error(FATAL,'read_param_real_array: read error for real array '//trim(varname)// &
+ 1004 call MOM_error(FATAL, 'read_param_real_array: read error for real array '//trim(varname)// &
                              ' parsing "'//trim(value_string(1))//'"')
 end subroutine read_param_real_array
 
@@ -825,17 +825,17 @@ subroutine read_param_char_array(CS, varname, value, fail_if_missing, set)
   call get_variable_line(CS, varname, found, defined, value_string)
   if (found) then
     loc_string = trim(value_string(1))
-    i = index(loc_string,",")
+    i = index(loc_string, ",")
     i_out = 1
     do while(i>0)
       value(i_out) = trim(strip_quotes(loc_string(:i-1)))
-      i_out = i_out+1
+      i_out = i_out + 1
       loc_string = trim(adjustl(loc_string(i+1:)))
-      i = index(loc_string,",")
+      i = index(loc_string, ",")
     enddo
     if (len_trim(loc_string)>0) then
       value(i_out) = trim(strip_quotes(adjustl(loc_string)))
-      i_out = i_out+1
+      i_out = i_out + 1
     endif
     do i=i_out,SIZE(value) ; value(i) = " " ; enddo
   elseif (present(fail_if_missing)) then ; if (fail_if_missing) then
@@ -902,25 +902,25 @@ subroutine read_param_time(CS, varname, value, timeunit, fail_if_missing, date_f
   if (found .and. defined .and. (LEN_TRIM(value_string(1)) > 0)) then
     ! Determine whether value string should be parsed for a real number
     ! or a date, in either a string format or a comma-delimited list of values.
-    if ((INDEX(value_string(1),'-') > 0) .and. &
-        (INDEX(value_string(1),'-',back=.true.) > INDEX(value_string(1),'-'))) then
+    if ((INDEX(value_string(1), '-') > 0) .and. &
+        (INDEX(value_string(1), '-', back=.true.) > INDEX(value_string(1), '-'))) then
       ! There are two dashes, so this must be a date format.
       value = set_date(value_string(1), err_msg=err_msg)
-      if (LEN_TRIM(err_msg) > 0) call MOM_error(FATAL,'read_param_time: '//&
+      if (LEN_TRIM(err_msg) > 0) call MOM_error(FATAL, 'read_param_time: '//&
           trim(err_msg)//' in integer list read error for time-type variable '//&
           trim(varname)// ' parsing "'//trim(value_string(1))//'"')
       if (present(date_format)) date_format = .true.
-    elseif (INDEX(value_string(1),',') > 0) then
+    elseif (INDEX(value_string(1), ',') > 0) then
       ! Initialize vals with an invalid date.
       vals(:) = (/ -999, -999, -999, 0, 0, 0, 0 /)
       read(value_string(1), *, end=995, err=1005) vals
       995 continue
       if ((vals(1) < 0) .or. (vals(2) < 0) .or. (vals(3) < 0)) &
-        call MOM_error(FATAL,'read_param_time: integer list read error for time-type variable '//&
+        call MOM_error(FATAL, 'read_param_time: integer list read error for time-type variable '//&
                        trim(varname)// ' parsing "'//trim(value_string(1))//'"')
       value = set_date(vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), &
                        vals(7), err_msg=err_msg)
-      if (LEN_TRIM(err_msg) > 0) call MOM_error(FATAL,'read_param_time: '//&
+      if (LEN_TRIM(err_msg) > 0) call MOM_error(FATAL, 'read_param_time: '//&
           trim(err_msg)//' in integer list read error for time-type variable '//&
           trim(varname)// ' parsing "'//trim(value_string(1))//'"')
       if (present(date_format)) date_format = .true.
@@ -953,17 +953,17 @@ function strip_quotes(val_str)
   ! Local variables
   integer :: i
   strip_quotes = val_str
-  i = index(strip_quotes,ACHAR(34)) ! Double quote
+  i = index(strip_quotes, ACHAR(34)) ! Double quote
   do while (i>0)
     if (i > 1) then ; strip_quotes = strip_quotes(:i-1)//strip_quotes(i+1:)
     else ; strip_quotes = strip_quotes(2:) ; endif
-    i = index(strip_quotes,ACHAR(34)) ! Double quote
+    i = index(strip_quotes, ACHAR(34)) ! Double quote
   enddo
-  i = index(strip_quotes,ACHAR(39)) ! Single quote
+  i = index(strip_quotes, ACHAR(39)) ! Single quote
   do while (i>0)
     if (i > 1) then ; strip_quotes = strip_quotes(:i-1)//strip_quotes(i+1:)
     else ; strip_quotes = strip_quotes(2:) ; endif
-    i = index(strip_quotes,ACHAR(39)) ! Single quote
+    i = index(strip_quotes, ACHAR(39)) ! Single quote
   enddo
 end function strip_quotes
 
@@ -1062,7 +1062,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
   continuationBuffer = repeat(" ", CS%max_line_len)
   contBufSize = 0
 
-  variableKindIsLogical=.false.
+  variableKindIsLogical = .false.
   if (present(paramIsLogical)) variableKindIsLogical = paramIsLogical
 
   ! Find the first instance (if any) where the named variable is found, and
@@ -1091,12 +1091,12 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         CS%param_data(ipf)%line_used(count) = .true.
       endif
 
-      last1 = max(1,last)
+      last1 = max(1, last)
       ! Check if line ends in continuation character (either & or \)
       ! Note achar(92) is a backslash
       if (line(last1:last1) == achar(92).or.line(last1:last1) == "&") then
-        continuationBuffer(contBufSize+1:contBufSize+len_trim(line))=line(:last-1)
-        contBufSize=contBufSize + len_trim(line)-1
+        continuationBuffer(contBufSize+1:contBufSize+len_trim(line)) = line(:last-1)
+        contBufSize = contBufSize + len_trim(line)-1
         continuedLine = .true.
         if (count==CS%param_data(ipf)%num_lines .and. is_root_pe()) &
           call MOM_error(FATAL, "MOM_file_parser : the last line"// &
@@ -1107,9 +1107,9 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         cycle ! cycle in order to append the next line of the file
       elseif (continuedLine) then
         ! If we reached this point then this is the end of line continuation
-        continuationBuffer(contBufSize+1:contBufSize+len_trim(line))=line(:last)
+        continuationBuffer(contBufSize+1:contBufSize+len_trim(line)) = line(:last)
         line = continuationBuffer
-        continuationBuffer=repeat(" ",CS%max_line_len) ! Clear for next use
+        continuationBuffer = repeat(" ", CS%max_line_len) ! Clear for next use
         contBufSize = 0
         continuedLine = .false.
         last = len_trim(line)
@@ -1136,7 +1136,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       endif
 
       ! Newer form of parameter block, block%, %block or block%param or
-      iso=index(line(:last),'%')
+      iso = index(line(:last), '%')
       fullPathParameter = .false.
       if (iso==1) then ! % is first character means this is a close
         if (len_trim(blockName)==0 .and. is_root_pe()) call MOM_error(FATAL, &
@@ -1154,7 +1154,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         blockName = pushBlockLevel(blockName, line(:iso-1))
         CS%param_data(ipf)%line_used(start_line_num) = .true.
       else ! This is of the form block%parameter = ... (full path parameter)
-        iso=index(line(:last),'%',.true.)
+        iso = index(line(:last), '%', .true.)
         ! Check that the parameter block names on the line matches the state set by the caller
         if (iso>0 .and. trim(CS%blockName%name)==trim(line(:iso-1))) then
           fullPathParameter = .true.
@@ -1174,7 +1174,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
 
       if (inWrongBlock .and. .not. fullPathParameter) then
         if (index(" "//line(:last+1), " "//trim(varname)//" ")>0) &
-          call MOM_error(WARNING,"MOM_file_parser : "//trim(varname)// &
+          call MOM_error(WARNING, "MOM_file_parser : "//trim(varname)// &
                ' found outside of block '//trim(CS%blockName%name)//'%. Ignoring.')
         cycle
       endif
@@ -1278,13 +1278,13 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       if (found_override .and. (oval >= max_vals)) then
         if (is_root_pe()) then
           if ((defined_in_line .neqv. defined) .or. .not. valueIsSame) then
-            call MOM_error(FATAL,"MOM_file_parser : "//trim(varname)// &
+            call MOM_error(FATAL, "MOM_file_parser : "//trim(varname)// &
                      " found with multiple inconsistent overrides."// &
                      " Line A: '"//trim(value_string(max_vals))//"'"//&
                      " Line B: '"//trim(line(:last))//"'"//&
                      " in file "//trim(filename)//" caused the model failure.")
           else
-            call MOM_error(WARNING,"MOM_file_parser : "//trim(varname)// &
+            call MOM_error(WARNING, "MOM_file_parser : "//trim(varname)// &
                      " over-ridden more times than is permitted."// &
                      " Line: '"//trim(line(:last))//"'"//&
                      " in file "//trim(filename)//" is being ignored.")
@@ -1294,7 +1294,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       endif
       if (.not.found_override .and. (oval > 0)) then
         if (is_root_pe()) &
-          call MOM_error(WARNING,"MOM_file_parser : "//trim(varname)// &
+          call MOM_error(WARNING, "MOM_file_parser : "//trim(varname)// &
                    " has already been over-ridden."// &
                    " Line: '"//trim(line(:last))//"'"//&
                    " in file "//trim(filename)//" is being ignored.")
@@ -1303,13 +1303,13 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
       if (.not.found_override .and. (ival >= max_vals)) then
         if (is_root_pe()) then
           if ((defined_in_line .neqv. defined) .or. .not. valueIsSame) then
-            call MOM_error(FATAL,"MOM_file_parser : "//trim(varname)// &
+            call MOM_error(FATAL, "MOM_file_parser : "//trim(varname)// &
                      " found with multiple inconsistent definitions."// &
                      " Line A: '"//trim(value_string(max_vals))//"'"//&
                      " Line B: '"//trim(line(:last))//"'"//&
                      " in file "//trim(filename)//" caused the model failure.")
           else
-            call MOM_error(WARNING,"MOM_file_parser : "//trim(varname)// &
+            call MOM_error(WARNING, "MOM_file_parser : "//trim(varname)// &
                      " occurs more times than is permitted."// &
                      " Line: '"//trim(line(:last))//"'"//&
                      " in file "//trim(filename)//" is being ignored.")
@@ -1326,7 +1326,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         defined = defined_in_line
         if (verbose > 0 .and. ival > 0 .and. is_root_pe() .and. &
             .not. overrideWarningHasBeenIssued(CS%chain, trim(varname)) ) &
-          call MOM_error(WARNING,"MOM_file_parser : "//trim(varname)// &
+          call MOM_error(WARNING, "MOM_file_parser : "//trim(varname)// &
                  " over-ridden.  Line: '"//trim(line(:last))//"'"//&
                  " in file "//trim(filename)//".")
       else ! (.not. found_overide)
@@ -1335,7 +1335,7 @@ subroutine get_variable_line(CS, varname, found, defined, value_string, paramIsL
         defined = defined_in_line
 
         if (verbose > 1 .and. is_root_pe()) &
-          call MOM_error(WARNING,"MOM_file_parser : "//trim(varname)// &
+          call MOM_error(WARNING, "MOM_file_parser : "//trim(varname)// &
                  " set.  Line: '"//trim(line(:last))//"'"//&
                  " in file "//trim(filename)//".")
       endif
@@ -1437,7 +1437,7 @@ subroutine label_absented_lines_as_used(CS, last_unused_line)
           param_block = blockName
         endif
 
-        varlen = index(line,' ') ; if (varlen == 0) varlen = last
+        varlen = index(line, ' ') ; if (varlen == 0) varlen = last
         varname = line(:varlen)
 
         ! This set of calls sets line_used to true for any lines that match this name.
@@ -1878,7 +1878,7 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
   if (present(desc)) then
     if (present(timeunit)) use_timeunit = (timeunit > 0.0)
     if (date_format) then
-      myunits='[date]'
+      myunits = '[date]'
 
       date_string = convert_date_to_string(value)
       if (present(default)) then
@@ -1898,7 +1898,7 @@ subroutine log_param_time(CS, modulename, varname, value, desc, units, &
         elseif (abs(timeunit-3600.0) < 1.0) then ; myunits = "hours"
         elseif (abs(timeunit-86400.0) < 1.0) then ; myunits = "days"
         elseif (abs(timeunit-3.1e7) < 1.0e6) then ; myunits = "years"
-        else ; write(myunits,'(es8.2," sec")') timeunit ; endif
+        else ; write(myunits, '(es8.2," sec")') timeunit ; endif
       endif
       real_time = (86400.0/timeunit)*days + secs/timeunit
       if (ticks > 0) real_time = real_time + &
@@ -2571,7 +2571,7 @@ subroutine openParameterBlock(CS, blockName, desc, do_not_log)
 
   if (associated(CS%blockName)) then
     block => CS%blockName
-    block%name = pushBlockLevel(block%name,blockName)
+    block%name = pushBlockLevel(block%name, blockName)
     if (do_log) then
       call doc_openBlock(CS%doc, block%name, desc)
       block%log_access = .true.
@@ -2605,15 +2605,15 @@ subroutine closeParameterBlock(CS)
 end subroutine closeParameterBlock
 
 !> Extends block name (deeper level of parameter block)
-function pushBlockLevel(oldblockName,newBlockName)
+function pushBlockLevel(oldblockName, newBlockName)
   character(len=*),        intent(in) :: oldBlockName  !< A sequence of hierarchical parameter block names
   character(len=*),        intent(in) :: newBlockName  !< A new block name to add to the end of the sequence
   character(len=len(oldBlockName)+40) :: pushBlockLevel
 
   if (len_trim(oldBlockName)>0) then
-    pushBlockLevel=trim(oldBlockName)//'%'//trim(newBlockName)
+    pushBlockLevel = trim(oldBlockName)//'%'//trim(newBlockName)
   else
-    pushBlockLevel=trim(newBlockName)
+    pushBlockLevel = trim(newBlockName)
   endif
 end function pushBlockLevel
 


### PR DESCRIPTION
  Corrected the white space in 91 lines in MOM_file_parser.F90 to bring it into accord with the guidance in the MOM6 style guide.  Only white space is changed, and all answers are bitwise identical.