### PR TITLE
Dynamic ice sheet/shelf restart reproducibility bug fix

### DIFF
--- a/config_src/drivers/FMS_cap/ocean_model_MOM.F90
+++ b/config_src/drivers/FMS_cap/ocean_model_MOM.F90
@@ -288,7 +288,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, wind_stagger, gas
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
                       Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       diag_ptr=OS%diag, count_calls=.true., ice_shelf_CSp=OS%ice_shelf_CSp, &
-                      waves_CSp=OS%Waves, calve_ice_shelf_bergs=point_calving)
+                      waves_CSp=OS%Waves, calve_ice_shelf_bergs=point_calving, fluxes_in=OS%fluxes)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
                               C_p_scaled=OS%fluxes%C_p, use_temp=use_temperature)
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -682,6 +682,13 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
     fluxes => fluxes_in
   endif
 
+  ! With a dynamic ice shelf, synchronize the geometry used by ALE remapping
+  ! with the area fraction updated during shelf flux calculations.
+  if (associated(CS%frac_shelf_h)) then
+    if (associated(fluxes%frac_shelf_h)) &
+      CS%frac_shelf_h(:,:) = fluxes%frac_shelf_h(:,:)
+  endif
+
   ! Homogenize the forces
   if (CS%homogenize_forcings) then
     ! Homogenize all forcing and fluxes fields.
@@ -2296,7 +2303,7 @@ end subroutine step_offline
 subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                           Time_in, offline_tracer_mode, input_restart_file, diag_ptr, &
                           count_calls, tracer_flow_CSp,  ice_shelf_CSp, waves_CSp, ensemble_num, &
-                          calve_ice_shelf_bergs)
+                          calve_ice_shelf_bergs, fluxes_in)
   type(time_type), target,   intent(inout) :: Time        !< model time, set in this routine
   type(time_type),           intent(in)    :: Time_init   !< The start time for the coupled model's calendar
   type(param_file_type),     intent(out)   :: param_file  !< structure indicating parameter file to parse
@@ -2321,6 +2328,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                                                           !! ensemble manager)
   logical, optional :: calve_ice_shelf_bergs !< If true, will add point iceberg calving variables to the ice
                                              !! shelf restart
+  type(forcing), optional, target, intent(inout) :: fluxes_in !< Surface thermodynamic and mass-flux forcing.
   ! local variables
   type(ocean_grid_type),  pointer :: G => NULL()    ! A pointer to the metric grid use for the run
   type(ocean_grid_type),  pointer :: G_in => NULL() ! Pointer to the input grid
@@ -3326,7 +3334,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       ! when using an ice shelf. Passing the ice shelf diagnostics CS from MOM
       ! for legacy reasons. The actual ice shelf diag CS is internal to the ice shelf
       call initialize_ice_shelf(param_file, G, Time, ice_shelf_CSp, diag_ptr, &
-                                Time_init, dirs%output_directory, calve_ice_shelf_bergs=point_calving)
+                                Time_init, dirs%output_directory, fluxes_in=fluxes_in, &
+                                calve_ice_shelf_bergs=point_calving, defer_flux_initialization=.true.)
       allocate(frac_shelf_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed), source=0.0)
       allocate(mass_shelf_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed), source=0.0)
       allocate(CS%frac_shelf_h(isd:ied, jsd:jed), source=0.0)
@@ -3385,7 +3394,8 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   else  ! The model is being run without grid rotation.  This is true of all production runs.
     if (use_ice_shelf) then
       call initialize_ice_shelf(param_file, G, Time, ice_shelf_CSp, diag_ptr, Time_init, &
-                               dirs%output_directory, calve_ice_shelf_bergs=point_calving)
+                                dirs%output_directory, fluxes_in=fluxes_in, &
+                                calve_ice_shelf_bergs=point_calving, defer_flux_initialization=.true.)
       allocate(CS%frac_shelf_h(isd:ied, jsd:jed), source=0.0)
       allocate(CS%mass_shelf(isd:ied, jsd:jed), source=0.0)
       call ice_shelf_query(ice_shelf_CSp,G,CS%frac_shelf_h, CS%mass_shelf)

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -250,6 +250,11 @@ type, public :: ice_shelf_CS ; private
 
   logical :: debug                !< If true, write verbose checksums for debugging purposes
                                   !! and use reproducible sums
