### PR TITLE
Mass conservation for ice-shelf zstar bug fix

### DIFF
--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -54,6 +54,9 @@ type, public :: continuity_PPM_CS ; private
   real :: h_marg_min         !< Negligible floor on h_marg, the marginal thickness
                              !! used to calculate the partial derivative of transports
                              !! with velocities [H ~> m or kg m-2]
+  real :: h_min              !< The minimum layer thickness that the continuity solver will
+                             !! leave behind after the thickness fluxes have been applied
+                             !! [H ~> m or kg m-2].  h_min could be 0.
   logical :: aggress_adjust  !< If true, allow the adjusted velocities to have a
                              !! relative CFL change up to 0.5.  False by default.
   logical :: vol_CFL         !< If true, use the ratio of the open face lengths
@@ -154,7 +157,7 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   type(cont_loop_bounds_type) :: LB ! A type indicating the loop range for a phase of the updates
   logical :: x_first
 
-  h_min = GV%Angstrom_H
+  h_min = CS%h_min
 
   if (.not.CS%initialized) call MOM_error(FATAL, &
          "MOM_continuity_PPM: Module must be initialized before it is used.")
@@ -2783,6 +2786,15 @@ subroutine continuity_PPM_init(Time, G, GV, US, param_file, diag, CS, OBC)
                  "is 0.5*NK*ANGSTROM, and this should not be set less "//&
                  "than about 10^-15*MAXIMUM_DEPTH.", units="m", scale=GV%m_to_H, &
                  default=0.5*GV%ke*GV%Angstrom_m)
