### PR TITLE
Add spaces around equal sign in 277 assignments

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -1155,7 +1155,7 @@ subroutine ALE_remap_velocities(CS, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, u
 
   ! Setup related to KE conservation
   variance_option = .false.
-  if (present(allow_preserve_variance)) variance_option=allow_preserve_variance
+  if (present(allow_preserve_variance)) variance_option = allow_preserve_variance
   if (present(dt)) I_dt = 1.0 / dt
 
   if (CS%id_remap_delta_integ_u2>0) du2h_tot(:,:) = 0.

--- a/src/ALE/MOM_hybgen_remap.F90
+++ b/src/ALE/MOM_hybgen_remap.F90
@@ -262,7 +262,7 @@ subroutine hybgen_weno_coefs(s, h_src, edges, nk, ns, thin, PCM_lay)
 !     Alan J. Wallcraft,  Naval Research Laboratory,  July 2008.
 !-----------------------------------------------------------------------
 !
-!  real, parameter :: dsmll=1.0e-8  ! This has units of [A2], and hence can not be a parameter.
+!  real, parameter :: dsmll = 1.0e-8  ! This has units of [A2], and hence can not be a parameter.
 !
   real :: curv_cell   ! An estimate of the tracer curvature centered on a cell times the grid
                       ! spacing [A H-1 ~> A m-1 or A m2 kg-1]

--- a/src/ALE/MOM_hybgen_unmix.F90
+++ b/src/ALE/MOM_hybgen_unmix.F90
@@ -344,7 +344,7 @@ subroutine hybgen_column_unmix(CS, nk, Rcv_tgt, temp, saln, Rcv, eqn_of_state, &
   real :: swap_T      ! A swap variable for temperature [C ~> degC]
   real :: swap_S      ! A swap variable for salinity [S ~> ppt]
   real :: swap_tr     ! A temporary swap variable for the tracers [conc]
-  logical, parameter :: lunmix=.true.     ! unmix a too light deepest layer
+  logical, parameter :: lunmix = .true.   ! unmix a too light deepest layer
   integer :: k, ka, kp, kt, m
 
   ! --- identify the deepest layer kp with significant thickness (> h_thin)

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -304,8 +304,8 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
 
-  main_parameters=.false.
-  if (len_trim(param_prefix)==0) main_parameters=.true.
+  main_parameters = .false.
+  if (len_trim(param_prefix) == 0) main_parameters = .true.
   if (main_parameters .and. len_trim(param_suffix)>0) call MOM_error(FATAL,trim(mdl)//&
               ' initialize_regridding: Suffix provided without prefix for parameter names!')
 
@@ -381,7 +381,7 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
     param_name = create_coord_param(param_prefix, "DEF", param_suffix)
     coord_res_param = create_coord_param(param_prefix, "RES", param_suffix)
     string2 = 'UNIFORM'
-    if ((maximum_depth>3000.) .and. (maximum_depth<9250.)) string2='WOA09' ! For convenience
+    if ((maximum_depth > 3000.) .and. (maximum_depth < 9250.)) string2 = 'WOA09' ! For convenience
   endif
   call get_param(param_file, mdl, param_name, string, &
                  "Determines how to specify the coordinate "//&
@@ -910,7 +910,7 @@ subroutine initialize_regridding(CS, G, GV, US, max_depth, param_file, mdl, &
     deallocate(dz_shallow)
   endif !REGRIDDING_HYCOM1
 
-  CS%nk=ke
+  CS%nk = ke
 
   ! Target resolution (for fixed coordinates)
   if (allocated(dz_3d)) then
@@ -1412,7 +1412,7 @@ subroutine check_grid_column( nk, h, dzInterface, msg )
   real :: total_h_new  ! The total thickness in the updated column, in [Z ~> m] or arbitrary units
   real :: h_new        ! A thickness in the updated column, in [Z ~> m] or arbitrary units
 
-  eps =1. ; eps = epsilon(eps)
+  eps = 1. ; eps = epsilon(eps)
 
   ! Total thickness of grid h
   total_h_old = 0.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2881,7 +2881,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                  "If true, use a bug in which the particles are advected inconsistently"//&
                  "with the dynamics timestep instead of the tracer timestep.", &
                  default=enable_bugs, do_not_log=.not.CS%use_uh_particles)
-  CS%ensemble_ocean=.false.
+  CS%ensemble_ocean = .false.
   call get_param(param_file, "MOM", "ENSEMBLE_OCEAN", CS%ensemble_ocean, &
                  "If False, The model is being run in serial mode as a single realization. "//&
                  "If True, The current model realization is part of a larger ensemble "//&
@@ -4180,7 +4180,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
 
   use_temperature = associated(CS%tv%T)
 
-  use_iceshelves=.false.
+  use_iceshelves = .false.
   if (associated(CS%frac_shelf_h)) use_iceshelves = .true.
 
   turns = 0
@@ -4474,7 +4474,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
   endif
 
   if (CS%check_bad_sfc_vals) then
-    numberOfErrors=0 ! count number of errors
+    numberOfErrors = 0 ! count number of errors
     do j=js,je ; do i=is,ie
       if (G%mask2dT(i,j)>0.) then
         localError = sfc_state%sea_lev(i,j) < -G%bathyT(i,j) - G%Z_ref &
@@ -4487,7 +4487,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
                 .or. sfc_state%SST(i,j)< CS%bad_val_sst_min       &
                 .or. sfc_state%SST(i,j)>=CS%bad_val_sst_max
         if (localError) then
-          numberOfErrors=numberOfErrors+1
+          numberOfErrors = numberOfErrors + 1
           if (numberOfErrors<9) then ! Only report details for the first few errors
             ig = i + G%HI%idg_offset ! Global i-index
             jg = j + G%HI%jdg_offset ! Global j-index

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -267,7 +267,7 @@ subroutine PressureForce_FV_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, AD
   integer :: i, j, k, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  nkmb=GV%nk_rho_varies
+  nkmb = GV%nk_rho_varies
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   EOSdom(1) = Isq - (G%isd-1) ;  EOSdom(2) = G%iec+1 - (G%isd-1)
   EOSdom_u(1) = Isq - (G%IsdB-1) ; EOSdom_u(2) = Ieq - (G%IsdB-1)
@@ -1104,7 +1104,7 @@ subroutine PressureForce_FV_Bouss(h, tv, PFu, PFv, G, GV, US, CS, ALE_CSp, ADp, 
   integer :: i, j, k, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  nkmb=GV%nk_rho_varies
+  nkmb = GV%nk_rho_varies
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   EOSdom(1) = Isq - (G%isd-1) ;  EOSdom(2) = G%iec+1 - (G%isd-1)
   EOSdom_u(1) = Isq - (G%IsdB-1) ; EOSdom_u(2) = Ieq - (G%IsdB-1)

--- a/src/core/MOM_PressureForce_Montgomery.F90
+++ b/src/core/MOM_PressureForce_Montgomery.F90
@@ -139,7 +139,7 @@ subroutine PressureForce_Mont_nonBouss(h, tv, PFu, PFv, G, GV, US, CS, p_atm, pb
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, nkmb
   integer :: i, j, k
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  nkmb=GV%nk_rho_varies
+  nkmb = GV%nk_rho_varies
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   EOSdom(1) = Isq - (G%isd-1) ;  EOSdom(2) = G%iec+1 - (G%isd-1)
 
@@ -438,13 +438,13 @@ subroutine PressureForce_Mont_Bouss(h, tv, PFu, PFv, G, GV, US, CS, p_atm, pbce,
   logical :: is_split        ! A flag indicating whether the pressure
                              ! gradient terms are to be split into
                              ! barotropic and baroclinic pieces.
-  type(thermo_var_ptrs) :: tv_tmp! A structure of temporary T & S.
+  type(thermo_var_ptrs) :: tv_tmp ! A structure of temporary T & S.
   integer, dimension(2) :: EOSdom ! The computational domain for the equation of state
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, nkmb
   integer :: i, j, k
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  nkmb=GV%nk_rho_varies
+  nkmb = GV%nk_rho_varies
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   EOSdom(1) = Isq - (G%isd-1) ;  EOSdom(2) = G%iec+1 - (G%isd-1)
 

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -2404,7 +2404,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
         segment => OBC%segment(n)
         if (.not. segment%on_pe) cycle
         if (segment%is_E_or_W) then
-          I=segment%HI%IsdB
+          I = segment%HI%IsdB
           do j=segment%HI%jsd,segment%HI%jed
             slp(i+1,j) = 0.0
             slp(i,j) = 0.0
@@ -2431,7 +2431,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
       segment => OBC%segment(n)
       if (.not. segment%on_pe) cycle
       if (segment%direction == OBC_DIRECTION_E) then
-        I=segment%HI%IsdB
+        I = segment%HI%IsdB
         if (associated(segment%h_Reg)) then
           do j=segment%HI%jsd,segment%HI%jed
             h_W(i+1,j) = segment%h_Reg%h_res(i,j,k)
@@ -2448,7 +2448,7 @@ subroutine PPM_reconstruction_x(h_in, h_W, h_E, G, LB, h_min, monotonic, simple_
           enddo
         endif
       elseif (segment%direction == OBC_DIRECTION_W) then
-        I=segment%HI%IsdB
+        I = segment%HI%IsdB
         if (associated(segment%h_Reg)) then
           do j=segment%HI%jsd,segment%HI%jed
             h_W(i,j) = segment%h_Reg%h_res(i,j,k)
@@ -2558,7 +2558,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
         segment => OBC%segment(n)
         if (.not. segment%on_pe) cycle
         if (segment%is_N_or_S) then
-          J=segment%HI%JsdB
+          J = segment%HI%JsdB
           do i=segment%HI%isd,segment%HI%ied
             slp(i,j+1) = 0.0
             slp(i,j) = 0.0
@@ -2583,7 +2583,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
       segment => OBC%segment(n)
       if (.not. segment%on_pe) cycle
       if (segment%direction == OBC_DIRECTION_N) then
-        J=segment%HI%JsdB
+        J = segment%HI%JsdB
         if (associated(segment%h_Reg)) then
           do i=segment%HI%isd,segment%HI%ied
             h_S(i,j+1) = segment%h_Reg%h_res(i,j,k)
@@ -2600,7 +2600,7 @@ subroutine PPM_reconstruction_y(h_in, h_S, h_N, G, LB, h_min, monotonic, simple_
           enddo
         endif
       elseif (segment%direction == OBC_DIRECTION_S) then
-        J=segment%HI%JsdB
+        J = segment%HI%JsdB
         if (associated(segment%h_Reg)) then
           do i=segment%HI%isd,segment%HI%ied
             h_S(i,j) = segment%h_Reg%h_res(i,j,k)

--- a/src/core/MOM_grid.F90
+++ b/src/core/MOM_grid.F90
@@ -493,7 +493,7 @@ logical function isPointInCell(G, i, j, x, y)
   p3 = sign(1., l3) ; if (l3 == 0.) p3=0.
 
   if ( (abs(p0)+abs(p2)) + (abs(p1)+abs(p3)) == abs((p0+p2) + (p1+p3)) ) then
-    isPointInCell=.true.
+    isPointInCell = .true.
   endif
 end function isPointInCell
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -148,7 +148,7 @@ type, public :: OBC_segment_data_type
   real              :: resrv_lfac_in = 1.   !< The reservoir inverse length scale factor for the inward
                                             !! direction per field [nondim].  The general 1/Lscale_in is
                                             !! multiplied by this factor for a specific tracer or thickness.
-  real              :: resrv_lfac_out= 1.   !< The reservoir inverse length scale factor for the outward
+  real              :: resrv_lfac_out = 1.  !< The reservoir inverse length scale factor for the outward
                                             !! direction per field [nondim].  The general 1/Lscale_out is
                                             !! multiplied by this factor for a specific tracer or thickness.
 end type OBC_segment_data_type
@@ -309,8 +309,8 @@ type, public :: OBC_segment_type
                                               !! discretized at the corner (PV) points.
   real, allocatable :: nudged_tangential_grad(:,:,:)  !< The layer dvdx or dudy towards which nudging
                                               !! can occur [T-1 ~> s-1].
-  type(OBC_segment_thickness_type), pointer  :: h_Reg=> NULL()!< A pointer to the thickness for the segment.
-  type(segment_tracer_registry_type), pointer  :: tr_Reg=> NULL()!< A pointer to the tracer registry for the segment.
+  type(OBC_segment_thickness_type), pointer :: h_Reg => NULL() !< A pointer to the thickness for the segment.
+  type(segment_tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry for the segment.
   type(hor_index_type) :: HI !< Horizontal index ranges
   real :: Tr_InvLscale_out                                  !< An effective inverse length scale for restoring
                                                             !! the tracer concentration in a fictitious
@@ -1240,7 +1240,7 @@ subroutine initialize_segment_data(GV, US, OBC, PF, turns, use_temperature)
   integer, dimension(:), allocatable :: saved_pelist
   integer :: current_pe
   integer, dimension(1) :: single_pelist
-  type(external_tracers_segments_props), pointer :: obgc_segments_props_list =>NULL()
+  type(external_tracers_segments_props), pointer :: obgc_segments_props_list => NULL()
   logical :: check_ts_needed ! Check if temperature and salinity are explicitly specified.
   integer :: idx
   character(len=256) :: routine_name ! Name of this subroutine
@@ -2817,7 +2817,7 @@ subroutine copy_OBC_thickness_reservoirs(OBC, G, GV)
 
   ! Now thickness reservoirs
   do n=1,OBC%number_of_segments
-    segment=>OBC%segment(n)
+    segment => OBC%segment(n)
     if (associated(segment%h_Reg)) then
       if (segment%is_E_or_W) then
         I = segment%HI%IsdB
@@ -5152,7 +5152,7 @@ subroutine segment_thickness_reservoir_init(GV, US, OBC, param_file)
   if (.not. associated(OBC)) return
 
   do nseg=1, OBC%number_of_segments
-    segment=>OBC%segment(nseg)
+    segment => OBC%segment(nseg)
     if (.not. segment%on_pe) cycle
 
     if (associated(segment%h_Reg)) &
@@ -6166,7 +6166,7 @@ subroutine update_segment_thickness_reservoirs(G, GV, uhr, vhr, h, OBC)
   type(ocean_OBC_type),                       pointer    :: OBC !< Open boundary structure
 
   ! Local variable
-  type(OBC_segment_type), pointer :: segment=>NULL()
+  type(OBC_segment_type), pointer :: segment => NULL()
   real :: u_L_in, u_L_out ! The zonal distance moved in or out of a cell, normalized by the reservoir
                           ! length scale [nondim]
   real :: v_L_in, v_L_out ! The meridional distance moved in or out of a cell, normalized by the reservoir
@@ -6189,7 +6189,7 @@ subroutine update_segment_thickness_reservoirs(G, GV, uhr, vhr, h, OBC)
   nz = GV%ke
 
   if (associated(OBC)) then ; if (OBC%OBC_pe) then ; do n=1,OBC%number_of_segments
-    segment=>OBC%segment(n)
+    segment => OBC%segment(n)
     if (.not. associated(segment%h_Reg)) cycle
     b_in  = 0.0 ; if (segment%Tr_InvLscale_in  < 0.0) b_in  = 1.0
     b_out = 0.0 ; if (segment%Tr_InvLscale_out < 0.0) b_out = 1.0

--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -530,7 +530,7 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
               Cc2 = ( R2 * D2 ) * ( 2.* Zr + pe_dir * ( 2. * D1 + D2 ) )
             endif
 
-            IT=0
+            IT = 0
             do while(IT<10)!We can iterate up to 10 times
 
               ! G and its derivative
@@ -559,13 +559,13 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
                   ! The iteration seems to be robust, but we need to do something *if*
                   ! things go wrong... How should we treat failed iteration?
                   ! Present solution: Stop trying to compute and just say we can't mix this layer.
-                  X=0
+                  X = 0
                   exit
                 else
                   X = X2
                 endif
               else
-                exit! Quit the iteration
+                exit ! Quit the iteration
               endif
             enddo
             H_ML = H_ML + X

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -697,7 +697,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
           (volbelow < CS%DL%vol_below(CS%lH(k)+1))) then
         li = CS%lH(k)
       else
-        labove=CS%DL%listsize
+        labove = CS%DL%listsize
         li = (labove + lbelow) / 2
         do while (li > lbelow)
           if (volbelow < CS%DL%vol_below(li)) then ; labove = li
@@ -1274,7 +1274,7 @@ subroutine create_depth_list(G, DL, min_depth_inc)
       ir = ir - 1
       if (ir == 1) then ; indx2(1) = indxt ; exit ; endif
     endif
-    i=k ; j=k*2
+    i = k ; j = k*2
     do ; if (j > ir) exit
       if (j < ir .AND. Dlist(indx2(j)) < Dlist(indx2(j+1))) j = j + 1
       if (Dnow < Dlist(indx2(j))) then ; indx2(i) = indx2(j) ; i = j ; j = j + i

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -675,7 +675,7 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, halo_size, use_ebt_mode, mono_N
             if (mode_struct(1)/=0.) then ! Normalize
               mode_struct(1:kc) = mode_struct(1:kc) / mode_struct(1)
             else
-              mode_struct(1:kc)=0.
+              mode_struct(1:kc) = 0.
             endif
 
             if (CS%remap_answer_date < 20190101) then

--- a/src/framework/MOM_diag_buffers.F90
+++ b/src/framework/MOM_diag_buffers.F90
@@ -298,7 +298,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
   function grow_buffer_2d() result(local_fail)
     type(diag_buffer_2d) :: buffer
     logical :: local_fail !< True if any of the unit tests fail
-    integer, parameter :: is=1, ie=2, js=3, je=6
+    integer, parameter :: is = 1, ie = 2, js = 3, je = 6
     integer :: i
 
     local_fail = .false.
@@ -320,7 +320,7 @@ function diag_buffer_unit_tests_2d(verbose) result(fail)
   function fill_value_2d() result(local_fail)
     type(diag_buffer_2d) :: buffer
     logical :: local_fail !< True if any of the unit tests fail
-    integer, parameter :: is=1, ie=2, js=3, je=6
+    integer, parameter :: is = 1, ie = 2, js = 3, je = 6
     real, parameter :: fill_value = -123.456
 
 
@@ -431,7 +431,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
   function grow_buffer_3d() result(local_fail)
     type(diag_buffer_3d) :: buffer
     logical :: local_fail !< True if any of the unit tests fail
-    integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10
+    integer, parameter :: is = 1, ie = 2, js = 3, je = 6, ks = 1, ke = 10
     integer :: i
 
     local_fail = .false.
@@ -457,7 +457,7 @@ function diag_buffer_unit_tests_3d(verbose) result(fail)
   function fill_value_3d() result(local_fail)
     type(diag_buffer_3d) :: buffer
     logical :: local_fail !< True if any of the unit tests fail
-    integer, parameter :: is=1, ie=2, js=3, je=6, ks=1, ke=10
+    integer, parameter :: is = 1, ie = 2, js = 3, je = 6, ks = 1, ke = 10
     real, parameter :: fill_value = -123.456
 
     local_fail = .false.

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -631,16 +631,16 @@ subroutine set_axes_info_dsamp(G, GV, param_file, diag_cs, id_zl_native, id_zi_n
   ! Local variables
   integer :: id_xq, id_yq, id_zl, id_zi, id_xh, id_yh
   integer :: i, j, nz, dl, dlfac
-  real, dimension(:), pointer :: gridLonT_dsamp =>NULL() ! The longitude of downsampled T points for labeling
+  real, dimension(:), pointer :: gridLonT_dsamp => NULL() ! The longitude of downsampled T points for labeling
                                                          ! the output axes, often in units of [degrees_N] or
                                                          ! [km] or [m] or [gridpoints].
-  real, dimension(:), pointer :: gridLatT_dsamp =>NULL() ! The latitude of downsampled T points for labeling
+  real, dimension(:), pointer :: gridLatT_dsamp => NULL() ! The latitude of downsampled T points for labeling
                                                          ! the output axes, often in units of [degrees_N] or
                                                          ! [km] or [m] or [gridpoints].
-  real, dimension(:), pointer :: gridLonB_dsamp =>NULL() ! The longitude of downsampled B points for labeling
+  real, dimension(:), pointer :: gridLonB_dsamp => NULL() ! The longitude of downsampled B points for labeling
                                                          ! the output axes, often in units of [degrees_N] or
                                                          ! [km] or [m] or [gridpoints].
-  real, dimension(:), pointer :: gridLatB_dsamp =>NULL() ! The latitude of downsampled B points for labeling
+  real, dimension(:), pointer :: gridLatB_dsamp => NULL() ! The latitude of downsampled B points for labeling
                                                          ! the output axes, often in units of [degrees_N] or
                                                          ! [km] or [m] or [gridpoints].
 
@@ -2869,9 +2869,9 @@ integer function xyz_method(axes, x_cell_method, y_cell_method, v_cell_method, v
     if (present(v_cell_method)) call MOM_error(FATAL, "xyz_method: " // &
        'Vertical cell method was specified along with the vertically extensive flag.')
     if (v_extensive) then
-      mstr='sum'
+      mstr = 'sum'
     else
-      mstr='mean'
+      mstr = 'mean'
     endif
   elseif (present(v_cell_method)) then
     mstr = v_cell_method

--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -722,7 +722,7 @@ function real_array_string(vals, sep)
       else
         real_array_string = real_array_string // trim(real_string(vals(j)))
       endif
-      n=1
+      n = 1
     endif
   enddo
 end function real_array_string
@@ -771,7 +771,7 @@ function int_array_string(vals, sep)
       else
         int_array_string = int_array_string // trim(int_string(vals(j)))
       endif
-      n=1
+      n = 1
     endif
   enddo
 end function int_array_string
@@ -786,9 +786,9 @@ function testFormattedFloatIsReal(str, val)
 
   read(str(1:),*) scannedVal
   if (scannedVal == val) then
-    testFormattedFloatIsReal=.true.
+    testFormattedFloatIsReal = .true.
   else
-    testFormattedFloatIsReal=.false.
+    testFormattedFloatIsReal = .false.
   endif
 end function testFormattedFloatIsReal
 

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -534,7 +534,7 @@ subroutine gen_auto_mask_table(n_global, reentrant, tripolar_N, npes, param_file
   real :: ar             ! layout aspect ratio to check if it is too extreme        [nondim]
   real :: m_to_Z         ! A conversion factor from m to height units           [Z m-1 ~> 1]
   integer :: nx, ny      ! global domain sizes
-  integer, parameter :: ibuf=2, jbuf=2
+  integer, parameter :: ibuf = 2, jbuf = 2
   real, parameter :: r_extreme = 4.0 ! aspect ratio limit (>1) for a layout to be considered [nondim]
   integer :: num_masked_blocks
   integer, allocatable :: mask_table(:,:)
@@ -742,7 +742,7 @@ subroutine write_auto_mask_file(mask_table, layout, npes, filename)
   integer, intent(in) :: npes                 !> Number of divisions (incl. eliminated ones)
   character(len=:), allocatable, intent(in) :: filename !> file name for the mask_table to be written
   ! local
-  integer :: file_ascii= -1  !< The unit number of the auto-generated mask_file file.
+  integer :: file_ascii = -1  !< The unit number of the auto-generated mask_file file.
   integer :: true_num_masked_blocks
   integer :: p
 

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -579,7 +579,7 @@ function simplifyWhiteSpace(string)
   ! Local variables
   integer :: i, j
   logical :: nonBlank = .false., insideString = .false.
-  character(len=1) :: quoteChar=" "
+  character(len=1) :: quoteChar = " "
 
   nonBlank  = .false. ; insideString = .false. ! NOTE: For some reason this line is needed??
   i = 0
@@ -588,7 +588,7 @@ function simplifyWhiteSpace(string)
     if (insideString) then ! Do not change formatting inside strings
       i = i + 1
       simplifyWhiteSpace(i:i) = string(j:j)
-      if (string(j:j)==quoteChar) insideString=.false. ! End of string
+      if (string(j:j) == quoteChar) insideString = .false. ! End of string
     else ! The following is outside of string delimiters
       if (string(j:j)==" " .or. string(j:j)==achar(9)) then ! Space or tab
         if (nonBlank) then ! Only copy a blank if the preceding character was non-blank

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -143,8 +143,8 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, acrit, num_pass, relc, debug,
   real    :: ares   ! The maximum magnitude change in aout [A]
   logical :: debug_it, ans_2018
 
-  debug_it=.false.
-  if (PRESENT(debug)) debug_it=debug
+  debug_it = .false.
+  if (PRESENT(debug)) debug_it = debug
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
@@ -177,9 +177,9 @@ subroutine fill_miss_2d(aout, good, fill, prev, G, acrit, num_pass, relc, debug,
 
       if (good_(i,j) == 1.0 .or. fill(i,j) == 0.) cycle
 
-      ge=good_(i+1,j) ; gw=good_(i-1,j)
-      gn=good_(i,j+1) ; gs=good_(i,j-1)
-      east=0.0 ; west=0.0 ; north=0.0 ; south=0.0
+      ge = good_(i+1,j) ; gw = good_(i-1,j)
+      gn = good_(i,j+1) ; gs = good_(i,j-1)
+      east = 0.0 ; west = 0.0 ; north = 0.0 ; south = 0.0
       if (ge == 1.0) east = aout(i+1,j)*ge
       if (gw == 1.0) west = aout(i-1,j)*gw
       if (gn == 1.0) north = aout(i,j+1)*gn
@@ -351,7 +351,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
   integer :: isg, ieg, jsg, jeg ! global extent
   integer :: isd, ied, jsd, jed ! data domain indices
   integer :: id_clock_read
-  logical :: debug=.false.
+  logical :: debug = .false.
   real :: I_scale               ! The inverse of the scale factor for diagnostic output [a A-1 ~> 1]
   real :: dtr_iter_stop         ! The tolerance for changes in tracer concentrations between smoothing
                                 ! iterations that determines when to stop iterating [A ~> a]
@@ -697,7 +697,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
   integer :: isd, ied, jsd, jed ! data domain indices
   integer :: id_clock_read
   integer, dimension(4) :: fld_sz
-  logical :: debug=.false.
+  logical :: debug = .false.
   logical :: is_ongrid
   integer :: ans_date           ! The vintage of the expressions and order of arithmetic to use
   real :: I_scale               ! The inverse of the scale factor for diagnostic output [a A-1 ~> 1]

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -31,8 +31,8 @@ integer, parameter :: &
     LMASK     = 2147483647      !< least significant r bits (0x7fffffffUL)
 
 ! Private tempering parameters for the Mersenne Twister
-integer, parameter :: TMASKB= -1658038656, & !< (0x9d2c5680UL)
-                      TMASKC= -272236544     !< (0xefc60000UL)
+integer, parameter :: TMASKB = -1658038656, & !< (0x9d2c5680UL)
+                      TMASKC = -272236544     !< (0xefc60000UL)
 
 !> A private type used by the Mersenne Twistor
 type randomNumberSequence

--- a/src/framework/MOM_string_functions.F90
+++ b/src/framework/MOM_string_functions.F90
@@ -32,7 +32,7 @@ function lowercase(input_string)
 !   This function returns a string in which all uppercase letters have been
 ! replaced by their lowercase counterparts.  It is loosely based on the
 ! lowercase function in mpp_util.F90.
-  integer, parameter :: co=iachar('a')-iachar('A') ! case offset
+  integer, parameter :: co = iachar('a')-iachar('A') ! case offset
   integer :: k
 
   lowercase = input_string
@@ -50,7 +50,7 @@ function uppercase(input_string)
 !   This function returns a string in which all lowercase letters have been
 ! replaced by their uppercase counterparts.  It is loosely based on the
 ! uppercase function in mpp_util.F90.
-  integer, parameter :: co=iachar('A')-iachar('a') ! case offset
+  integer, parameter :: co = iachar('A')-iachar('a') ! case offset
   integer :: k
 
   uppercase = input_string
@@ -82,7 +82,7 @@ function left_ints(i)
   write(left_ints(1:1320),'(A)') trim(left_int(i(1)))
   if (size(i)>1) then
     do j=2,size(i)
-      tmp=left_ints
+      tmp = left_ints
       write(left_ints(1:1320),'(A,", ",A)') trim(tmp),trim(left_int(i(j)))
     enddo
   endif
@@ -152,18 +152,18 @@ function left_reals(r,sep)
   logical :: doWrite
   character(len=10) :: separator
 
-  n=1 ; doWrite=.true. ; left_reals=''
+  n = 1 ; doWrite = .true. ; left_reals = ''
   if (present(sep)) then
-    separator=sep ; ns=len(sep)
+    separator = sep ; ns = len(sep)
   else
-    separator=', ' ; ns=2
+    separator = ', ' ; ns = 2
   endif
   do j=1,size(r)
-    doWrite=.true.
+    doWrite = .true.
     if (j<size(r)) then
       if (r(j)==r(j+1)) then
-        n=n+1
-        doWrite=.false.
+        n = n+1
+        doWrite = .false.
       endif
     endif
     if (doWrite) then
@@ -175,7 +175,7 @@ function left_reals(r,sep)
       else
         left_reals = left_reals // trim(left_real(r(j)))
       endif
-      n=1
+      n = 1
     endif
   enddo
 end function left_reals
@@ -188,9 +188,9 @@ function isFormattedFloatEqualTo(str, val)
   ! Local variables
   real :: scannedVal ! The value extraced from str, in arbitrary units [A]
 
-  isFormattedFloatEqualTo=.false.
+  isFormattedFloatEqualTo = .false.
   read(str(1:),*,err=987) scannedVal
-  if (scannedVal == val) isFormattedFloatEqualTo=.true.
+  if (scannedVal == val) isFormattedFloatEqualTo = .true.
  987 return
 end function isFormattedFloatEqualTo
 
@@ -366,8 +366,8 @@ logical function localTestS(verbose,str1,str2)
   logical, intent(in) :: verbose !< If true, write results to stdout
   character(len=*), intent(in) :: str1 !< String
   character(len=*), intent(in) :: str2 !< String
-  localTestS=.false.
-  if (trim(str1)/=trim(str2)) localTestS=.true.
+  localTestS = .false.
+  if (trim(str1) /= trim(str2)) localTestS = .true.
   if (localTestS .or. verbose) then
     write(stdout,*) '>'//trim(str1)//'<'
     if (localTestS) then
@@ -382,8 +382,8 @@ logical function localTestI(verbose,i1,i2)
   logical, intent(in) :: verbose !< If true, write results to stdout
   integer, intent(in) :: i1 !< Integer
   integer, intent(in) :: i2 !< Integer
-  localTestI=.false.
-  if (i1/=i2) localTestI=.true.
+  localTestI = .false.
+  if (i1 /= i2) localTestI = .true.
   if (localTestI .or. verbose) then
     write(stdout,*) i1,i2
     if (localTestI) then
@@ -398,8 +398,8 @@ logical function localTestR(verbose,r1,r2)
   logical, intent(in) :: verbose !< If true, write results to stdout
   real, intent(in) :: r1 !< The first value to compare, in arbitrary units [A]
   real, intent(in) :: r2 !< The first value to compare, in arbitrary units [A]
-  localTestR=.false.
-  if (r1/=r2) localTestR=.true.
+  localTestR = .false.
+  if (r1 /= r2) localTestR = .true.
   if (localTestR .or. verbose) then
     write(stdout,*) r1,r2
     if (localTestR) then

--- a/src/framework/MOM_write_cputime.F90
+++ b/src/framework/MOM_write_cputime.F90
@@ -36,7 +36,7 @@ type, public :: write_cputime_CS ; private
   real :: cputime2 = 0.0        !< The accumulated CPU time [clock_cycles].
   integer :: previous_calls = 0 !< The number of times write_CPUtime has been called.
   integer :: prev_n = 0         !< The value of n from the last call.
-  integer :: fileCPU_ascii= -1  !< The unit number of the CPU time file.
+  integer :: fileCPU_ascii = -1 !< The unit number of the CPU time file.
   character(len=200) :: CPUfile !< The name of the CPU time file.
 end type write_cputime_CS
 

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -157,8 +157,8 @@ type, public :: ice_shelf_CS ; private
                             !! will be called (note: GL_regularize and GL_couple
                             !! should be exclusive)
   logical :: calve_to_mask  !< If true, calve any ice that passes outside of a masked area
-  logical :: calve_ice_shelf_bergs=.false. !< If true, flux through a static ice front is converted
-                                           !! to point bergs
+  logical :: calve_ice_shelf_bergs = .false. !< If true, flux through a static ice front is converted
+                            !! to point bergs
   real :: min_thickness_simple_calve !< min. ice shelf thickness criteria for calving [Z ~> m].
   real :: T0                !< temperature at ocean surface in the restoring region [C ~> degC]
   real :: S0                !< Salinity at ocean surface in the restoring region [S ~> ppt].
@@ -844,7 +844,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
       ISS%water_flux(i,j) = ISS%water_flux(i,j) * CS%flux_factor
       ISS%tflux_ocn(i,j) = ISS%tflux_ocn(i,j) * CS%flux_factor
       if (CS%threeeq .and. ISS%tflux_ocn(i,j) < 0.0 .and. (.not. CS%insulator)) &
-        ISS%tflux_shelf(i,j)=ISS%tflux_ocn(i,j) + CS%Lat_fusion * ISS%water_flux(i,j)
+        ISS%tflux_shelf(i,j) = ISS%tflux_ocn(i,j) + CS%Lat_fusion * ISS%water_flux(i,j)
     endif
 
     if ((sfc_state%ocean_mass(i,j) > CS%col_mass_melt_threshold) .and. &
@@ -1079,15 +1079,15 @@ function integrate_over_ice_sheet_area(G, ISS, var, unscale, hemisphere) result(
   endif
 
   mask(:,:) = 0
-  if (IS_ID==0) then     !Antarctica (S. Hemisphere) only
+  if (IS_ID == 0) then     ! Antarctica (S. Hemisphere) only
     do j = G%jsc,G%jec ; do i = G%isc,G%iec
-      if (ISS%hmask(i,j)>0 .and. G%geoLatT(i,j)<=0.0) mask(i,j)=1
+      if (ISS%hmask(i,j) > 0 .and. G%geoLatT(i,j) <= 0.0) mask(i,j) = 1
     enddo ; enddo
-  elseif (IS_ID==1) then !Greenland (N. Hemisphere) only
+  elseif (IS_ID == 1) then ! Greenland (N. Hemisphere) only
     do j = G%jsc,G%jec ; do i = G%isc,G%iec
-      if (ISS%hmask(i,j)>0 .and. G%geoLatT(i,j)>0.0)  mask(i,j)=1
+      if (ISS%hmask(i,j) > 0 .and. G%geoLatT(i,j) > 0.0)  mask(i,j) = 1
     enddo ; enddo
-  else                   !All ice sheets
+  else                   ! All ice sheets
     mask(G%isc:G%iec,G%jsc:G%jec) = ISS%hmask(G%isc:G%iec,G%jsc:G%jec)
   endif
 
@@ -1113,14 +1113,14 @@ subroutine ice_sheet_calving_to_ocean_sfc(CS,US,calving,calving_hflx)
   type(ocean_grid_type), pointer :: G => NULL()   !< A pointer to the ocean grid metric.
   integer :: is, ie, js, je
 
-  G=>CS%Grid
+  G => CS%Grid
   ISS => CS%ISS
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   calving = US%RZ_T_to_kg_m2s * ISS%calving(is:ie,js:je)
   calving_hflx = US%QRZ_T_to_W_m2 * ISS%calving_hflx(is:ie,js:je)
 
-  !CS%calve_ice_shelf_bergs=.true.
+  ! CS%calve_ice_shelf_bergs = .true.
 
 end subroutine ice_sheet_calving_to_ocean_sfc
 
@@ -1208,10 +1208,10 @@ subroutine add_shelf_forces(Ocn_grid, US, CS, forces_in, do_shelf_area, external
         (Ocn_grid%jsc /= CS%Grid%jsc) .or. (Ocn_grid%jec /= CS%Grid%jec)) &
       call MOM_error(FATAL,"add_shelf_forces: Incompatible Ocean and internal Ice shelf grids.")
 
-    forces=>forces_in
+    forces => forces_in
   endif
 
-  G=>CS%Grid
+  G => CS%Grid
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; jsd = G%jsd ; ied = G%ied ; jed = G%jed
@@ -1292,7 +1292,7 @@ subroutine add_shelf_pressure(Ocn_grid, US, CS, fluxes)
   real :: press_ice       !< The pressure of the ice shelf per unit area of ocean (not ice) [R L2 T-2 ~> Pa].
   integer :: i, j, is, ie, js, je
 
-  G=>CS%Grid
+  G => CS%Grid
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   if ((CS%grid%isc /= G%isc) .or. (CS%grid%iec /= G%iec) .or. &
@@ -1616,7 +1616,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
                  default=.false., layoutParam=.true.)
 
   ! Set up the ice-shelf domain and grid
-  wd_halos(:)=0
+  wd_halos(:) = 0
   allocate(CS%Grid_in)
   call MOM_domains_init(CS%Grid_in%domain, param_file, min_halo=wd_halos, symmetric=GRID_SYM_,&
                         domain_name='MOM_Ice_Shelf_in', US=CS%US)
@@ -1986,7 +1986,7 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
                  units="m s-1", default=-1.0, scale=US%m_to_Z*US%T_to_s, &
                  do_not_log=CS%ustar_shelf_from_vel)
 
-  if (present(calve_ice_shelf_bergs)) CS%calve_ice_shelf_bergs=calve_ice_shelf_bergs
+  if (present(calve_ice_shelf_bergs)) CS%calve_ice_shelf_bergs = calve_ice_shelf_bergs
 
   ! Allocate and initialize state variables to default values
   call ice_shelf_state_init(CS%ISS, CS%grid)
@@ -1996,10 +1996,10 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   if ((dirs%input_filename(1:1) == 'n') .and. &
       (LEN_TRIM(dirs%input_filename) == 1)) new_sim = .true.
 
-  ISS%area_shelf_h(:,:)=0.0
-  ISS%h_shelf(:,:)=0.0
-  ISS%hmask(:,:)=0.0
-  ISS%mass_shelf(:,:)=0.0
+  ISS%area_shelf_h(:,:) = 0.0
+  ISS%h_shelf(:,:) = 0.0
+  ISS%hmask(:,:) = 0.0
+  ISS%mass_shelf(:,:) = 0.0
 
   if (CS%override_shelf_movement .and. CS%mass_from_file) then
 
@@ -2374,9 +2374,9 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
         CS%id_Ant_adot >0 .or. CS%id_Ant_g_adot >0 .or. CS%id_Ant_f_adot >0 .or. &
         CS%id_Gr_adott>0  .or. CS%id_Gr_g_adott>0  .or. CS%id_Gr_f_adott>0  .or. &
         CS%id_Gr_adot >0  .or. CS%id_Gr_g_adot >0  .or. CS%id_Gr_f_adot >0) then
-      CS%smb_diag=.true.
+      CS%smb_diag = .true.
     else
-      CS%smb_diag=.false.
+      CS%smb_diag = .false.
     endif
 
     if (CS%id_bdott>0     .or. CS%id_bdott_melt>0     .or. CS%id_bdott_accum>0     .or. &
@@ -2385,9 +2385,9 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
         CS%id_Ant_bdot >0 .or. CS%id_Ant_bdot_melt >0 .or. CS%id_Ant_bdot_accum >0 .or. &
         CS%id_Gr_bdott>0  .or. CS%id_Gr_bdott_melt>0  .or. CS%id_Gr_bdott_accum>0  .or. &
         CS%id_Gr_bdot >0  .or. CS%id_Gr_bdot_melt >0  .or. CS%id_Gr_bdot_accum >0) then
-      CS%bmb_diag=.true.
+      CS%bmb_diag = .true.
     else
-      CS%bmb_diag=.false.
+      CS%bmb_diag = .false.
     endif
 
   call MOM_IS_diag_mediator_close_registration(CS%diag)
@@ -2470,7 +2470,7 @@ subroutine initialize_ice_shelf_forces(CS, ocn_grid, US, forces_in)
     call allocate_mech_forcing(forces_in, CS%Grid, forces)
     call rotate_mech_forcing(forces_in, CS%turns, forces)
   else
-    forces=>forces_in
+    forces => forces_in
   endif
 
   call add_shelf_forces(CS%grid, US, CS, forces, do_shelf_area=.not.CS%solo_ice_sheet, &
@@ -2710,7 +2710,7 @@ subroutine ice_shelf_query(CS, G, frac_shelf_h, mass_shelf, data_override_shelf_
   endif
 
   if (present(data_override_shelf_fluxes)) then
-    data_override_shelf_fluxes=.false.
+    data_override_shelf_fluxes = .false.
     if (CS%active_shelf_dynamics) data_override_shelf_fluxes = CS%data_override_shelf_fluxes
   endif
 
@@ -2804,7 +2804,7 @@ subroutine solo_step_ice_shelf(CS, time_interval, nsteps, Time, min_time_step_in
 
   ISS%dhdt_shelf(:,:) = ISS%h_shelf(:,:)
 
-  dh_adott(:,:)=0.0
+  dh_adott(:,:) = 0.0
 
   if (CS%smb_diag) dh_adott_sum(:,:) = 0.0
 
@@ -2918,7 +2918,7 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     if (CS%id_bdot  > 0) call post_scalar_data(CS%id_bdot ,val*Itime_step,CS%diag)
   endif
   if (CS%id_bdott_melt > 0 .or. CS%id_bdot_melt > 0) then !bottom melt
-    tmp(:,:)=0.0
+    tmp(:,:) = 0.0
     do j=js,je ; do i=is,ie
       if (dh_bdott(i,j) < 0) tmp(i,j) = -dh_bdott(i,j)
     enddo ; enddo
@@ -2927,7 +2927,7 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     if (CS%id_bdot_melt  > 0) call post_scalar_data(CS%id_bdot_melt ,val*Itime_step,CS%diag)
   endif
   if (CS%id_bdott_accum > 0 .or. CS%id_bdot_accum > 0) then !bottom accumulation
-    tmp(:,:)=0.0
+    tmp(:,:) = 0.0
     do j=js,je ; do i=is,ie
       if (dh_bdott(i,j) > 0) tmp(i,j) = dh_bdott(i,j)
     enddo ; enddo
@@ -2982,7 +2982,7 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     if (CS%id_Ant_bdot  > 0) call post_scalar_data(CS%id_Ant_bdot ,val*Itime_step,CS%diag)
   endif
   if (CS%id_Ant_bdott_melt > 0 .or. CS%id_Ant_bdot_melt > 0) then !bottom melt
-    tmp(:,:)=0.0
+    tmp(:,:) = 0.0
     do j=js,je ; do i=is,ie
       if (dh_bdott(i,j) < 0) tmp(i,j) = -dh_bdott(i,j)
     enddo ; enddo
@@ -2991,7 +2991,7 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     if (CS%id_Ant_bdot_melt  > 0) call post_scalar_data(CS%id_Ant_bdot_melt ,val*Itime_step,CS%diag)
   endif
   if (CS%id_Ant_bdott_accum > 0 .or. CS%id_Ant_bdot_accum > 0) then !bottom accumulation
-    tmp(:,:)=0.0
+    tmp(:,:) = 0.0
     do j=js,je ; do i=is,ie
       if (dh_bdott(i,j) > 0) tmp(i,j) = dh_bdott(i,j)
     enddo ; enddo
@@ -3046,7 +3046,7 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     if (CS%id_Gr_bdot  > 0) call post_scalar_data(CS%id_Gr_bdot ,val*Itime_step,CS%diag)
   endif
   if (CS%id_Gr_bdott_melt > 0 .or. CS%id_Gr_bdot_melt > 0) then !bottom melt
-    tmp(:,:)=0.0
+    tmp(:,:) = 0.0
     do j=js,je ; do i=is,ie
       if (dh_bdott(i,j) < 0) tmp(i,j) = -dh_bdott(i,j)
     enddo ; enddo
@@ -3055,7 +3055,7 @@ subroutine process_and_post_scalar_data(CS, vaf0, vaf0_A, vaf0_G, Itime_step, dh
     if (CS%id_Gr_bdot_melt  > 0) call post_scalar_data(CS%id_Gr_bdot_melt ,val*Itime_step,CS%diag)
   endif
   if (CS%id_Gr_bdott_accum > 0 .or. CS%id_Gr_bdot_accum > 0) then !bottom accumulation
-    tmp(:,:)=0.0
+    tmp(:,:) = 0.0
     do j=js,je ; do i=is,ie
       if (dh_bdott(i,j) > 0) tmp(i,j) = dh_bdott(i,j)
     enddo ; enddo

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -645,8 +645,8 @@ subroutine initialize_ice_shelf_dyn(param_file, Time, ISS, CS, G, US, diag, new_
                  "A typical density of ice.", units="kg m-3", default=917.0, scale=US%kg_m3_to_R)
 
     ! Precompute commonly-used density ratios
-    CS%rhoi_rhow=CS%density_ice / CS%density_ocean_avg
-    CS%rhow_rhoi=CS%density_ocean_avg / CS%density_ice
+    CS%rhoi_rhow = CS%density_ice / CS%density_ocean_avg
+    CS%rhow_rhoi = CS%density_ocean_avg / CS%density_ice
 
     call get_param(param_file, mdl, "CONJUGATE_GRADIENT_TOLERANCE", CS%cg_tolerance, &
                  "For Picard iterations, the tolerance in CG solver, relative to initial residual", &
@@ -1175,7 +1175,7 @@ subroutine update_ice_shelf(CS, ISS, G, US, time_step, Time, calve_ice_shelf_ber
     call update_OD_ffrac(CS, G, US, ocean_mass, update_ice_vel)
   elseif (update_ice_vel) then
     call update_OD_ffrac_uncoupled(CS, G, ISS%h_shelf(:,:))
-    CS%GL_couple=.false.
+    CS%GL_couple = .false.
   endif
 
   if (update_ice_vel) then
@@ -1205,25 +1205,25 @@ subroutine volume_above_floatation(CS, G, ISS, vaf, hemisphere)
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
   if (present(hemisphere)) then
-    IS_ID=hemisphere
+    IS_ID = hemisphere
   else
-    IS_ID=-1
+    IS_ID = -1
   endif
 
-  mask(:,:)=0
-  if (IS_ID==0) then     !Antarctica (S. Hemisphere) only
+  mask(:,:) = 0
+  if (IS_ID == 0) then     ! Antarctica (S. Hemisphere) only
     do j = js,je ; do i = is,ie
-      if (ISS%hmask(i,j)>0 .and. G%geoLatT(i,j)<=0.0) mask(i,j)=1
+      if (ISS%hmask(i,j) > 0 .and. G%geoLatT(i,j) <= 0.0) mask(i,j) = 1
     enddo ; enddo
-  elseif (IS_ID==1) then !Greenland (N. Hemisphere) only
+  elseif (IS_ID == 1) then ! Greenland (N. Hemisphere) only
     do j = js,je ; do i = is,ie
-      if (ISS%hmask(i,j)>0 .and. G%geoLatT(i,j)>0.0)  mask(i,j)=1
+      if (ISS%hmask(i,j) > 0 .and. G%geoLatT(i,j) > 0.0)  mask(i,j) = 1
     enddo ; enddo
-  else                   !All ice sheets
-    mask(is:ie,js:je)=ISS%hmask(is:ie,js:je)
+  else                   ! All ice sheets
+    mask(is:ie,js:je) = ISS%hmask(is:ie,js:je)
   endif
 
-  vaf_cell(:,:)=0.0
+  vaf_cell(:,:) = 0.0
   do j = js,je ; do i = is,ie
     if (mask(i,j)>0) then
       if (CS%bed_elev(i,j) <= 0) then
@@ -1342,7 +1342,7 @@ subroutine ice_visc_diag(CS,G,ice_visc)
                                                                !! [R L2 Z T-1 ~> Pa s m]
   integer :: i, j
 
-  ice_visc(:,:)=0.0
+  ice_visc(:,:) = 0.0
   if (CS%visc_qps==4) then
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       ice_visc(i,j) = (0.25 * G%IareaT(i,j)) * &
@@ -1693,13 +1693,13 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, US, u_shlf, v_shlf, taudx, taudy, i
     do j=G%jsc,G%jec ; do i=G%isc,G%iec
       if (CS%rhoi_rhow * max(ISS%h_shelf(i,j),CS%min_h_shelf) - CS%bed_elev(i,j) > 0) then
         CS%ground_frac(i,j) = 1.0
-        CS%OD_av(i,j) =0.0
+        CS%OD_av(i,j) = 0.0
       endif
     enddo ; enddo
   endif
 
   ! Warning: This turns off Picard entirely and may not converge.
-  if (CS%newton_after_tolerance<0.0) CS%doing_newton=.true.
+  if (CS%newton_after_tolerance < 0.0) CS%doing_newton = .true.
 
   ! Calculate RHS
   call calc_shelf_driving_stress(CS, ISS, G, US, taudx, taudy, CS%OD_av)
@@ -2004,9 +2004,9 @@ subroutine ice_shelf_solve_outer(CS, ISS, G, US, u_shlf, v_shlf, taudx, taudy, i
       if (CS%doing_newton .and. CS%newton_adapt_cg_tol) then
         !calculate residual needed for EW; some convergence criteria already did this
         if (CS%nonlin_solve_err_mode >= 4) then
-          ew_resid=err_max
+          ew_resid = err_max
         elseif (CS%ssa_add_rel_resid) then
-          ew_resid=err_rr
+          ew_resid = err_rr
         else
           if (.not. calc_Au_for_convergence) then
             Au(:,:) = 0 ; Av(:,:) = 0
@@ -3645,9 +3645,9 @@ subroutine CG_action(CS, uret, vret, u_shlf, v_shlf, Phi, Phisub, umask, vmask, 
   xquad(1) = .5 * (1-sqrt(1./3)) ; xquad(2) = .5 * (1+sqrt(1./3))
 
   if (CS%visc_qps == 4) then
-    visc_qp4=.true.
+    visc_qp4 = .true.
   else
-    visc_qp4=.false.
+    visc_qp4 = .false.
     qpv = 1
   endif
 
@@ -4116,16 +4116,16 @@ subroutine matrix_diagonal(CS, G, US, float_cond, H_node, ice_visc, u_curr, v_cu
   xquad(1) = .5 * (1-sqrt(1./3)) ; xquad(2) = .5 * (1+sqrt(1./3))
 
   if (CS%visc_qps == 4) then
-    visc_qp4=.true.
+    visc_qp4 = .true.
   else
-    visc_qp4=.false.
+    visc_qp4 = .false.
     qpv = 1
   endif
 
   do_newton_visc = CS%doing_newton .and. trim(CS%ice_viscosity_compute) == "MODEL"
 
-  u_diag_b(:,:,:)=0.0
-  v_diag_b(:,:,:)=0.0
+  u_diag_b(:,:,:) = 0.0
+  v_diag_b(:,:,:) = 0.0
 
   do j=jsc-1,jec+1 ; do i=isc-1,iec+1 ; if (hmask(i,j) == 1 .or. hmask(i,j)==3) then
 
@@ -4498,7 +4498,7 @@ subroutine IS_dynamics_post_data_2(CS, ISS, G)
       call ice_visc_diag(CS,G,ice_visc)
 
       if (CS%id_devstress_xx > 0 .or. CS%id_devstress_yy > 0 .or. CS%id_devstress_xy > 0) then
-        dev_stress(:,:,:)=0.0
+        dev_stress(:,:,:) = 0.0
         do j=G%jsc,G%jec ; do i=G%isc,G%iec
           if (ISS%h_shelf(i,j)>0) then
             dev_stress(i,j,1) = 2*ice_visc(i,j)*strain_rate(i,j,1)/ISS%h_shelf(i,j) !deviatoric stress xx
@@ -4512,7 +4512,7 @@ subroutine IS_dynamics_post_data_2(CS, ISS, G)
       endif
 
       if (CS%id_pdevstress_1 > 0 .or. CS%id_pdevstress_2 > 0) then
-        p_dev_stress(:,:,:)=0.0
+        p_dev_stress(:,:,:) = 0.0
         do j=G%jsc,G%jec ; do i=G%isc,G%iec
           if (ISS%h_shelf(i,j)>0) then
             p_dev_stress(i,j,1) = 2*ice_visc(i,j)*p_strain_rate(i,j,1)/ISS%h_shelf(i,j) !max horiz principal dev stress
@@ -4562,17 +4562,17 @@ subroutine calc_shelf_visc(CS, ISS, G, US, u_shlf, v_shlf)
 
   if (trim(CS%ice_viscosity_compute) == "MODEL") then
     if (CS%visc_qps==1) then
-      model_qp1=.true.
-      model_qp4=.false.
+      model_qp1 = .true.
+      model_qp4 = .false.
     else
-      model_qp1=.false.
-      model_qp4=.true.
+      model_qp1 = .false.
+      model_qp4 = .true.
     endif
   endif
 
   n_g = CS%n_glen ; eps_min = CS%eps_glen_min
-  In_g=1./n_g
-  eps_e2_exp=(1.-n_g)/(2.*n_g)
+  In_g = 1./n_g
+  eps_e2_exp = (1.-n_g)/(2.*n_g)
 
   do j=jsc,jec ; do i=isc,iec
 
@@ -5041,7 +5041,7 @@ subroutine bilinear_shape_fn_grid_1qp(G, i, j, Phi)
 ! Phi_i is equal to 1 at vertex i, and 0 at vertex k /= i, and bilinear
 
   real :: a, d       ! Interpolated grid spacings [L ~> m]
-  real :: xexp=0.5, yexp=0.5 ! [nondim]
+  real :: xexp = 0.5, yexp = 0.5 ! [nondim]
   integer :: node, qpoint, xnode, ynode
 
     ! d(x)/d(x*)
@@ -5165,8 +5165,8 @@ subroutine update_velocity_masks(CS, G, hmask, umask, vmask, u_face_mask, v_face
 
   do j=js,G%jed ; do i=is,G%ied
     if (hmask(i,j) == 1 .or. hmask(i,j)==3) then
-      umask(I-1:I,J-1:J)=1
-      vmask(I-1:I,J-1:J)=1
+      umask(I-1:I,J-1:J) = 1
+      vmask(I-1:I,J-1:J) = 1
     endif
   enddo ; enddo
 
@@ -5305,10 +5305,10 @@ subroutine interpolate_H_to_B(G, h_shelf, hmask, H_node, min_h_shelf)
       num_h = 0
       do l=1,2 ; jc=j-1+l ; do k=1,2 ; ic=i-1+k
         if (hmask(ic,jc) == 1.0 .or. hmask(ic,jc) == 3.0) then
-          h_arr(k,l)=max(h_shelf(ic,jc),min_h_shelf)
+          h_arr(k,l) = max(h_shelf(ic,jc),min_h_shelf)
           num_h = num_h + 1
         else
-          h_arr(k,l)=0.0
+          h_arr(k,l) = 0.0
         endif
         if (num_h > 0) then
           H_node(i,j) = ((h_arr(1,1)+h_arr(2,2))+(h_arr(1,2)+h_arr(2,1))) / num_h
@@ -5492,15 +5492,15 @@ subroutine ice_shelf_advect_temp_x(CS, G, time_step, hmask, h0, h_after_uflux)
              ((i+i_off) >= G%domain%nihalo+1)) then
 
           if (i+i_off == G%domain%nihalo+1) then
-            at_west_bdry=.true.
+            at_west_bdry = .true.
           else
-            at_west_bdry=.false.
+            at_west_bdry = .false.
           endif
 
           if (i+i_off == G%domain%niglobal+G%domain%nihalo) then
-            at_east_bdry=.true.
+            at_east_bdry = .true.
           else
-            at_east_bdry=.false.
+            at_east_bdry = .false.
           endif
 
           if (hmask(i,j) == 1) then
@@ -5660,14 +5660,14 @@ subroutine ice_shelf_advect_temp_y(CS, G, time_step, hmask, h_after_uflux, h_aft
              ((j+j_off) >= G%domain%njhalo+1)) then
 
           if (j+j_off == G%domain%njhalo+1) then
-            at_south_bdry=.true.
+            at_south_bdry = .true.
           else
-            at_south_bdry=.false.
+            at_south_bdry = .false.
           endif
           if (j+j_off == G%domain%njglobal+G%domain%njhalo) then
-            at_north_bdry=.true.
+            at_north_bdry = .true.
           else
-            at_north_bdry=.false.
+            at_north_bdry = .false.
           endif
 
           if (hmask(i,j) == 1) then

--- a/src/ice_shelf/MOM_ice_shelf_initialize.F90
+++ b/src/ice_shelf/MOM_ice_shelf_initialize.F90
@@ -63,7 +63,7 @@ subroutine initialize_ice_thickness(h_shelf, area_shelf_h, hmask, melt_mask, G, 
                  "Valid values are: CHANNEL, FILE, and USER.", &
                  fail_if_missing=.true.)
 
-  if (PRESENT(rotate_index)) rotate=rotate_index
+  if (PRESENT(rotate_index)) rotate = rotate_index
 
   if (rotate) then
     allocate(tmp1_2d(G_in%isd:G_in%ied,G_in%jsd:G_in%jed), source=0.0)
@@ -154,7 +154,7 @@ subroutine initialize_ice_thickness_from_file(h_shelf, area_shelf_h, hmask, melt
   if (field_exists(filename, trim(melt_mask_varname), MOM_domain=G%Domain)) then
     call MOM_read_data(filename, trim(melt_mask_varname), melt_mask, G%Domain)
   else
-    melt_mask(:,:)=1.0
+    melt_mask(:,:) = 1.0
   endif
 
   isc = G%isc ; jsc = G%jsc ; iec = G%iec ; jec = G%jec
@@ -187,7 +187,7 @@ subroutine initialize_ice_thickness_from_file(h_shelf, area_shelf_h, hmask, melt
 
         if (area_shelf_h(i,j) >= G%areaT(i,j)) then
           hmask(i,j) = 1.
-          area_shelf_h(i,j)=G%areaT(i,j)
+          area_shelf_h(i,j) = G%areaT(i,j)
         elseif (area_shelf_h(i,j) == 0.0) then
           hmask(i,j) = 0.
         elseif ((area_shelf_h(i,j) > 0) .and. (area_shelf_h(i,j) <= G%areaT(i,j))) then

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2604,7 +2604,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                          ! correct_thickness is false [Z ~> m]
   character(len=40) :: potemp_var, salin_var
 
-  integer, parameter :: niter=10   ! number of iterations for t/s adjustment to layer density
+  integer, parameter :: niter = 10 ! number of iterations for t/s adjustment to layer density
   logical            :: adjust_temperature = .true.  ! fit t/s to target densities
   real    :: temp_land_fill  ! A temperature value to use for land points [C ~> degC]
   real    :: salt_land_fill  ! A salinity value to use for land points [C ~> degC]
@@ -2672,7 +2672,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   isg = G%isg ; ieg = G%ieg ; jsg = G%jsg ; jeg = G%jeg
 
-  PI_180=atan(1.0)/45.
+  PI_180 = atan(1.0)/45.
 
   if (.not.just_read) call callTree_enter(trim(mdl)//"(), MOM_state_initialization.F90")
   if (.not.just_read) call log_version(PF, mdl, version, "")
@@ -3217,7 +3217,7 @@ subroutine MOM_state_init_tests(G, GV, US, tv)
   type(thermo_var_ptrs),     intent(in)    :: tv   !< Thermodynamics structure.
 
   ! Local variables
-  integer, parameter :: nk=5
+  integer, parameter :: nk = 5
   real, dimension(nk) :: T, T_t, T_b ! Temperatures [C ~> degC]
   real, dimension(nk) :: S, S_t, S_b ! Salinities [S ~> ppt]
   real, dimension(nk) :: rho ! Layer density [R ~> kg m-3]

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -160,9 +160,9 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) hor_regrid_answer_date = max(hor_regrid_answer_date, 20230701)
 
-  if (PRESENT(homogenize)) homog=homogenize
-  if (PRESENT(useALEremapping)) useALE=useALEremapping
-  if (PRESENT(remappingScheme)) remapScheme=remappingScheme
+  if (PRESENT(homogenize)) homog = homogenize
+  if (PRESENT(useALEremapping)) useALE = useALEremapping
+  if (PRESENT(remappingScheme)) remapScheme = remappingScheme
   recnum = 1
   if (PRESENT(src_var_record)) recnum = src_var_record
   convert = 1.0

--- a/src/ocean_data_assim/MOM_oda_driver.F90
+++ b/src/ocean_data_assim/MOM_oda_driver.F90
@@ -92,10 +92,10 @@ end type INC_CS
 
 !> Control structure that contains a transpose of the ocean state across ensemble members.
 type, public :: ODA_CS ; private
-  type(ocean_control_struct), pointer :: Ocean_prior=> NULL() !< ensemble ocean prior states in DA space
-  type(ocean_control_struct), pointer :: Ocean_posterior=> NULL() !< ensemble ocean posterior states
+  type(ocean_control_struct), pointer :: Ocean_prior => NULL() !< ensemble ocean prior states in DA space
+  type(ocean_control_struct), pointer :: Ocean_posterior => NULL() !< ensemble ocean posterior states
                                                                   !! or increments to prior in DA space
-  type(ocean_control_struct), pointer :: Ocean_increment=> NULL() !< A separate structure for
+  type(ocean_control_struct), pointer :: Ocean_increment => NULL() !< A separate structure for
                                                                   !! increment diagnostics
   integer :: nk !< number of vertical layers used for DA
   type(ocean_grid_type), pointer :: Grid => NULL() !< MOM6 grid type and decomposition for the DA
@@ -135,12 +135,12 @@ type, public :: ODA_CS ; private
   type(ocean_profile_type), pointer :: Profiles => NULL() !< pointer to linked list of all available profiles
   type(ocean_profile_type), pointer :: CProfiles => NULL()!< pointer to linked list of current profiles
   type(kd_root), pointer :: kdroot => NULL() !< A structure for storing nearest neighbors
-  type(ALE_CS), pointer :: ALE_CS=>NULL() !< ALE control structure for DA
+  type(ALE_CS), pointer :: ALE_CS => NULL() !< ALE control structure for DA
   logical :: use_ALE_algorithm !< true is using ALE remapping
   type(regridding_CS) :: regridCS !< ALE control structure for regridding
   type(remapping_CS) :: remapCS !< ALE control structure for remapping
   type(time_type) :: Time !< Current Analysis time
-  type(diag_ctrl), pointer :: diag_cs=> NULL() !<Pointer to diagnostics control structure
+  type(diag_ctrl), pointer :: diag_cs => NULL() !<Pointer to diagnostics control structure
   type(INC_CS) :: INC_CS !< A Structure containing integer file handles for bias adjustment
   integer :: id_inc_t !< A diagnostic handle for the temperature climatological adjustment
   integer :: id_inc_s !< A diagnostic handle for the salinity climatological adjustment
@@ -172,8 +172,8 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
 
 ! Local variables
   type(thermo_var_ptrs) :: tv_dummy
-  type(dyn_horgrid_type), pointer :: dG=> NULL()
-  type(hor_index_type), pointer :: HI=> NULL()
+  type(dyn_horgrid_type), pointer :: dG => NULL()
+  type(hor_index_type), pointer :: HI => NULL()
   type(directories) :: dirs
 
   type(grid_type), pointer :: T_grid !< global tracer grid
@@ -197,7 +197,7 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
   if (associated(CS)) call MOM_error(FATAL, 'Calling oda_init with associated control structure')
   allocate(CS)
 
-  id_clock_oda_init=cpu_clock_id('(ODA initialization)')
+  id_clock_oda_init = cpu_clock_id('(ODA initialization)')
   call cpu_clock_begin(id_clock_oda_init)
 
 ! Use ens1 parameters , this could be changed at a later time
@@ -286,7 +286,7 @@ subroutine init_oda(Time, G, GV, US, diag_CS, CS)
 
   ens_info = get_ensemble_size()
   CS%ensemble_size = ens_info(1)
-  npes_pm=ens_info(3)
+  npes_pm = ens_info(3)
   CS%ensemble_id = get_ensemble_id()
   !! Switch to global pelist
   allocate(CS%ensemble_pelist(CS%ensemble_size,npes_pm))
@@ -489,7 +489,7 @@ subroutine get_posterior_tracer(Time, CS, increment)
   type(ODA_CS), pointer :: CS !< ocean DA control structure
   logical, optional, intent(in) :: increment !< True if returning increment only
 
-  type(ocean_control_struct), pointer :: Ocean_increment=>NULL()
+  type(ocean_control_struct), pointer :: Ocean_increment => NULL()
   integer :: m
   logical :: get_inc
 
@@ -591,7 +591,7 @@ subroutine get_bias_correction_tracer(Time, US, CS)
 
   ! This should be replaced to use mask_z instead of the following lines
   ! which are intended to zero land values using an arbitrary limit.
-  fld_sz=shape(T_bias)
+  fld_sz = shape(T_bias)
   if (CS%reproduce_2018_nmme) then
     do i=1,fld_sz(1)
       do j=1,fld_sz(2)
@@ -608,8 +608,8 @@ subroutine get_bias_correction_tracer(Time, US, CS)
       do j=1,fld_sz(2)
         do k=1,fld_sz(3)
           if (valid_flag(i,j,k)==0.) then
-            T_bias(i,j,k)=0.0
-            S_bias(i,j,k)=0.0
+            T_bias(i,j,k) = 0.0
+            S_bias(i,j,k) = 0.0
           endif
         enddo
       enddo
@@ -726,7 +726,7 @@ subroutine apply_oda_tracer_increments(dt, Time_end, G, GV, tv, h, CS)
     S_tend = S_tend + CS%S_bc_tend
   endif
 
-  isc=G%isc ; iec=G%iec ; jsc=G%jsc ; jec=G%jec
+  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec=G%jec
   do j=jsc,jec ; do i=isc,iec
     call remapping_core_h(CS%remapCS, CS%nk, CS%h(i,j,:), T_tend(i,j,:), &
                           G%ke, h(i,j,:), T_tend_inc(i,j,:))

--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -407,7 +407,7 @@ subroutine calc_oda_increments(h, tv, u, v, G, GV, US, CS)
         sum_h2 = sum_h2+h_obs(i,j,k)
       enddo
       do k=1,nz_data
-        tmp_h(k)=(sum_h1/sum_h2)*h_obs(i,j,k)
+        tmp_h(k) = (sum_h1/sum_h2) * h_obs(i,j,k)
       enddo
       ! get temperature
       do k=1,nz
@@ -461,7 +461,7 @@ subroutine calc_oda_increments(h, tv, u, v, G, GV, US, CS)
           sum_h2 = sum_h2+hu_obs(k)
         enddo
         do k=1,nz_data
-          hu_obs(k)=(sum_h1/sum_h2)*hu_obs(k)
+          hu_obs(k) = (sum_h1/sum_h2) * hu_obs(k)
         enddo
         ! remap model u on hu_obs
         call remapping_core_h(CS%remap_cs, nz, hu(1:nz), tmp_val1, &
@@ -496,7 +496,7 @@ subroutine calc_oda_increments(h, tv, u, v, G, GV, US, CS)
           sum_h2 = sum_h2+hv_obs(k)
         enddo
         do k=1,nz_data
-          hv_obs(k)=(sum_h1/sum_h2)*hv_obs(k)
+          hv_obs(k) = (sum_h1/sum_h2) * hv_obs(k)
         enddo
         ! remap model v on hv_obs
         call remapping_core_h(CS%remap_cs, nz, hv(1:nz), tmp_val1, &
@@ -713,7 +713,7 @@ subroutine apply_oda_incupd(h, tv, u, v, dt, G, GV, US, CS)
           sum_h2 = sum_h2 + hv_obs(k)
         enddo
         do k=1,nz_data
-          hv_obs(k)=( sum_h1 / sum_h2 ) * hv_obs(k)
+          hv_obs(k) = ( sum_h1 / sum_h2 ) * hv_obs(k)
         enddo
         ! remap increment profile on hv
         call remapping_core_h(CS%remap_cs, nz_data, hv_obs(1:nz_data), tmp_val2, &

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -1266,9 +1266,9 @@ subroutine sum_En(G, GV, US, CS, En, label)
   CS%En_sum = En_sum
   !En_sum_diff = En_sum - CS%En_sum
   !if (CS%En_sum /= 0.0) then
-  !  En_sum_pdiff= (En_sum_diff/CS%En_sum)*100.0
+  !  En_sum_pdiff = (En_sum_diff/CS%En_sum)*100.0
   !else
-  !  En_sum_pdiff= 0.0
+  !  En_sum_pdiff = 0.0
   !endif
   !! Print to screen
   !if (is_root_pe()) then
@@ -1505,7 +1505,7 @@ subroutine get_lowmode_diffusivity(G, GV, h, tv, US, h_bot, k_bot, j, N2_lay, N2
   logical :: non_Bous ! fully Non-Boussinesq
   integer :: i, k, is, ie, nz
 
-  is=G%isc ; ie=G%iec ; nz=GV%ke
+  is = G%isc ; ie = G%iec ; nz = GV%ke
 
   non_Bous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
 
@@ -2678,7 +2678,7 @@ subroutine turning_latitude(En, NAngle, freq2, CS, G, LB)
   ! init local arrays
   angle_c(:,:) = CS%nullangle
   angle_wall = 0
-  angle_wall0 =0
+  angle_wall0 = 0
   angle_r = 0
   angle_r0 = 0
   angle_to_wall = 0

--- a/src/parameterizations/lateral/MOM_meso_sfn_ANN.F90
+++ b/src/parameterizations/lateral/MOM_meso_sfn_ANN.F90
@@ -270,9 +270,9 @@ subroutine meso_sfn_ANN_compute(h, e, sfn_u, sfn_v, G, GV, US, tv, CS, dt, u, v)
     ! Call the ANN
     call ANN_apply_array_sio(nij, x,y, CS%ann_rho_flux)
 
-    m=0
+    m = 0
     do j = js-1, je+1 ; do i = is-1, ie+1
-      m=m+1
+      m = m + 1
       ! Dimensionalize the output. The factors applied here must match the
       ! nondimensionalization used when the network was trained; this is
       ! an implicit contract with the training procedure.

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -434,7 +434,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
               line_is_empty = .false.
             endif
           enddo
-          if (line_is_empty) keep_going=.false.
+          if (line_is_empty) keep_going = .false.
         endif
       enddo
 
@@ -477,7 +477,7 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
               line_is_empty = .false.
             endif
           enddo
-          if (line_is_empty) keep_going=.false.
+          if (line_is_empty) keep_going = .false.
         endif
       enddo
 
@@ -1078,7 +1078,7 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
             line_is_empty = .false.
           endif
         enddo
-        if (line_is_empty) keep_going=.false.
+        if (line_is_empty) keep_going = .false.
       endif
     enddo
 

--- a/src/parameterizations/lateral/MOM_tidal_forcing.F90
+++ b/src/parameterizations/lateral/MOM_tidal_forcing.F90
@@ -338,11 +338,11 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS)
 
   ! Determine how many tidal components are to be used.
   nc = 0
-  if (use_M2) nc=nc+1 ; if (use_S2) nc=nc+1
-  if (use_N2) nc=nc+1 ; if (use_K2) nc=nc+1
-  if (use_K1) nc=nc+1 ; if (use_O1) nc=nc+1
-  if (use_P1) nc=nc+1 ; if (use_Q1) nc=nc+1
-  if (use_MF) nc=nc+1 ; if (use_MM) nc=nc+1
+  if (use_M2) nc = nc + 1 ; if (use_S2) nc = nc + 1
+  if (use_N2) nc = nc + 1 ; if (use_K2) nc = nc + 1
+  if (use_K1) nc = nc + 1 ; if (use_O1) nc = nc + 1
+  if (use_P1) nc = nc + 1 ; if (use_Q1) nc = nc + 1
+  if (use_MF) nc = nc + 1 ; if (use_MM) nc = nc + 1
   CS%nc = nc
 
   if (nc == 0) then
@@ -407,54 +407,54 @@ subroutine tidal_forcing_init(Time, G, US, param_file, CS)
   if (CS%use_eq_phase) call astro_longitudes_init(CS%time_ref, CS%tidal_longitudes)
 
   ! Set the parameters for all components that are in use.
-  c=0
+  c = 0
   if (use_M2) then
-    c=c+1 ; CS%const_name(c) = "M2" ; CS%struct(c) = 2
+    c = c+1 ; CS%const_name(c) = "M2" ; CS%struct(c) = 2
     CS%love_no(c) = 0.693 ; amp_def(c) = 0.242334 ! Default amplitude in m.
   endif
 
   if (use_S2) then
-    c=c+1 ; CS%const_name(c) = "S2" ; CS%struct(c) = 2
+    c = c+1 ; CS%const_name(c) = "S2" ; CS%struct(c) = 2
     CS%love_no(c) = 0.693 ; amp_def(c) = 0.112743 ! Default amplitude in m.
   endif
 
   if (use_N2) then
-    c=c+1 ; CS%const_name(c) = "N2" ; CS%struct(c) = 2
+    c = c+1 ; CS%const_name(c) = "N2" ; CS%struct(c) = 2
     CS%love_no(c) = 0.693 ; amp_def(c) = 0.046397 ! Default amplitude in m.
   endif
 
   if (use_K2) then
-    c=c+1 ; CS%const_name(c) = "K2" ; CS%struct(c) = 2
+    c = c+1 ; CS%const_name(c) = "K2" ; CS%struct(c) = 2
     CS%love_no(c) = 0.693 ; amp_def(c) = 0.030684 ! Default amplitude in m.
   endif
 
   if (use_K1) then
-    c=c+1 ; CS%const_name(c) = "K1" ; CS%struct(c) = 1
+    c = c+1 ; CS%const_name(c) = "K1" ; CS%struct(c) = 1
     CS%love_no(c) = 0.736 ; amp_def(c) = 0.141565 ! Default amplitude in m.
   endif
 
   if (use_O1) then
-    c=c+1 ; CS%const_name(c) = "O1" ; CS%struct(c) = 1
+    c = c+1 ; CS%const_name(c) = "O1" ; CS%struct(c) = 1
     CS%love_no(c) = 0.695 ; amp_def(c) = 0.100661 ! Default amplitude in m.
   endif
 
   if (use_P1) then
-    c=c+1 ; CS%const_name(c) = "P1" ; CS%struct(c) = 1
+    c = c+1 ; CS%const_name(c) = "P1" ; CS%struct(c) = 1
     CS%love_no(c) = 0.706 ; amp_def(c) = 0.046848 ! Default amplitude in m.
   endif
 
   if (use_Q1) then
-    c=c+1 ; CS%const_name(c) = "Q1" ; CS%struct(c) = 1
+    c = c+1 ; CS%const_name(c) = "Q1" ; CS%struct(c) = 1
     CS%love_no(c) = 0.695 ; amp_def(c) = 0.019273 ! Default amplitude in m.
   endif
 
   if (use_MF) then
-    c=c+1 ; CS%const_name(c) = "MF" ; CS%struct(c) = 3
+    c = c+1 ; CS%const_name(c) = "MF" ; CS%struct(c) = 3
     CS%love_no(c) = 0.693 ; amp_def(c) = 0.042041 ! Default amplitude in m.
   endif
 
   if (use_MM) then
-    c=c+1 ; CS%const_name(c) = "MM" ; CS%struct(c) = 3
+    c = c+1 ; CS%const_name(c) = "MM" ; CS%struct(c) = 3
     CS%love_no(c) = 0.693 ; amp_def(c) = 0.022191 ! Default amplitude in m.
   endif
 

--- a/src/parameterizations/vertical/MOM_ALE_sponge.F90
+++ b/src/parameterizations/vertical/MOM_ALE_sponge.F90
@@ -897,7 +897,7 @@ subroutine set_up_ALE_sponge_vel_field_varying(filename_u, fieldname_u, filename
   integer, dimension(4) :: fld_sz
   if (.not.associated(CS)) return
 
-  override =.true.
+  override = .true.
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   isdB = G%isdB ; iedB = G%iedB ; jsdB = G%jsdB ; jedB = G%jedB

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -263,8 +263,8 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
   character(len=20) :: langmuir_entrainment_opt = 'NONE' !< Langmuir entrainment option to be
                                        !! passed to CVMix, e.g., LWF16
   integer :: default_answer_date       ! The default setting for the various ANSWER_DATE flags.
-  logical :: CS_IS_ONE=.false.         !< Logical for setting Cs based on Non-local
-  logical :: lnoDGat1=.false.          !< True => G'(1) = 0 (shape function)
+  logical :: CS_IS_ONE = .false.       !< Logical for setting Cs based on Non-local
+  logical :: lnoDGat1 = .false.        !< True => G'(1) = 0 (shape function)
                                        !! False => compute G'(1) as in LMD94
   ! Read parameters
   call get_param(paramFile, mdl, "USE_KPP", KPP_init, default=.false., do_not_log=.true.)
@@ -287,8 +287,8 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
                   default=.False.)
   !BGR: Note using PASSIVE for KPP creates warning for PASSIVE from Convection
   !     should we create a separate flag?
-  if (present(passive)) passive=CS%passiveMode ! This is passed back to the caller so
-                                               ! the caller knows to not use KPP output
+  if (present(passive)) passive = CS%passiveMode ! This is passed back to the caller so
+                                                 ! the caller knows to not use KPP output
   call get_param(paramFile, mdl, 'APPLY_NONLOCAL_TRANSPORT', CS%applyNonLocalTrans,  &
                  'If True, applies the non-local transport to all tracers. '//  &
                  'If False, calculates the non-local transport and tendencies but '//&
@@ -398,11 +398,11 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
   if (CS%MatchTechnique == 'ParabolicNonLocal') then
     ! This forces Cs2 (Cs in non-local computation) to equal 1 for parabolic non-local option.
     !  May be used during CVMix initialization.
-    Cs_is_one=.true.
+    Cs_is_one = .true.
   endif
   if (CS%MatchTechnique == 'ParabolicNonLocal' .or. CS%MatchTechnique == 'SimpleShapes') then
     ! if gradient won't be matched, lnoDGat1=.true.
-    lnoDGat1=.true.
+    lnoDGat1 = .true.
   endif
 
   ! safety check to avoid negative diff/visc

--- a/src/parameterizations/vertical/MOM_CVMix_shear.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_shear.F90
@@ -113,7 +113,7 @@ subroutine calculate_CVMix_shear(u_H, v_H, h, tv, kd, kv, G, GV, US, CS )
 
       ! Richardson number computed for each cell in a column.
       pRef = 0. ; if (associated(tv%p_surf)) pRef = tv%p_surf(i,j)
-      Ri_Grad(:)=1.e8 !Initialize w/ large Richardson value
+      Ri_Grad(:) = 1.e8 ! Initialize w/ large Richardson value
       do k=1,GV%ke
         ! pressure, temp, and saln for EOS
         ! kk+1 = k fields
@@ -232,7 +232,7 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
   type(diag_ctrl), target, intent(inout) :: diag !< Diagnostics control structure.
   type(CVMix_shear_cs),    pointer       :: CS !< This module's control structure.
   ! Local variables
-  integer :: NumberTrue=0
+  integer :: NumberTrue = 0
   logical :: use_JHL
   logical :: use_LMD94
   logical :: use_PP81
@@ -256,13 +256,13 @@ logical function CVMix_shear_init(Time, G, GV, US, param_file, diag, CS)
                  "If true, use the Large-McWilliams-Doney (JGR 1994) "//&
                  "shear mixing parameterization.", default=.false.)
   if (use_LMD94) &
-    NumberTrue=NumberTrue + 1
+    NumberTrue = NumberTrue + 1
   call get_param(param_file, mdl, "USE_PP81", use_PP81, &
                  "If true, use the Pacanowski and Philander (JPO 1981) "//&
                  "shear mixing parameterization.", default=.false.)
   if (use_PP81) &
     NumberTrue = NumberTrue + 1
-  use_JHL=kappa_shear_is_used(param_file)
+  use_JHL = kappa_shear_is_used(param_file)
   if (use_JHL) NumberTrue = NumberTrue + 1
   ! After testing for interior schemes, make sure only 0 or 1 are enabled.
   ! Otherwise, warn user and kill job.

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -160,7 +160,7 @@ type, public :: bulkmixedlayer_CS ; private
 end type bulkmixedlayer_CS
 
 !>@{ CPU clock IDs
-integer :: id_clock_pass=0
+integer :: id_clock_pass = 0
 !>@}
 
 contains

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -3944,7 +3944,7 @@ subroutine register_diabatic_restarts(G, GV, US, param_file, int_tide_CSp, resta
     allocate(CS)
   endif
 
-  use_int_tides=.false.
+  use_int_tides = .false.
 
   call read_param(param_file, "INTERNAL_TIDES", use_int_tides)
 

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -236,7 +236,7 @@ type, public :: energetic_PBL_CS ; private
                              !! calls occur.
 
   !/ Others
-  type(time_type), pointer :: Time=>NULL() !< A pointer to the ocean model's clock.
+  type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
 
   logical :: TKE_diagnostics = .false. !< If true, diagnostics of the TKE budget are being calculated.
   integer :: answer_date     !< The vintage of the order of arithmetic and expressions in the ePBL
@@ -251,7 +251,7 @@ type, public :: energetic_PBL_CS ; private
                              !! that can work with successive increments to the diffusivity in
                              !! upward or downward passes.
   logical :: debug           !< If true, write verbose checksums for debugging purposes.
-  type(diag_ctrl), pointer :: diag=>NULL() !< A structure that is used to regulate the
+  type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to regulate the
                              !! timing of diagnostic output.
 
   real, allocatable, dimension(:,:) :: &

--- a/src/parameterizations/vertical/MOM_entrain_diffusive.F90
+++ b/src/parameterizations/vertical/MOM_entrain_diffusive.F90
@@ -775,7 +775,7 @@ subroutine entrainment_diffusive(h, tv, fluxes, dt, G, GV, US, CS, ea, eb, &
         enddo ; enddo
 
         ! Repetitive, unless ea(kb) has been corrected.
-        k=kmb
+        k = kmb
         do i=is,ie
           ! Do not adjust eb through the base of the buffer layers, but it
           ! may be necessary to change entrainment from above.

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -503,7 +503,7 @@ subroutine geothermal_in_place(h, tv, dt, G, GV, US, CS, BFlx_geothermal, halo)
           if (calc_diags) dTdt_diag(i,j,k) = dTemp * Idt
         endif
 
-        if (heat_rem(i) > 0.0) do_any= .true.
+        if (heat_rem(i) > 0.0) do_any = .true.
       enddo
 
       if (.not.do_any) exit

--- a/src/parameterizations/vertical/MOM_internal_tide_input.F90
+++ b/src/parameterizations/vertical/MOM_internal_tide_input.F90
@@ -461,7 +461,7 @@ subroutine int_tide_input_init(Time, G, GV, US, param_file, diag, CS, itide)
                units="m s-1", default=0.0, scale=US%m_s_to_L_T)
 
   call read_param(param_file, "INTERNAL_TIDE_FREQS", num_freq)
-  CS%nFreq= num_freq
+  CS%nFreq = num_freq
 
   allocate(itide%Nb(isd:ied,jsd:jed), source=0.0)
   allocate(itide%Rho_bot(isd:ied,jsd:jed), source=0.0)

--- a/src/parameterizations/vertical/MOM_opacity.F90
+++ b/src/parameterizations/vertical/MOM_opacity.F90
@@ -1388,7 +1388,7 @@ subroutine init_ohlmann_table(optics)
 
   !! Make the table big enough so step size is smaller
   !! in log-space that any increment in Table 1a
-  integer, parameter :: nval_lut=401
+  integer, parameter :: nval_lut = 401
   real :: chl, log10chl_lut, w1, w2
   integer :: n, m, mm1, err
 

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1768,7 +1768,7 @@ subroutine find_L_open_convex(vol_below, D_vel, Dp, Dm, L, GV, US, CS)
                            ! accuracy of a single L(:) Newton iteration [Z5 ~> m5]
   real, parameter :: C1_3 = 1.0/3.0, C1_6 = 1.0/6.0 ! Rational constants [nondim]
   logical :: use_L0, do_one_L_iter  ! Control flags for L(:) Newton iteration
-  integer :: K, nz, itt, maxitt=20
+  integer :: K, nz, itt, maxitt = 20
 
   nz = GV%ke
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -640,8 +640,8 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
 
   accel_underflow = CS%vel_underflow * Idt
 
-  !Check if Stokes mixing allowed if requested (present and associated)
-  DoStokesMixing=.false.
+  ! Check if Stokes mixing allowed if requested (present and associated)
+  DoStokesMixing = .false.
   if (CS%StokesMixing) then
     if (present(Waves)) DoStokesMixing = associated(Waves)
     if (.not. DoStokesMixing) &
@@ -2648,7 +2648,7 @@ subroutine vertvisc_limit_vel(u, v, h, ADp, CDp, forces, visc, dt, G, GV, US, CS
   endif
 
   if (len_trim(CS%v_trunc_file) > 0) then
-    do_any_write =.false.
+    do_any_write = .false.
     trunc_any = .false.
 
 

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -249,7 +249,7 @@ subroutine initialize_DOME_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
                 else
                   d_tr = 0.0
                 endif
-                if (dz(i,k) < 2.0*GV%Angstrom_Z) d_tr=0.0
+                if (dz(i,k) < 2.0*GV%Angstrom_Z) d_tr = 0.0
                 CS%tr(i,j,k,m) = CS%tr(i,j,k,m) + d_tr
               enddo
             enddo

--- a/src/tracer/MOM_hor_bnd_diffusion.F90
+++ b/src/tracer/MOM_hor_bnd_diffusion.F90
@@ -858,11 +858,11 @@ logical function near_boundary_unit_tests( verbose )
 
   allocate(CS)
   ! fill required fields in CS
-  CS%linear=.false.
+  CS%linear = .false.
   CS%H_subroundoff = 1.0E-20
-  CS%debug=.false.
-  CS%limiter=.false.
-  CS%limiter_remap=.false.
+  CS%debug = .false.
+  CS%limiter = .false.
+  CS%limiter_remap = .false.
   CS%hbd_nk = 2 + (2*2)
   call initialize_remapping( CS%remap_CS, 'PLM', boundary_extrapolation=.true., &
                              om4_remap_via_sub_cells=.true., & ! ### see fail below when using fixed remapping alg.

--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -164,7 +164,7 @@ subroutine limit_mass_flux_3d(G, GV, uh, vh, ea, eb, h_pre)
     bottom_flux(i,j,k) = -(eb(i,j,k)-ea(i,j,k+1))
   enddo ; enddo ; enddo
 
-  k=nz
+  k = nz
   do j=js-1,je+1 ; do i=is-1,ie+1
     top_flux(i,j,k) = -(ea(i,j,k)-eb(i,j,k-1))
     bottom_flux(i,j,k) = -eb(i,j,k)

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -199,7 +199,7 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
     do j=jsd,jed ; do I=IsdB,IedB ; uhr(I,j,k) = 0.0 ; enddo ; enddo
     do J=jsdB,jedB ; do i=Isd,Ied ; vhr(i,J,k) = 0.0 ; enddo ; enddo
     do j=jsd,jed ; do i=Isd,Ied ; hprev(i,j,k) = 0.0 ; enddo ; enddo
-    domore_k(k)=1
+    domore_k(k) = 1
     !  Put the remaining (total) thickness fluxes into uhr and vhr.
     do j=js,je ; do I=is-1,ie ; uhr(I,j,k) = uhtr(I,j,k) ; enddo ; enddo
     do J=js-1,je ; do i=is,ie ; vhr(i,J,k) = vhtr(i,J,k) ; enddo ; enddo
@@ -467,7 +467,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
   logical :: do_i(SZI_(G),SZJ_(G))     ! If true, work on given points.
   logical :: usePLMslope
   integer :: i, j, m, n, i_up, stencil, ntr_id
-  type(OBC_segment_type), pointer :: segment=>NULL()
+  type(OBC_segment_type), pointer :: segment => NULL()
   logical, dimension(SZJ_(G),SZK_(GV)) :: domore_u_initial
 
   ! keep a local copy of the initial values of domore_u, which is to be used when computing ad2d_x
@@ -513,7 +513,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
            !endif
             Tp = Tr(m)%t(i+1,j,k) ; Tc = Tr(m)%t(i,j,k) ; Tm = Tr(m)%t(i-1,j,k)
             dMx = max( Tp, Tc, Tm ) - Tc
-            dMn= Tc - min( Tp, Tc, Tm )
+            dMn = Tc - min( Tp, Tc, Tm )
             slope_x(i,m) = G%mask2dCu(I,j)*G%mask2dCu(I-1,j) * &
                 sign( min(0.5*abs(Tp-Tm), 2.0*dMx, 2.0*dMn), Tp-Tm )
           enddo
@@ -532,7 +532,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
     ! loop through open boundaries and recalculate flux terms
     if (associated(OBC)) then ; if (OBC%OBC_pe) then
       do n=1,OBC%number_of_segments
-        segment=>OBC%segment(n)
+        segment => OBC%segment(n)
         if (.not. associated(segment%tr_Reg)) cycle
         if (segment%is_E_or_W) then
           if (j>=segment%HI%jsd .and. j<=segment%HI%jed) then
@@ -552,7 +552,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
                 do i=segment%HI%IsdB-1,segment%HI%IsdB+1
                   Tp = T_tmp(i+1,m) ; Tc = T_tmp(i,m) ; Tm = T_tmp(i-1,m)
                   dMx = max( Tp, Tc, Tm ) - Tc
-                  dMn= Tc - min( Tp, Tc, Tm )
+                  dMn = Tc - min( Tp, Tc, Tm )
                   slope_x(i,m) = G%mask2dCu(I,j)*G%mask2dCu(I-1,j) * &
                        sign( min(0.5*abs(Tp-Tm), 2.0*dMx, 2.0*dMn), Tp-Tm )
                 enddo
@@ -670,7 +670,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
     if (associated(OBC)) then ; if (OBC%OBC_pe) then
       if (OBC%specified_u_BCs_exist_globally .or. OBC%open_u_BCs_exist_globally) then
         do n=1,OBC%number_of_segments
-          segment=>OBC%segment(n)
+          segment => OBC%segment(n)
           if (.not. associated(segment%tr_Reg)) cycle
           if (segment%is_E_or_W) then
             if (j>=segment%HI%jsd .and. j<=segment%HI%jed) then
@@ -695,7 +695,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
 
       if (OBC%open_u_BCs_exist_globally) then
         do n=1,OBC%number_of_segments
-          segment=>OBC%segment(n)
+          segment => OBC%segment(n)
           I = segment%HI%IsdB
           if (segment%is_E_or_W .and. (j >= segment%HI%jsd .and. j<= segment%HI%jed)) then
             if (segment%specified) cycle
@@ -883,7 +883,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   logical :: do_i(SZI_(G), SZJ_(G))     ! If true, work on given points.
   logical :: usePLMslope
   integer :: i, j, j2, m, n, j_up, stencil, ntr_id
-  type(OBC_segment_type), pointer :: segment=>NULL()
+  type(OBC_segment_type), pointer :: segment => NULL()
   logical :: domore_v_initial(SZJB_(G)) ! Initial state of domore_v
 
   usePLMslope = .false.
@@ -959,7 +959,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   ! loop through open boundaries and recalculate flux terms
   if (associated(OBC)) then ; if (OBC%OBC_pe) then
     do n=1,OBC%number_of_segments
-      segment=>OBC%segment(n)
+      segment => OBC%segment(n)
       if (.not. associated(segment%tr_Reg)) cycle
       do i=is,ie
         if (segment%is_N_or_S) then
@@ -980,7 +980,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
                 do j=segment%HI%JsdB-1,segment%HI%JsdB+1
                   Tp = T_tmp(i,m,j+1) ; Tc = T_tmp(i,m,j) ; Tm = T_tmp(i,m,j-1)
                   dMx = max( Tp, Tc, Tm ) - Tc
-                  dMn= Tc - min( Tp, Tc, Tm )
+                  dMn = Tc - min( Tp, Tc, Tm )
                   slope_y(i,m,j) = G%mask2dCv(i,J)*G%mask2dCv(i,J-1) * &
                        sign( min(0.5*abs(Tp-Tm), 2.0*dMx, 2.0*dMn), Tp-Tm )
                 enddo
@@ -1100,7 +1100,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
     if (associated(OBC)) then ; if (OBC%OBC_pe) then
       if (OBC%specified_v_BCs_exist_globally .or. OBC%open_v_BCs_exist_globally) then
         do n=1,OBC%number_of_segments
-          segment=>OBC%segment(n)
+          segment => OBC%segment(n)
           if (.not. segment%specified) cycle
           if (.not. associated(segment%tr_Reg)) cycle
           if (OBC%segment(n)%is_N_or_S) then
@@ -1126,7 +1126,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
 
       if (OBC%open_v_BCs_exist_globally) then
         do n=1,OBC%number_of_segments
-          segment=>OBC%segment(n)
+          segment => OBC%segment(n)
           if (segment%specified) cycle
           if (.not. associated(segment%tr_Reg)) cycle
           if (segment%is_N_or_S .and. (J >= segment%HI%JsdB .and. J<= segment%HI%JedB)) then

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -90,7 +90,7 @@ type, public :: tracer_flow_control_CS ; private
   logical :: use_USER_tracer_example = .false.     !< If true, use the USER_tracer_example package
   logical :: use_DOME_tracer = .false.             !< If true, use the DOME_tracer package
   logical :: use_ISOMIP_tracer = .false.           !< If true, use the ISOMPE_tracer package
-  logical :: use_RGC_tracer =.false.               !< If true, use the RGC_tracer package
+  logical :: use_RGC_tracer = .false.              !< If true, use the RGC_tracer package
   logical :: use_ideal_age = .false.               !< If true, use the ideal age tracer package
   logical :: use_MARBL_tracers = .false.           !< If true, use the MARBL tracer package
   logical :: use_regional_dyes = .false.           !< If true, use the regional dyes tracer package
@@ -810,7 +810,7 @@ subroutine call_tracer_stocks(h, stock_values, G, GV, US, CS, stock_names, stock
                                    names, units, stock_index)
     call store_stocks("MOM_generic_tracer", ns, names, units, values_EFP, index, stock_val_EFP, &
                       set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
-    nn=ns_tot-ns+1
+    nn = ns_tot - ns + 1
     if (present(got_min_max) .and. present(global_min) .and. present(global_max)) &
       nn = MOM_generic_tracer_min_max(nn, got_min_max, global_min, global_max, &
                                       G, CS%MOM_generic_tracer_CSp, names, units, &

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -249,7 +249,7 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
           Kh_loc = Kh_loc * 0.5*(VarMix%Res_fn_h(i,j) + VarMix%Res_fn_h(i+1,j))
         Kh_u(I,j,1) = max(Kh_loc, CS%KhTr_min)
         if (CS%KhTr_passivity_coeff>0.) then ! Apply passivity
-          Rd_dx=0.5*( VarMix%Rd_dx_h(i,j)+VarMix%Rd_dx_h(i+1,j) ) ! Rd/dx at u-points
+          Rd_dx = 0.5*( VarMix%Rd_dx_h(i,j)+VarMix%Rd_dx_h(i+1,j) ) ! Rd/dx at u-points
           Kh_loc = Kh_u(I,j,1)*max( CS%KhTr_passivity_min, CS%KhTr_passivity_coeff*Rd_dx )
           if (CS%KhTr_max > 0.) Kh_loc = min(Kh_loc, CS%KhTr_max) ! Re-apply max
           Kh_u(I,j,1) = max(Kh_loc, CS%KhTr_min) ! Re-apply min

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -140,7 +140,7 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
                                                                 !! indicating to use the scheme from MOM_tracer_advect
 
   logical :: mand
-  type(tracer_type), pointer :: Tr=>NULL()
+  type(tracer_type), pointer :: Tr => NULL()
   character(len=256) :: mesg    ! Message for error messages.
 
   if (.not. associated(Reg)) call tracer_registry_init(param_file, Reg)
@@ -315,7 +315,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
   character(len=120) :: var_lname      ! A temporary longname for a diagnostic.
   character(len=120) :: cmor_var_lname ! The temporary CMOR long name for a diagnostic
   real :: conversion ! Temporary term while we address a bug [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
-  type(tracer_type), pointer :: Tr=>NULL()
+  type(tracer_type), pointer :: Tr => NULL()
   integer :: i, j, k, is, ie, js, je, nz, m, m2, nTr_in
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -612,7 +612,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
     ! Vertical regridding/remapping tendencies
     if (use_ALE .and. Tr%remap_tr) then
       var_lname = "Vertical remapping tracer concentration tendency for "//trim(Reg%Tr(m)%name)
-      Tr%id_remap_conc= register_diag_field('ocean_model', &
+      Tr%id_remap_conc = register_diag_field('ocean_model', &
           trim(Tr%flux_nameroot)//'_tendency_vert_remap', diag%axesTL, Time, var_lname, &
           trim(units)//' s-1', conversion=Tr%conc_scale*US%s_to_T)
 
@@ -740,7 +740,7 @@ subroutine post_tracer_diagnostics_at_sync(Reg, h, diag_prev, diag, G, GV, dt)
   real    :: work2d(SZI_(G),SZJ_(G)) ! The vertically integrated time tendency of a diagnostic
                                      ! in [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   real    :: Idt ! The inverse of the time step [T-1 ~> s-1]
-  type(tracer_type), pointer :: Tr=>NULL()
+  type(tracer_type), pointer :: Tr => NULL()
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -792,7 +792,7 @@ subroutine post_tracer_transport_diagnostics(G, GV, Reg, h_diag, diag)
   integer :: i, j, k, is, ie, js, je, nz, m
   real    :: work2d(SZI_(G),SZJ_(G))      ! The vertically integrated convergence of lateral advective
                                           ! tracer fluxes [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
-  type(tracer_type), pointer :: Tr=>NULL()
+  type(tracer_type), pointer :: Tr => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -843,7 +843,7 @@ subroutine post_tracer_integral_diagnostics(G, GV, US, Reg, h_diag, tv, diag)
   real    :: zbot(SZI_(G),SZJ_(G))    ! position of the bottom interface [Z ~> m]
   real    :: Z_100  ! 100 m in depth units [Z ~> m]
   logical :: dz_needed, dz100_used
-  type(tracer_type), pointer :: Tr=>NULL()
+  type(tracer_type), pointer :: Tr => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/tracer/RGC_tracer.F90
+++ b/src/tracer/RGC_tracer.F90
@@ -194,7 +194,7 @@ subroutine initialize_RGC_tracer(restart, day, G, GV, h, diag, OBC, CS, &
           CS%tr(i,j,k,m) = 0.0
         enddo ; enddo ; enddo
       enddo
-      m=1
+      m = 1
       do j=js,je ; do i=is,ie
          !set tracer to 1.0 in the surface of the continental shelf
          if (G%geoLonT(i,j) <= (CS%CSL)) then
@@ -287,7 +287,7 @@ subroutine RGC_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, 
 
   if (.not.associated(CS)) return
 
-  m=1
+  m = 1
   do j=js,je ; do i=is,ie
     ! set tracer to 1.0 in the surface of the continental shelf
     if (G%geoLonT(i,j) <= (CS%CSL)) then

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -206,30 +206,30 @@ subroutine initialize_advection_test_tracer(restart, day, G, GV, h,diag, OBC, CS
       do k=1,nz ; do j=js,je ; do i=is,ie
         CS%tr(i,j,k,m) = 0.0
       enddo ; enddo ; enddo
-      k=1 ! Square wave
+      k = 1 ! Square wave
       do j=js,je ; do i=is,ie
         if (abs(G%geoLonT(i,j)-CS%x_origin)<0.5*CS%x_width .and. &
             abs(G%geoLatT(i,j)-CS%y_origin)<0.5*CS%y_width) CS%tr(i,j,k,m) = 1.0
       enddo ; enddo
-      k=2 ! Triangle wave
+      k = 2 ! Triangle wave
       do j=js,je ; do i=is,ie
         locx = abs(G%geoLonT(i,j)-CS%x_origin)/CS%x_width
         locy = abs(G%geoLatT(i,j)-CS%y_origin)/CS%y_width
         CS%tr(i,j,k,m) = max(0.0, 1.0-locx)*max(0.0, 1.0-locy)
       enddo ; enddo
-      k=3 ! Cosine bell
+      k = 3 ! Cosine bell
       do j=js,je ; do i=is,ie
         locx = min(1.0, abs(G%geoLonT(i,j)-CS%x_origin)/CS%x_width) * (acos(0.0)*2.)
         locy = min(1.0, abs(G%geoLatT(i,j)-CS%y_origin)/CS%y_width) * (acos(0.0)*2.)
         CS%tr(i,j,k,m) = (1.0+cos(locx))*(1.0+cos(locy))*0.25
       enddo ; enddo
-      k=4 ! Cylinder
+      k = 4 ! Cylinder
       do j=js,je ; do i=is,ie
         locx = abs(G%geoLonT(i,j)-CS%x_origin)/CS%x_width
         locy = abs(G%geoLatT(i,j)-CS%y_origin)/CS%y_width
         if ((locx**2) + (locy**2) <= 1.0) CS%tr(i,j,k,m) = 1.0
       enddo ; enddo
-      k=5 ! Cut cylinder
+      k = 5 ! Cut cylinder
       do j=js,je ; do i=is,ie
         locx = (G%geoLonT(i,j)-CS%x_origin)/CS%x_width
         locy = (G%geoLatT(i,j)-CS%y_origin)/CS%y_width

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -39,7 +39,7 @@ integer, parameter :: NTR_MAX = 1
 
 !> The control structure for the boundary impulse tracer package
 type, public :: boundary_impulse_tracer_CS ; private
-  integer :: ntr=NTR_MAX    !< The number of tracers that are actually used.
+  integer :: ntr = NTR_MAX  !< The number of tracers that are actually used.
   logical :: coupled_tracers = .false. !< These tracers are not offered to the  coupler.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -46,8 +46,8 @@ type, public :: oil_tracer_CS ; private
   logical :: Z_IC_file         !< If true, the IC_file is in Z-space.  The default is false.
   real :: oil_source_longitude !< Latitude of source location (geographic) [degrees_N]
   real :: oil_source_latitude  !< Longitude of source location (geographic) [degrees_E]
-  integer :: oil_source_i=-999 !< Local i of source location (computational index location)
-  integer :: oil_source_j=-999 !< Local j of source location (computational index location)
+  integer :: oil_source_i = -999 !< Local i of source location (computational index location)
+  integer :: oil_source_j = -999 !< Local j of source location (computational index location)
   real :: oil_source_rate     !< Rate of oil injection [kg T-1 ~> kg s-1]
   real :: oil_start_year      !< The time at which the oil source starts [years]
   real :: oil_end_year        !< The time at which the oil source ends [years]
@@ -240,8 +240,8 @@ subroutine initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS, &
         CS%oil_source_longitude>=G%geoLonBu(I-1,J) .and. &
         CS%oil_source_latitude<G%geoLatBu(I,J) .and. &
         CS%oil_source_latitude>=G%geoLatBu(I,J-1) ) then
-      CS%oil_source_i=i
-      CS%oil_source_j=j
+      CS%oil_source_i = i
+      CS%oil_source_j = j
     endif
   enddo ; enddo
 
@@ -380,7 +380,7 @@ subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
     vol_scale = GV%H_to_m * US%L_to_m**2
     do k=nz, 2, -1
       h_total = h_total + h_new(i,j,k)
-      if (h_total < 10.*GV%m_to_H) k_max=k-1 ! Find bottom most interface that is 10 m above bottom
+      if (h_total < 10.*GV%m_to_H) k_max = k-1 ! Find bottom most interface that is 10 m above bottom
     enddo
     do m=1,CS%ntr
       k = CS%oil_source_k(m)

--- a/src/user/DOME_initialization.F90
+++ b/src/user/DOME_initialization.F90
@@ -138,7 +138,7 @@ subroutine DOME_initialize_thickness(h, depth_tot, G, GV, param_file, just_read)
 
   call MOM_mesg("  DOME_initialization.F90, DOME_initialize_thickness: setting thickness", 5)
 
-  e0(1)=0.0
+  e0(1) = 0.0
   do k=2,nz
     e0(K) = -G%max_depth * (real(k-1)-0.5)/real(nz-1)
   enddo

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -1836,8 +1836,8 @@ subroutine Stokes_PGF(G, GV, US, dz, u, v, PFu_Stokes, PFv_Stokes, CS )
         dP_Stokes_r_dz = 0.0
         dP_Stokes_l = 0.0
         dP_Stokes_r = 0.0
-        dP_lay_Stokes_l=0.0
-        dP_lay_Stokes_r=0.0
+        dP_lay_Stokes_l = 0.0
+        dP_lay_Stokes_r = 0.0
 
         do l = 1, CS%numbands
 
@@ -1962,8 +1962,8 @@ subroutine Stokes_PGF(G, GV, US, dz, u, v, PFu_Stokes, PFv_Stokes, CS )
         dP_Stokes_r_dz = 0.0
         dP_Stokes_l = 0.0
         dP_Stokes_r = 0.0
-        dP_lay_Stokes_l=0.0
-        dP_lay_Stokes_r=0.0
+        dP_lay_Stokes_l = 0.0
+        dP_lay_Stokes_r = 0.0
 
         do l = 1, CS%numbands
 
@@ -2093,9 +2093,9 @@ subroutine ust_2_u10_coare3p5(USTair, U10, GV, US, CS)
   if (CS%answer_date < 20230103) then
     u10 = US%Z_to_L*USTair / sqrt(0.001)  ! Guess for u10
     ten_m_scale = 10.0*US%m_to_Z
-    CT=0
+    CT = 0
     do while (abs(u10a/u10 - 1.) > 0.001)
-      CT=CT+1
+      CT = CT+1
       u10a = u10
       alpha = min(CS%Charnock_min, CS%Charnock_slope_U10 * u10 + CS%Charnock_intercept)
       z0rough = alpha * (US%Z_to_L*USTair)**2 / GV%g_Earth ! Compute z0rough from ustar guess

--- a/src/user/Phillips_initialization.F90
+++ b/src/user/Phillips_initialization.F90
@@ -430,7 +430,7 @@ subroutine Phillips_initialize_topography(D, G, param_file, max_depth, US)
   call get_param(param_file, mdl, "PHILLIPS_HTOP", Htop, &
                  "The maximum height of the topography.", units="m", scale=US%m_to_Z, &
                  fail_if_missing=.true.)
-! Htop=0.375*max_depth     ! max height of topog. above max_depth
+! Htop = 0.375*max_depth   ! max height of topog. above max_depth
   Wtop = 0.5*G%len_lat     ! meridional width of drake and mount
   Ltop = 0.25*G%len_lon    ! zonal width of topographic features
   offset = 0.1*G%len_lat   ! meridional offset from center
@@ -440,7 +440,7 @@ subroutine Phillips_initialize_topography(D, G, param_file, max_depth, US)
   x1 = G%west_lon+0.1*G%len_lon ; x2 = x1+Ltop ; x3 = x1+dist ; x4 = x3+3.0/2.0*Ltop
 
   do j=js,je ; do i=is,ie
-    D(i,j)=0.0
+    D(i,j) = 0.0
     if (G%geoLonT(i,j)>x1 .and. G%geoLonT(i,j)<x2) then
       D(i,j) = Htop*sin(PI*(G%geoLonT(i,j)-x1)/(x2-x1))**2
       if (G%geoLatT(i,j)>y1 .and. G%geoLatT(i,j)<y2) then

--- a/src/user/circle_obcs_initialization.F90
+++ b/src/user/circle_obcs_initialization.F90
@@ -100,7 +100,7 @@ subroutine circle_obcs_initialize_thickness(h, depth_tot, G, GV, US, param_file,
   enddo ; enddo
 
   ! Perturb base state by circular anomaly in center
-  k=nz
+  k = nz
   latC = G%south_lat + 0.5*G%len_lat
   lonC = G%west_lon + 0.5*G%len_lon + xOffset
   do j=js,je ; do i=is,ie

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -469,7 +469,7 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
       enddo
       eta(i,j,nz+1) = -depth_tot(i,j)
       do k=1,nz
-        S(i,j,k)= tv%S(i,j,k)
+        S(i,j,k) = tv%S(i,j,k)
       enddo
     enddo ; enddo
 

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -260,7 +260,7 @@ subroutine dumbbell_surface_forcing_init(Time, G, US, param_file, diag, CS)
         else
           x = ( G%geoLonT(i,j) - G%west_lon ) / G%len_lon - 0.5
         endif
-        CS%forcing_mask(i,j)=0
+        CS%forcing_mask(i,j) = 0
         CS%S_restore(i,j) = S_surf
         if ((x>0.25)) then
           CS%forcing_mask(i,j) = 1


### PR DESCRIPTION
  Added spaces around the equal sign in 277 assignment statements scattered across 62 files, bringing them into alignment with the MOM6 style guide and more clearly delineating Fortran tokens.  Only white space was changed, and all answers and output are bitwise identical.