+
+  logical :: just_restarted = .false. !< True from reading this run's ice-shelf state from a restart
+                                  !! until the next call to adjust_ice_sheet_frazil, used to avoid removing
+                                  !! the ice-sheet's share of frazil from sfc_state%frazil twice for the
+                                  !! same instant in time.
 end type ice_shelf_CS
 
 !>@{ CPU time clock IDs
@@ -397,7 +402,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; ied = G%ied ; jed = G%jed
   if (CS%data_override_shelf_fluxes .and. CS%active_shelf_dynamics) then
-    call data_override(G%Domain, 'shelf_sfc_mass_flux', fluxes_in%shelf_sfc_mass_flux(is:ie,js:je), CS%Time, &
+    call data_override(G%Domain, 'shelf_sfc_mass_flux', fluxes_in%shelf_sfc_mass_flux(is:ie,js:je), Time, &
                        scale=US%kg_m2s_to_RZ_T)
     call pass_var(fluxes_in%shelf_sfc_mass_flux, G%domain, complete=.true.)
   endif
@@ -1020,7 +1025,14 @@ subroutine adjust_ice_sheet_frazil(sfc_state_in, fluxes_in, CS)
                                                  !! the ice-shelf state
   type(surface), pointer :: sfc_state => NULL()
   type(forcing), pointer :: fluxes => NULL()
+  logical :: reduce_sfc_frazil ! If true, remove the ice-sheet's share of frazil from
+                               ! sfc_state%frazil before it is sent onward to the sea-ice model.
   integer :: i, j, is, ie, js, je
+
+  ! After a restart, ISS%frazil is reconstructed from the restored frazil state.
+  ! Do not remove the ice-sheet contribution from it a second time.
+  reduce_sfc_frazil = .not.CS%just_restarted
+  CS%just_restarted = .false.
 
   G => CS%grid ; ISS => CS%ISS
 
@@ -1044,7 +1056,8 @@ subroutine adjust_ice_sheet_frazil(sfc_state_in, fluxes_in, CS)
     if (fluxes%frac_shelf_h(i,j)>0.0) ISS%frazil(i,j) = sfc_state%frazil(i,j)
     !Remove the frazil that is used by the ice sheet from sfc_state%frazil
     !The sfc_state%frazil is sent to the sea-ice module
-    sfc_state%frazil(i,j) = sfc_state%frazil(i,j) * (1.0-fluxes%frac_shelf_h(i,j))
+    if (reduce_sfc_frazil) &
+      sfc_state%frazil(i,j) = sfc_state%frazil(i,j) * (1.0-fluxes%frac_shelf_h(i,j))
   enddo ; enddo
 
   if (CS%rotate_index) then
@@ -1530,7 +1543,8 @@ end subroutine add_shelf_flux
 
 !> Initializes shelf model data, parameters and diagnostics
 subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init, directory, forces_in, &
-                                fluxes_in, sfc_state_in, solo_ice_sheet_in, calve_ice_shelf_bergs)
+                                fluxes_in, sfc_state_in, solo_ice_sheet_in, calve_ice_shelf_bergs, &
+                                defer_flux_initialization)
   type(param_file_type),        intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(ocean_grid_type),        pointer       :: ocn_grid   !< The calling ocean model's horizontal grid structure
   type(time_type),              intent(inout) :: Time !< The clock that that will indicate the model time
@@ -1550,6 +1564,8 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
                                                    !! a solo ice-sheet driver.
   logical, optional :: calve_ice_shelf_bergs !< If true, will add point iceberg calving variables to the ice
                                              !! shelf restart
+  logical, optional, intent(in) :: defer_flux_initialization !< If true, allocate fluxes without initializing
+                                                               !! state-dependent flux fields.
 
   type(ocean_grid_type), pointer :: G  => NULL(), OG  => NULL() ! Pointers to grids for convenience.
   type(unit_scale_type), pointer :: US => NULL() ! Pointer to a structure containing
@@ -1575,6 +1591,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   logical :: showCallTree
   logical :: read_TideAmp, debug
   logical :: global_indexing
+  logical :: initialize_fluxes
   logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
                           ! recreate the bugs, or if false bugs are only used if actively selected.
   character(len=240) :: Tideamp_file  ! Input file names
@@ -1704,6 +1721,8 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   ! model solo_ice_sheet_in is not preset.
   CS%solo_ice_sheet = .false.
   if (present(solo_ice_sheet_in)) CS%solo_ice_sheet = solo_ice_sheet_in
+  initialize_fluxes = .true.
+  if (present(defer_flux_initialization)) initialize_fluxes = .not.defer_flux_initialization
 
   !if (present(Time_in)) Time = Time_in
 