+
+  call get_param(param_file, mdl, "CONTINUITY_MIN_THICKNESS", CS%h_min, &
+                 "The minimum layer thickness that the continuity solver leaves behind "//&
+                 "after applying the thickness fluxes.  The default of ANGSTROM reproduces "//&
+                 "the previous hard-coded behavior, but because this floor is applied to "//&
+                 "layers that a regridding step has set to zero thickness, it acts as a "//&
+                 "spurious source of mass in configurations with many vanished layers.  "//&
+                 "Setting this to 0 avoids that spurious mass source.", &
+                 units="m", scale=GV%m_to_H, default=GV%Angstrom_m)
 
   call get_param(param_file, mdl, "VELOCITY_TOLERANCE", CS%tol_vel, &
                  "The tolerance for barotropic velocity discrepancies "//&

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -137,6 +137,11 @@ type, public :: ice_shelf_CS ; private
                        !< This number should be specified by the user.
   real :: col_mass_melt_threshold !< An ocean column mass below the iceshelf below which melting
                        !! does not occur [R Z ~> kg m-2]
+  logical :: frazil_refreeze_bug !< If true, recover a bug that frazil is refrozen onto the
+                       !! ice shelf even in columns that can not supply the corresponding mass.
+  real :: frazil_col_mass_frac !< The maximum fraction of the ocean column mass in excess of
+                       !! COL_THICK_MELT_THRESHOLD that can be removed by frazil refreezing
+                       !! onto the base of an ice shelf in a single time step [nondim]
   logical :: mass_from_file !< Read the ice shelf mass from a file every dt
   logical :: ustar_shelf_from_vel !< If true, use the surface velocities, and not the previous
                        !! values of the stresses to set ustar.
@@ -296,7 +301,9 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     exch_vel_t, &   !< Sub-shelf thermal exchange velocity [Z T-1 ~> m s-1]
     exch_vel_s, &   !< Sub-shelf salt exchange velocity [Z T-1 ~> m s-1]
     dh_bdott, & !< Basal melt/accumulation over a time step, used for diagnostics [Z ~> m]
-    dh_adott    !< Surface melt/accumulation over a time step, used for diagnostics [Z ~> m]
+    dh_adott, & !< Surface melt/accumulation over a time step, used for diagnostics [Z ~> m]
+    frazil_used !< The frazil heat that is actually converted into refreezing onto the base
+                !! of the ice shelf during this time step [Q R Z ~> J m-2]
   real, dimension(SZDI_(CS%grid),SZDJ_(CS%grid)) :: &
     mass_flux  !< Total mass flux of freshwater across the ice-ocean interface. [R Z L2 T-1 ~> kg s-1]
   real, dimension(SZDI_(CS%grid),SZDJ_(CS%grid)) :: &
@@ -312,6 +319,9 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   real :: I_2Zeta_N !< Half the inverse of Zeta_N [nondim].
   real :: I_LF     !< The inverse of the latent heat of fusion [Q-1 ~> kg J-1].
   real :: I_dt_LHF  ! The inverse of the timestep times the latent heat of fusion [Q-1 T-1 ~> kg J-1 s-1].
+  real :: frazil_avail ! The largest amount of frazil heat that can be converted into refreezing
+                   ! onto the ice shelf without removing more mass than the ocean column holds
+                   ! [Q R Z ~> J m-2].
   real :: I_VK     !< The inverse of the Von Karman constant [nondim].
   real :: PR, SC   !< The Prandtl number and Schmidt number [nondim].
 
@@ -837,6 +847,7 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   else
     add_frazil = .false.
   endif
+  frazil_used(:,:) = 0.0
 
   do j=js,je ; do i=is,ie
     ! ISS%water_flux = net liquid water into the ocean [R Z T-1 ~> kg m-2 s-1]
@@ -887,8 +898,25 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
     mass_flux(i,j) = ISS%water_flux(i,j) * ISS%area_shelf_h(i,j)
 
     !Add frazil formation
-    if (add_frazil .and. (ISS%hmask(i,j) == 1 .or. ISS%hmask(i,j) == 2)) &
-      ISS%water_flux(i,j) = ISS%water_flux(i,j) - ISS%frazil(i,j) * I_dt_LHF
+    if (add_frazil .and. (ISS%hmask(i,j) == 1 .or. ISS%hmask(i,j) == 2)) then
+      if (CS%frazil_refreeze_bug) then
+        ISS%water_flux(i,j) = ISS%water_flux(i,j) - ISS%frazil(i,j) * I_dt_LHF
+        frazil_used(i,j) = ISS%frazil(i,j)
+      else
+        ! Frazil refreezes onto the base of the ice shelf, so the corresponding mass has to be
+        ! taken out of the ocean column.  Only do this where there is an ocean column that can
+        ! actually give up that mass, and limit the amount that is taken to a fraction of the
+        ! mass that is available.  Any frazil that is not used here is retained in ISS%frazil
+        ! and is applied during a subsequent time step, so that neither mass nor heat is lost.
+        frazil_avail = 0.0
+        if ((sfc_state%ocean_mass(i,j) > CS%col_mass_melt_threshold) .and. &
+            (ISS%area_shelf_h(i,j) > 0.0) .and. (ISS%melt_mask(i,j) > 0.0) .and. (CS%isthermo)) &
+          frazil_avail = (CS%frazil_col_mass_frac * CS%Lat_fusion) * &
+                         (sfc_state%ocean_mass(i,j) - CS%col_mass_melt_threshold)
+        frazil_used(i,j) = min(ISS%frazil(i,j), frazil_avail)
+        ISS%water_flux(i,j) = ISS%water_flux(i,j) - frazil_used(i,j) * I_dt_LHF
+      endif
+    endif
     fluxes%iceshelf_melt(i,j) = ISS%water_flux(i,j)
   enddo ; enddo ! i- and j-loops
 
@@ -987,7 +1015,17 @@ subroutine shelf_calc_flux(sfc_state_in, fluxes_in, Time, time_step_in, CS)
   call disable_averaging(CS%diag)
 
   !reset used frazil
-  if (add_frazil) ISS%frazil(:,:) = 0.0
+  if (add_frazil) then
+    if (CS%frazil_refreeze_bug) then
+      ISS%frazil(:,:) = 0.0
+    else
+      ! Retain any frazil that could not be refrozen onto the ice shelf this time step so that
+      ! it can be applied later, rather than discarding it and losing heat and mass.
+      do j=js,je ; do i=is,ie
+        ISS%frazil(i,j) = max(ISS%frazil(i,j) - frazil_used(i,j), 0.0)
+      enddo ; enddo
+    endif
+  endif
 
   call cpu_clock_end(id_clock_shelf)
 
@@ -1041,7 +1079,15 @@ subroutine adjust_ice_sheet_frazil(sfc_state_in, fluxes_in, CS)
     !Copy frazil to the ice sheet module where ice sheet is present.
     !No scaling to account for partial ice-sheet cells is necessary here, as
     !this is taken care of when applied to the ice sheet.
-    if (fluxes%frac_shelf_h(i,j)>0.0) ISS%frazil(i,j) = sfc_state%frazil(i,j)
+    if (fluxes%frac_shelf_h(i,j)>0.0) then
+      if (CS%frazil_refreeze_bug) then
+        ISS%frazil(i,j) = sfc_state%frazil(i,j)
+      else
+        ! Accumulate the newly formed frazil onto any frazil that the ice shelf has not yet
+        ! been able to refreeze, so that none of it is discarded.
+        ISS%frazil(i,j) = ISS%frazil(i,j) + sfc_state%frazil(i,j)
+      endif
+    endif
     !Remove the frazil that is used by the ice sheet from sfc_state%frazil
     !The sfc_state%frazil is sent to the sea-ice module
     sfc_state%frazil(i,j) = sfc_state%frazil(i,j) * (1.0-fluxes%frac_shelf_h(i,j))
@@ -1890,6 +1936,18 @@ subroutine initialize_ice_shelf(param_file, ocn_grid, Time, CS, diag, Time_init,
   call get_param(param_file, mdl, "ICE_SHELF_USTAR_FROM_VEL_BUGFIX", CS%ustar_from_vel_bugfix, &
                  "Bug fix for ice-area weighting of squared ocean velocities "//&
                  "used to calculate friction velocity under ice shelves", default=.not.enable_bugs)
+  call get_param(param_file, mdl, "ICE_SHELF_FRAZIL_REFREEZE_BUG", CS%frazil_refreeze_bug, &
+                 "If true, recover a bug that frazil is refrozen onto the base of the ice "//&
+                 "shelf even in ocean columns that are too thin to supply the corresponding "//&
+                 "mass, and that any frazil that can not be refrozen is discarded.  This "//&
+                 "causes mass and heat to be created or destroyed spuriously.", &
+                 default=enable_bugs)
+  call get_param(param_file, mdl, "ICE_SHELF_FRAZIL_COL_MASS_FRAC", CS%frazil_col_mass_frac, &
+                 "The maximum fraction of the ocean column mass in excess of the mass "//&
+                 "corresponding to COL_THICK_MELT_THRESHOLD that can be removed by frazil "//&
+                 "refreezing onto the base of an ice shelf in a single time step.  Any "//&
+                 "remaining frazil is retained and applied during a subsequent time step.", &
+                 units="nondim", default=0.5, do_not_log=CS%frazil_refreeze_bug)
   call get_param(param_file, mdl, "ICE_SHELF_BUOYANCY_FLUX_ITT_BUGFIX", CS%buoy_flux_itt_bugfix, &
                  "Bug fix of buoyancy iteration", default=.true., old_name="ICE_SHELF_BUOYANCY_FLUX_ITT_BUG")
   call get_param(param_file, mdl, "ICE_SHELF_SALT_FLUX_ITT_BUGFIX", CS%salt_flux_itt_bugfix, &

--- a/src/parameterizations/lateral/MOM_interface_filter.F90
+++ b/src/parameterizations/lateral/MOM_interface_filter.F90
@@ -36,6 +36,9 @@ type, public :: interface_filter_CS ; private
   integer :: filter_order        !< The even power of the interface height smoothing.
                                  !! At present valid values are 0, 2, or 4.
   logical :: interface_filter    !< If true, interfaces heights are diffused.
+  real    :: h_min               !< The minimum layer thickness that the interface filter will
+                                 !! leave behind after the filtering transports have been applied
+                                 !! [H ~> m or kg m-2].  h_min could be 0.
   logical :: isotropic_filter    !< If true, use the same filtering lengthscales in both directions,
                                  !! otherwise use filtering lengthscales in each direction that scale
                                  !! with the grid spacing in that direction.
@@ -212,7 +215,7 @@ subroutine interface_filter(h, uhtr, vhtr, tv, dt, G, GV, US, CDp, CS)
     do j=js,je ; do i=is,ie
       h(i,j,k) = h(i,j,k) - G%IareaT(i,j) * &
           ((uhD(I,j,k) - uhD(I-1,j,k)) + (vhD(i,J,k) - vhD(i,J-1,k)))
-      if (h(i,j,k) < GV%Angstrom_H) h(i,j,k) = GV%Angstrom_H
+      if (h(i,j,k) < CS%h_min) h(i,j,k) = CS%h_min
     enddo ; enddo
 
     ! Store the transports associated with the smoothing if they are needed for diagnostics.
@@ -399,6 +402,15 @@ subroutine interface_filter_init(Time, G, GV, US, param_file, diag, CDp, CS)
   CS%filter_rate = 0.0
   if (interface_filter_time > 0.0) CS%filter_rate = 1.0 / interface_filter_time
   CS%interface_filter  = (interface_filter_time > 0.0)
+  call get_param(param_file, mdl, "INTERFACE_FILTER_MIN_THICKNESS", CS%h_min, &
+                 "The minimum layer thickness that the interface height filter leaves behind "//&
+                 "after the filtering transports have been applied.  The default of ANGSTROM "//&
+                 "reproduces the previous hard-coded behavior, but because this floor is "//&
+                 "applied to layers that a regridding step has set to zero thickness, it acts "//&
+                 "as a spurious source of mass in configurations with many vanished layers.  "//&
+                 "Setting this to 0 avoids that spurious mass source.", &
+                 units="m", scale=GV%m_to_H, default=GV%Angstrom_m, &
+                 do_not_log=.not.CS%interface_filter)
   call get_param(param_file, mdl, "INTERFACE_FILTER_MAX_CFL", CS%max_smoothing_CFL, &
                  "The maximum value of the local CFL ratio that "//&
                  "is permitted for the interface height smoothing. 1.0 is the "//&

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -54,6 +54,9 @@ type, public :: thickness_diffuse_CS ; private
   real    :: kappa_smooth        !< Vertical diffusivity used to interpolate more sensible values
                                  !! of T & S into thin layers [H Z T-1 ~> m2 s-1 or kg m-1 s-1]
   logical :: thickness_diffuse   !< If true, interfaces heights are diffused.
+  real    :: h_min               !< The minimum layer thickness that thickness diffusion will
+                                 !! leave behind after the diffusive transports have been applied
+                                 !! [H ~> m or kg m-2].  h_min could be 0.
   logical :: full_depth_khth_min !< If true, KHTH_MIN is enforced throughout the whole water column.
                                  !! Otherwise, KHTH_MIN is only enforced at the surface. This parameter
                                  !! is only available when KHTH_USE_EBT_STRUCT=True and KHTH_MIN>0.
@@ -635,7 +638,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     do j=js,je ; do i=is,ie
       h(i,j,k) = h(i,j,k) - dt * G%IareaT(i,j) * &
           ((uhD(I,j,k) - uhD(I-1,j,k)) + (vhD(i,J,k) - vhD(i,J-1,k)))
-      if (h(i,j,k) < GV%Angstrom_H) h(i,j,k) = GV%Angstrom_H
+      if (h(i,j,k) < CS%h_min) h(i,j,k) = CS%h_min
     enddo ; enddo
   enddo
 
@@ -2290,6 +2293,15 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
   call get_param(param_file, mdl, "THICKNESSDIFFUSE", CS%thickness_diffuse, &
                  "If true, interface heights are diffused with a "//&
                  "coefficient of KHTH.", default=.false.)
+  call get_param(param_file, mdl, "THICKNESS_DIFFUSE_MIN_THICKNESS", CS%h_min, &
+                 "The minimum layer thickness that thickness diffusion leaves behind after "//&
+                 "the diffusive transports have been applied.  The default of ANGSTROM "//&
+                 "reproduces the previous hard-coded behavior, but because this floor is "//&
+                 "applied to layers that a regridding step has set to zero thickness, it acts "//&
+                 "as a spurious source of mass in configurations with many vanished layers.  "//&
+                 "Setting this to 0 avoids that spurious mass source.", &
+                 units="m", scale=GV%m_to_H, default=GV%Angstrom_m, &
+                 do_not_log=.not.CS%thickness_diffuse)
   call get_param(param_file, mdl, "USE_THICKNESS_DIFFUSE_ANN", CS%use_meso_sfn_ANN, &
                  "If true, use the ANN to compute the mesoscale streamfunction "//&
                  "for thickness diffusivity.", default=.false.)


### PR DESCRIPTION
This PR adds configurable minimum thickness floors in the continuity, thickness-diffusion, and interface-filter updates, and fixes frazil refreezing at ice-shelf bases. Together, the changes address artificial ocean mass sources and losses in configurations with collapsed water columns beneath dynamic ice shelves.

The thickness-floor controls are added across three files:

* `CONTINUITY_MIN_THICKNESS`
* `THICKNESS_DIFFUSE_MIN_THICKNESS`
* `INTERFACE_FILTER_MIN_THICKNESS`

Each defaults to `ANGSTROM`, preserving the former hard-coded behavior and bitwise-identical answers. Setting a floor to zero prevents layers intentionally collapsed by ALE regridding from gaining artificial mass.

The frazil fix is controlled by `ICE_SHELF_FRAZIL_REFREEZE_BUG`, which defaults to `ENABLE_BUGS_BY_DEFAULT` and therefore preserves existing answers by default. When set to `False`, refreezing is capped by the available ocean-column mass above `COL_THICK_MELT_THRESHOLD`; unused frazil is retained for later timesteps. The new
`ICE_SHELF_FRAZIL_COL_MASS_FRAC` parameter defaults to `0.5` and limits each timestep to removing half of that available mass.

ALE regridding may validly collapse layers to zero thickness. Applying an ANGSTROM floor after subsequent thickness updates creates mass without a corresponding transport, an effect that grows with the number of collapsed layers. Separately, unconditional frazil refreezing can remove more mass than a thin sub-ice-shelf column contains and discards frazil that cannot be refrozen, violating mass and heat conservation.

All answers are bitwise identical with default parameters:

* The three minimum thickness parameters default to the previous `ANGSTROM` floors.
* `ICE_SHELF_FRAZIL_REFREEZE_BUG` defaults to the legacy behavior through `ENABLE_BUGS_BY_DEFAULT`.

Setting a minimum thickness to zero or setting
`ICE_SHELF_FRAZIL_REFREEZE_BUG=False` intentionally changes answers to remove the corresponding conservation error.

NOTE: AI tools were used in this contribution.