@@ -2082,10 +2101,19 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   CS%restart_output_dir = dirs%restart_output_dir
 
   if (present(fluxes_in)) then
-     call initialize_ice_shelf_fluxes(CS, ocn_grid, US, fluxes_in)
-     call register_restart_field(fluxes_in%shelf_sfc_mass_flux, "sfc_mass_flux", .true., CS%restart_CSp, &
-        "ice shelf surface mass flux deposition from atmosphere", &
-        'kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
+    if (initialize_fluxes) then
+      call initialize_ice_shelf_fluxes(CS, ocn_grid, US, fluxes_in)
+    elseif (CS%active_shelf_dynamics) then
+      call allocate_forcing_type(CS%Grid_in, fluxes_in, shelf=.true., &
+                                 shelf_sfc_accumulation=.true.)
+    endif
+    if (CS%active_shelf_dynamics) then
+      if (associated(fluxes_in%shelf_sfc_mass_flux)) then
+        ! Preserve the internal value because the field is consumed immediately after a restart.
+        call register_restart_field(fluxes_in%shelf_sfc_mass_flux, "sfc_mass_flux", .true., CS%restart_CSp, &
+            "ice shelf surface mass flux accumulation (adot)", 'R Z T-1')
+      endif
+    endif
   endif
 
   if (new_sim .and. (.not. (CS%override_shelf_movement .and. CS%mass_from_file))) then
@@ -2109,6 +2137,8 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
     ! This line calls a subroutine that reads the initial conditions from a restart file.
     call MOM_mesg("MOM_ice_shelf.F90, initialize_ice_shelf: Restoring ice shelf from file.")
     call restore_state(dirs%input_filename, dirs%restart_input_dir, Time, G, CS%restart_CSp)
+    ! ISS%frazil is reconstructed from sfc_state%frazil, not restored directly.
+    CS%just_restarted = .true.
 
   endif ! .not. new_sim
 
@@ -2124,6 +2154,10 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   call pass_var(ISS%h_shelf, G%domain, complete=.false.)
   call pass_var(ISS%mass_shelf, G%domain, complete=.false.)
   call pass_var(ISS%hmask, G%domain, complete=.false.)
+  if (present(fluxes_in)) then
+    if (associated(fluxes_in%shelf_sfc_mass_flux)) &
+      call pass_var(fluxes_in%shelf_sfc_mass_flux, G%domain, complete=.false.)
+  endif
   call pass_var(G%bathyT, G%domain)
   call cpu_clock_end(id_clock_pass)
 
@@ -2434,9 +2468,13 @@ subroutine initialize_ice_shelf_fluxes(CS, ocn_grid, US, fluxes_in)
   endif
 
   do j=jsd,jed ; do i=isd,ied
-    if (G%areaT(i,j)>0.) fluxes%frac_shelf_h(i,j) = CS%ISS%area_shelf_h(i,j) / G%areaT(i,j)
+    fluxes%frac_shelf_h(i,j) = 0.0
+    if (G%areaT(i,j)>0.) &
+      fluxes%frac_shelf_h(i,j) = min(1.0, CS%ISS%area_shelf_h(i,j) * G%IareaT(i,j))
   enddo ; enddo
   if (CS%debug) call hchksum(fluxes%frac_shelf_h, "IS init: frac_shelf_h", G%HI, haloshift=0)
+  if (CS%debug) call hchksum(CS%ISS%mass_shelf, "IS init: mass_shelf (fluxes)", G%HI, haloshift=0, &
+                             unscale=US%RZ_to_kg_m2)
   call add_shelf_pressure(ocn_grid, US, CS, fluxes)
 
   if (CS%rotate_index) then
@@ -2698,7 +2736,8 @@ subroutine ice_shelf_query(CS, G, frac_shelf_h, mass_shelf, data_override_shelf_
   if (present(frac_shelf_h)) then
     do j=G%jsd,G%jed ; do i=G%isd,G%ied
       frac_shelf_h(i,j) = 0.0
-      if (G%areaT(i,j)>0.) frac_shelf_h(i,j) = CS%ISS%area_shelf_h(i,j) / G%areaT(i,j)
+      if (G%areaT(i,j)>0.) &
+        frac_shelf_h(i,j) = min(1.0, CS%ISS%area_shelf_h(i,j) * G%IareaT(i,j))
     enddo ; enddo
   endif
 

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -152,6 +152,8 @@ type, public :: ice_shelf_dyn_CS ; private
   real, pointer, dimension(:,:,:,:,:,:) :: Phisub => NULL() !< Quadrature structure weights at subgridscale
                                                 !!  locations for finite element calculations [nondim]
   integer :: OD_rt_counter = 0 !< A counter of the number of contributions to OD_rt.
+  real    :: OD_rt_counter_restart = -1.0 !< A real copy of CS%OD_rt_counter for use in restart files;
+                              !! -1.0 is a sentinel meaning the field was not present in the restart file [nondim].
 
   real :: velocity_update_time_step !< The time interval over which to update the ice shelf velocity
                     !! using the nonlinear elliptic equation, or 0 to update every timestep [T ~> s].
@@ -160,6 +162,9 @@ type, public :: ice_shelf_dyn_CS ; private
                     ! this time interval, and solving for the equilibrated flow will begin to lose
                     ! meaning if it is done too frequently.
   real :: elapsed_velocity_time  !< The elapsed time since the ice velocities were last updated [T ~> s].
+  real :: elapsed_vel_time_restart = -1.0 !< A copy of CS%elapsed_velocity_time for use in restart
+                              !! files [T ~> s]; -1.0 is a sentinel meaning the field was not present
+                              !! in the restart file.
 
   real :: g_Earth      !< The gravitational acceleration [L2 Z-1 T-2 ~> m s-2].
   real :: density_ice  !< A typical density of ice [R ~> kg m-3].
@@ -448,6 +453,11 @@ subroutine register_ice_shelf_dyn_restarts(G, US, param_file, CS, restart_CS)
     allocate(CS%v_face_mask_bdry(IsdB:iedB,JsdB:JedB), source=-2.0)
     allocate(CS%h_bdry_val(isd:ied,jsd:jed), source=0.0)
 
+    ! Allocate running-total arrays for OD_av/ground_frac averaging under coupled grounding.
+    ! OD_rt is initialized to a default open-ocean depth (10 m) for new runs.
+    allocate(CS%OD_rt(isd:ied,jsd:jed), source=10.0*US%m_to_Z)
+    allocate(CS%ground_frac_rt(isd:ied,jsd:jed), source=0.0)
+
     ! Create group pass handles
     call create_group_pass(CS%pass_visc_and_newton, CS%ice_visc, G%domain)
     call create_group_pass(CS%pass_visc_and_newton, CS%newton_str_sh, G%domain)
@@ -490,6 +500,16 @@ subroutine register_ice_shelf_dyn_restarts(G, US, param_file, CS, restart_CS)
                                 "bed elevation", "m", conversion=US%Z_to_m)
     call register_restart_field(CS%first_dir_restart_IS, "first_direction_IS", .false., restart_CS, &
                                 "Indicator of the first direction in split ice shelf calculations.", "nondim")
+    call register_restart_field(CS%elapsed_vel_time_restart, "elapsed_velocity_time", .false., restart_CS, &
+                                "Time elapsed since the last ice shelf velocity update.", &
+                                units="s", conversion=US%T_to_s)
+    call register_restart_field(CS%OD_rt, "OD_rt", .false., restart_CS, &
+                                "Running total of open ocean depth for OD_av averaging", &
+                                "m", conversion=US%Z_to_m)
+    call register_restart_field(CS%ground_frac_rt, "ground_frac_rt", .false., restart_CS, &
+                                "Running total for ground_frac averaging", "nondim")
+    call register_restart_field(CS%OD_rt_counter_restart, "OD_rt_counter", .false., restart_CS, &
+                                "Number of contributions accumulated in OD_rt and ground_frac_rt.", "nondim")
   endif
 
 end subroutine register_ice_shelf_dyn_restarts
@@ -833,8 +853,9 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
     allocate( CS%float_cond(isd:ied,jsd:jed))
 
     CS%OD_rt_counter = 0
-    allocate( CS%OD_rt(isd:ied,jsd:jed), source=0.0)
-    allocate( CS%ground_frac_rt(isd:ied,jsd:jed), source=0.0)
+    ! These arrays may contain values restored by register_ice_shelf_dyn_restarts.
+    if (CS%OD_rt_counter_restart >= 0.0) &
+      CS%OD_rt_counter = NINT(CS%OD_rt_counter_restart)
 
     if (CS%calve_to_mask) then
       allocate( CS%calve_mask(isd:ied,jsd:jed), source=0.0)
@@ -859,7 +880,12 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
       enddo ; enddo
     endif
 
-    CS%elapsed_velocity_time = 0.0
+    if (CS%elapsed_vel_time_restart >= 0.0) then
+      CS%elapsed_velocity_time = CS%elapsed_vel_time_restart
+    else
+      CS%elapsed_velocity_time = 0.0
+      CS%elapsed_vel_time_restart = 0.0
+    endif
 
     call update_velocity_masks(CS, G, ISS%hmask, CS%umask, CS%vmask, CS%u_face_mask, CS%v_face_mask)
   endif
@@ -1169,6 +1195,7 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, calve_ice_shelf_ber
     endif
   endif
   CS%elapsed_velocity_time = CS%elapsed_velocity_time + time_step
+  CS%elapsed_vel_time_restart = CS%elapsed_velocity_time
   if (CS%elapsed_velocity_time >= CS%velocity_update_time_step) update_ice_vel = .true.
 
   if (coupled_GL) then
@@ -1181,6 +1208,7 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, calve_ice_shelf_ber
   if (update_ice_vel) then
     call ice_shelf_solve_outer(CS, ISS, G, US, CS%u_shelf, CS%v_shelf,CS%taudx_shelf,CS%taudy_shelf, iters, Time)
     CS%elapsed_velocity_time = 0.0
+    CS%elapsed_vel_time_restart = 0.0
   endif
 
 ! call ice_shelf_temp(CS, ISS, G, US, time_step, ISS%water_flux, Time)
@@ -4789,6 +4817,7 @@ subroutine update_OD_ffrac(CS, G, US, ocean_mass, find_avg)
     endif
   enddo ; enddo
   CS%OD_rt_counter = CS%OD_rt_counter + 1
+  CS%OD_rt_counter_restart = real(CS%OD_rt_counter)
 
   if (find_avg) then
     I_counter = 1.0 / real(CS%OD_rt_counter)
@@ -4796,8 +4825,9 @@ subroutine update_OD_ffrac(CS, G, US, ocean_mass, find_avg)
       CS%ground_frac(i,j) = 1.0 - (CS%ground_frac_rt(i,j) * I_counter)
       CS%OD_av(i,j) = CS%OD_rt(i,j) * I_counter
 
-      CS%OD_rt(i,j) = 0.0 ; CS%ground_frac_rt(i,j) = 0.0 ; CS%OD_rt_counter = 0
+      CS%OD_rt(i,j) = 0.0 ; CS%ground_frac_rt(i,j) = 0.0
     enddo ; enddo
+    CS%OD_rt_counter = 0 ; CS%OD_rt_counter_restart = 0.0
 
     call pass_var(CS%ground_frac, G%domain, complete=.false.)
     call pass_var(CS%OD_av, G%domain, complete=.true.)


### PR DESCRIPTION
This PR fixes restart reproducibility for the dynamic ice sheet when used with the `data_override` for `shelf_sfc_mass_flux`. It updates four files in the FMS cap, MOM core, and ice-shelf components so that state required immediately after a restart is preserved and the current ice-shelf geometry is used by MOM.

Specifically, this PR:

* Passes the cap forcing structure through `initialize_MOM` to `initialize_ice_shelf`, while deferring initialization of state-dependent shelf flux fields until their normal initialization point.
* Registers and restores the dynamic-ice-shelf surface mass flux accumulation field. This prevents its valid restart value from being overwritten before it is first consumed.
* Registers and restores the coupled-grounding running totals (`OD_rt`, `ground_frac_rt`, and their count), as well as the elapsed interval since the last ice-shelf velocity solve. These fields determine the next coupled-grounding average and velocity update, respectively.
* Marks the first post-restart frazil adjustment so that the ice-sheet share of frazil is not removed twice from the restored surface state.
* Synchronizes MOM's shelf-area fraction with the fraction updated during dynamic ice-shelf flux calculations, so ALE remapping uses current geometry after every step.
* Bounds the shelf-area fraction by one when it is initialized or queried, and uses the current flux-calculation time when overriding shelf surface mass fluxes.

The added restart fields allow a restarted dynamic-ice-shelf calculation to continue from the same internal state as an uninterrupted calculation. They change results only where the previous restart path lost or reused state incorrectly; new runs and restart -free integrations are unchanged.

No runtime parameters or public configuration options are added. The restart file gains fields for dynamic ice-shelf runs; missing fields from older restart files retain the existing fresh-start defaults where applicable.

Restart reproducibility requires SIS2 parameter  `APPLY_MASKS_AFTER_RESTART = False`.

Note that an AI tool was used in making this contribution.